### PR TITLE
style(gui): consistent layout margins, typography, and font-scale fixes across the GUI

### DIFF
--- a/rheojax/gui/dialogs/bayesian_options.py
+++ b/rheojax/gui/dialogs/bayesian_options.py
@@ -27,6 +27,7 @@ from rheojax.gui.compat import (
     QVBoxLayout,
     QWidget,
 )
+from rheojax.gui.resources.styles.tokens import Typography, themed
 from rheojax.logging import get_logger
 
 logger = get_logger(__name__)
@@ -253,7 +254,9 @@ class BayesianOptionsDialog(QDialog):
             "(R-hat < 1.01, ESS > 400)"
         )
         info_label.setWordWrap(True)
-        info_label.setStyleSheet("color: #666; font-size: 11px;")
+        info_label.setStyleSheet(
+            f"color: {themed('TEXT_MUTED')}; font-size: {Typography.SIZE_SM}pt;"
+        )
         layout.addWidget(info_label)
 
         layout.addStretch()

--- a/rheojax/gui/dialogs/pipeline_templates.py
+++ b/rheojax/gui/dialogs/pipeline_templates.py
@@ -21,7 +21,7 @@ from rheojax.gui.compat import (
     QVBoxLayout,
     QWidget,
 )
-from rheojax.gui.resources.styles.tokens import Spacing
+from rheojax.gui.resources.styles.tokens import Spacing, Typography, themed
 from rheojax.logging import get_logger
 
 logger = get_logger(__name__)
@@ -76,7 +76,9 @@ class PipelineTemplateDialog(QDialog):
         instruction = QLabel(
             "Select a template to use as the starting point for your pipeline."
         )
-        instruction.setStyleSheet("font-size: 10pt; color: gray;")
+        instruction.setStyleSheet(
+            f"font-size: {Typography.SIZE_SM}pt; color: {themed('TEXT_MUTED')};"
+        )
         instruction.setWordWrap(True)
         root.addWidget(instruction)
 
@@ -93,7 +95,9 @@ class PipelineTemplateDialog(QDialog):
         left_layout.setSpacing(Spacing.XS)
 
         list_label = QLabel("Templates")
-        list_label.setStyleSheet("font-size: 10pt; font-weight: bold;")
+        list_label.setStyleSheet(
+            f"font-size: {Typography.SIZE_SM}pt; font-weight: {Typography.WEIGHT_BOLD};"
+        )
         left_layout.addWidget(list_label)
 
         self.template_list = QListWidget()
@@ -110,12 +114,16 @@ class PipelineTemplateDialog(QDialog):
         right_layout.setSpacing(Spacing.XS)
 
         preview_label = QLabel("Preview")
-        preview_label.setStyleSheet("font-size: 10pt; font-weight: bold;")
+        preview_label.setStyleSheet(
+            f"font-size: {Typography.SIZE_SM}pt; font-weight: {Typography.WEIGHT_BOLD};"
+        )
         right_layout.addWidget(preview_label)
 
         self.preview_edit = QTextEdit()
         self.preview_edit.setReadOnly(True)
-        self.preview_edit.setStyleSheet("font-family: monospace; font-size: 10pt;")
+        self.preview_edit.setStyleSheet(
+            f"font-family: {Typography.FONT_FAMILY_MONO}; font-size: {Typography.SIZE_SM}pt;"
+        )
         self.preview_edit.setPlaceholderText("Select a template to preview its YAML...")
         right_layout.addWidget(self.preview_edit)
 
@@ -127,7 +135,9 @@ class PipelineTemplateDialog(QDialog):
 
         # Description row beneath the splitter
         self.description_label = QLabel("")
-        self.description_label.setStyleSheet("font-size: 10pt; color: gray;")
+        self.description_label.setStyleSheet(
+            f"font-size: {Typography.SIZE_SM}pt; color: {themed('TEXT_MUTED')};"
+        )
         self.description_label.setWordWrap(True)
         root.addWidget(self.description_label)
 

--- a/rheojax/gui/main.py
+++ b/rheojax/gui/main.py
@@ -348,6 +348,7 @@ def main(argv: list[str] | None = None) -> int:
     base_font = QFont()
     base_font.setFamilies(
         [
+            "Inter",
             "Segoe UI",
             "Helvetica Neue",
             "Helvetica",

--- a/rheojax/gui/resources/styles/base.qss
+++ b/rheojax/gui/resources/styles/base.qss
@@ -18,7 +18,6 @@ QWidget {
     background-color: @bg_surface;
     color: @text_primary;
     font-family: "Inter", -apple-system, BlinkMacSystemFont, "Segoe UI", "Roboto", "Helvetica Neue", sans-serif;
-    font-size: 13px;
 }
 
 QWidget:disabled {
@@ -197,7 +196,7 @@ QTabBar::tab {
     padding: 12px 24px;
     margin-right: 2px;
     font-weight: 500;
-    font-size: 14px;
+    font-size: 11pt;
 }
 
 QTabBar::tab:hover {
@@ -233,7 +232,7 @@ QHeaderView::section {
     border-right: 1px solid @border_default;
     padding: 8px 12px;
     font-weight: 600;
-    font-size: 12px;
+    font-size: 10pt;
     text-transform: uppercase;
     letter-spacing: 0.5px;
 }
@@ -631,7 +630,7 @@ QGroupBox::title {
     subcontrol-position: top left;
     padding: 4px 12px;
     color: @text_secondary;
-    font-size: 12px;
+    font-size: 10pt;
     text-transform: uppercase;
     letter-spacing: 0.5px;
 }
@@ -664,7 +663,7 @@ QProgressBar {
     height: 8px;
     text-align: center;
     color: @text_primary;
-    font-size: 10px;
+    font-size: 9pt;
 }
 
 QProgressBar::chunk {
@@ -722,13 +721,13 @@ QMenuBar::item:selected {
 
 QLabel[class="empty-message"] {
     color: @text_disabled;
-    font-size: 13px;
+    font-size: 12pt;
     padding: 0;
 }
 
 QLabel[class="empty-desc"] {
     color: @text_disabled;
-    font-size: 11px;
+    font-size: 10pt;
     padding: 0;
 }
 
@@ -736,7 +735,7 @@ QLabel[class="empty-desc"] {
 
 QPushButton[density="compact"] {
     padding: 4px 12px;
-    font-size: 11px;
+    font-size: 10pt;
     min-width: 60px;
 }
 

--- a/rheojax/gui/resources/styles/tokens.py
+++ b/rheojax/gui/resources/styles/tokens.py
@@ -488,6 +488,21 @@ def section_header_style() -> str:
     """
 
 
+def field_label_style() -> str:
+    """Generate a caption-style label for form fields (e.g. "Protocol", "Model").
+
+    Distinguishes field captions from body/value text with a smaller,
+    medium-weight, secondary-colored treatment.
+    """
+    typography = Typography
+
+    return f"""
+        color: {themed("TEXT_SECONDARY")};
+        font-size: {typography.SIZE_SM}pt;
+        font-weight: {typography.WEIGHT_MEDIUM};
+    """
+
+
 def empty_state_style() -> str:
     """Generate empty state placeholder style string."""
     spacing = Spacing
@@ -645,5 +660,6 @@ __all__ = [
     "card_style",
     "status_badge_style",
     "section_header_style",
+    "field_label_style",
     "empty_state_style",
 ]

--- a/rheojax/gui/widgets/batch_panel.py
+++ b/rheojax/gui/widgets/batch_panel.py
@@ -28,7 +28,7 @@ from rheojax.gui.compat import (
     QWidget,
     Signal,
 )
-from rheojax.gui.resources.styles.tokens import Spacing
+from rheojax.gui.resources.styles.tokens import Spacing, Typography, themed
 from rheojax.logging import get_logger
 
 logger = get_logger(__name__)
@@ -92,7 +92,9 @@ class BatchPanel(QWidget):
 
         # Title
         title = QLabel("Batch Processing")
-        title.setStyleSheet("font-size: 13pt; font-weight: bold;")
+        title.setStyleSheet(
+            f"font-size: {Typography.SIZE_MD}pt; font-weight: {Typography.WEIGHT_BOLD};"
+        )
         root.addWidget(title)
 
         # Directory + pattern group
@@ -135,7 +137,7 @@ class BatchPanel(QWidget):
         files_layout = QVBoxLayout(files_group)
 
         self.files_count_label = QLabel("Files Found: 0")
-        self.files_count_label.setStyleSheet("font-size: 10pt;")
+        self.files_count_label.setStyleSheet(f"font-size: {Typography.SIZE_SM}pt;")
         files_layout.addWidget(self.files_count_label)
 
         self.file_table = QTableWidget(0, 3)
@@ -189,7 +191,9 @@ class BatchPanel(QWidget):
 
         # Status label
         self.status_label = QLabel("Ready.")
-        self.status_label.setStyleSheet("font-size: 10pt; color: gray;")
+        self.status_label.setStyleSheet(
+            f"font-size: {Typography.SIZE_SM}pt; color: {themed('TEXT_MUTED')};"
+        )
         progress_layout.addWidget(self.status_label)
 
         root.addWidget(progress_group)

--- a/rheojax/gui/widgets/pipeline_chips.py
+++ b/rheojax/gui/widgets/pipeline_chips.py
@@ -17,7 +17,7 @@ from rheojax.gui.compat import (
     QWidget,
     Signal,
 )
-from rheojax.gui.resources.styles.tokens import Spacing
+from rheojax.gui.resources.styles.tokens import Spacing, Typography
 from rheojax.gui.state.store import PipelineStep, StepStatus
 from rheojax.logging import get_logger
 
@@ -155,7 +155,7 @@ class PipelineChips(QWidget):
         """
         arrow = QLabel("→")
         font = QFont()
-        font.setPointSize(14)
+        font.setPointSize(Typography.SIZE_LG)
         font.setBold(True)
         arrow.setFont(font)
         arrow.setAlignment(Qt.AlignCenter)

--- a/rheojax/gui/widgets/pipeline_sidebar.py
+++ b/rheojax/gui/widgets/pipeline_sidebar.py
@@ -22,6 +22,7 @@ from rheojax.gui.compat import (
     QWidget,
     Signal,
 )
+from rheojax.gui.resources.styles.tokens import Spacing, Typography, themed
 from rheojax.gui.state import actions as pipeline_actions
 from rheojax.gui.state.selectors import (
     get_pipeline_name,
@@ -92,12 +93,15 @@ class PipelineSidebar(QWidget):
         self.setMaximumWidth(300)
 
         root = QVBoxLayout(self)
-        root.setContentsMargins(8, 8, 8, 8)
-        root.setSpacing(6)
+        root.setContentsMargins(Spacing.SM, Spacing.SM, Spacing.SM, Spacing.SM)
+        root.setSpacing(Spacing.XS)
 
         # --- Pipeline name ---
         name_label = QLabel("Pipeline")
-        name_label.setStyleSheet("font-weight: bold; font-size: 10pt; color: #374151;")
+        name_label.setStyleSheet(
+            f"font-weight: bold; font-size: {Typography.SIZE_SM}pt;"
+            f" color: {themed('TEXT_SECONDARY')};"
+        )
         root.addWidget(name_label)
 
         self._name_edit = QLineEdit()
@@ -124,7 +128,9 @@ class PipelineSidebar(QWidget):
 
         # --- Step list ---
         steps_label = QLabel("Steps")
-        steps_label.setStyleSheet("font-size: 8pt; color: #6B7280; margin-top: 4px;")
+        steps_label.setStyleSheet(
+            f"font-size: {Typography.SIZE_XS}pt; color: {themed('TEXT_MUTED')}; margin-top: 4px;"
+        )
         root.addWidget(steps_label)
 
         self._list = QListWidget()
@@ -173,7 +179,8 @@ class PipelineSidebar(QWidget):
         # --- Datasets placeholder ---
         datasets_label = QLabel("Datasets")
         datasets_label.setStyleSheet(
-            "font-weight: bold; font-size: 9pt; color: #374151; margin-top: 6px;"
+            f"font-weight: bold; font-size: {Typography.SIZE_XS}pt;"
+            f" color: {themed('TEXT_SECONDARY')}; margin-top: {Spacing.SM}px;"
         )
         root.addWidget(datasets_label)
 

--- a/rheojax/gui/widgets/pipeline_step_delegate.py
+++ b/rheojax/gui/widgets/pipeline_step_delegate.py
@@ -17,6 +17,7 @@ from rheojax.gui.compat import (
     QtWidgets,
     QWidget,
 )
+from rheojax.gui.resources.styles.tokens import Typography
 from rheojax.gui.state.store import StepStatus
 from rheojax.logging import get_logger
 
@@ -151,7 +152,7 @@ class PipelineStepDelegate(QStyledItemDelegate):
         position_text = str(index.row() + 1)
         pos_font = QFont()
         pos_font.setBold(True)
-        pos_font.setPointSize(9)
+        pos_font.setPointSize(Typography.SIZE_XS)
         painter.setFont(pos_font)
         painter.setPen(QColor("#374151"))  # gray-700
 
@@ -165,7 +166,7 @@ class PipelineStepDelegate(QStyledItemDelegate):
 
         # Draw step name
         name_font = QFont()
-        name_font.setPointSize(9)
+        name_font.setPointSize(Typography.SIZE_XS)
         painter.setFont(name_font)
         painter.setPen(QColor("#111827") if not is_selected else QColor("#1E1B4B"))
 
@@ -187,7 +188,7 @@ class PipelineStepDelegate(QStyledItemDelegate):
         # Draw step_type label (muted, right-aligned)
         if step_type:
             type_font = QFont()
-            type_font.setPointSize(8)
+            type_font.setPointSize(Typography.SIZE_XS)
             painter.setFont(type_font)
             painter.setPen(QColor("#9CA3AF"))  # gray-400
 

--- a/rheojax/gui/widgets/results_panel.py
+++ b/rheojax/gui/widgets/results_panel.py
@@ -8,7 +8,7 @@ Displays summary metrics for the latest fit and Bayesian runs.
 from __future__ import annotations
 
 from rheojax.gui.compat import QLabel, QTextEdit, QVBoxLayout, QWidget
-from rheojax.gui.resources.styles.tokens import Spacing
+from rheojax.gui.resources.styles.tokens import Spacing, Typography
 from rheojax.gui.state.store import BayesianResult, FitResult
 from rheojax.logging import get_logger
 
@@ -26,18 +26,22 @@ class ResultsPanel(QWidget):
         layout.setSpacing(Spacing.XS)
 
         self.fit_label = QLabel("Fit Results")
-        self.fit_label.setStyleSheet("font-size: 11pt; font-weight: bold;")
+        self.fit_label.setStyleSheet(
+            f"font-size: {Typography.SIZE_MD_SM}pt; font-weight: {Typography.WEIGHT_BOLD};"
+        )
         self.fit_text = QTextEdit()
         self.fit_text.setReadOnly(True)
         self.fit_text.setMaximumHeight(120)
-        self.fit_text.setStyleSheet("font-size: 11pt;")
+        self.fit_text.setStyleSheet(f"font-size: {Typography.SIZE_MD_SM}pt;")
 
         self.bayes_label = QLabel("Bayesian Results")
-        self.bayes_label.setStyleSheet("font-size: 11pt; font-weight: bold;")
+        self.bayes_label.setStyleSheet(
+            f"font-size: {Typography.SIZE_MD_SM}pt; font-weight: {Typography.WEIGHT_BOLD};"
+        )
         self.bayes_text = QTextEdit()
         self.bayes_text.setReadOnly(True)
         self.bayes_text.setMaximumHeight(140)
-        self.bayes_text.setStyleSheet("font-size: 11pt;")
+        self.bayes_text.setStyleSheet(f"font-size: {Typography.SIZE_MD_SM}pt;")
 
         layout.addWidget(self.fit_label)
         layout.addWidget(self.fit_text)

--- a/rheojax/gui/workspace/fit/step1_protocol_model.py
+++ b/rheojax/gui/workspace/fit/step1_protocol_model.py
@@ -18,6 +18,8 @@ from PySide6.QtWidgets import (
 
 from rheojax.core.registry import ModelRegistry
 from rheojax.gui.foundation.state import FitState
+from rheojax.gui.resources.styles.tokens import field_label_style
+from rheojax.gui.utils.layout_helpers import set_panel_margins
 
 _PROTOCOLS = ["flow_curve", "creep", "relaxation", "startup", "oscillation", "laos"]
 
@@ -95,15 +97,22 @@ class ProtocolModelStep(QWidget):
         self._config_form = QFormLayout()
         self._params = QLabel("", self)
         lay = QVBoxLayout(self)
+        set_panel_margins(lay)
+        protocol_caption = QLabel("Protocol")
+        protocol_caption.setStyleSheet(field_label_style())
+        model_caption = QLabel("Model")
+        model_caption.setStyleSheet(field_label_style())
         for w in (
-            QLabel("Protocol"),
+            protocol_caption,
             self._protocol,
-            QLabel("Model"),
+            model_caption,
             self._model,
         ):
             lay.addWidget(w)
         lay.addLayout(self._config_form)
-        lay.addWidget(QLabel("Parameters"))
+        params_caption = QLabel("Parameters")
+        params_caption.setStyleSheet(field_label_style())
+        lay.addWidget(params_caption)
         lay.addWidget(self._params)
         self._protocol.currentTextChanged.connect(self._on_protocol)
         self._model.currentTextChanged.connect(self._on_model)

--- a/rheojax/gui/workspace/fit/step2_data.py
+++ b/rheojax/gui/workspace/fit/step2_data.py
@@ -9,6 +9,8 @@ from PySide6.QtWidgets import QComboBox, QLabel, QPushButton, QVBoxLayout, QWidg
 from rheojax.gui.foundation.contract import input_contract
 from rheojax.gui.foundation.library import DatasetLibrary
 from rheojax.gui.foundation.state import FitState
+from rheojax.gui.resources.styles.tokens import field_label_style
+from rheojax.gui.utils.layout_helpers import set_panel_margins
 
 
 def _validate_shape_and_values(rheo_data) -> list[str]:
@@ -56,9 +58,12 @@ class DataStep(QWidget):
         self._convert_btn = QPushButton("⇄ Convert Hz → rad/s", self)
         self._error_label = QLabel("", self)
         lay = QVBoxLayout(self)
+        set_panel_margins(lay)
+        source_caption = QLabel("Source")
+        source_caption.setStyleSheet(field_label_style())
         for w in (
             self._expected,
-            QLabel("Source"),
+            source_caption,
             self._source,
             self._guard,
             self._convert_btn,

--- a/rheojax/gui/workspace/fit/step3_nlsq.py
+++ b/rheojax/gui/workspace/fit/step3_nlsq.py
@@ -15,6 +15,7 @@ from PySide6.QtWidgets import (
 from rheojax.core.registry import ModelRegistry
 from rheojax.gui.foundation.state import FitState
 from rheojax.gui.state.store import ParameterState
+from rheojax.gui.utils.layout_helpers import set_panel_margins
 from rheojax.gui.widgets.parameter_table import ParameterTable
 
 
@@ -51,6 +52,7 @@ class NlsqStep(QWidget):
         self._run_btn = QPushButton("▶ Run NLSQ", self)
         self._result = QLabel("", self)
         lay = QVBoxLayout(self)
+        set_panel_margins(lay)
         for w in (self._table, self._ms_enabled, self._ms_count, self._run_btn, self._result):
             lay.addWidget(w)
         self._run_btn.clicked.connect(self.run)

--- a/rheojax/gui/workspace/fit/step4_nuts.py
+++ b/rheojax/gui/workspace/fit/step4_nuts.py
@@ -10,6 +10,7 @@ from PySide6.QtWidgets import QDoubleSpinBox, QLabel, QPushButton, QVBoxLayout, 
 from rheojax.gui.foundation.metrics import bfmi
 from rheojax.gui.foundation.priors import adapt_prior, map_centered_priors
 from rheojax.gui.foundation.state import FitState
+from rheojax.gui.utils.layout_helpers import set_panel_margins
 from rheojax.gui.widgets.priors_editor import PriorsEditor
 
 _R_HAT_THRESHOLD = 1.05
@@ -121,6 +122,7 @@ class NutsStep(QWidget):
         self._run_btn = QPushButton("▶ Sample", self)
         self._result = QLabel("", self)
         lay = QVBoxLayout(self)
+        set_panel_margins(lay)
         for w in (
             self._banner,
             self._priors_editor,

--- a/rheojax/gui/workspace/fit/step5_visualize.py
+++ b/rheojax/gui/workspace/fit/step5_visualize.py
@@ -7,6 +7,7 @@ from PySide6.QtWidgets import QGridLayout, QLabel, QTabWidget, QVBoxLayout, QWid
 
 from rheojax.core.arviz_utils import inference_data_from_dict
 from rheojax.gui.foundation.state import FitState
+from rheojax.gui.utils.layout_helpers import set_panel_margins
 from rheojax.gui.widgets.arviz_canvas import ArvizCanvas
 from rheojax.gui.widgets.pyqtgraph_canvas import PyQtGraphCanvas
 from rheojax.gui.widgets.residuals_panel import ResidualsPanel
@@ -48,7 +49,9 @@ class VisualizeStep(QWidget):
 
         # NOTE: Do NOT add Diagnostics here — nuts_result is always None at
         # controller build time. refresh() adds it once NUTS completes.
-        QVBoxLayout(self).addWidget(self._tabs)
+        lay = QVBoxLayout(self)
+        set_panel_margins(lay)
+        lay.addWidget(self._tabs)
         self.refresh()
 
     def _add(self, name: str, widget: QWidget) -> None:

--- a/rheojax/gui/workspace/fit/step6_export.py
+++ b/rheojax/gui/workspace/fit/step6_export.py
@@ -10,7 +10,9 @@ from PySide6.QtWidgets import QLabel, QPushButton, QVBoxLayout, QWidget
 
 from rheojax.gui.foundation.library import DatasetLibrary, DatasetRef
 from rheojax.gui.foundation.state import FitState
+from rheojax.gui.resources.styles.tokens import field_label_style
 from rheojax.gui.services.export_service import ExportService
+from rheojax.gui.utils.layout_helpers import set_panel_margins
 
 
 class ExportStep(QWidget):
@@ -26,7 +28,10 @@ class ExportStep(QWidget):
         self._save_btn = QPushButton("＋ Save fit → library", self)
         self._export_btn = QPushButton("⤓ Export", self)
         lay = QVBoxLayout(self)
-        for w in (QLabel("Export bundle"), self._save_btn, self._export_btn):
+        set_panel_margins(lay)
+        bundle_caption = QLabel("Export bundle")
+        bundle_caption.setStyleSheet(field_label_style())
+        for w in (bundle_caption, self._save_btn, self._export_btn):
             lay.addWidget(w)
         self._save_btn.clicked.connect(self.save_to_library)
         self._export_btn.clicked.connect(lambda: self.export_bundle(Path.cwd()))

--- a/rheojax/gui/workspace/inspector.py
+++ b/rheojax/gui/workspace/inspector.py
@@ -2,6 +2,8 @@ from __future__ import annotations
 
 from PySide6.QtWidgets import QTabWidget, QVBoxLayout, QWidget
 
+from rheojax.gui.utils.layout_helpers import set_zero_margins
+
 
 class InspectorPanel(QWidget):
     _TABS = ["params", "priors", "log"]
@@ -12,7 +14,9 @@ class InspectorPanel(QWidget):
         self._index: dict[str, int] = {}
         for name in self._TABS:
             self._index[name] = self._tabs.addTab(QWidget(self), name)
-        QVBoxLayout(self).addWidget(self._tabs)
+        lay = QVBoxLayout(self)
+        set_zero_margins(lay)
+        lay.addWidget(self._tabs)
 
     def tab_names(self) -> list[str]:
         return list(self._TABS)

--- a/rheojax/gui/workspace/library_rail.py
+++ b/rheojax/gui/workspace/library_rail.py
@@ -10,6 +10,7 @@ from PySide6.QtWidgets import (
 )
 
 from rheojax.gui.foundation.library import DatasetLibrary
+from rheojax.gui.utils.layout_helpers import set_panel_margins
 
 
 class LibraryRail(QWidget):
@@ -22,6 +23,7 @@ class LibraryRail(QWidget):
         self._list = QListWidget(self)
         self._import = QPushButton("+ Import data…", self)
         lay = QVBoxLayout(self)
+        set_panel_margins(lay)
         lay.addWidget(self._list)
         lay.addWidget(self._import)
         self._list.itemClicked.connect(

--- a/rheojax/gui/workspace/stepper_canvas.py
+++ b/rheojax/gui/workspace/stepper_canvas.py
@@ -9,6 +9,7 @@ from PySide6.QtWidgets import (
     QWidget,
 )
 
+from rheojax.gui.utils.layout_helpers import set_toolbar_margins, set_zero_margins
 from rheojax.gui.workspace.controller import WorkflowController
 
 
@@ -28,7 +29,9 @@ class StepperCanvas(QWidget):
             self._buttons.append(b)
             self._rail.addWidget(b)
             self._stack.addWidget(QWidget(self))  # placeholder body
+        set_toolbar_margins(self._rail)
         lay = QVBoxLayout(self)
+        set_zero_margins(lay)
         lay.addLayout(self._rail)
         lay.addWidget(self._stack)
         self.refresh()

--- a/rheojax/gui/workspace/transform/step1_pick.py
+++ b/rheojax/gui/workspace/transform/step1_pick.py
@@ -6,6 +6,7 @@ from PySide6.QtWidgets import QListWidget, QListWidgetItem, QVBoxLayout, QWidget
 import rheojax.transforms  # noqa: F401
 from rheojax.core.registry import TransformRegistry
 from rheojax.gui.foundation.state import TransformState
+from rheojax.gui.utils.layout_helpers import set_panel_margins
 
 
 class TransformPickStep(QWidget):
@@ -20,7 +21,9 @@ class TransformPickStep(QWidget):
                 it = QListWidgetItem(f"{k}   [{cat}]")
                 it.setData(Qt.ItemDataRole.UserRole, k)
                 self._list.addItem(it)
-        QVBoxLayout(self).addWidget(self._list)
+        lay = QVBoxLayout(self)
+        set_panel_margins(lay)
+        lay.addWidget(self._list)
         self._list.itemClicked.connect(lambda it: self._select(it.data(Qt.ItemDataRole.UserRole)))
 
     def groups(self) -> dict[str, list[str]]:

--- a/rheojax/gui/workspace/transform/step2_slots.py
+++ b/rheojax/gui/workspace/transform/step2_slots.py
@@ -12,6 +12,8 @@ from PySide6.QtWidgets import (
 
 from rheojax.gui.foundation.library import DatasetLibrary
 from rheojax.gui.foundation.state import TransformState
+from rheojax.gui.resources.styles.tokens import field_label_style
+from rheojax.gui.utils.layout_helpers import set_panel_margins
 from rheojax.gui.workspace.transform.slots_spec import SlotSpec, transform_slots
 
 
@@ -34,6 +36,7 @@ class SlotsStep(QWidget):
         self._list_add_buttons: dict[str, QPushButton] = {}
         self._list_remove_buttons: dict[str, QPushButton] = {}
         self._layout = QVBoxLayout(self)
+        set_panel_margins(self._layout)
         self.refresh()
 
     def refresh(self) -> None:
@@ -58,12 +61,12 @@ class SlotsStep(QWidget):
         self._list_remove_buttons.clear()
 
         for s in self._specs:
-            self._layout.addWidget(
-                QLabel(
-                    f"Slot: {s.name} ({s.accepts or 'any'})"
-                    + (" [list]" if s.is_list else "")
-                )
+            caption = QLabel(
+                f"Slot: {s.name} ({s.accepts or 'any'})"
+                + (" [list]" if s.is_list else "")
             )
+            caption.setStyleSheet(field_label_style())
+            self._layout.addWidget(caption)
             if s.is_list:
                 self._add_list_slot_widgets(s)
             else:

--- a/rheojax/gui/workspace/transform/step3_run.py
+++ b/rheojax/gui/workspace/transform/step3_run.py
@@ -6,6 +6,7 @@ from PySide6.QtCore import Signal
 from PySide6.QtWidgets import QLabel, QPushButton, QVBoxLayout, QWidget
 
 from rheojax.gui.foundation.state import TransformState
+from rheojax.gui.utils.layout_helpers import set_panel_margins
 
 
 def _default_run_fn(transform_key, slots, config):
@@ -35,6 +36,7 @@ class RunStep(QWidget):
         self._btn = QPushButton("▶ Run transform", self)
         self._status = QLabel("", self)
         lay = QVBoxLayout(self)
+        set_panel_margins(lay)
         lay.addWidget(self._btn)
         lay.addWidget(self._status)
         self._btn.clicked.connect(self.run)

--- a/rheojax/gui/workspace/transform/step4_visualize.py
+++ b/rheojax/gui/workspace/transform/step4_visualize.py
@@ -7,6 +7,7 @@ from PySide6.QtWidgets import QHBoxLayout, QLabel, QTabWidget, QVBoxLayout, QWid
 import rheojax.transforms  # noqa: F401
 from rheojax.core.registry import TransformRegistry
 from rheojax.gui.foundation.state import TransformState
+from rheojax.gui.utils.layout_helpers import set_panel_margins
 from rheojax.gui.widgets.pyqtgraph_canvas import PyQtGraphCanvas
 
 _DOMAIN_CHANGING = {"spectral", "decomposition"}
@@ -46,7 +47,9 @@ class TransformVisualizeStep(QWidget):
         self._state = state
         self._tabs = QTabWidget(self)
         self._names: list[str] = []
-        QVBoxLayout(self).addWidget(self._tabs)
+        lay = QVBoxLayout(self)
+        set_panel_margins(lay)
+        lay.addWidget(self._tabs)
         self.refresh()
 
     def refresh(self) -> None:

--- a/rheojax/gui/workspace/transform/step5_export.py
+++ b/rheojax/gui/workspace/transform/step5_export.py
@@ -8,7 +8,9 @@ from PySide6.QtWidgets import QLabel, QPushButton, QVBoxLayout, QWidget
 
 from rheojax.gui.foundation.library import DatasetLibrary, DatasetRef
 from rheojax.gui.foundation.state import TransformState
+from rheojax.gui.resources.styles.tokens import field_label_style
 from rheojax.gui.services.export_service import ExportService
+from rheojax.gui.utils.layout_helpers import set_panel_margins
 
 
 class TransformExportStep(QWidget):
@@ -27,7 +29,10 @@ class TransformExportStep(QWidget):
         self._save_btn = QPushButton("＋ Save output → library", self)
         self._export_btn = QPushButton("⤓ Export", self)
         lay = QVBoxLayout(self)
-        for w in (QLabel("Export"), self._save_btn, self._export_btn):
+        set_panel_margins(lay)
+        caption = QLabel("Export")
+        caption.setStyleSheet(field_label_style())
+        for w in (caption, self._save_btn, self._export_btn):
             lay.addWidget(w)
         self._save_btn.clicked.connect(self.save_to_library)
         self._export_btn.clicked.connect(lambda: self.export_bundle(Path.cwd()))


### PR DESCRIPTION
## Summary

Fixes a real font-size bug and closes the biggest styling/layout gap in the GUI, using the existing design-token system (`rheojax/gui/resources/styles/tokens.py`) rather than inventing anything new.

**Root-cause fix:** `base.qss` had `QWidget { font-size: 13px; }`. Because a type selector beats the universal-selector rule `main.py` appends for DPI-adaptive sizing, this silently pinned nearly every label in the app to ~9.75pt regardless of screen DPI, defeating the adaptive base font entirely. Removed it, and converted the remaining mixed `px` font-size rules in `base.qss` to `pt` to match the `Typography` scale.

**Font-family fix:** `main.py`'s `QFont` fallback list was missing `"Inter"`, so widgets not covered by a QSS selector silently diverged from the QSS/`Typography.FONT_FAMILY` font stack. Added it.

**Biggest layout gap — the new "workspace" wizard shell** (`rheojax/gui/workspace/fit/*`, `rheojax/gui/workspace/transform/*`, and the shell containers) had *zero* styling: no margins, no spacing, no fonts, pure Qt defaults. Applied the project's existing `set_panel_margins`/`set_zero_margins`/`set_toolbar_margins` helpers and a new `field_label_style()` token (matching the existing `section_header_style()` pattern) for form-field captions like "Protocol", "Model", "Slot".

**Token-conformance cleanup** on widgets/dialogs that bypassed the token system with hardcoded hex colors, raw px font sizes, and magic-number margins (`results_panel.py`, `pipeline_sidebar.py`, `pipeline_chips.py`, `pipeline_step_delegate.py`, `batch_panel.py`, `bayesian_options.py`, `pipeline_templates.py`) — now use `themed()`/`Typography`/`Spacing`.

No business logic, signal wiring, or widget behavior changed — pure layout/typography.

## Test plan
- [x] `tests/gui/test_design_tokens_accessibility.py` — 26/26 passed
- [x] `tests/gui/workspace/` + `tests/gui/test_gui_smoke.py` — 191/191 passed
- [x] Full `tests/gui/` suite — 603/603 passed (matches pre-existing baseline)
- [x] `ast.parse` syntax check on every touched file
- [x] Offscreen (`QT_QPA_PLATFORM=offscreen`) construction of `RheoJAXMainWindow`, `WorkspaceWindow`, and all fit/transform step widgets

🤖 Generated with [Claude Code](https://claude.com/claude-code)