### PR TITLE
docs: document GUI architecture, fix stale user-guide claims

### DIFF
--- a/README.md
+++ b/README.md
@@ -903,6 +903,9 @@ rheojax-gui
 # Start maximized (useful on high-DPI desktops)
 rheojax-gui --maximized
 
+# Preview the new step-wizard workspace shell (experimental)
+rheojax-gui --workspace
+
 # Or from Python
 from rheojax.gui import main
 main()

--- a/docs/STRUCTURE.md
+++ b/docs/STRUCTURE.md
@@ -1,6 +1,6 @@
 # RheoJAX Documentation Structure
 
-**Last Updated:** February 9, 2026
+**Last Updated:** July 2, 2026
 
 ## Production Documentation
 

--- a/docs/architecture-overview.md
+++ b/docs/architecture-overview.md
@@ -337,6 +337,25 @@ Structured, JAX-safe logging system.
 
 ---
 
+## GUI (`gui/`)
+
+PySide6/Qt6 desktop app (`rheojax-gui`). Two architectures currently coexist:
+
+| Layer | Shipped default | `--workspace` preview |
+|-------|------------------|------------------------|
+| Shell | `app/main_window.py` (`RheoJAXMainWindow`) | `workspace/window.py` (`WorkspaceWindow`) |
+| Pages | `pages/*.py`, one flat panel per stage, no step indicator | `workspace/fit/step1..6`, `workspace/transform/step1..5`, rendered as a numbered wizard by `stepper_canvas.py` |
+| State | `state/store.py` — single `AppState` dataclass + `StateStore` singleton (Redux-like: `dispatch()` → `reducers/*.py` → new state → Qt signal via `signals.py`) | `foundation/state.py` — lightweight `AppState(library, fit: FitState, transform: TransformState, jobs, project)`, one instance per `WorkspaceWindow`, no reducer/signal layer |
+| Background execution | `jobs/worker_pool.py` (QThreadPool, in-process threads: `fit_worker.py`, `bayesian_worker.py`, ...) | `jobs/process_adapter.py` (true OS subprocess isolation via `subprocess_fit.py`/`subprocess_bayesian.py`) |
+
+**Invalidation cascade** (`foundation/invalidation.py::invalidate_downstream()`): editing an earlier step (e.g. model choice) clears dependent downstream `FitState`/`TransformState` fields (`nlsq_result`, `nuts_result`, ...) via a static cascade table, and `WorkflowController.on_edit()` (`workspace/controller.py`) re-locks every step after the edited one in the stepper UI — prevents a stale result from surviving an upstream edit.
+
+**Other layers:** `services/` (business logic called by pages/controllers — `data_service.py`, `transform_service.py`, `pipeline_execution_service.py` for the drag/drop visual pipeline builder, ...), `widgets/` (reusable Qt widgets — `parameter_table.py`, `plot_canvas.py`, `pipeline_sidebar.py`, ...), `dialogs/` (modal dialogs — `import_wizard.py`, `fitting_options.py`, ...).
+
+See [GUI Reference Guide](source/user_guide/06_gui/index.rst) for end-user docs of the shipped default GUI.
+
+---
+
 ## Critical Design Invariants
 
 ### 1. Float64 Enforcement (MANDATORY)

--- a/docs/source/developer/architecture.rst
+++ b/docs/source/developer/architecture.rst
@@ -633,29 +633,77 @@ Use type hints for clarity:
         """Process rheological data."""
         pass
 
+GUI Architecture
+----------------
+
+The desktop app (``gui/``, ``rheojax-gui``) currently ships **two coexisting
+architectures**: the default main window and an opt-in ``--workspace``
+preview. See :doc:`../../architecture-overview` (GUI section) for the
+package-layout table; the summary below covers what a contributor needs to
+know before touching either one.
+
+Shipped default: ``app/main_window.py``
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+``RheoJAXMainWindow`` swaps flat page panels (``pages/*.py`` — Data, Transform,
+Fit, Bayesian, Diagnostics, Export) into a ``QStackedWidget`` via
+``navigate_to()``. All pages share one process-wide singleton,
+``state/store.py::StateStore``: a Redux-like store holding a single
+``AppState`` dataclass. ``dispatch(action)`` looks up a reducer in
+``state/reducers/*.py``, mutates state immutably (pushing the previous state
+onto an undo stack), and emits both a generic ``state_changed`` Qt signal and
+domain-specific signals (``fit_completed``, ``dataset_added``, ...) via
+``state/signals.py``. Dispatches from a worker thread defer signal emission
+to the GUI thread with ``QMetaObject.invokeMethod(QueuedConnection)``.
+Fitting/Bayesian sampling run on in-process ``QThreadPool`` workers
+(``jobs/worker_pool.py``, ``jobs/fit_worker.py``, ``jobs/bayesian_worker.py``).
+
+``--workspace`` preview: ``workspace/window.py``
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Launched via ``rheojax-gui --workspace`` (explicitly labeled "preview" in
+``main.py``; does not yet support ``--project``/``--import``).
+``WorkspaceWindow`` renders the Fit and Transform workflows as a literal
+numbered step wizard (``workspace/stepper_canvas.py``), backed by
+``workspace/fit/step1_protocol_model.py`` .. ``step6_export.py`` and
+``workspace/transform/step1_pick.py`` .. ``step5_export.py``. State lives in a
+separate, lighter ``foundation/state.py::AppState`` (``library``, ``fit:
+FitState``, ``transform: TransformState``, ``jobs``, ``project``) — one
+instance per window, no reducer/signal layer; components mutate
+``FitState``/``TransformState`` fields directly via
+``dataclasses.replace()``. NLSQ/NUTS runs go through true OS subprocess
+isolation (``jobs/process_adapter.py``, ``jobs/subprocess_fit.py``,
+``jobs/subprocess_bayesian.py``) rather than in-process threads.
+
+Editing an earlier step (e.g. changing the model) calls
+``foundation/invalidation.py::invalidate_downstream()``, which clears
+dependent downstream ``FitState``/``TransformState`` fields (``nlsq_result``,
+``nuts_result``, ...) via a static cascade table, and
+``workspace/controller.py::WorkflowController.on_edit()`` re-locks every step
+after the edited one in the stepper UI — this is what prevents a stale result
+computed under an old upstream choice from surviving an edit.
+
+**When touching the GUI:** confirm which of the two architectures a file
+belongs to before assuming behavior — ``state/store.py`` and
+``foundation/state.py`` are unrelated ``AppState`` types with the same name.
+
 Future Extensions
 -----------------
 
-Phase 2: Models and Transforms
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Most of the originally-planned phases below are implemented; this section now
+tracks what remains open rather than a roadmap from project inception.
 
-- 20+ rheological models
-- Master curve generation
-- FFT analysis
-- OWChirp signal processing
-- Mutation number calculation
+Near-Term
+~~~~~~~~~
 
-Phase 3: Advanced Features
-~~~~~~~~~~~~~~~~~~~~~~~~~~
+- Promote the ``--workspace`` step-pipeline shell to the default GUI (add
+  ``--project``/``--import`` support, then retire the legacy
+  ``app/main_window.py`` + ``state/store.py`` stack)
+- Unify the two GUI ``AppState`` implementations once the workspace shell is
+  the default, removing the dual-architecture maintenance burden
 
-- Bayesian parameter estimation
-- Uncertainty quantification
-- Multi-objective optimization
-- Parallel batch processing
-- GPU-accelerated model fitting
-
-Phase 4: Machine Learning
-~~~~~~~~~~~~~~~~~~~~~~~~~
+Longer-Term
+~~~~~~~~~~~
 
 - Neural network surrogate models
 - Active learning for parameter estimation

--- a/docs/source/user_guide/06_gui/model_fitting.rst
+++ b/docs/source/user_guide/06_gui/model_fitting.rst
@@ -73,8 +73,10 @@ Initial parameters
 The GUI uses initial parameters from the current application state when
 available; otherwise it falls back to model defaults.
 
-At the moment, the Fit page does not expose an editable parameters table.
-To fully control initial values/bounds/fixed parameters, use the Python API.
+The **Parameters** panel is a fully editable table (Value / Min / Max columns,
+plus a **Fixed** checkbox per row) populated from the model defaults or the
+current state. Edit a cell to change the initial value or bound before
+fitting, and check **Fixed** to hold a parameter constant during the fit.
 
 Running the Fit
 ===============
@@ -83,18 +85,15 @@ Starting a Fit
 --------------
 
 1. Ensure data is loaded and model selected
-2. Configure options (or use defaults)
+2. Adjust the parameter table and/or click **"Options..."** to configure the
+   optimizer (or use defaults)
 3. Click **"Fit Model"** button
 
 Progress
 --------
 
-During fitting the application status bar updates with progress.
-
-Stopping a Fit
---------------
-
-Click **"Cancel"** to stop early (results may be partial).
+Fitting runs on a background worker thread; the application status bar
+updates with progress while the GUI stays responsive.
 
 Fit Results
 ===========
@@ -170,38 +169,28 @@ Advanced Options
 Optimization Settings
 ---------------------
 
-Access via **Settings > Fitting Options**:
+Click **"Options..."** on the Fit page to open the Fitting Options dialog:
 
 - **Algorithm**: NLSQ algorithm variant
 - **Max Iterations**: Iteration limit
 - **Tolerance**: Convergence criteria (ftol, xtol)
 - **Multi-start**: Number of random initializations
-
-Warm Start
-----------
-
-Use previous fit results as starting point:
-
-1. Fit with model A
-2. Switch to similar model B
-3. Enable **Warm Start** checkbox
-4. Fit model B (starts from model A values)
+- **Bounds**: Parameter bound overrides
+- **Verbose**: Print solver progress
 
 Batch Fitting
 -------------
 
-Fit multiple datasets with same model:
-
-1. Load all datasets
-2. Configure model once
-3. Click **Fit All Datasets**
+To apply a fit (and any other steps) across many files at once, build a
+pipeline in the sidebar and run it over a folder using the **Batch** panel,
+rather than fitting datasets one at a time on the Fit page.
 
 Tips for Good Fits
 ==================
 
 1. **Start simple**: Try simpler models first
 2. **Check data range**: Ensure data spans model features
-3. **Initial values**: Use Auto Initialize or manual estimates
+3. **Initial values**: Adjust the parameter table or set bounds manually
 4. **Bounds**: Set physically meaningful constraints
 5. **Check residuals**: Look for systematic patterns
 6. **Compare models**: Use R² and AIC for model selection

--- a/docs/source/user_guide/06_gui/transforms.rst
+++ b/docs/source/user_guide/06_gui/transforms.rst
@@ -123,19 +123,22 @@ Basic Workflow
 --------------
 
 1. Navigate to **Transform** page
-2. Select source dataset from dropdown
-3. Choose transform from list
-4. Configure parameters
-5. Click **Apply Transform**
-6. Review result in preview
-7. **Accept** to add as new dataset
+2. Choose a transform from the sidebar list. Single-dataset transforms
+   (FFT, IFFT, Derivative) act on the application's active dataset; for
+   multi-dataset transforms (Mastercurve, SRFS) check the datasets to
+   include from the dataset checklist
+3. Configure parameters in the auto-generated form
+4. Review the live before/after preview, which updates automatically as you
+   change parameters
+5. Click **Apply Transform** to commit the result as a new dataset
 
 Transform Preview
 -----------------
 
-Before accepting:
+Before applying:
 
-- View transformed data plot
+- View the before/after transformed data plot (updates automatically,
+  debounced, as parameters change)
 - Check data ranges
 - Verify expected behavior
 - Adjust parameters if needed
@@ -158,11 +161,11 @@ Chaining Transforms
 
 Apply multiple transforms sequentially:
 
-1. Apply first transform
-2. Accept result as new dataset
-3. Select new dataset
-4. Apply next transform
-5. Repeat as needed
+1. Apply the first transform (result is added as a new dataset and becomes
+   active)
+2. Select the new dataset if it isn't already active
+3. Apply the next transform
+4. Repeat as needed
 
 Transform Parameters
 ====================


### PR DESCRIPTION
## Summary
- Used the graphify knowledge graph (`graphify-out/GRAPH_REPORT.md` community structure: GUI App & Main Window, GUI Bayesian Page & Jobs, Transform Page & Worker, Import Wizard Dialog, ...) to locate documentation gaps, then verified every claim against the actual current `rheojax/gui/` code before writing anything.
- **Gap found**: `docs/architecture-overview.md` and `docs/source/developer/architecture.rst` never documented the `gui/` package internals at all, despite listing it in the package tree — added a "GUI Architecture" section to both, covering the two architectures that currently coexist:
  - shipped default: `app/main_window.py` + `state/store.py` (`StateStore` singleton, Redux-like dispatch → reducers → Qt signals) + in-process `QThreadPool` workers
  - `--workspace` preview: `workspace/window.py` step-wizard shell + `foundation/state.py` lightweight `AppState` + `invalidate_downstream()` cascade + true OS-subprocess isolation for NLSQ/NUTS
- Replaced the stale "Future Extensions" phase list in `developer/architecture.rst`, which described already-shipped features (Bayesian inference, GPU fitting, batch processing) as unbuilt roadmap items.
- Fixed concrete factual mismatches in the user-facing GUI guide against current code:
  - `model_fitting.rst`: the Fit page now has a fully editable parameter table (doc said it didn't); removed documented-but-nonexistent Cancel button, Warm Start checkbox, "Fit All Datasets" button, "Auto Initialize", and "Settings > Fitting Options" menu path (it's a page button, "Options...")
  - `transforms.rst`: replaced the described "dropdown + Apply + separate Accept" flow with the actual single-Apply-button + live-preview + dataset-checklist (for multi-dataset transforms) flow
- `README.md`: mentioned the new `--workspace` preview flag.
- `docs/STRUCTURE.md`: bumped last-updated date.

## Test plan
- [x] `sphinx-build -b html docs/source docs/_build/html -W --keep-going` → `build succeeded`, zero warnings
- [x] Every architectural claim in the new GUI Architecture sections was verified against the actual source files (`state/store.py`, `foundation/state.py`, `foundation/invalidation.py`, `workspace/controller.py`, `jobs/process_adapter.py`, etc.), not inferred from the graph report alone
- [x] Every corrected user-guide claim (parameter table, Cancel button, Warm Start, Fit All Datasets, Settings menu, Transform Apply/Accept) was checked against current code with targeted greps before editing

🤖 Generated with [Claude Code](https://claude.com/claude-code)