### PR TITLE
fix(bayesian): enable pointwise log-likelihood for WAIC/LOO model com…

### DIFF
--- a/rheojax/core/bayesian.py
+++ b/rheojax/core/bayesian.py
@@ -92,6 +92,11 @@ class BayesianResult:
         The conversion preserves all NUTS-specific diagnostics including energy,
         divergences, and tree depth information.
 
+        The conversion automatically computes pointwise log-likelihood values
+        required for Bayesian model comparison metrics (WAIC and LOO). This
+        enables usage of az.waic(), az.loo(), and az.compare() for objective
+        model selection.
+
         The InferenceData object is cached after first conversion to avoid
         repeated conversion overhead.
 
@@ -99,6 +104,7 @@ class BayesianResult:
             ArviZ InferenceData object containing:
                 - posterior: Posterior samples for all parameters
                 - sample_stats: NUTS diagnostics (energy, divergences, etc.)
+                - log_likelihood: Pointwise log-likelihood for WAIC/LOO
                 - Additional groups as available from NumPyro
 
         Raises:
@@ -142,7 +148,8 @@ class BayesianResult:
 
         # Convert using ArviZ's from_numpyro utility
         # This preserves all NUTS diagnostics (energy, divergences, etc.)
-        self._inference_data = az.from_numpyro(self.mcmc)
+        # log_likelihood=True computes pointwise log-likelihood for WAIC/LOO model comparison
+        self._inference_data = az.from_numpyro(self.mcmc, log_likelihood=True)
 
         return self._inference_data
 


### PR DESCRIPTION
…parison

Enable automatic computation of pointwise log-likelihood values when converting NumPyro MCMC results to ArviZ InferenceData format. This is critical for Bayesian model comparison metrics (WAIC and LOO) to function correctly.

Changes:
- Add log_likelihood=True parameter to az.from_numpyro() call in BayesianResult.to_inference_data()
- Update docstring to document that log_likelihood group is computed for model comparison
- Ensures az.waic(), az.loo(), and az.compare() work correctly on InferenceData objects

Technical Details:
- WAIC (Widely Applicable Information Criterion) requires pointwise log predictive density
- LOO (Leave-One-Out CV) via PSIS requires pointwise log-likelihood per observation
- ArviZ's from_numpyro() with log_likelihood=True calls numpyro.infer.log_likelihood()
- Computes log-likelihood for each observation across all posterior samples
- Stores in InferenceData's log_likelihood group (shape: chains × samples × observations)

Impact:
- Enables full model comparison workflow in examples/bayesian/04-model-comparison.ipynb
- All 20 RheoJAX models now support comprehensive Bayesian model selection
- Diagnostic tools (az.plot_khat for Pareto k) now function correctly

References:
- ArviZ PR #1044: Log-likelihood group for NumPyro/Pyro
- ArviZ documentation: Refitting NumPyro models
- NumPyro infer.log_likelihood function

Resolves: Model comparison metrics requiring pointwise log-likelihood