### PR TITLE
GUI: flip default entry point to WorkspaceWindow (project save/load, Pipeline mode, --legacy rollback)

### DIFF
--- a/rheojax/gui/foundation/import_service.py
+++ b/rheojax/gui/foundation/import_service.py
@@ -65,12 +65,27 @@ def import_dataset(path: Path, protocol: str) -> tuple[DatasetRef, RheoData]:
 
     data.update_metadata({"test_mode": protocol})
 
+    # Mirror step2_data.py's needs_hz_conversion/apply_unit_conversion: a contract
+    # declaring "x": "Hz->rad/s" means fits assume rad/s, but the reader only
+    # *detects* Hz for classification -- it never converts (data_formats_by_protocol.md
+    # §2, §6.1). Skipping this here would silently feed Hz-labeled x into a fit,
+    # off by a factor of 2*pi with no error.
+    units: dict[str, str] = {}
+    if data.x_units:
+        if contract.unit_conversions.get("x") == "Hz->rad/s" and data.x_units.strip().lower() in (
+            "hz",
+            "hertz",
+        ):
+            data.x = np.asarray(data.x) * (2 * np.pi)
+            data.x_units = "rad/s"
+        units["x"] = data.x_units
+
     ref = DatasetRef(
         id=uuid.uuid4().hex,
         name=path.stem,
         protocol_type=protocol,
         origin="imported",
-        units={},
+        units=units,
         row_count=len(data.x),
         hash=hashlib.sha256(path.read_bytes()).hexdigest(),
         provenance={"source": "cli_import", "path": str(path)},

--- a/rheojax/gui/foundation/import_service.py
+++ b/rheojax/gui/foundation/import_service.py
@@ -1,0 +1,79 @@
+"""CLI/non-interactive dataset import, backing `rheojax-gui --import FILE --protocol PROTOCOL`.
+
+Deliberately does NOT reuse the legacy ImportWizard/DataService.load_file path (per the design
+spec, that path is bug-prone); this uses rheojax.io's format auto-detection directly and
+validates against the same shape/NaN/monotonicity checks the workspace's Data step already
+enforces (rheojax.gui.workspace.fit.step2_data._validate_shape_and_values), plus a
+contract-driven column-count check.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import uuid
+from pathlib import Path
+
+import numpy as np
+
+from rheojax.core.data import RheoData
+from rheojax.core.inventory import Protocol
+from rheojax.gui.foundation.contract import input_contract
+from rheojax.gui.foundation.library import DatasetRef
+from rheojax.gui.workspace.fit.step2_data import _validate_shape_and_values
+from rheojax.io import auto_load
+
+
+def import_dataset(path: Path, protocol: str) -> tuple[DatasetRef, RheoData]:
+    path = Path(path)
+    if not path.exists():
+        raise FileNotFoundError(f"Import file not found: {path}")
+
+    valid_protocols = {p.value for p in Protocol}
+    if protocol not in valid_protocols:
+        raise ValueError(
+            f"Unknown protocol {protocol!r}; expected one of {sorted(valid_protocols)}"
+        )
+
+    data = auto_load(str(path))
+    if isinstance(data, list):
+        raise ValueError(
+            f"Import file contains {len(data)} segments; "
+            "CLI import supports single-segment files only"
+        )
+
+    contract = input_contract(protocol)
+    errors = _validate_shape_and_values(data)
+    # A contract with 3 columns (x + 2 y-roles, e.g. omega/G_prime/G_double_prime)
+    # expects a complex-valued y (G' + i*G''), matching how rheojax.io's CSV
+    # reader packs a detected modulus pair; anything else expects real 1-D y.
+    y_arr = np.asarray(data.y)
+    expects_complex = len(contract.columns) == 3
+    if expects_complex and not np.iscomplexobj(y_arr):
+        errors.append(
+            f"expected complex modulus data (G', G'') for protocol {protocol!r}, "
+            "got real-valued y"
+        )
+    elif not expects_complex and (y_arr.ndim != 1 or np.iscomplexobj(y_arr)):
+        errors.append(
+            f"expected a single real-valued y column for protocol {protocol!r}, "
+            f"got shape {y_arr.shape} dtype {y_arr.dtype}"
+        )
+    if errors:
+        raise ValueError(
+            f"Import file failed contract validation for protocol {protocol!r}: {errors}"
+        )
+
+    data.update_metadata({"test_mode": protocol})
+
+    ref = DatasetRef(
+        id=uuid.uuid4().hex,
+        name=path.stem,
+        protocol_type=protocol,
+        origin="imported",
+        units={},
+        row_count=len(data.x),
+        hash=hashlib.sha256(path.read_bytes()).hexdigest(),
+        provenance={"source": "cli_import", "path": str(path)},
+        lineage=[],
+    )
+    return ref, data

--- a/rheojax/gui/foundation/library.py
+++ b/rheojax/gui/foundation/library.py
@@ -26,7 +26,14 @@ class DatasetLibrary:
         self._by_id: dict[str, DatasetRef] = {}
         self._payloads: dict[str, Any] = {}  # id -> RheoData; needed to resolve data_ref strings
 
-    def add(self, ref: DatasetRef) -> None:
+    def add(self, ref: DatasetRef, overwrite: bool = False) -> None:
+        if not overwrite and ref.id in self._by_id:
+            raise ValueError(f"Dataset id {ref.id!r} already exists (pass overwrite=True to replace)")
+        # An overwrite replaces the reference AND clears any stale payload under the old
+        # reference -- without this, a caller that overwrites a ref but doesn't also call
+        # store_payload() (e.g. a fit export whose result has no derived RheoData) would leave
+        # the PREVIOUS ref's payload silently reachable under the new ref's id/metadata.
+        self._payloads.pop(ref.id, None)
         self._by_id[ref.id] = ref
 
     def get(self, id: str) -> DatasetRef:

--- a/rheojax/gui/foundation/notifier.py
+++ b/rheojax/gui/foundation/notifier.py
@@ -1,0 +1,14 @@
+"""Qt signal carrier for DatasetLibrary mutations.
+
+DatasetLibrary itself stays a plain, Qt-unaware class (required for the project codec's
+decode-into-a-temporary-AppState path). This notifier is owned by WorkspaceWindow, constructed
+exactly once, and is what call sites emit into after a library mutation -- see
+WorkspaceWindow._commit_dataset() (window.py).
+"""
+from __future__ import annotations
+
+from PySide6.QtCore import QObject, Signal
+
+
+class DatasetLibraryNotifier(QObject):
+    changed = Signal()

--- a/rheojax/gui/foundation/pipeline_bridge.py
+++ b/rheojax/gui/foundation/pipeline_bridge.py
@@ -29,4 +29,4 @@ def pipeline_context_from_library(lib: DatasetLibrary, ids: list[str]) -> dict[s
     """
     if not ids:
         return {}
-    return {"data": lib.load_payload(ids[0])}
+    return {"data": lib.load_payload(ids[0]), "dataset_id": ids[0]}

--- a/rheojax/gui/foundation/project_codec.py
+++ b/rheojax/gui/foundation/project_codec.py
@@ -220,13 +220,18 @@ def save_project_v2(state, path: Path) -> None:
                     # RheoData is handled above (save_hdf5, not write_result_arrays -- this is
                     # a real RheoData, not a result dict), into transform_results/ (the same
                     # prefix, since it's the same kind of payload).
+                    # A failed transform step may carry "output": None -- mirror the "no ref
+                    # means no output" convention _restore_result_dict already uses on load,
+                    # rather than crashing inside save_hdf5.
                     output = step_record.pop("output")
-                    result_id = uuid.uuid4().hex
-                    rel = f"transform_results/{result_id}.hdf5"
-                    full = tmp_root / rel
-                    full.parent.mkdir(parents=True, exist_ok=True)
-                    save_hdf5(output, str(full))
-                    _register_binary(rel)
+                    result_id = None
+                    if output is not None:
+                        result_id = uuid.uuid4().hex
+                        rel = f"transform_results/{result_id}.hdf5"
+                        full = tmp_root / rel
+                        full.parent.mkdir(parents=True, exist_ok=True)
+                        save_hdf5(output, str(full))
+                        _register_binary(rel)
                     step_record["output_ref"] = result_id
                 step_results_out[step_id] = step_record
             record["step_results"] = step_results_out
@@ -422,12 +427,17 @@ def load_project_v2(path: Path):
                     elif "output_ref" in step_record:
                         # Inverse of save_project_v2's "output" -> "output_ref" persistence
                         # for a "transform" pipeline step's record (see the matching comment
-                        # there).
+                        # there). A None ref_id means the step had no output (e.g. a failed
+                        # transform) -- mirror _restore_result_dict's "no ref means no output"
+                        # convention rather than validating a None id.
                         ref_id = step_record.pop("output_ref")
-                        _validate_ref_id(ref_id)
-                        step_record["output"] = load_hdf5(
-                            str(tmp_root / "transform_results" / f"{ref_id}.hdf5")
-                        )
+                        if ref_id is None:
+                            step_record["output"] = None
+                        else:
+                            _validate_ref_id(ref_id)
+                            step_record["output"] = load_hdf5(
+                                str(tmp_root / "transform_results" / f"{ref_id}.hdf5")
+                            )
             state.job_history = JobHistoryState(by_id=job_history_dict)
 
             project_dict = json.loads((tmp_root / "project.json").read_text())

--- a/rheojax/gui/foundation/project_codec.py
+++ b/rheojax/gui/foundation/project_codec.py
@@ -1,0 +1,67 @@
+"""Versioned .rheojax v2 project persistence.
+
+write_result_arrays()/read_result_arrays() recursively split an NLSQ/NUTS result dict (or any
+value tree over the same universe rheojax.gui.jobs.subprocess_fit's _is_serializable() already
+enumerates: str/int/float/bool/None/np.ndarray/dict/list/tuple, at any nesting depth) between an
+HDF5 file (array leaves) and a JSON-safe structure (everything else). This is the SAME raw-h5py
+pattern ExportService.save_project() v1 already uses for posterior_samples -- not the
+RheoData-typed save_hdf5()/load_hdf5() helpers, which don't apply to this shape.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+import h5py
+import numpy as np
+
+
+def _write_walk(value: Any, key_path: str, hf: h5py.File, out: dict | list) -> Any:
+    if isinstance(value, np.ndarray):
+        hf.create_dataset(key_path, data=value)
+        return {"$hdf5_ref": key_path}
+    if isinstance(value, (np.floating, np.integer)):
+        return value.item()
+    if isinstance(value, np.bool_):
+        return bool(value)
+    if isinstance(value, (str, int, float, bool)) or value is None:
+        return value
+    if isinstance(value, dict):
+        return {
+            k: _write_walk(v, f"{key_path}/{k}" if key_path else str(k), hf, out)
+            for k, v in value.items()
+        }
+    if isinstance(value, tuple):
+        return {"$tuple": [
+            _write_walk(v, f"{key_path}/{i}", hf, out) for i, v in enumerate(value)
+        ]}
+    if isinstance(value, list):
+        return [_write_walk(v, f"{key_path}/{i}", hf, out) for i, v in enumerate(value)]
+    raise TypeError(
+        f"write_result_arrays: unsupported value type {type(value).__name__!r} at "
+        f"{key_path or '<root>'} -- not one of str/int/float/bool/None/np.ndarray/dict/list/tuple"
+    )
+
+
+def write_result_arrays(path: Path, result: dict[str, Any]) -> dict[str, Any]:
+    path = Path(path)
+    with h5py.File(path, "w") as hf:
+        return {k: _write_walk(v, str(k), hf, {}) for k, v in result.items()}
+
+
+def _read_walk(node: Any, hf: h5py.File) -> Any:
+    if isinstance(node, dict):
+        if set(node.keys()) == {"$hdf5_ref"}:
+            return np.asarray(hf[node["$hdf5_ref"]])
+        if set(node.keys()) == {"$tuple"}:
+            return tuple(_read_walk(v, hf) for v in node["$tuple"])
+        return {k: _read_walk(v, hf) for k, v in node.items()}
+    if isinstance(node, list):
+        return [_read_walk(v, hf) for v in node]
+    return node
+
+
+def read_result_arrays(path: Path, json_shape: dict[str, Any]) -> dict[str, Any]:
+    path = Path(path)
+    with h5py.File(path, "r") as hf:
+        return {k: _read_walk(v, hf) for k, v in json_shape.items()}

--- a/rheojax/gui/foundation/project_codec.py
+++ b/rheojax/gui/foundation/project_codec.py
@@ -265,9 +265,20 @@ _MAX_MEMBER_BYTES = 500 * 1024**2
 
 
 def _is_allowed_member(name: str) -> bool:
+    if "\\" in name or name.startswith("/") or any(part == ".." for part in name.split("/")):
+        return False
     if name in _ALLOWED_TOP_LEVEL:
         return True
     return any(name.startswith(p) and name.endswith((".hdf5", "/manifest.json")) for p in _ALLOWED_PREFIXES)
+
+
+def _validate_ref_id(ref_id: str) -> str:
+    """Rejects a ref id that could escape tmp_root when interpolated into a path
+    (spec §6.2) -- legitimate ids are always uuid4().hex, which never contains
+    '/', '\\', or '..'."""
+    if not ref_id or "/" in ref_id or "\\" in ref_id or ".." in ref_id:
+        raise ValueError(f"invalid archive reference id: {ref_id!r}")
+    return ref_id
 
 
 def load_project_v2(path: Path):
@@ -333,8 +344,11 @@ def load_project_v2(path: Path):
 
         with tempfile.TemporaryDirectory() as tmpdir:
             tmp_root = Path(tmpdir)
+            resolved_root = tmp_root.resolve()
             for name in seen_names:
                 dest = tmp_root / name
+                if resolved_root not in dest.resolve().parents:
+                    raise ValueError(f"archive member resolves outside extraction root: {name}")
                 dest.parent.mkdir(parents=True, exist_ok=True)
                 dest.write_bytes(zf.read(name))
 
@@ -343,6 +357,7 @@ def load_project_v2(path: Path):
             library_manifest = json.loads((tmp_root / "library" / "manifest.json").read_text())
             for ref_dict in library_manifest:
                 ref = DatasetRef(**ref_dict)
+                _validate_ref_id(ref.id)
                 state.library.add(ref)
                 hdf5_path = tmp_root / "library" / f"{ref.id}.hdf5"
                 if hdf5_path.exists():
@@ -355,6 +370,7 @@ def load_project_v2(path: Path):
                 result, mirroring how they share one persistence path on save."""
                 if ref_id is None:
                     return None
+                _validate_ref_id(ref_id)
                 result_path = tmp_root / result_dir / f"{ref_id}.hdf5"
                 return read_result_arrays(result_path, meta)
 
@@ -383,6 +399,7 @@ def load_project_v2(path: Path):
                 for side in ("input", "output"):
                     ref_id = result_refs.get(side)
                     if ref_id is not None:
+                        _validate_ref_id(ref_id)
                         restored_result[side] = load_hdf5(str(tmp_root / "transform_results" / f"{ref_id}.hdf5"))
             transform_dict["result"] = restored_result
             state.transform = TransformState(**transform_dict)
@@ -407,6 +424,7 @@ def load_project_v2(path: Path):
                         # for a "transform" pipeline step's record (see the matching comment
                         # there).
                         ref_id = step_record.pop("output_ref")
+                        _validate_ref_id(ref_id)
                         step_record["output"] = load_hdf5(
                             str(tmp_root / "transform_results" / f"{ref_id}.hdf5")
                         )

--- a/rheojax/gui/foundation/project_codec.py
+++ b/rheojax/gui/foundation/project_codec.py
@@ -23,7 +23,7 @@ from zipfile import ZIP_DEFLATED, ZipFile
 import h5py
 import numpy as np
 
-from rheojax.io import save_hdf5
+from rheojax.io import load_hdf5, save_hdf5
 
 
 def _write_walk(value: Any, key_path: str, hf: h5py.File, out: dict | list) -> Any:
@@ -251,3 +251,171 @@ def save_project_v2(state, path: Path) -> None:
             if tmp_zip.exists():
                 tmp_zip.unlink()
             raise
+
+
+_ALLOWED_TOP_LEVEL = {
+    "metadata.json", "manifest.json", "library/manifest.json", "fit.json",
+    "transform.json", "pipeline.json", "job_history.json", "project.json", "ui.json",
+}
+_ALLOWED_PREFIXES = ("library/", "fit_results/", "transform_results/", "job_results/")
+
+_MAX_MEMBERS = 10_000
+_MAX_TOTAL_BYTES = 2 * 1024**3
+_MAX_MEMBER_BYTES = 500 * 1024**2
+
+
+def _is_allowed_member(name: str) -> bool:
+    if name in _ALLOWED_TOP_LEVEL:
+        return True
+    return any(name.startswith(p) and name.endswith((".hdf5", "/manifest.json")) for p in _ALLOWED_PREFIXES)
+
+
+def load_project_v2(path: Path):
+    """Decode a versioned .rheojax v2 ZIP archive back into an AppState (spec §6.2):
+    archive-member allowlist, size/count limits, duplicate-entry rejection, encrypted/
+    unsupported-compression rejection, SHA-256 checksum verification, all-or-nothing decode."""
+    from rheojax.gui.foundation.library import DatasetRef
+    from rheojax.gui.foundation.state import (
+        AppState,
+        FitState,
+        JobHistoryState,
+        NlsqConfig,
+        NutsConfig,
+        ParameterConfig,
+        PipelineState,
+        PipelineStepConfig,
+        ProjectState,
+        TransformState,
+        UiState,
+    )
+
+    path = Path(path)
+    with ZipFile(path) as zf:
+        infos = zf.infolist()
+
+        if len(infos) > _MAX_MEMBERS:
+            raise ValueError(f"Archive has {len(infos)} members, exceeds limit of {_MAX_MEMBERS}")
+
+        seen_names: set[str] = set()
+        total_bytes = 0
+        for info in infos:
+            if info.filename in seen_names:
+                raise ValueError(f"Archive contains duplicate member: {info.filename}")
+            seen_names.add(info.filename)
+            if info.flag_bits & 0x1:
+                raise ValueError(f"Archive member {info.filename} is encrypted; rejected")
+            if info.compress_type not in (0, 8):  # ZIP_STORED, ZIP_DEFLATED
+                raise ValueError(f"Archive member {info.filename} uses an unsupported compression type")
+            if info.file_size > _MAX_MEMBER_BYTES:
+                raise ValueError(f"Archive member {info.filename} exceeds the {_MAX_MEMBER_BYTES}-byte limit")
+            total_bytes += info.file_size
+            if not _is_allowed_member(info.filename):
+                raise ValueError(f"Archive contains a disallowed member: {info.filename}")
+        if total_bytes > _MAX_TOTAL_BYTES:
+            raise ValueError(f"Archive's total uncompressed size exceeds {_MAX_TOTAL_BYTES} bytes")
+
+        metadata = json.loads(zf.read("metadata.json"))
+        if metadata.get("version") != _ARCHIVE_VERSION:
+            raise ValueError(
+                f"Unsupported project version {metadata.get('version')!r}, expected {_ARCHIVE_VERSION!r}"
+            )
+
+        manifest = json.loads(zf.read("manifest.json"))
+        checksums = manifest["members"]
+        for name in seen_names:
+            if name in ("manifest.json", "metadata.json"):
+                continue
+            data = zf.read(name)
+            expected = checksums.get(name, {}).get("sha256")
+            actual = hashlib.sha256(data).hexdigest()
+            if expected != actual:
+                raise ValueError(f"checksum mismatch for archive member: {name}")
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            tmp_root = Path(tmpdir)
+            for name in seen_names:
+                dest = tmp_root / name
+                dest.parent.mkdir(parents=True, exist_ok=True)
+                dest.write_bytes(zf.read(name))
+
+            state = AppState()
+
+            library_manifest = json.loads((tmp_root / "library" / "manifest.json").read_text())
+            for ref_dict in library_manifest:
+                ref = DatasetRef(**ref_dict)
+                state.library.add(ref)
+                hdf5_path = tmp_root / "library" / f"{ref.id}.hdf5"
+                if hdf5_path.exists():
+                    state.library.store_payload(ref.id, load_hdf5(str(hdf5_path)))
+
+            def _restore_result_dict(ref_id: str | None, meta: dict | None, result_dir: str) -> dict | None:
+                """Inverse of save_project_v2's _persist_result_dict -- the ONE restoration
+                path for any persisted fit/NUTS/phase result dict, used below for both
+                fit.json's nlsq_result/nuts_result and every job_history.json fit-step phase
+                result, mirroring how they share one persistence path on save."""
+                if ref_id is None:
+                    return None
+                result_path = tmp_root / result_dir / f"{ref_id}.hdf5"
+                return read_result_arrays(result_path, meta)
+
+            fit_dict = json.loads((tmp_root / "fit.json").read_text())
+            for result_key in ("nlsq_result", "nuts_result"):
+                ref_id = fit_dict.pop(f"{result_key}_ref", None)
+                meta = fit_dict.pop(f"{result_key}_meta", None)
+                fit_dict[result_key] = _restore_result_dict(ref_id, meta, "fit_results")
+            nlsq_cfg = fit_dict.pop("nlsq_config", {}) or {}
+            nuts_cfg = fit_dict.pop("nuts_config", {}) or {}
+            raw_parameters = nlsq_cfg.pop("parameters", []) or []
+            state.fit = FitState(
+                **{k: v for k, v in fit_dict.items() if k in FitState.__dataclass_fields__},
+                nlsq_config=NlsqConfig(
+                    **nlsq_cfg, parameters=[ParameterConfig(**p) for p in raw_parameters]
+                ),
+                nuts_config=NutsConfig(**nuts_cfg),
+            )
+
+            transform_dict = json.loads((tmp_root / "transform.json").read_text())
+            result_refs = transform_dict.pop("result_refs", {}) or {}
+            result_extras = transform_dict.pop("result_extras", {}) or {}
+            restored_result: dict | None = None
+            if any(result_refs.values()) or result_extras:
+                restored_result = dict(result_extras)
+                for side in ("input", "output"):
+                    ref_id = result_refs.get(side)
+                    if ref_id is not None:
+                        restored_result[side] = load_hdf5(str(tmp_root / "transform_results" / f"{ref_id}.hdf5"))
+            transform_dict["result"] = restored_result
+            state.transform = TransformState(**transform_dict)
+
+            pipeline_dict = json.loads((tmp_root / "pipeline.json").read_text())
+            pipeline_dict["steps"] = [PipelineStepConfig(**s) for s in pipeline_dict.get("steps", [])]
+            state.pipeline = PipelineState(**pipeline_dict)
+
+            job_history_dict = json.loads((tmp_root / "job_history.json").read_text())
+            for record in job_history_dict.values():
+                for step_record in record.get("step_results", {}).values():
+                    if step_record.get("step_type") == "fit":
+                        for phase_key in ("nlsq", "nuts"):
+                            phase = step_record.get(phase_key)
+                            if phase is None:
+                                continue
+                            ref_id = phase.pop("result_ref", None)
+                            meta = phase.pop("result_meta", None)
+                            phase["result"] = _restore_result_dict(ref_id, meta, "job_results")
+                    elif "output_ref" in step_record:
+                        # Inverse of save_project_v2's "output" -> "output_ref" persistence
+                        # for a "transform" pipeline step's record (see the matching comment
+                        # there).
+                        ref_id = step_record.pop("output_ref")
+                        step_record["output"] = load_hdf5(
+                            str(tmp_root / "transform_results" / f"{ref_id}.hdf5")
+                        )
+            state.job_history = JobHistoryState(by_id=job_history_dict)
+
+            project_dict = json.loads((tmp_root / "project.json").read_text())
+            state.project = ProjectState(path=project_dict.get("path"), name=project_dict.get("name"))
+
+            ui_dict = json.loads((tmp_root / "ui.json").read_text())
+            state.ui = UiState(**ui_dict)
+
+            return state

--- a/rheojax/gui/foundation/project_codec.py
+++ b/rheojax/gui/foundation/project_codec.py
@@ -9,11 +9,21 @@ RheoData-typed save_hdf5()/load_hdf5() helpers, which don't apply to this shape.
 """
 from __future__ import annotations
 
+import dataclasses
+import hashlib
+import json
+import os
+import tempfile
+import uuid
+from datetime import UTC, datetime
 from pathlib import Path
 from typing import Any
+from zipfile import ZIP_DEFLATED, ZipFile
 
 import h5py
 import numpy as np
+
+from rheojax.io import save_hdf5
 
 
 def _write_walk(value: Any, key_path: str, hf: h5py.File, out: dict | list) -> Any:
@@ -65,3 +75,179 @@ def read_result_arrays(path: Path, json_shape: dict[str, Any]) -> dict[str, Any]
     path = Path(path)
     with h5py.File(path, "r") as hf:
         return {k: _read_walk(v, hf) for k, v in json_shape.items()}
+
+
+_ARCHIVE_VERSION = "2.0"
+
+
+def save_project_v2(state, path: Path) -> None:
+    """Encode an AppState into a versioned .rheojax v2 ZIP archive (spec §6.1), written
+    atomically via a temp-file + fsync + os.replace (spec §6.2)."""
+    path = Path(path)
+    with tempfile.TemporaryDirectory() as tmpdir:
+        tmp_root = Path(tmpdir)
+        member_hashes: dict[str, dict[str, int | str]] = {}
+
+        def _write_json(rel_path: str, obj: Any) -> None:
+            full = tmp_root / rel_path
+            full.parent.mkdir(parents=True, exist_ok=True)
+            data = json.dumps(obj, indent=2).encode("utf-8")
+            full.write_bytes(data)
+            member_hashes[rel_path] = {
+                "sha256": hashlib.sha256(data).hexdigest(),
+                "size": len(data),
+            }
+
+        def _register_binary(rel_path: str) -> None:
+            full = tmp_root / rel_path
+            data = full.read_bytes()
+            member_hashes[rel_path] = {
+                "sha256": hashlib.sha256(data).hexdigest(),
+                "size": len(data),
+            }
+
+        _write_json("metadata.json", {
+            "version": _ARCHIVE_VERSION,
+            "timestamp": datetime.now(UTC).strftime("%Y-%m-%dT%H:%M:%SZ"),
+        })
+
+        library_manifest = [dataclasses.asdict(ref) for ref in state.library.all()]
+        _write_json("library/manifest.json", library_manifest)
+        for ref in state.library.all():
+            rel = f"library/{ref.id}.hdf5"
+            full = tmp_root / rel
+            full.parent.mkdir(parents=True, exist_ok=True)
+            try:
+                payload = state.library.load_payload(ref.id)
+            except KeyError:
+                continue
+            save_hdf5(payload, str(full))
+            _register_binary(rel)
+
+        def _persist_result_dict(raw: dict | None, result_dir: str) -> tuple[str | None, dict | None]:
+            """Splits a raw NLSQ/NUTS/phase result dict into an HDF5 array payload
+            (result_dir/<uuid>.hdf5, via write_result_arrays) plus a JSON-safe metadata
+            shape, returning (result_id, json_shape). Returns (None, None) for a falsy
+            `raw`. This is the ONE place any raw fit/NUTS-shaped result dict gets
+            persisted -- fit.json's nlsq_result/nuts_result AND every job_history.json
+            fit-step phase result both route through this helper, so there is exactly one
+            persistence path for this value shape, not two independently-maintained ones."""
+            if not raw:
+                return None, None
+            result_id = uuid.uuid4().hex
+            rel = f"{result_dir}/{result_id}.hdf5"
+            full = tmp_root / rel
+            full.parent.mkdir(parents=True, exist_ok=True)
+            json_shape = write_result_arrays(full, raw)
+            _register_binary(rel)
+            return result_id, json_shape
+
+        # nlsq_result/nuts_result are "Any"-typed fields that may hold nested dataclass
+        # instances (e.g. RheoData); dataclasses.asdict() recurses into dict/list values
+        # regardless of what they hold, so asdict-ing state.fit directly would silently
+        # flatten any such nested dataclass before we get a chance to persist it specially.
+        # Source the raw values from the live object and strip the fields via replace()
+        # before asdict, instead of asdict-then-pop.
+        raw_nlsq_result = state.fit.nlsq_result
+        raw_nuts_result = state.fit.nuts_result
+        fit_dict = dataclasses.asdict(
+            dataclasses.replace(state.fit, nlsq_result=None, nuts_result=None)
+        )
+        for result_key, raw in (("nlsq_result", raw_nlsq_result), ("nuts_result", raw_nuts_result)):
+            fit_dict.pop(result_key, None)
+            result_id, json_shape = _persist_result_dict(raw, "fit_results")
+            fit_dict[f"{result_key}_ref"] = result_id
+            fit_dict[f"{result_key}_meta"] = json_shape
+        _write_json("fit.json", fit_dict)
+
+        # TransformState.result holds real RheoData objects under "input"/"output" (set by
+        # transform_controller.py's _run()) -- these are not JSON-serializable, so they're
+        # extracted to transform_results/<id>.hdf5 via save_hdf5 (the RheoData-typed helper,
+        # NOT write_result_arrays -- these are real RheoData, unlike fit/NUTS result dicts),
+        # exactly mirroring how library/<dataset_id>.hdf5 payloads above are handled.
+        # Same asdict-recursion hazard as above: source `result` from the live object and
+        # strip it via replace() before asdict, rather than asdict-then-pop.
+        raw_transform_result = state.transform.result
+        transform_dict = dataclasses.asdict(dataclasses.replace(state.transform, result=None))
+        transform_dict.pop("result", None)
+        transform_result_refs: dict[str, str | None] = {"input": None, "output": None}
+        if raw_transform_result:
+            for side in ("input", "output"):
+                payload = raw_transform_result.get(side)
+                if payload is None:
+                    continue
+                result_id = uuid.uuid4().hex
+                rel = f"transform_results/{result_id}.hdf5"
+                full = tmp_root / rel
+                full.parent.mkdir(parents=True, exist_ok=True)
+                save_hdf5(payload, str(full))
+                _register_binary(rel)
+                transform_result_refs[side] = result_id
+        transform_dict["result_refs"] = transform_result_refs
+        transform_dict["result_extras"] = {
+            k: v for k, v in (raw_transform_result or {}).items() if k not in ("input", "output")
+        }
+        _write_json("transform.json", transform_dict)
+
+        _write_json("pipeline.json", dataclasses.asdict(state.pipeline))
+
+        # job_history.by_id records hold RAW fit-phase result dicts in memory (Plan 2's
+        # PipelineBatchRunner._prepare_job_record() intentionally does NOT persist them itself
+        # -- see Plan 2 Task 7 -- so there is exactly one place, here, that ever calls
+        # write_result_arrays() for a pipeline job's results, avoiding the "external results_dir
+        # never actually gets copied into the archive" gap).
+        job_history_out: dict[str, dict] = {}
+        for job_id, record in state.job_history.by_id.items():
+            record = dict(record)
+            step_results_out = {}
+            for step_id, step_record in record.get("step_results", {}).items():
+                step_record = dict(step_record)
+                if step_record.get("step_type") == "fit":
+                    for phase_key in ("nlsq", "nuts"):
+                        phase = step_record.get(phase_key)
+                        if phase is None:
+                            continue
+                        phase = dict(phase)
+                        result_id, json_shape = _persist_result_dict(phase.pop("result", None), "job_results")
+                        phase["result_ref"] = result_id
+                        phase["result_meta"] = json_shape
+                        step_record[phase_key] = phase
+                elif "output" in step_record:
+                    # A "transform" pipeline step's record (Plan 2's
+                    # PipelineBatchRunner._prepare_job_record(), step_type == "other") embeds
+                    # the transformed RheoData directly under "output" -- this is NOT
+                    # JSON-serializable, so it's persisted the same way state.transform.result's
+                    # RheoData is handled above (save_hdf5, not write_result_arrays -- this is
+                    # a real RheoData, not a result dict), into transform_results/ (the same
+                    # prefix, since it's the same kind of payload).
+                    output = step_record.pop("output")
+                    result_id = uuid.uuid4().hex
+                    rel = f"transform_results/{result_id}.hdf5"
+                    full = tmp_root / rel
+                    full.parent.mkdir(parents=True, exist_ok=True)
+                    save_hdf5(output, str(full))
+                    _register_binary(rel)
+                    step_record["output_ref"] = result_id
+                step_results_out[step_id] = step_record
+            record["step_results"] = step_results_out
+            job_history_out[job_id] = record
+        _write_json("job_history.json", job_history_out)
+
+        _write_json("project.json", {"path": state.project.path, "name": state.project.name})
+        _write_json("ui.json", dataclasses.asdict(state.ui))
+
+        _write_json("manifest.json", {"members": member_hashes})
+
+        tmp_zip = path.with_name(f"{path.name}.tmp-{uuid.uuid4().hex}")
+        try:
+            with ZipFile(tmp_zip, "w", compression=ZIP_DEFLATED) as zf:
+                for rel_path in tmp_root.rglob("*"):
+                    if rel_path.is_file():
+                        zf.write(rel_path, rel_path.relative_to(tmp_root).as_posix())
+            with open(tmp_zip, "rb") as f:
+                os.fsync(f.fileno())
+            os.replace(tmp_zip, path)
+        except Exception:
+            if tmp_zip.exists():
+                tmp_zip.unlink()
+            raise

--- a/rheojax/gui/foundation/state.py
+++ b/rheojax/gui/foundation/state.py
@@ -7,6 +7,31 @@ from rheojax.gui.foundation.library import DatasetLibrary
 
 
 @dataclass
+class ParameterConfig:
+    name: str
+    value: float
+    lower: float
+    upper: float
+    fixed: bool
+
+@dataclass
+class NlsqConfig:
+    multi_start: bool = False
+    n_starts: int = 8
+    parameters: list[ParameterConfig] = field(default_factory=list)
+
+@dataclass
+class NutsConfig:
+    run_nuts: bool = True
+    num_warmup: int = 500
+    num_samples: int = 1000
+    num_chains: int = 4
+    target_accept: float = 0.8
+    seed: int = 0
+    warm_start: bool = True
+    priors: dict[str, Any] = field(default_factory=dict)
+
+@dataclass
 class FitState:
     protocol: str | None = None
     model_key: str | None = None
@@ -22,7 +47,8 @@ class FitState:
     # vocabulary first (they don't match 1:1 today, e.g. "gamma_dot0" vs
     # "gdot"); do that reconciliation before wiring a widget to this field.
     control_vars: dict[str, float] = field(default_factory=dict)
-    nlsq_config: dict = field(default_factory=dict)       # multi-start / solver settings
+    nlsq_config: NlsqConfig = field(default_factory=NlsqConfig)
+    nuts_config: NutsConfig = field(default_factory=NutsConfig)
     nlsq_result: Any | None = None  # FitResult from ModelService.fit(); typed Any to avoid circular import
     nuts_result: dict | None = None
     step: int = 0
@@ -57,4 +83,7 @@ class AppState:
     ui: dict[str, Any] = field(default_factory=lambda: {"mode": "fit"})
 
 # re-export replace for invalidation.py
-__all__ = ["FitState", "TransformState", "JobsState", "ProjectState", "AppState", "replace"]
+__all__ = [
+    "ParameterConfig", "NlsqConfig", "NutsConfig",
+    "FitState", "TransformState", "JobsState", "ProjectState", "AppState", "replace",
+]

--- a/rheojax/gui/foundation/state.py
+++ b/rheojax/gui/foundation/state.py
@@ -64,8 +64,35 @@ class TransformState:
     revision: int = 0
 
 @dataclass
-class JobsState:
+class PipelineStepConfig:
+    id: str
+    step_type: str            # "transform" | "fit" | "export"
+    config: dict[str, Any] = field(default_factory=dict)
+
+@dataclass
+class JobResultRef:
+    result_id: str
+
+@dataclass
+class ActiveJobsState:
     by_id: dict[str, dict] = field(default_factory=dict)
+
+@dataclass
+class JobHistoryState:
+    by_id: dict[str, dict] = field(default_factory=dict)
+
+@dataclass
+class PipelineState:
+    steps: list[PipelineStepConfig] = field(default_factory=list)
+    selected_dataset_ids: list[str] = field(default_factory=list)
+    name: str | None = None
+    job_id: str | None = None
+
+@dataclass
+class UiState:
+    mode: str = "fit"
+    theme: str = "system"
+    inspector_tab: str = "log"
 
 @dataclass
 class ProjectState:
@@ -78,12 +105,15 @@ class AppState:
     library: DatasetLibrary = field(default_factory=DatasetLibrary)
     fit: FitState = field(default_factory=FitState)
     transform: TransformState = field(default_factory=TransformState)
-    jobs: JobsState = field(default_factory=JobsState)
+    pipeline: PipelineState = field(default_factory=PipelineState)
+    active_jobs: ActiveJobsState = field(default_factory=ActiveJobsState)
+    job_history: JobHistoryState = field(default_factory=JobHistoryState)
     project: ProjectState = field(default_factory=ProjectState)
-    ui: dict[str, Any] = field(default_factory=lambda: {"mode": "fit"})
+    ui: UiState = field(default_factory=UiState)
 
 # re-export replace for invalidation.py
 __all__ = [
-    "ParameterConfig", "NlsqConfig", "NutsConfig",
-    "FitState", "TransformState", "JobsState", "ProjectState", "AppState", "replace",
+    "ParameterConfig", "NlsqConfig", "NutsConfig", "FitState", "TransformState",
+    "PipelineStepConfig", "JobResultRef", "ActiveJobsState", "JobHistoryState",
+    "PipelineState", "UiState", "ProjectState", "AppState", "replace",
 ]

--- a/rheojax/gui/main.py
+++ b/rheojax/gui/main.py
@@ -154,21 +154,29 @@ For more information, visit: https://github.com/imewei/rheojax
         """,
     )
 
-    parser.add_argument(
+    group = parser.add_mutually_exclusive_group()
+    group.add_argument(
         "--project",
         "-p",
         type=Path,
         metavar="FILE",
         help="Project file to open on startup (.rheojax)",
     )
-
-    parser.add_argument(
+    group.add_argument(
         "--import",
         "-i",
         dest="import_file",
         type=Path,
         metavar="FILE",
-        help="Data file to import on startup (TRIOS, Excel, CSV, etc.)",
+        help="Data file to import on startup (requires --protocol)",
+    )
+
+    parser.add_argument(
+        "--protocol",
+        type=str,
+        metavar="PROTOCOL",
+        help="Protocol for --import (required together): flow_curve, creep, relaxation, "
+        "startup, oscillation, laos",
     )
 
     parser.add_argument(
@@ -197,7 +205,14 @@ For more information, visit: https://github.com/imewei/rheojax
         version=f"%(prog)s {__version__}",
     )
 
-    return parser.parse_args(argv)
+    args = parser.parse_args(argv)
+
+    if args.import_file and not args.protocol:
+        parser.error("--protocol is required when --import is given")
+    if args.protocol and not args.import_file:
+        parser.error("--protocol is only valid together with --import")
+
+    return args
 
 
 def main(argv: list[str] | None = None) -> int:
@@ -383,25 +398,27 @@ def main(argv: list[str] | None = None) -> int:
         logger.info("RheoJAX GUI workspace shell ready", version=__version__)
 
         if args.project:
-            logger.info(
-                "Workspace shell: project loading not yet implemented",
-                path=str(args.project),
-            )
-            print(
-                "NOTE: --project is not yet supported by the workspace shell "
-                "(--workspace); ignored.",
-                file=sys.stderr,
-            )
+            from rheojax.gui.foundation.project_codec import load_project_v2
+
+            try:
+                loaded_state = load_project_v2(args.project)
+            except (ValueError, FileNotFoundError) as e:
+                logger.error("Failed to load project", path=str(args.project), error=str(e))
+                print(f"ERROR: Failed to load project: {e}", file=sys.stderr)
+                return 1
+            workspace_window._rebuild(loaded_state)
+            workspace_window._state.project.path = str(args.project)
+
         if args.import_file:
-            logger.info(
-                "Workspace shell: data import not yet implemented",
-                path=str(args.import_file),
-            )
-            print(
-                "NOTE: --import is not yet supported by the workspace shell "
-                "(--workspace); ignored.",
-                file=sys.stderr,
-            )
+            from rheojax.gui.foundation.import_service import import_dataset
+
+            try:
+                ref, data = import_dataset(args.import_file, args.protocol)
+            except (ValueError, FileNotFoundError) as e:
+                logger.error("Failed to import data", path=str(args.import_file), error=str(e))
+                print(f"ERROR: Failed to import data: {e}", file=sys.stderr)
+                return 1
+            workspace_window._commit_dataset(ref, data, overwrite=False)
 
         exit_code = app.exec()
         logger.info("Application exiting", exit_code=exit_code)

--- a/rheojax/gui/main.py
+++ b/rheojax/gui/main.py
@@ -7,12 +7,13 @@ main event loop.
 
 Usage
 -----
-    rheojax-gui                    # Launch GUI
+    rheojax-gui                    # Launch GUI (workspace shell, now the default)
+    rheojax-gui --legacy           # Launch the legacy main window
     rheojax-gui --project FILE     # Open project
-    rheojax-gui --import FILE      # Import data file on startup
+    rheojax-gui --import FILE --protocol PROTOCOL   # Import data file on startup
     rheojax-gui --maximized        # Start window maximized
     rheojax-gui --verbose          # Enable verbose logging
-    rheojax-gui --workspace        # Launch the new workspace shell (preview)
+    rheojax-gui --workspace        # Deprecated no-op alias (workspace is now default)
     rheojax-gui --help             # Show help
 
 Example
@@ -196,7 +197,12 @@ For more information, visit: https://github.com/imewei/rheojax
     parser.add_argument(
         "--workspace",
         action="store_true",
-        help="Launch the new workspace shell (preview) instead of the legacy main window",
+        help="Deprecated no-op alias; the workspace shell is now the default",
+    )
+
+    parser.add_argument(
+        "--legacy", action="store_true",
+        help="Launch the legacy main window instead of the (now default) workspace shell",
     )
 
     parser.add_argument(
@@ -384,8 +390,18 @@ def main(argv: list[str] | None = None) -> int:
     # Workspace shell (preview): early-return path, kept separate from the
     # legacy window's project/import/smoke-fit hooks below since those are
     # RheoJAXMainWindow-specific APIs the workspace shell does not have yet.
-    if args.workspace:
-        logger.debug("Launching workspace shell (preview)")
+    if not args.legacy:
+        if args.workspace:
+            logger.warning(
+                "--workspace is deprecated and no longer needed -- the workspace shell is now "
+                "the default. This flag will be removed in a future release."
+            )
+            print(
+                "WARNING: --workspace is deprecated (workspace is now the default); "
+                "this flag will be removed in a future release.",
+                file=sys.stderr,
+            )
+        logger.debug("Launching workspace shell (now the default)")
         try:
             workspace_window = _create_workspace_window()
         except Exception as e:

--- a/rheojax/gui/services/pipeline_execution_service.py
+++ b/rheojax/gui/services/pipeline_execution_service.py
@@ -23,7 +23,7 @@ from worker threads (GUI-006).  The per-action signals (e.g.
 from __future__ import annotations
 
 from pathlib import Path
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 from PySide6.QtCore import QObject, Signal
 
@@ -31,7 +31,19 @@ from rheojax.gui.state import actions as pipeline_actions
 from rheojax.gui.state.store import StepStatus
 from rheojax.logging import get_logger
 
+if TYPE_CHECKING:
+    from rheojax.gui.workspace.pipeline.models import FitStepResult, PhaseResult
+
 logger = get_logger(__name__)
+
+
+class WorkerIsolationRequiredError(RuntimeError):
+    """Raised when a Pipeline-mode fit step runs under thread-mode worker isolation.
+
+    Distinct from ordinary step failures so ``execute()``'s per-step exception
+    handling can re-raise it as a fatal precondition error instead of
+    recording it as a per-step ``status="failed"`` result.
+    """
 
 
 def _coerce_bayesian_int(
@@ -244,11 +256,15 @@ class PipelineExecutionService(QObject):
                 if step.step_type == "transform":
                     step_results[step.id] = self._execute_pipeline_transform(step, context, library)
                 elif step.step_type == "fit":
-                    raise NotImplementedError("fit step handling added in a later task")
+                    step_results[step.id] = self._execute_pipeline_fit(step, context)
                 elif step.step_type == "export":
                     raise NotImplementedError("export step handling added in a later task")
                 else:
                     raise ValueError(f"Unknown pipeline step_type: {step.step_type!r}")
+            except WorkerIsolationRequiredError:
+                # Fatal precondition error (misconfigured environment), not a
+                # per-step runtime failure -- propagate out of execute() itself.
+                raise
             except Exception as exc:
                 self.step_failed.emit(step.id, str(exc))
                 return PipelineRunResult(step_results=step_results, status="failed", error=str(exc))
@@ -285,6 +301,102 @@ class PipelineExecutionService(QObject):
 
         context["data"] = transformed
         return {"output": transformed, "protocol_type": protocol_type}
+
+    def _execute_pipeline_fit(self, step, context: dict) -> FitStepResult:
+        """Run one Pipeline-mode fit step: synchronous NLSQ, then optional NUTS.
+
+        Named distinctly from ``_execute_fit`` (the visual pipeline builder's
+        handler below), which takes a different step shape.
+        """
+        from rheojax.gui.jobs.process_adapter import (
+            get_worker_isolation_mode,
+            make_bayesian_worker,
+            make_fit_worker,
+        )
+        from rheojax.gui.workspace.pipeline.models import FitStepResult
+
+        if get_worker_isolation_mode() != "subprocess":
+            raise WorkerIsolationRequiredError(
+                "Pipeline fit steps require subprocess worker isolation "
+                "(set RHEOJAX_WORKER_ISOLATION=subprocess); thread-mode is not supported."
+            )
+
+        config = step.config
+        dataset_id = context["dataset_id"]
+
+        self.step_phase_started.emit(step.id, "nlsq")
+        nlsq_worker = make_fit_worker(
+            model_name=config["model_name"],
+            data=context["data"],
+            initial_params=config.get("initial_params"),
+            options=config.get("nlsq_options"),
+            dataset_id=dataset_id,
+            model_config=config.get("model_config"),
+        )
+        self.phase_worker_ready.emit(dataset_id, step.id, "nlsq", nlsq_worker)
+        nlsq_phase = self._run_worker_phase(nlsq_worker)
+        if nlsq_phase.status == "completed":
+            self.step_phase_completed.emit(step.id, "nlsq")
+        else:
+            self.step_phase_failed.emit(step.id, "nlsq", nlsq_phase.error or "")
+
+        if not config.get("run_nuts", False) or nlsq_phase.status != "completed":
+            return FitStepResult(nlsq=nlsq_phase, nuts=None)
+
+        nuts_cfg = config.get("nuts_config", {})
+        warm_start = (nlsq_phase.result or {}).get("parameters", {})
+        self.step_phase_started.emit(step.id, "nuts")
+        nuts_worker = make_bayesian_worker(
+            model_name=config["model_name"],
+            data=context["data"],
+            num_warmup=nuts_cfg.get("num_warmup", 500),
+            num_samples=nuts_cfg.get("num_samples", 1000),
+            num_chains=nuts_cfg.get("num_chains", 4),
+            warm_start=warm_start if nuts_cfg.get("warm_start", True) else None,
+            priors=nuts_cfg.get("priors"),
+            seed=nuts_cfg.get("seed", 0),
+            dataset_id=dataset_id,
+            target_accept=nuts_cfg.get("target_accept", 0.8),
+        )
+        self.phase_worker_ready.emit(dataset_id, step.id, "nuts", nuts_worker)
+        nuts_phase = self._run_worker_phase(nuts_worker)
+        if nuts_phase.status == "completed":
+            self.step_phase_completed.emit(step.id, "nuts")
+        else:
+            self.step_phase_failed.emit(step.id, "nuts", nuts_phase.error or "")
+
+        return FitStepResult(nlsq=nlsq_phase, nuts=nuts_phase)
+
+    @staticmethod
+    def _run_worker_phase(worker) -> PhaseResult:
+        """Runs `worker` (FitWorker or ProcessWorkerAdapter) synchronously, capturing its
+        terminal signal via a plain (same-thread) connection -- must be called from the same
+        thread execute() itself runs on. worker.run() blocks that thread until the terminal
+        message arrives, so the local closures below fire before this function returns."""
+        from rheojax.gui.workspace.pipeline.models import PhaseResult
+
+        captured: dict = {}
+
+        def _on_completed(result):
+            captured["status"] = "completed"
+            captured["result"] = result
+
+        def _on_failed(error):
+            captured["status"] = "failed"
+            captured["error"] = error
+
+        def _on_cancelled():
+            captured["status"] = "cancelled"
+
+        worker.signals.completed.connect(_on_completed)
+        worker.signals.failed.connect(_on_failed)
+        worker.signals.cancelled.connect(_on_cancelled)
+        worker.run()
+        return PhaseResult(
+            status=captured.get("status", "failed"),
+            result=captured.get("result"),
+            error=captured.get("error"),
+        )
 
     # ------------------------------------------------------------------
     # Internal routing

--- a/rheojax/gui/services/pipeline_execution_service.py
+++ b/rheojax/gui/services/pipeline_execution_service.py
@@ -244,6 +244,12 @@ class PipelineExecutionService(QObject):
         """
         from rheojax.gui.workspace.pipeline.models import PipelineRunResult
 
+        seen_ids: set[str] = set()
+        for step in steps:
+            if step.id in seen_ids:
+                raise ValueError(f"duplicate pipeline step id: {step.id!r}")
+            seen_ids.add(step.id)
+
         context = dict(initial_context)
         step_results: dict = {}
 
@@ -254,7 +260,19 @@ class PipelineExecutionService(QObject):
             self.step_started.emit(step.id)
             try:
                 if step.step_type == "transform":
-                    step_results[step.id] = self._execute_pipeline_transform(step, context, library)
+                    # A transform's output is "consumed downstream" -- and therefore worth a
+                    # persisted DatasetRef -- whenever it is part of a real multi-step run
+                    # rather than a standalone preview. Step types are only ever
+                    # transform/fit/export, so "another step exists anywhere in this run"
+                    # (before OR after) is exactly "len(steps) > 1": a transform->export or
+                    # transform->transform chain persists every transform's output, since each
+                    # is either read by a later step in-memory (context["data"]) or is itself
+                    # the run's terminal derived dataset worth keeping addressable; a lone
+                    # transform run by itself is a throwaway preview and stays unpersisted.
+                    consumed_downstream = len(steps) > 1
+                    step_results[step.id] = self._execute_pipeline_transform(
+                        step, context, library, persist=consumed_downstream
+                    )
                 elif step.step_type == "fit":
                     step_results[step.id] = self._execute_pipeline_fit(step, context)
                 elif step.step_type == "export":
@@ -272,13 +290,22 @@ class PipelineExecutionService(QObject):
 
         return PipelineRunResult(step_results=step_results, status="completed")
 
-    def _execute_pipeline_transform(self, step, context: dict, library) -> dict:
+    def _execute_pipeline_transform(self, step, context: dict, library, persist: bool) -> dict:
         """Run one Pipeline-mode transform step against its sole primary slot.
 
         Named distinctly from ``_execute_transform`` (the visual pipeline
         builder's handler above) since the two take different step shapes
         and report results differently.
+
+        ``persist`` controls whether the transformed output is written into
+        ``library`` as a new derived ``DatasetRef`` (per §3.4: retained only
+        if a later step consumes it, or export explicitly requests it) --
+        the caller decides this from whether a later step in the same run
+        actually reads the output.
         """
+        import uuid
+
+        from rheojax.gui.foundation.library import DatasetRef
         from rheojax.gui.workspace.transform.slots_spec import transform_slots
         from rheojax.gui.workspace.transform.transform_controller import (
             infer_output_protocol,
@@ -300,7 +327,22 @@ class PipelineExecutionService(QObject):
         protocol_type = infer_output_protocol(library, transform_key, {primary_slot: dataset_id})
 
         context["data"] = transformed
-        return {"output": transformed, "protocol_type": protocol_type}
+        new_dataset_id = None
+        if persist:
+            new_dataset_id = uuid.uuid4().hex
+            library.add(DatasetRef(
+                id=new_dataset_id, name=f"{transform_key}_{dataset_id}", protocol_type=protocol_type,
+                origin="derived", units={}, row_count=0, hash="", provenance={"pipeline_step": step.id},
+                lineage=[dataset_id],
+            ))
+            library.store_payload(new_dataset_id, transformed)
+            # A later step (another transform, or infer_output_protocol() on one further down
+            # the chain) must see the NEWLY persisted dataset as the current one, not the
+            # original input -- otherwise a 3-transform chain's third step would still report
+            # lineage=["d1"] instead of the immediately-preceding derived dataset's id.
+            context["dataset_id"] = new_dataset_id
+
+        return {"output": transformed, "protocol_type": protocol_type, "dataset_id": new_dataset_id}
 
     def _execute_pipeline_fit(self, step, context: dict) -> FitStepResult:
         """Run one Pipeline-mode fit step: synchronous NLSQ, then optional NUTS.

--- a/rheojax/gui/services/pipeline_execution_service.py
+++ b/rheojax/gui/services/pipeline_execution_service.py
@@ -88,6 +88,17 @@ class PipelineExecutionService(QObject):
     pipeline_completed = Signal()
     pipeline_failed = Signal(str)
 
+    step_phase_started = Signal(str, str)      # step_id, phase ("nlsq" | "nuts")
+    step_phase_completed = Signal(str, str)
+    step_phase_failed = Signal(str, str, str)  # step_id, phase, error
+    phase_worker_ready = Signal(str, str, str, object)  # dataset_id, step_id, phase, worker
+    dataset_run_started = Signal(str)               # dataset_id -- emitted once per dataset,
+                                                       # right before its execute() call, so
+                                                       # active_jobs is populated one dataset at
+                                                       # a time rather than for the whole batch
+                                                       # upfront
+    dataset_run_finished = Signal(str, object)      # dataset_id, PipelineRunResult
+
     def __init__(self, parent: QObject | None = None) -> None:
         super().__init__(parent)
         # Lazy service creation — instantiated on first use per step type.
@@ -202,6 +213,78 @@ class PipelineExecutionService(QObject):
             pipeline_actions.set_pipeline_running(False)
             self.pipeline_failed.emit(error_msg)
             raise
+
+    def execute(
+        self,
+        steps: list,
+        initial_context: dict,
+        library,
+        stop_requested,
+    ):
+        """Run a Pipeline-mode batch (transform/fit/export steps) over one dataset.
+
+        Distinct from ``execute_all``/``execute_single_step`` (the visual
+        pipeline builder's load/transform/fit/bayesian/export steps, driven
+        by ``StepStatus`` dispatch). This is the new Pipeline batch-execution
+        mode's per-dataset runner: it consumes ``foundation.state.PipelineStepConfig``
+        and reports results via ``PipelineRunResult``/``FitStepResult``
+        (``workspace.pipeline.models``) rather than caching into the state store.
+        """
+        from rheojax.gui.workspace.pipeline.models import PipelineRunResult
+
+        context = dict(initial_context)
+        step_results: dict = {}
+
+        for step in steps:
+            if stop_requested.is_set():
+                return PipelineRunResult(step_results=step_results, status="cancelled")
+
+            self.step_started.emit(step.id)
+            try:
+                if step.step_type == "transform":
+                    step_results[step.id] = self._execute_pipeline_transform(step, context, library)
+                elif step.step_type == "fit":
+                    raise NotImplementedError("fit step handling added in a later task")
+                elif step.step_type == "export":
+                    raise NotImplementedError("export step handling added in a later task")
+                else:
+                    raise ValueError(f"Unknown pipeline step_type: {step.step_type!r}")
+            except Exception as exc:
+                self.step_failed.emit(step.id, str(exc))
+                return PipelineRunResult(step_results=step_results, status="failed", error=str(exc))
+            self.step_completed.emit(step.id)
+
+        return PipelineRunResult(step_results=step_results, status="completed")
+
+    def _execute_pipeline_transform(self, step, context: dict, library) -> dict:
+        """Run one Pipeline-mode transform step against its sole primary slot.
+
+        Named distinctly from ``_execute_transform`` (the visual pipeline
+        builder's handler above) since the two take different step shapes
+        and report results differently.
+        """
+        from rheojax.gui.workspace.transform.slots_spec import transform_slots
+        from rheojax.gui.workspace.transform.transform_controller import (
+            infer_output_protocol,
+        )
+
+        if self._transform_service is None:
+            from rheojax.gui.services.transform_service import TransformService
+            self._transform_service = TransformService()
+
+        transform_key = step.config["name"]
+        specs = transform_slots(transform_key)
+        primary_slot = specs[0].name
+        dataset_id = context["dataset_id"]
+
+        result = self._transform_service.apply_transform(
+            transform_key, context["data"], {k: v for k, v in step.config.items() if k != "name"}
+        )
+        transformed = result[0] if isinstance(result, tuple) else result
+        protocol_type = infer_output_protocol(library, transform_key, {primary_slot: dataset_id})
+
+        context["data"] = transformed
+        return {"output": transformed, "protocol_type": protocol_type}
 
     # ------------------------------------------------------------------
     # Internal routing

--- a/rheojax/gui/services/pipeline_execution_service.py
+++ b/rheojax/gui/services/pipeline_execution_service.py
@@ -253,7 +253,7 @@ class PipelineExecutionService(QObject):
         context = dict(initial_context)
         step_results: dict = {}
 
-        for step in steps:
+        for i, step in enumerate(steps):
             if stop_requested.is_set():
                 return PipelineRunResult(step_results=step_results, status="cancelled")
 
@@ -261,15 +261,16 @@ class PipelineExecutionService(QObject):
             try:
                 if step.step_type == "transform":
                     # A transform's output is "consumed downstream" -- and therefore worth a
-                    # persisted DatasetRef -- whenever it is part of a real multi-step run
-                    # rather than a standalone preview. Step types are only ever
-                    # transform/fit/export, so "another step exists anywhere in this run"
-                    # (before OR after) is exactly "len(steps) > 1": a transform->export or
-                    # transform->transform chain persists every transform's output, since each
-                    # is either read by a later step in-memory (context["data"]) or is itself
-                    # the run's terminal derived dataset worth keeping addressable; a lone
-                    # transform run by itself is a throwaway preview and stays unpersisted.
-                    consumed_downstream = len(steps) > 1
+                    # persisted DatasetRef -- when a later step exists (and can read it from
+                    # context["data"]), OR when this transform is the run's terminal step but
+                    # follows an earlier transform (part of a transform chain, so its output is
+                    # the chain's addressable end product). A lone terminal transform preceded
+                    # only by unrelated steps (e.g. a fit) is a throwaway preview and stays
+                    # unpersisted.
+                    is_last = i == len(steps) - 1
+                    consumed_downstream = (not is_last) or any(
+                        s.step_type == "transform" for s in steps[:i]
+                    )
                     step_results[step.id] = self._execute_pipeline_transform(
                         step, context, library, persist=consumed_downstream
                     )

--- a/rheojax/gui/services/pipeline_execution_service.py
+++ b/rheojax/gui/services/pipeline_execution_service.py
@@ -454,11 +454,8 @@ class PipelineExecutionService(QObject):
 
         path = step.config["path"]
         fmt = step.config.get("format")
-        try:
-            self._export_service.export_data(context["data"], path, format=fmt)
-            return {"paths": [path]}
-        except Exception:
-            return {"paths": []}
+        self._export_service.export_data(context["data"], path, format=fmt)
+        return {"paths": [path]}
 
     # ------------------------------------------------------------------
     # Internal routing

--- a/rheojax/gui/services/pipeline_execution_service.py
+++ b/rheojax/gui/services/pipeline_execution_service.py
@@ -258,7 +258,7 @@ class PipelineExecutionService(QObject):
                 elif step.step_type == "fit":
                     step_results[step.id] = self._execute_pipeline_fit(step, context)
                 elif step.step_type == "export":
-                    raise NotImplementedError("export step handling added in a later task")
+                    step_results[step.id] = self._execute_pipeline_export(step, context)
                 else:
                     raise ValueError(f"Unknown pipeline step_type: {step.step_type!r}")
             except WorkerIsolationRequiredError:
@@ -397,6 +397,25 @@ class PipelineExecutionService(QObject):
             result=captured.get("result"),
             error=captured.get("error"),
         )
+
+    def _execute_pipeline_export(self, step, context: dict) -> dict:
+        """Run one Pipeline-mode export step via ExportService.export_data.
+
+        Named distinctly from ``_execute_export`` (the visual pipeline
+        builder's handler below), which takes a different step shape and
+        supports multiple artefact types (fit/bayesian results too).
+        """
+        if self._export_service is None:
+            from rheojax.gui.services.export_service import ExportService
+            self._export_service = ExportService()
+
+        path = step.config["path"]
+        fmt = step.config.get("format")
+        try:
+            self._export_service.export_data(context["data"], path, format=fmt)
+            return {"paths": [path]}
+        except Exception:
+            return {"paths": []}
 
     # ------------------------------------------------------------------
     # Internal routing

--- a/rheojax/gui/workspace/fit/step2_data.py
+++ b/rheojax/gui/workspace/fit/step2_data.py
@@ -196,7 +196,6 @@ class DataStep(QWidget):
             return
         rheo_data = self._library.load_payload(self._state.data_ref)
         rheo_data.x = np.asarray(rheo_data.x) * (2 * np.pi)
-        self._library.store_payload(self._state.data_ref, rheo_data)
         # Persist the conversion in the library's authoritative units
         # metadata, not just this widget's transient _unit_converted flag --
         # _on_select() unconditionally resets that flag to False on every
@@ -204,8 +203,12 @@ class DataStep(QWidget):
         # SAME already-converted dataset. Without updating DatasetRef.units,
         # needs_hz_conversion() would report True again and a second click
         # would silently re-apply the x2pi conversion.
+        # add(overwrite=True) clears any stale payload under this id, so it
+        # must run BEFORE store_payload() re-establishes the converted data --
+        # doing it after would wipe out the very payload just stored.
         ref = self._library.get(self._state.data_ref)
-        self._library.add(replace(ref, units={**ref.units, "x": "rad/s"}))
+        self._library.add(replace(ref, units={**ref.units, "x": "rad/s"}), overwrite=True)
+        self._library.store_payload(self._state.data_ref, rheo_data)
         self._unit_converted = True
         self._guard.setText("")
         self.edited.emit()

--- a/rheojax/gui/workspace/fit/step6_export.py
+++ b/rheojax/gui/workspace/fit/step6_export.py
@@ -16,7 +16,7 @@ from rheojax.gui.utils.layout_helpers import set_panel_margins
 
 
 class ExportStep(QWidget):
-    exported = Signal()
+    dataset_commit_requested = Signal(object, object, bool)  # ref, payload | None, overwrite
 
     def __init__(
         self, state: FitState, library: DatasetLibrary, parent: QWidget | None = None
@@ -113,28 +113,25 @@ class ExportStep(QWidget):
 
     def save_to_library(self) -> str:
         new_id = f"{self._state.model_key}_fit_{self._state.revision}"
-        self._library.add(
-            DatasetRef(
-                id=new_id,
-                name=new_id,
-                protocol_type=self._state.protocol,
-                origin="derived",
-                units={},
-                row_count=0,
-                hash="",
-                provenance=self.provenance(),
-                lineage=(
-                    [self._state.data_ref]
-                    if self._state.data_ref
-                    else []
-                ),
-            )
+        ref = DatasetRef(
+            id=new_id,
+            name=new_id,
+            protocol_type=self._state.protocol,
+            origin="derived",
+            units={},
+            row_count=0,
+            hash="",
+            provenance=self.provenance(),
+            lineage=(
+                [self._state.data_ref]
+                if self._state.data_ref
+                else []
+            ),
         )
         result = self._state.nlsq_result or {}
         x, y_fit = result.get("x"), result.get("y_fit")
+        output = None
         if x is not None and y_fit is not None:
-            self._library.store_payload(
-                new_id, SimpleNamespace(x=np.asarray(x), y=np.asarray(y_fit))
-            )
-        self.exported.emit()
+            output = SimpleNamespace(x=np.asarray(x), y=np.asarray(y_fit))
+        self.dataset_commit_requested.emit(ref, output, True)
         return new_id

--- a/rheojax/gui/workspace/pipeline/batch_runner.py
+++ b/rheojax/gui/workspace/pipeline/batch_runner.py
@@ -1,0 +1,75 @@
+"""QRunnable driving PipelineExecutionService.execute() once per selected dataset, sequentially.
+
+This is the WT-side half of the job-commit split (design spec §3.3): _prepare_job_record() builds
+a plain-dict record shape (still holding raw, in-memory PhaseResult.result values -- persistence
+to job_results/*.hdf5 happens later, at Save time, in save_project_v2(); see the design note
+above this task's Interfaces section) but never mutates AppState directly -- that happens only
+in PipelineController._commit_job_result() (controller.py), the GUI-thread slot connected to
+dataset_run_finished.
+"""
+from __future__ import annotations
+
+from typing import Any
+
+from PySide6.QtCore import QRunnable
+
+from rheojax.gui.foundation.pipeline_bridge import pipeline_context_from_library
+from rheojax.gui.workspace.pipeline.models import FitStepResult
+
+
+class PipelineBatchRunner(QRunnable):
+    def __init__(self, service, steps, selected_dataset_ids, library, stop_requested) -> None:
+        super().__init__()
+        self._service = service
+        self._steps = steps
+        self._selected_dataset_ids = selected_dataset_ids
+        self._library = library
+        self._stop_requested = stop_requested
+
+    def run(self) -> None:
+        for dataset_id in self._selected_dataset_ids:
+            if self._stop_requested.is_set():
+                break
+            self._service.dataset_run_started.emit(dataset_id)
+            ctx = pipeline_context_from_library(self._library, [dataset_id])
+            steps_for_dataset = self._substitute_dataset_id(self._steps, dataset_id)
+            result = self._service.execute(
+                steps=steps_for_dataset, initial_context=ctx, library=self._library,
+                stop_requested=self._stop_requested,
+            )
+            record = self._prepare_job_record(dataset_id, result)
+            self._service.dataset_run_finished.emit(dataset_id, record)
+
+    @staticmethod
+    def _substitute_dataset_id(steps, dataset_id: str) -> list:
+        substituted = []
+        for step in steps:
+            new_config = dict(step.config)
+            if "path" in new_config and "{id}" in new_config["path"]:
+                new_config["path"] = new_config["path"].format(id=dataset_id)
+            substituted.append(type(step)(id=step.id, step_type=step.step_type, config=new_config))
+        return substituted
+
+    def _prepare_job_record(self, dataset_id: str, result) -> dict:
+        step_results_out: dict[str, Any] = {}
+        for step_id, step_result in result.step_results.items():
+            if isinstance(step_result, FitStepResult):
+                step_results_out[step_id] = {
+                    "step_type": "fit",
+                    "nlsq": self._phase_to_dict(step_result.nlsq),
+                    "nuts": self._phase_to_dict(step_result.nuts) if step_result.nuts else None,
+                }
+            else:
+                step_results_out[step_id] = {"step_type": "other", **step_result}
+
+        return {
+            "dataset_id": dataset_id,
+            "status": result.status,
+            "error": result.error,
+            "step_results": step_results_out,
+        }
+
+    @staticmethod
+    def _phase_to_dict(phase) -> dict:
+        # Deliberately NOT calling write_result_arrays() here -- see this task's design note.
+        return {"status": phase.status, "error": phase.error, "result": phase.result}

--- a/rheojax/gui/workspace/pipeline/cancel_runnable.py
+++ b/rheojax/gui/workspace/pipeline/cancel_runnable.py
@@ -1,0 +1,21 @@
+"""Dispatches a worker's .cancel() off the GUI thread.
+
+ProcessWorkerAdapter.cancel() (and FitWorker.cancel(), where applicable) performs a real
+SIGTERM/SIGKILL escalation with blocking process.join(timeout=...) calls (up to ~7 seconds
+combined by default). Calling it directly from the GUI thread would freeze the UI -- this
+QRunnable exists so callers submit it to QThreadPool.globalInstance() instead.
+"""
+from __future__ import annotations
+
+from typing import Any
+
+from PySide6.QtCore import QRunnable
+
+
+class CancelWorkerRunnable(QRunnable):
+    def __init__(self, worker: Any) -> None:
+        super().__init__()
+        self._worker = worker
+
+    def run(self) -> None:
+        self._worker.cancel()

--- a/rheojax/gui/workspace/pipeline/controller.py
+++ b/rheojax/gui/workspace/pipeline/controller.py
@@ -43,3 +43,14 @@ class PipelineController(WorkflowController):
         self._state.job_history.by_id[job_id] = record
         self._state.pipeline.job_id = job_id
         self._on_dirty()
+
+
+def build_pipeline_controller(app_state, service):
+    from rheojax.gui.workspace.controller import Step
+    from rheojax.gui.workspace.pipeline.step1_configure_run import PipelineConfigureRunStep
+
+    body = PipelineConfigureRunStep(app_state.pipeline, app_state.library)
+    ctl = PipelineController(app_state, service, on_dirty=lambda: setattr(app_state.project, "dirty", True))
+    ctl.steps = [Step(id="configure_run", title="Configure & Run", is_ready=body.is_ready, validate=lambda: True)]
+    ctl.reached = {0}
+    return ctl, [body]

--- a/rheojax/gui/workspace/pipeline/controller.py
+++ b/rheojax/gui/workspace/pipeline/controller.py
@@ -1,0 +1,45 @@
+"""PipelineController: Pipeline mode's WorkflowController plus the sole GUI-thread commit path
+for a finished batch job (design spec §3.3)."""
+from __future__ import annotations
+
+import uuid
+from typing import Callable
+
+from rheojax.gui.workspace.controller import WorkflowController
+
+# ponytail: Qt.AutoConnection (the connect() default) resolves to Direct for
+# same-thread emission and Queued for cross-thread emission, so it already
+# guarantees GUI-thread delivery when PipelineBatchRunner emits from a worker
+# thread. An explicit QueuedConnection would always defer to the next event
+# loop iteration -- which breaks pytest-qt's waitSignal() (its internal
+# listener fires synchronously and short-circuits the loop before a queued
+# slot on this object gets a chance to run).
+
+
+class PipelineController(WorkflowController):
+    STEP_IDS = ["configure_run"]
+
+    def __init__(self, app_state, service, on_dirty: Callable[[], None]) -> None:
+        self._state = app_state
+        self._service = service
+        self._on_dirty = on_dirty
+        super().__init__(steps=[])
+        self._service.dataset_run_started.connect(self._on_dataset_run_started)
+        self._service.dataset_run_finished.connect(self._commit_job_result)
+
+    def _on_dataset_run_started(self, dataset_id: str) -> None:
+        # Registers ONE dataset's active_jobs entry right before it starts running -- not the
+        # whole batch upfront. If the batch is cancelled mid-run, only the currently-running
+        # dataset is ever "active"; PipelineBatchRunner.run()'s stop_requested check (batch_runner.py)
+        # is what actually prevents it from advancing to the next queued dataset, so there's
+        # never a queued-but-never-cleared active_jobs entry (design spec §3.3's job-lifecycle
+        # rule; see this plan's window.py Task 10/11 for why pre-registering the whole batch was
+        # a bug).
+        self._state.active_jobs.by_id[dataset_id] = {"status": "running"}
+
+    def _commit_job_result(self, dataset_id: str, record: dict) -> None:
+        self._state.active_jobs.by_id.pop(dataset_id, None)
+        job_id = uuid.uuid4().hex
+        self._state.job_history.by_id[job_id] = record
+        self._state.pipeline.job_id = job_id
+        self._on_dirty()

--- a/rheojax/gui/workspace/pipeline/controller.py
+++ b/rheojax/gui/workspace/pipeline/controller.py
@@ -19,13 +19,28 @@ from rheojax.gui.workspace.controller import WorkflowController
 class PipelineController(WorkflowController):
     STEP_IDS = ["configure_run"]
 
-    def __init__(self, app_state, service, on_dirty: Callable[[], None]) -> None:
+    def __init__(
+        self,
+        app_state,
+        service,
+        on_dirty: Callable[[], None],
+        epoch: int = 0,
+        guard: Callable[[int, Callable], Callable] | None = None,
+    ) -> None:
         self._state = app_state
         self._service = service
         self._on_dirty = on_dirty
         super().__init__(steps=[])
-        self._service.dataset_run_started.connect(self._on_dataset_run_started)
-        self._service.dataset_run_finished.connect(self._commit_job_result)
+        on_started = self._on_dataset_run_started
+        on_finished = self._commit_job_result
+        # guard() no-ops these handlers once WorkspaceWindow._epoch advances past
+        # `epoch` (a rebuild happened), so a stale controller left connected to the
+        # persistent PipelineExecutionService can't write into a discarded AppState.
+        if guard is not None:
+            on_started = guard(epoch, on_started)
+            on_finished = guard(epoch, on_finished)
+        self._service.dataset_run_started.connect(on_started)
+        self._service.dataset_run_finished.connect(on_finished)
 
     def _on_dataset_run_started(self, dataset_id: str) -> None:
         # Registers ONE dataset's active_jobs entry right before it starts running -- not the
@@ -45,12 +60,18 @@ class PipelineController(WorkflowController):
         self._on_dirty()
 
 
-def build_pipeline_controller(app_state, service):
+def build_pipeline_controller(app_state, service, epoch: int = 0, guard=None):
     from rheojax.gui.workspace.controller import Step
     from rheojax.gui.workspace.pipeline.step1_configure_run import PipelineConfigureRunStep
 
     body = PipelineConfigureRunStep(app_state.pipeline, app_state.library)
-    ctl = PipelineController(app_state, service, on_dirty=lambda: setattr(app_state.project, "dirty", True))
+    ctl = PipelineController(
+        app_state,
+        service,
+        on_dirty=lambda: setattr(app_state.project, "dirty", True),
+        epoch=epoch,
+        guard=guard,
+    )
     ctl.steps = [Step(id="configure_run", title="Configure & Run", is_ready=body.is_ready, validate=lambda: True)]
     ctl.reached = {0}
     return ctl, [body]

--- a/rheojax/gui/workspace/pipeline/controller.py
+++ b/rheojax/gui/workspace/pipeline/controller.py
@@ -3,7 +3,7 @@ for a finished batch job (design spec §3.3)."""
 from __future__ import annotations
 
 import uuid
-from typing import Callable
+from collections.abc import Callable
 
 from rheojax.gui.workspace.controller import WorkflowController
 
@@ -62,7 +62,9 @@ class PipelineController(WorkflowController):
 
 def build_pipeline_controller(app_state, service, epoch: int = 0, guard=None):
     from rheojax.gui.workspace.controller import Step
-    from rheojax.gui.workspace.pipeline.step1_configure_run import PipelineConfigureRunStep
+    from rheojax.gui.workspace.pipeline.step1_configure_run import (
+        PipelineConfigureRunStep,
+    )
 
     body = PipelineConfigureRunStep(app_state.pipeline, app_state.library)
     ctl = PipelineController(

--- a/rheojax/gui/workspace/pipeline/models.py
+++ b/rheojax/gui/workspace/pipeline/models.py
@@ -1,0 +1,51 @@
+"""Runtime result/artifact shapes for Pipeline mode execution.
+
+Distinct from the persisted AppState dataclasses in foundation/state.py: PhaseResult.result
+holds a RAW result dict while a run is active/in-memory; PipelineBatchRunner._prepare_job_record
+(batch_runner.py) is what converts it into a JobResultRef (foundation/state.py) for persistence
+into AppState.job_history -- see design spec §3.2.
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any, Literal
+
+
+@dataclass
+class PhaseResult:
+    status: Literal["pending", "running", "completed", "failed", "cancelled"]
+    result: dict[str, Any] | None = None
+    error: str | None = None
+
+
+@dataclass
+class FitStepResult:
+    nlsq: PhaseResult
+    nuts: PhaseResult | None
+
+
+@dataclass
+class PipelineRunResult:
+    step_results: dict[str, FitStepResult | dict] = field(default_factory=dict)
+    status: Literal["completed", "failed", "cancelled"] = "completed"
+    error: str | None = None
+
+
+@dataclass
+class DatasetArtifact:
+    dataset_id: str
+    source_step_id: str
+    produced_at_revision: int
+
+
+@dataclass
+class FitArtifact:
+    step_id: str
+    source_dataset_id: str
+    result: FitStepResult
+
+
+@dataclass
+class FileArtifact:
+    step_id: str
+    paths: list[str] = field(default_factory=list)

--- a/rheojax/gui/workspace/pipeline/step1_configure_run.py
+++ b/rheojax/gui/workspace/pipeline/step1_configure_run.py
@@ -1,0 +1,153 @@
+"""Pipeline mode's single step body: assemble a step sequence, select datasets, Run All.
+
+No per-step "Run Step" button by design (design spec §3) -- running a single step interactively
+is already what Fit/Transform modes are for. This widget only supports batch orchestration.
+
+Each step type has real configuration controls (model/NUTS for "fit", path/format for
+"export", transform key for "transform") -- an earlier version of this widget only collected
+config for "transform" steps, so a user-added "fit" or "export" step had an empty {} config and
+failed with KeyError at execute() time. is_ready() now also validates that every configured
+step has the fields execute() actually requires, not just that the steps list is non-empty.
+"""
+from __future__ import annotations
+
+import uuid
+
+from PySide6.QtCore import Qt, Signal
+from PySide6.QtWidgets import (
+    QAbstractItemView,
+    QCheckBox,
+    QComboBox,
+    QLineEdit,
+    QListWidget,
+    QListWidgetItem,
+    QPushButton,
+    QVBoxLayout,
+    QWidget,
+)
+
+from rheojax.core.registry import ModelRegistry, TransformRegistry
+from rheojax.gui.foundation.state import PipelineStepConfig
+from rheojax.gui.workspace.transform.slots_spec import _MULTI, _TYPED_PAIRS
+
+_EXCLUDED_TRANSFORM_KEYS = set(_MULTI) | set(_TYPED_PAIRS)
+_DATASET_ID_ROLE = Qt.ItemDataRole.UserRole
+
+
+def _step_config_is_complete(step: PipelineStepConfig) -> bool:
+    """A step's config must actually satisfy what execute() requires for that step_type
+    (§3.2/§3.4) -- an empty {} is never valid for "fit" or "export"."""
+    if step.step_type == "transform":
+        return bool(step.config.get("name"))
+    if step.step_type == "fit":
+        return bool(step.config.get("model_name"))
+    if step.step_type == "export":
+        return bool(step.config.get("path"))
+    return False
+
+
+class PipelineConfigureRunStep(QWidget):
+    edited = Signal()
+    run_requested = Signal()
+
+    def __init__(self, state, library, parent: QWidget | None = None) -> None:
+        super().__init__(parent)
+        self._state = state
+        self._library = library
+
+        self._step_type_combo = QComboBox(self)
+        self._step_type_combo.addItems(["transform", "fit", "export"])
+
+        self._transform_key_combo = QComboBox(self)
+        self._transform_key_combo.addItems(self.available_transform_keys())
+
+        self._fit_model_combo = QComboBox(self)
+        self._fit_model_combo.addItems(ModelRegistry.list_models())
+        self._fit_run_nuts_checkbox = QCheckBox("Run NUTS after NLSQ", self)
+
+        self._export_path_edit = QLineEdit(self)
+        self._export_path_edit.setPlaceholderText("/path/to/output_{id}.csv  ({id} = dataset id)")
+        self._export_format_combo = QComboBox(self)
+        self._export_format_combo.addItems(["csv", "json", "xlsx", "hdf5"])
+
+        self._add_step_btn = QPushButton("+ Add Step", self)
+        self._add_step_btn.clicked.connect(self._on_add_step_clicked)
+        self._step_list = QListWidget(self)
+        self._remove_step_btn = QPushButton("Remove Selected Step", self)
+        self._remove_step_btn.clicked.connect(self._on_remove_step_clicked)
+
+        self._dataset_list = QListWidget(self)
+        self._dataset_list.setSelectionMode(QAbstractItemView.SelectionMode.ExtendedSelection)
+        self._refresh_dataset_list()
+        self._dataset_list.itemSelectionChanged.connect(self._on_dataset_selection_changed)
+
+        self._run_all_btn = QPushButton("▶ Run All", self)
+        self._run_all_btn.clicked.connect(self.run_requested.emit)
+
+        layout = QVBoxLayout(self)
+        layout.addWidget(self._step_type_combo)
+        layout.addWidget(self._transform_key_combo)
+        layout.addWidget(self._fit_model_combo)
+        layout.addWidget(self._fit_run_nuts_checkbox)
+        layout.addWidget(self._export_path_edit)
+        layout.addWidget(self._export_format_combo)
+        layout.addWidget(self._add_step_btn)
+        layout.addWidget(self._step_list)
+        layout.addWidget(self._remove_step_btn)
+        layout.addWidget(self._dataset_list)
+        layout.addWidget(self._run_all_btn)
+
+    def available_transform_keys(self) -> list[str]:
+        return [k for k in TransformRegistry.list_transforms() if k not in _EXCLUDED_TRANSFORM_KEYS]
+
+    def add_step(self, step_type: str, config: dict) -> None:
+        step = PipelineStepConfig(id=uuid.uuid4().hex, step_type=step_type, config=dict(config))
+        self._state.steps.append(step)
+        self._step_list.addItem(QListWidgetItem(f"{step.step_type}: {step.config}"))
+        self.edited.emit()
+
+    def _on_add_step_clicked(self) -> None:
+        step_type = self._step_type_combo.currentText()
+        if step_type == "transform":
+            config = {"name": self._transform_key_combo.currentText()}
+        elif step_type == "fit":
+            config = {
+                "model_name": self._fit_model_combo.currentText(),
+                "run_nuts": self._fit_run_nuts_checkbox.isChecked(),
+            }
+        else:  # "export"
+            config = {
+                "path": self._export_path_edit.text(),
+                "format": self._export_format_combo.currentText(),
+            }
+        self.add_step(step_type, config)
+
+    def _on_remove_step_clicked(self) -> None:
+        row = self._step_list.currentRow()
+        if row < 0:
+            return
+        self._step_list.takeItem(row)
+        del self._state.steps[row]
+        self.edited.emit()
+
+    def _refresh_dataset_list(self) -> None:
+        self._dataset_list.clear()
+        for ref in self._library.all():
+            item = QListWidgetItem(ref.name)
+            item.setData(_DATASET_ID_ROLE, ref.id)
+            self._dataset_list.addItem(item)
+
+    def set_selected_dataset_ids(self, ids: list[str]) -> None:
+        self._state.selected_dataset_ids = list(ids)
+        self.edited.emit()
+
+    def _on_dataset_selection_changed(self) -> None:
+        selected = [item.data(_DATASET_ID_ROLE) for item in self._dataset_list.selectedItems()]
+        self.set_selected_dataset_ids(selected)
+
+    def is_ready(self) -> bool:
+        return (
+            bool(self._state.steps)
+            and all(_step_config_is_complete(s) for s in self._state.steps)
+            and bool(self._state.selected_dataset_ids)
+        )

--- a/rheojax/gui/workspace/transform/step5_export.py
+++ b/rheojax/gui/workspace/transform/step5_export.py
@@ -14,7 +14,7 @@ from rheojax.gui.utils.layout_helpers import set_panel_margins
 
 
 class TransformExportStep(QWidget):
-    exported = Signal()
+    dataset_commit_requested = Signal(object, object, bool)  # ref, payload | None, overwrite
 
     def __init__(
         self,
@@ -100,21 +100,17 @@ class TransformExportStep(QWidget):
                 lineage.extend(str(x) for x in v)
             elif v is not None:
                 lineage.append(str(v))
-        self._library.add(
-            DatasetRef(
-                id=new_id,
-                name=new_id,
-                protocol_type=ptype,
-                origin="derived",
-                units={},
-                row_count=0,
-                hash="",
-                provenance=self.provenance(),
-                lineage=lineage,
-            )
+        ref = DatasetRef(
+            id=new_id,
+            name=new_id,
+            protocol_type=ptype,
+            origin="derived",
+            units={},
+            row_count=0,
+            hash="",
+            provenance=self.provenance(),
+            lineage=lineage,
         )
         output = (self._state.result or {}).get("output")
-        if output is not None:
-            self._library.store_payload(new_id, output)
-        self.exported.emit()
+        self.dataset_commit_requested.emit(ref, output, False)
         return new_id

--- a/rheojax/gui/workspace/transform/transform_controller.py
+++ b/rheojax/gui/workspace/transform/transform_controller.py
@@ -41,7 +41,7 @@ def _is_same_domain(transform_key: str) -> bool:
     return category not in _DOMAIN_CHANGING
 
 
-def _infer_protocol_type(library, transform_key, slots) -> str:
+def infer_output_protocol(library, transform_key, slots) -> str:
     """Same-domain transforms (superposition/processing/analysis) plausibly
     keep the input's protocol type; domain-changing transforms (spectral/
     decomposition), and any case where the input protocol can't be resolved,
@@ -115,7 +115,7 @@ def _make_run_fn(library):
             "input": data,
             "output": tr.data,
             "result": tr.extras,
-            "protocol_type": _infer_protocol_type(library, transform_key, slots),
+            "protocol_type": infer_output_protocol(library, transform_key, slots),
         }
     return _run
 

--- a/rheojax/gui/workspace/window.py
+++ b/rheojax/gui/workspace/window.py
@@ -437,6 +437,12 @@ class WorkspaceWindow(QMainWindow):
         pass  # mirrors _on_fit_body_edited/_on_transform_body_edited's advance-eligibility recheck
 
     def _on_pipeline_run_requested(self) -> None:
+        if self._state.active_jobs.by_id:
+            # A batch is already running -- ignore a repeat "Run All" trigger rather than
+            # starting a second PipelineBatchRunner, which would orphan the first runner's
+            # stop event and race active_jobs/DatasetLibrary from two worker threads.
+            return
+
         from PySide6.QtCore import QThreadPool
 
         from rheojax.gui.workspace.pipeline.batch_runner import PipelineBatchRunner

--- a/rheojax/gui/workspace/window.py
+++ b/rheojax/gui/workspace/window.py
@@ -146,16 +146,23 @@ class WorkspaceWindow(QMainWindow):
         self._maybe_confirm_unsaved_changes(lambda: self._rebuild(AppState()))
 
     def _on_open(self) -> None:
-        from PySide6.QtWidgets import QFileDialog
+        from PySide6.QtWidgets import QFileDialog, QMessageBox
 
         def _open():
             path, _ = QFileDialog.getOpenFileName(
                 self, "Open Project", "", "RheoJAX Project (*.rheojax)"
             )
             if path:
+                from zipfile import BadZipFile
+
                 from rheojax.gui.foundation.project_codec import load_project_v2
 
-                self._rebuild(load_project_v2(path))
+                try:
+                    new_state = load_project_v2(path)
+                except (ValueError, FileNotFoundError, OSError, BadZipFile) as exc:
+                    QMessageBox.critical(self, "Open Failed", str(exc))
+                    return
+                self._rebuild(new_state)
                 self._state.project.dirty = False
                 self._state.project.path = path
 
@@ -165,13 +172,19 @@ class WorkspaceWindow(QMainWindow):
         if self._state.project.path is None:
             self._on_save_as()
             return
+        from PySide6.QtWidgets import QMessageBox
+
         from rheojax.gui.foundation.project_codec import save_project_v2
 
-        save_project_v2(self._state, self._state.project.path)
+        try:
+            save_project_v2(self._state, self._state.project.path)
+        except (ValueError, FileNotFoundError, OSError) as exc:
+            QMessageBox.critical(self, "Save Failed", str(exc))
+            return
         self._state.project.dirty = False
 
     def _on_save_as(self) -> None:
-        from PySide6.QtWidgets import QFileDialog
+        from PySide6.QtWidgets import QFileDialog, QMessageBox
 
         path, _ = QFileDialog.getSaveFileName(
             self, "Save Project As", "", "RheoJAX Project (*.rheojax)"
@@ -179,7 +192,11 @@ class WorkspaceWindow(QMainWindow):
         if path:
             from rheojax.gui.foundation.project_codec import save_project_v2
 
-            save_project_v2(self._state, path)
+            try:
+                save_project_v2(self._state, path)
+            except (ValueError, FileNotFoundError, OSError) as exc:
+                QMessageBox.critical(self, "Save Failed", str(exc))
+                return
             self._state.project.path = path
             self._state.project.name = Path(path).stem
             self._state.project.dirty = False
@@ -203,7 +220,8 @@ class WorkspaceWindow(QMainWindow):
         )
         if choice == QMessageBox.StandardButton.Save:
             self._on_save()
-            proceed()
+            if not self._state.project.dirty:
+                proceed()
         elif choice == QMessageBox.StandardButton.Discard:
             proceed()
 

--- a/rheojax/gui/workspace/window.py
+++ b/rheojax/gui/workspace/window.py
@@ -36,6 +36,10 @@ class WorkspaceWindow(QMainWindow):
         self._notifier.changed.connect(self._mark_dirty)
         self._pipeline_service = PipelineExecutionService()
         self._pipeline_stop_event: threading.Event | None = None
+        self._active_jobs_action_pending = False
+        self._pipeline_service.phase_worker_ready.connect(
+            self._on_phase_worker_ready, Qt.ConnectionType.QueuedConnection
+        )
 
         self.setWindowTitle("RheoJAX Workspace")
         self.resize(1200, 800)
@@ -176,7 +180,9 @@ class WorkspaceWindow(QMainWindow):
         return wrapped
 
     def _on_new(self) -> None:
-        self._maybe_confirm_unsaved_changes(lambda: self._rebuild(AppState()))
+        self._maybe_confirm_active_jobs(
+            lambda: self._maybe_confirm_unsaved_changes(lambda: self._rebuild(AppState()))
+        )
 
     def _on_open(self) -> None:
         from PySide6.QtWidgets import QFileDialog, QMessageBox
@@ -199,7 +205,9 @@ class WorkspaceWindow(QMainWindow):
                 self._state.project.dirty = False
                 self._state.project.path = path
 
-        self._maybe_confirm_unsaved_changes(_open)
+        self._maybe_confirm_active_jobs(
+            lambda: self._maybe_confirm_unsaved_changes(_open)
+        )
 
     def _on_save(self) -> None:
         if self._state.project.path is None:
@@ -235,7 +243,60 @@ class WorkspaceWindow(QMainWindow):
             self._state.project.dirty = False
 
     def _on_close(self) -> None:
-        self._maybe_confirm_unsaved_changes(lambda: self._rebuild(AppState()))
+        self._maybe_confirm_active_jobs(
+            lambda: self._maybe_confirm_unsaved_changes(lambda: self._rebuild(AppState()))
+        )
+
+    def _maybe_confirm_active_jobs(self, proceed) -> None:
+        if not self._state.active_jobs.by_id:
+            proceed()
+            return
+        if self._active_jobs_action_pending:
+            # A Close/New/Open request is already being handled (dialog shown or poll in
+            # flight) -- ignore this second trigger rather than showing a second dialog or
+            # starting a second, independent polling chain that could both call proceed().
+            return
+        self._active_jobs_action_pending = True
+
+        from PySide6.QtWidgets import QMessageBox
+
+        choice = QMessageBox.question(
+            self, "Jobs Running",
+            f"{len(self._state.active_jobs.by_id)} job(s) still running. Cancel them and continue?",
+            QMessageBox.StandardButton.Yes | QMessageBox.StandardButton.Cancel,
+            QMessageBox.StandardButton.Cancel,
+        )
+        if choice != QMessageBox.StandardButton.Yes:
+            self._active_jobs_action_pending = False
+            return
+
+        from PySide6.QtCore import QThreadPool
+
+        from rheojax.gui.workspace.pipeline.cancel_runnable import CancelWorkerRunnable
+
+        if self._pipeline_stop_event is not None:
+            self._pipeline_stop_event.set()  # stops PipelineBatchRunner from advancing to
+                                               # further queued datasets (Task 7's run() loop)
+        for job in self._state.active_jobs.by_id.values():
+            worker = job.get("worker")
+            if worker is not None:
+                QThreadPool.globalInstance().start(CancelWorkerRunnable(worker))
+
+        self._poll_active_jobs_then(proceed, remaining_polls=120)  # 120 * 250ms = 30s
+
+    def _poll_active_jobs_then(self, proceed, remaining_polls: int) -> None:
+        if not self._state.active_jobs.by_id or remaining_polls <= 0:
+            self._active_jobs_action_pending = False
+            proceed()
+            return
+        from PySide6.QtCore import QTimer
+
+        QTimer.singleShot(250, lambda: self._poll_active_jobs_then(proceed, remaining_polls - 1))
+
+    def _on_phase_worker_ready(self, dataset_id: str, step_id: str, phase: str, worker) -> None:
+        job = self._state.active_jobs.by_id.get(dataset_id)
+        if job is not None:
+            job["worker"] = worker
 
     def _maybe_confirm_unsaved_changes(self, proceed) -> None:
         if not self._state.project.dirty:

--- a/rheojax/gui/workspace/window.py
+++ b/rheojax/gui/workspace/window.py
@@ -80,7 +80,9 @@ class WorkspaceWindow(QMainWindow):
 
         fit_ctl, self._fit_bodies = build_fit_controller(state)
         transform_ctl, self._transform_bodies = build_transform_controller(state)
-        pipeline_ctl, self._pipeline_bodies = build_pipeline_controller(state, self._pipeline_service)
+        pipeline_ctl, self._pipeline_bodies = build_pipeline_controller(
+            state, self._pipeline_service, epoch=self._epoch, guard=self._guard
+        )
         self._controllers = {
             "fit": fit_ctl,
             "transform": transform_ctl,

--- a/rheojax/gui/workspace/window.py
+++ b/rheojax/gui/workspace/window.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+from pathlib import Path
+
 from PySide6.QtCore import Qt, Signal
 from PySide6.QtWidgets import (
     QLabel,
@@ -27,13 +29,43 @@ class WorkspaceWindow(QMainWindow):
 
     def __init__(self, app_state: AppState, parent: QWidget | None = None) -> None:
         super().__init__(parent)
-        self._state = app_state
-        initial_mode = app_state.ui.mode
-        self._mode = initial_mode if initial_mode in self.MODES else "fit"
+        self._epoch = 0
         self._notifier = DatasetLibraryNotifier()
         self._notifier.changed.connect(self._mark_dirty)
-        fit_ctl, self._fit_bodies = build_fit_controller(app_state)
-        transform_ctl, self._transform_bodies = build_transform_controller(app_state)
+
+        self.setWindowTitle("RheoJAX Workspace")
+        self.resize(1200, 800)
+
+        bar = QToolBar(self)
+        self.addToolBar(bar)
+        self._fit_btn = QPushButton("Fit", self)
+        self._tx_btn = QPushButton("Transform", self)
+        self._fit_btn.setCheckable(True)
+        self._tx_btn.setCheckable(True)
+        self._fit_btn.clicked.connect(lambda: self.set_mode("fit"))
+        self._tx_btn.clicked.connect(lambda: self.set_mode("transform"))
+        bar.addWidget(self._fit_btn)
+        bar.addWidget(self._tx_btn)
+        self._status_label = QLabel(self)
+        bar.addWidget(self._status_label)
+        self._build_file_menu()
+
+        self._build_workspace(app_state)
+
+    def _build_file_menu(self) -> None:
+        menu = self.menuBar().addMenu("&File")
+        menu.addAction("&New", self._on_new, "Ctrl+N")
+        menu.addAction("&Open...", self._on_open, "Ctrl+O")
+        menu.addAction("&Save", self._on_save, "Ctrl+S")
+        menu.addAction("Save &As...", self._on_save_as, "Ctrl+Shift+S")
+        menu.addAction("&Close", self._on_close)
+
+    def _build_workspace(self, state: AppState) -> None:
+        self._state = state
+        initial_mode = state.ui.mode
+        self._mode = initial_mode if initial_mode in self.MODES else "fit"
+        fit_ctl, self._fit_bodies = build_fit_controller(state)
+        transform_ctl, self._transform_bodies = build_transform_controller(state)
         self._controllers = {
             "fit": fit_ctl,
             "transform": transform_ctl,
@@ -55,25 +87,10 @@ class WorkspaceWindow(QMainWindow):
             if hasattr(body, "dataset_commit_requested"):
                 body.dataset_commit_requested.connect(self._commit_dataset)
 
-        self.setWindowTitle("RheoJAX Workspace")
-        self.resize(1200, 800)
-
-        bar = QToolBar(self)
-        self.addToolBar(bar)
-        self._fit_btn = QPushButton("Fit", self)
-        self._tx_btn = QPushButton("Transform", self)
-        self._fit_btn.setCheckable(True)
-        self._tx_btn.setCheckable(True)
-        self._fit_btn.clicked.connect(lambda: self.set_mode("fit"))
-        self._tx_btn.clicked.connect(lambda: self.set_mode("transform"))
-        bar.addWidget(self._fit_btn)
-        bar.addWidget(self._tx_btn)
-        self._status_label = QLabel(self)
-        bar.addWidget(self._status_label)
         self._sync_mode_buttons()
         self._refresh_status_label()
 
-        self._rail = LibraryRail(app_state.library, self)
+        self._rail = LibraryRail(state.library, self)
         self._inspector = InspectorPanel(self)
         self._canvas = StepperCanvas(self._controllers[self._mode], self)
         self._wire_canvas(self._canvas)
@@ -83,6 +100,112 @@ class WorkspaceWindow(QMainWindow):
         self._splitter.addWidget(self._canvas)
         self._splitter.addWidget(self._inspector)
         self.setCentralWidget(self._splitter)
+
+    def _dispose_workspace(self) -> None:
+        for body in list(self._fit_bodies) + list(self._transform_bodies):
+            if hasattr(body, "edited"):
+                try:
+                    body.edited.disconnect(self._on_fit_body_edited)
+                except (RuntimeError, TypeError):
+                    pass
+                try:
+                    body.edited.disconnect(self._on_transform_body_edited)
+                except (RuntimeError, TypeError):
+                    pass
+            if hasattr(body, "config_edited"):
+                try:
+                    body.config_edited.disconnect(self._on_fit_body_edited)
+                except (RuntimeError, TypeError):
+                    pass
+            if hasattr(body, "dataset_commit_requested"):
+                try:
+                    body.dataset_commit_requested.disconnect(self._commit_dataset)
+                except (RuntimeError, TypeError):
+                    pass
+            body.deleteLater()
+        for widget in (self._canvas, self._rail, self._inspector, self._splitter):
+            widget.deleteLater()
+        self._controllers = {}
+        self._fit_bodies = []
+        self._transform_bodies = []
+
+    def _rebuild(self, new_state: AppState) -> None:
+        self._epoch += 1
+        self._dispose_workspace()
+        self._build_workspace(new_state)
+
+    def _guard(self, epoch_at_connect: int, fn):
+        def wrapped(*args, **kwargs):
+            if epoch_at_connect == self._epoch:
+                return fn(*args, **kwargs)
+            return None
+
+        return wrapped
+
+    def _on_new(self) -> None:
+        self._maybe_confirm_unsaved_changes(lambda: self._rebuild(AppState()))
+
+    def _on_open(self) -> None:
+        from PySide6.QtWidgets import QFileDialog
+
+        def _open():
+            path, _ = QFileDialog.getOpenFileName(
+                self, "Open Project", "", "RheoJAX Project (*.rheojax)"
+            )
+            if path:
+                from rheojax.gui.foundation.project_codec import load_project_v2
+
+                self._rebuild(load_project_v2(path))
+                self._state.project.dirty = False
+                self._state.project.path = path
+
+        self._maybe_confirm_unsaved_changes(_open)
+
+    def _on_save(self) -> None:
+        if self._state.project.path is None:
+            self._on_save_as()
+            return
+        from rheojax.gui.foundation.project_codec import save_project_v2
+
+        save_project_v2(self._state, self._state.project.path)
+        self._state.project.dirty = False
+
+    def _on_save_as(self) -> None:
+        from PySide6.QtWidgets import QFileDialog
+
+        path, _ = QFileDialog.getSaveFileName(
+            self, "Save Project As", "", "RheoJAX Project (*.rheojax)"
+        )
+        if path:
+            from rheojax.gui.foundation.project_codec import save_project_v2
+
+            save_project_v2(self._state, path)
+            self._state.project.path = path
+            self._state.project.name = Path(path).stem
+            self._state.project.dirty = False
+
+    def _on_close(self) -> None:
+        self._maybe_confirm_unsaved_changes(lambda: self._rebuild(AppState()))
+
+    def _maybe_confirm_unsaved_changes(self, proceed) -> None:
+        if not self._state.project.dirty:
+            proceed()
+            return
+        from PySide6.QtWidgets import QMessageBox
+
+        choice = QMessageBox.question(
+            self,
+            "Unsaved Changes",
+            "Save changes before continuing?",
+            QMessageBox.StandardButton.Save
+            | QMessageBox.StandardButton.Discard
+            | QMessageBox.StandardButton.Cancel,
+        )
+        if choice == QMessageBox.StandardButton.Save:
+            self._on_save()
+            proceed()
+        elif choice == QMessageBox.StandardButton.Discard:
+            proceed()
 
     def mode(self) -> str:
         return self._mode

--- a/rheojax/gui/workspace/window.py
+++ b/rheojax/gui/workspace/window.py
@@ -10,6 +10,7 @@ from PySide6.QtWidgets import (
     QWidget,
 )
 
+from rheojax.gui.foundation.notifier import DatasetLibraryNotifier
 from rheojax.gui.foundation.state import AppState
 from rheojax.gui.workspace.fit.fit_controller import build_fit_controller
 from rheojax.gui.workspace.inspector import InspectorPanel
@@ -27,8 +28,10 @@ class WorkspaceWindow(QMainWindow):
     def __init__(self, app_state: AppState, parent: QWidget | None = None) -> None:
         super().__init__(parent)
         self._state = app_state
-        initial_mode = app_state.ui.get("mode", "fit")
+        initial_mode = app_state.ui.mode
         self._mode = initial_mode if initial_mode in self.MODES else "fit"
+        self._notifier = DatasetLibraryNotifier()
+        self._notifier.changed.connect(self._mark_dirty)
         fit_ctl, self._fit_bodies = build_fit_controller(app_state)
         transform_ctl, self._transform_bodies = build_transform_controller(app_state)
         self._controllers = {
@@ -44,9 +47,13 @@ class WorkspaceWindow(QMainWindow):
                 body.edited.connect(self._on_fit_body_edited)
             if hasattr(body, "config_edited"):
                 body.config_edited.connect(self._on_fit_body_edited)
+            if hasattr(body, "dataset_commit_requested"):
+                body.dataset_commit_requested.connect(self._commit_dataset)
         for body in self._transform_bodies:
             if hasattr(body, "edited"):
                 body.edited.connect(self._on_transform_body_edited)
+            if hasattr(body, "dataset_commit_requested"):
+                body.dataset_commit_requested.connect(self._commit_dataset)
 
         self.setWindowTitle("RheoJAX Workspace")
         self.resize(1200, 800)
@@ -102,9 +109,18 @@ class WorkspaceWindow(QMainWindow):
         if old_canvas is not None:
             old_canvas.deleteLater()
         self._canvas = new_canvas
-        self._state.ui["mode"] = mode
+        self._state.ui.mode = mode
         self._sync_mode_buttons()
         self.mode_changed.emit(mode)
+
+    def _mark_dirty(self) -> None:
+        self._state.project.dirty = True
+
+    def _commit_dataset(self, ref, payload=None, overwrite: bool = False) -> None:
+        self._state.library.add(ref, overwrite=overwrite)
+        if payload is not None:
+            self._state.library.store_payload(ref.id, payload)
+        self._notifier.changed.emit()
 
     def _sync_mode_buttons(self) -> None:
         self._fit_btn.setChecked(self._mode == "fit")

--- a/rheojax/gui/workspace/window.py
+++ b/rheojax/gui/workspace/window.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import threading
 from pathlib import Path
 
 from PySide6.QtCore import Qt, Signal
@@ -14,6 +15,7 @@ from PySide6.QtWidgets import (
 
 from rheojax.gui.foundation.notifier import DatasetLibraryNotifier
 from rheojax.gui.foundation.state import AppState
+from rheojax.gui.services.pipeline_execution_service import PipelineExecutionService
 from rheojax.gui.workspace.fit.fit_controller import build_fit_controller
 from rheojax.gui.workspace.inspector import InspectorPanel
 from rheojax.gui.workspace.library_rail import LibraryRail
@@ -25,13 +27,15 @@ from rheojax.gui.workspace.transform.transform_controller import (
 
 class WorkspaceWindow(QMainWindow):
     mode_changed = Signal(str)
-    MODES = ("fit", "transform")
+    MODES = ("fit", "transform", "pipeline")
 
     def __init__(self, app_state: AppState, parent: QWidget | None = None) -> None:
         super().__init__(parent)
         self._epoch = 0
         self._notifier = DatasetLibraryNotifier()
         self._notifier.changed.connect(self._mark_dirty)
+        self._pipeline_service = PipelineExecutionService()
+        self._pipeline_stop_event: threading.Event | None = None
 
         self.setWindowTitle("RheoJAX Workspace")
         self.resize(1200, 800)
@@ -40,12 +44,16 @@ class WorkspaceWindow(QMainWindow):
         self.addToolBar(bar)
         self._fit_btn = QPushButton("Fit", self)
         self._tx_btn = QPushButton("Transform", self)
+        self._pipeline_btn = QPushButton("Pipeline", self)
         self._fit_btn.setCheckable(True)
         self._tx_btn.setCheckable(True)
+        self._pipeline_btn.setCheckable(True)
         self._fit_btn.clicked.connect(lambda: self.set_mode("fit"))
         self._tx_btn.clicked.connect(lambda: self.set_mode("transform"))
+        self._pipeline_btn.clicked.connect(lambda: self.set_mode("pipeline"))
         bar.addWidget(self._fit_btn)
         bar.addWidget(self._tx_btn)
+        bar.addWidget(self._pipeline_btn)
         self._status_label = QLabel(self)
         bar.addWidget(self._status_label)
         self._build_file_menu()
@@ -64,11 +72,20 @@ class WorkspaceWindow(QMainWindow):
         self._state = state
         initial_mode = state.ui.mode
         self._mode = initial_mode if initial_mode in self.MODES else "fit"
+        from rheojax.gui.workspace.pipeline.controller import build_pipeline_controller
+
         fit_ctl, self._fit_bodies = build_fit_controller(state)
         transform_ctl, self._transform_bodies = build_transform_controller(state)
+        pipeline_ctl, self._pipeline_bodies = build_pipeline_controller(state, self._pipeline_service)
         self._controllers = {
             "fit": fit_ctl,
             "transform": transform_ctl,
+            "pipeline": pipeline_ctl,
+        }
+        self._body_lists = {
+            "fit": self._fit_bodies,
+            "transform": self._transform_bodies,
+            "pipeline": self._pipeline_bodies,
         }
         # Auto-advance each workflow whenever a step's edits make it ready.
         # Connected after build_*_controller so each body's own edited ->
@@ -86,6 +103,11 @@ class WorkspaceWindow(QMainWindow):
                 body.edited.connect(self._on_transform_body_edited)
             if hasattr(body, "dataset_commit_requested"):
                 body.dataset_commit_requested.connect(self._commit_dataset)
+        for body in self._pipeline_bodies:
+            if hasattr(body, "edited"):
+                body.edited.connect(self._on_pipeline_body_edited)
+            if hasattr(body, "run_requested"):
+                body.run_requested.connect(self._on_pipeline_run_requested)
 
         self._sync_mode_buttons()
         self._refresh_status_label()
@@ -102,7 +124,7 @@ class WorkspaceWindow(QMainWindow):
         self.setCentralWidget(self._splitter)
 
     def _dispose_workspace(self) -> None:
-        for body in list(self._fit_bodies) + list(self._transform_bodies):
+        for body in list(self._fit_bodies) + list(self._transform_bodies) + list(self._pipeline_bodies):
             if hasattr(body, "edited"):
                 try:
                     body.edited.disconnect(self._on_fit_body_edited)
@@ -110,6 +132,10 @@ class WorkspaceWindow(QMainWindow):
                     pass
                 try:
                     body.edited.disconnect(self._on_transform_body_edited)
+                except (RuntimeError, TypeError):
+                    pass
+                try:
+                    body.edited.disconnect(self._on_pipeline_body_edited)
                 except (RuntimeError, TypeError):
                     pass
             if hasattr(body, "config_edited"):
@@ -122,12 +148,19 @@ class WorkspaceWindow(QMainWindow):
                     body.dataset_commit_requested.disconnect(self._commit_dataset)
                 except (RuntimeError, TypeError):
                     pass
+            if hasattr(body, "run_requested"):
+                try:
+                    body.run_requested.disconnect(self._on_pipeline_run_requested)
+                except (RuntimeError, TypeError):
+                    pass
             body.deleteLater()
         for widget in (self._canvas, self._rail, self._inspector, self._splitter):
             widget.deleteLater()
         self._controllers = {}
+        self._body_lists = {}
         self._fit_bodies = []
         self._transform_bodies = []
+        self._pipeline_bodies = []
 
     def _rebuild(self, new_state: AppState) -> None:
         self._epoch += 1
@@ -233,7 +266,7 @@ class WorkspaceWindow(QMainWindow):
             raise ValueError(f"unknown mode {mode!r}; expected one of {self.MODES}")
         if mode == self._mode:
             return
-        old_bodies = self._fit_bodies if self._mode == "fit" else self._transform_bodies
+        old_bodies = self._body_lists[self._mode]
         self._mode = mode
         new_canvas = StepperCanvas(self._controllers[mode], self)
         self._wire_canvas(new_canvas)
@@ -266,6 +299,7 @@ class WorkspaceWindow(QMainWindow):
     def _sync_mode_buttons(self) -> None:
         self._fit_btn.setChecked(self._mode == "fit")
         self._tx_btn.setChecked(self._mode == "transform")
+        self._pipeline_btn.setChecked(self._mode == "pipeline")
 
     def _refresh_status_label(self) -> None:
         # ponytail: "active project" status deferred — needs the Plan 3/4
@@ -287,7 +321,7 @@ class WorkspaceWindow(QMainWindow):
         return self._transform_bodies
 
     def _install_bodies(self, mode: str, canvas: StepperCanvas) -> None:
-        bodies = self._fit_bodies if mode == "fit" else self._transform_bodies
+        bodies = self._body_lists[mode]
         for i, body in enumerate(bodies):
             canvas.set_body(i, body)
 
@@ -335,3 +369,20 @@ class WorkspaceWindow(QMainWindow):
 
     def _on_transform_body_edited(self) -> None:
         self._advance_and_unlock("transform")
+
+    def _on_pipeline_body_edited(self) -> None:
+        pass  # mirrors _on_fit_body_edited/_on_transform_body_edited's advance-eligibility recheck
+
+    def _on_pipeline_run_requested(self) -> None:
+        from PySide6.QtCore import QThreadPool
+
+        from rheojax.gui.workspace.pipeline.batch_runner import PipelineBatchRunner
+
+        pipeline_state = self._state.pipeline
+        self._pipeline_stop_event = threading.Event()
+        runner = PipelineBatchRunner(
+            service=self._pipeline_service, steps=pipeline_state.steps,
+            selected_dataset_ids=pipeline_state.selected_dataset_ids, library=self._state.library,
+            stop_requested=self._pipeline_stop_event,
+        )
+        QThreadPool.globalInstance().start(runner)

--- a/tests/gui/foundation/test_import_service.py
+++ b/tests/gui/foundation/test_import_service.py
@@ -1,5 +1,8 @@
+import numpy as np
 import pytest
 
+from rheojax.core.data import RheoData
+from rheojax.gui.foundation import import_service
 from rheojax.gui.foundation.import_service import import_dataset
 
 
@@ -15,6 +18,53 @@ def test_import_dataset_sets_protocol_and_metadata(tmp_path):
     assert ref.origin == "imported"
     assert ref.id  # non-empty uuid4 hex
     assert data.test_mode == "oscillation"
+
+
+def test_import_dataset_converts_hz_to_rad_per_s(tmp_path, monkeypatch):
+    # rheojax.io's generic-CSV auto-detect only recognizes bare x-column
+    # headers ("omega", "frequency", ...) -- a real Hz-labeled instrument
+    # export signals units via a separate metadata row/field, not a header
+    # a hand-rolled CSV can trivially reproduce. Stub auto_load to return
+    # what the reader hands back in that case (x_units="Hz", x unconverted)
+    # so this test isolates import_dataset's own conversion/unit-recording
+    # logic -- the thing this fix actually changes -- from that reader detail.
+    csv_path = tmp_path / "data.csv"
+    csv_path.write_text("placeholder\n")
+    raw = RheoData(
+        x=np.array([0.1, 1.0, 10.0]),
+        y=np.array([100.0 + 10.0j, 150.0 + 20.0j, 200.0 + 50.0j]),
+        x_units="Hz",
+        y_units="Pa",
+        domain="frequency",
+    )
+    monkeypatch.setattr(import_service, "auto_load", lambda path: raw)
+
+    ref, data = import_dataset(csv_path, "oscillation")
+
+    np.testing.assert_allclose(
+        np.asarray(data.x), np.array([0.1, 1.0, 10.0]) * (2 * np.pi)
+    )
+    assert data.x_units == "rad/s"
+    assert ref.units["x"] == "rad/s"
+
+
+def test_import_dataset_does_not_double_convert_rad_per_s(tmp_path, monkeypatch):
+    csv_path = tmp_path / "data.csv"
+    csv_path.write_text("placeholder\n")
+    raw = RheoData(
+        x=np.array([0.1, 1.0, 10.0]),
+        y=np.array([100.0 + 10.0j, 150.0 + 20.0j, 200.0 + 50.0j]),
+        x_units="rad/s",
+        y_units="Pa",
+        domain="frequency",
+    )
+    monkeypatch.setattr(import_service, "auto_load", lambda path: raw)
+
+    ref, data = import_dataset(csv_path, "oscillation")
+
+    np.testing.assert_allclose(np.asarray(data.x), np.array([0.1, 1.0, 10.0]))
+    assert data.x_units == "rad/s"
+    assert ref.units["x"] == "rad/s"
 
 
 def test_import_dataset_rejects_unknown_protocol(tmp_path):

--- a/tests/gui/foundation/test_import_service.py
+++ b/tests/gui/foundation/test_import_service.py
@@ -1,0 +1,36 @@
+import pytest
+
+from rheojax.gui.foundation.import_service import import_dataset
+
+
+def test_import_dataset_sets_protocol_and_metadata(tmp_path):
+    csv_path = tmp_path / "data.csv"
+    csv_path.write_text(
+        "omega,G',G''\n0.1,100.0,10.0\n1.0,150.0,20.0\n10.0,200.0,50.0\n"
+    )
+
+    ref, data = import_dataset(csv_path, "oscillation")
+
+    assert ref.protocol_type == "oscillation"
+    assert ref.origin == "imported"
+    assert ref.id  # non-empty uuid4 hex
+    assert data.test_mode == "oscillation"
+
+
+def test_import_dataset_rejects_unknown_protocol(tmp_path):
+    csv_path = tmp_path / "data.csv"
+    csv_path.write_text("x,y\n0.1,10\n")
+    with pytest.raises(ValueError):
+        import_dataset(csv_path, "not_a_real_protocol")
+
+
+def test_import_dataset_raises_on_missing_file(tmp_path):
+    with pytest.raises(FileNotFoundError):
+        import_dataset(tmp_path / "does_not_exist.csv", "oscillation")
+
+
+def test_import_dataset_rejects_wrong_column_count(tmp_path):
+    csv_path = tmp_path / "data.csv"
+    csv_path.write_text("time,stress\n0.1,10\n1.0,20\n10.0,30\n")
+    with pytest.raises(ValueError):
+        import_dataset(csv_path, "oscillation")

--- a/tests/gui/foundation/test_library.py
+++ b/tests/gui/foundation/test_library.py
@@ -1,3 +1,5 @@
+import pytest
+
 from rheojax.gui.foundation.library import DatasetLibrary, DatasetRef
 
 
@@ -26,3 +28,24 @@ def test_payload_roundtrip():
     payload = object()                  # stand-in for a real RheoData
     lib.store_payload("a", payload)
     assert lib.load_payload("a") is payload
+
+def test_add_rejects_collision_by_default():
+    lib = DatasetLibrary()
+    lib.add(_ref("a", "oscillation"))
+    with pytest.raises(ValueError):
+        lib.add(_ref("a", "creep"))
+    assert lib.get("a").protocol_type == "oscillation"  # unchanged
+
+def test_add_overwrite_true_replaces():
+    lib = DatasetLibrary()
+    lib.add(_ref("a", "oscillation"))
+    lib.add(_ref("a", "creep"), overwrite=True)
+    assert lib.get("a").protocol_type == "creep"
+
+def test_add_overwrite_clears_stale_payload_when_new_payload_absent():
+    lib = DatasetLibrary()
+    lib.add(_ref("a", "oscillation"))
+    lib.store_payload("a", object())
+    lib.add(_ref("a", "creep"), overwrite=True)  # no new store_payload call
+    with pytest.raises(KeyError):
+        lib.load_payload("a")

--- a/tests/gui/foundation/test_notifier.py
+++ b/tests/gui/foundation/test_notifier.py
@@ -1,0 +1,11 @@
+import pytest
+
+pytest.importorskip("PySide6")
+
+from rheojax.gui.foundation.notifier import DatasetLibraryNotifier
+
+
+def test_notifier_changed_signal_fires(qtbot):
+    notifier = DatasetLibraryNotifier()
+    with qtbot.waitSignal(notifier.changed, timeout=1000):
+        notifier.changed.emit()

--- a/tests/gui/foundation/test_pipeline_bridge_context.py
+++ b/tests/gui/foundation/test_pipeline_bridge_context.py
@@ -29,6 +29,15 @@ def test_pipeline_context_from_library_empty_ids():
     assert pipeline_context_from_library(lib, []) == {}
 
 
+def test_context_includes_dataset_id():
+    lib = DatasetLibrary()
+    lib.add(_ref("d1", "oscillation"))
+    lib.store_payload("d1", object())
+    ctx = pipeline_context_from_library(lib, ["d1"])
+    assert ctx["dataset_id"] == "d1"
+    assert "data" in ctx
+
+
 def test_pipeline_context_from_library_works_for_derived_datasets_too():
     """The whole point: a derived dataset (no backing file) must still be
     usable as pipeline input via context-seeding, unlike the file-path-only

--- a/tests/gui/foundation/test_project_codec.py
+++ b/tests/gui/foundation/test_project_codec.py
@@ -8,6 +8,7 @@ import pytest
 from rheojax.core.data import RheoData
 from rheojax.gui.foundation.library import DatasetRef
 from rheojax.gui.foundation.project_codec import (
+    load_project_v2,
     read_result_arrays,
     save_project_v2,
     write_result_arrays,
@@ -15,6 +16,9 @@ from rheojax.gui.foundation.project_codec import (
 from rheojax.gui.foundation.state import (
     AppState,
     FitState,
+    NlsqConfig,
+    NutsConfig,
+    ParameterConfig,
     PipelineState,
     PipelineStepConfig,
     TransformState,
@@ -228,3 +232,137 @@ def test_save_project_v2_multi_dataset_multi_slice_archive(tmp_path):
 
     # atomic write: no leftover temp files
     assert not list(tmp_path.glob(f"{out_path.name}.tmp-*"))
+
+
+def test_round_trip_full_state(tmp_path):
+    state = AppState()
+    ref = _dataset_ref("d1")
+    payload = RheoData(x=[1.0, 2.0, 3.0], y=[10.0, 20.0, 30.0], initial_test_mode="oscillation")
+    state.library.add(ref)
+    state.library.store_payload("d1", payload)
+    state.fit = FitState(
+        protocol="oscillation", model_key="maxwell",
+        nlsq_config=NlsqConfig(n_starts=5, parameters=[
+            ParameterConfig(name="G0", value=1.0, lower=0.0, upper=10.0, fixed=False)
+        ]),
+        nuts_config=NutsConfig(run_nuts=False),
+        nlsq_result={"parameters": {"G0": 1.0}, "x_fit": np.array([1.0, 2.0])},
+    )
+    # transform.result holds real RheoData under "input"/"output" (transform_controller.py's
+    # actual shape) plus non-array extras -- this must survive the round trip too (§6.1 fix).
+    state.transform.result = {
+        "input": payload, "output": payload, "protocol_type": "oscillation",
+    }
+
+    path = tmp_path / "project.rheojax"
+    save_project_v2(state, path)
+    loaded = load_project_v2(path)
+
+    assert loaded.fit.protocol == "oscillation"
+    assert loaded.fit.model_key == "maxwell"
+    assert loaded.fit.nlsq_config.n_starts == 5
+    assert loaded.fit.nlsq_config.parameters == [
+        ParameterConfig(name="G0", value=1.0, lower=0.0, upper=10.0, fixed=False)
+    ]
+    assert loaded.fit.nuts_config.run_nuts is False
+    assert loaded.fit.nlsq_result["parameters"] == {"G0": 1.0}
+    np.testing.assert_array_equal(loaded.fit.nlsq_result["x_fit"], np.array([1.0, 2.0]))
+    assert loaded.library.get("d1").protocol_type == "oscillation"
+    restored_payload = loaded.library.load_payload("d1")
+    np.testing.assert_array_equal(restored_payload.x, payload.x)
+    assert loaded.transform.result["protocol_type"] == "oscillation"
+    np.testing.assert_array_equal(loaded.transform.result["input"].x, payload.x)
+    np.testing.assert_array_equal(loaded.transform.result["output"].x, payload.x)
+
+
+def test_round_trip_job_history_with_fit_phase_results(tmp_path):
+    state = AppState()
+    state.job_history.by_id["job1"] = {
+        "dataset_id": "d1", "status": "completed", "error": None,
+        "step_results": {
+            "s1": {
+                "step_type": "fit",
+                "nlsq": {"status": "completed", "error": None,
+                         "result": {"parameters": {"G0": 2.0}, "x_fit": np.array([3.0, 4.0])}},
+                "nuts": None,
+            },
+        },
+    }
+    path = tmp_path / "project.rheojax"
+    save_project_v2(state, path)
+    loaded = load_project_v2(path)
+
+    phase = loaded.job_history.by_id["job1"]["step_results"]["s1"]["nlsq"]
+    assert phase["status"] == "completed"
+    assert phase["result"]["parameters"] == {"G0": 2.0}
+    np.testing.assert_array_equal(phase["result"]["x_fit"], np.array([3.0, 4.0]))
+    assert "result_ref" not in phase  # rehydrated back to a plain "result" dict, not left as a reference
+
+
+def test_round_trip_job_history_with_transform_step_output(tmp_path):
+    # A Pipeline "transform" step's job_history record embeds a real RheoData under "output"
+    # (Plan 2's PipelineBatchRunner._prepare_job_record(), step_type == "other") -- this must
+    # round-trip via save_hdf5/load_hdf5 (transform_results/), not raise TypeError from
+    # json.dumps() trying to serialize the RheoData directly.
+    state = AppState()
+    output_payload = RheoData(x=[0.1, 1.0], y=[5.0, 6.0], initial_test_mode="oscillation")
+    state.job_history.by_id["job1"] = {
+        "dataset_id": "d1", "status": "completed", "error": None,
+        "step_results": {
+            "s1": {"step_type": "other", "output": output_payload,
+                   "protocol_type": "oscillation", "dataset_id": None},
+        },
+    }
+    path = tmp_path / "project.rheojax"
+    save_project_v2(state, path)  # must not raise TypeError
+    loaded = load_project_v2(path)
+
+    step_record = loaded.job_history.by_id["job1"]["step_results"]["s1"]
+    assert "output_ref" not in step_record
+    np.testing.assert_array_equal(step_record["output"].x, output_payload.x)
+    assert step_record["protocol_type"] == "oscillation"
+
+
+def test_load_rejects_wrong_version(tmp_path):
+    path = tmp_path / "v1_style.rheojax"
+    with zipfile.ZipFile(path, "w") as zf:
+        zf.writestr("metadata.json", json.dumps({"version": "1.0"}))
+    with pytest.raises(ValueError, match="version"):
+        load_project_v2(path)
+
+
+def test_load_rejects_duplicate_zip_entries(tmp_path):
+    path = tmp_path / "dup.rheojax"
+    with zipfile.ZipFile(path, "w") as zf:
+        zf.writestr("metadata.json", json.dumps({"version": "2.0", "timestamp": "x"}))
+        zf.writestr("metadata.json", json.dumps({"version": "2.0", "timestamp": "y"}))
+    with pytest.raises(ValueError, match="duplicate"):
+        load_project_v2(path)
+
+
+def test_load_rejects_disallowed_member(tmp_path):
+    path = tmp_path / "extra.rheojax"
+    with zipfile.ZipFile(path, "w") as zf:
+        zf.writestr("metadata.json", json.dumps({"version": "2.0", "timestamp": "x"}))
+        zf.writestr("not_in_schema.txt", "hi")
+    with pytest.raises(ValueError, match="not_in_schema"):
+        load_project_v2(path)
+
+
+def test_load_rejects_checksum_mismatch(tmp_path):
+    state = AppState()
+    path = tmp_path / "project.rheojax"
+    save_project_v2(state, path)
+
+    import shutil
+    corrupted = tmp_path / "corrupted.rheojax"
+    shutil.copy(path, corrupted)
+    # Rewrite the zip with a tampered project.json (zipfile can't edit in place -- rebuild).
+    with zipfile.ZipFile(path) as src, zipfile.ZipFile(corrupted, "w") as dst:
+        for item in src.infolist():
+            data = src.read(item.filename)
+            if item.filename == "project.json":
+                data = b'{"path": "TAMPERED", "name": null}'
+            dst.writestr(item, data)
+    with pytest.raises(ValueError, match="checksum"):
+        load_project_v2(corrupted)

--- a/tests/gui/foundation/test_project_codec.py
+++ b/tests/gui/foundation/test_project_codec.py
@@ -1,0 +1,74 @@
+from pathlib import Path
+
+import numpy as np
+import pytest
+
+from rheojax.gui.foundation.project_codec import read_result_arrays, write_result_arrays
+
+
+def test_flat_scalar_and_array_roundtrip(tmp_path):
+    path = tmp_path / "result.hdf5"
+    result = {"r_squared": 0.98, "success": True, "message": "ok", "note": None,
+              "x_fit": np.array([1.0, 2.0, 3.0])}
+    json_shape = write_result_arrays(path, result)
+    assert json_shape["r_squared"] == 0.98
+    assert json_shape["x_fit"] == {"$hdf5_ref": "x_fit"}
+    restored = read_result_arrays(path, json_shape)
+    assert restored["r_squared"] == 0.98
+    assert restored["success"] is True
+    assert restored["note"] is None
+    np.testing.assert_array_equal(restored["x_fit"], result["x_fit"])
+
+
+def test_nested_dict_of_arrays_roundtrip(tmp_path):
+    # posterior_samples / sample_stats shape from subprocess_bayesian.py
+    path = tmp_path / "nuts_result.hdf5"
+    result = {
+        "posterior_samples": {"G_p": np.array([1.0, 2.0]), "tau": np.array([0.5, 0.6])},
+        "sample_stats": {"energy": np.array([10.0, 11.0])},
+        "r_hat": {"G_p": 1.01, "tau": 1.02},
+    }
+    json_shape = write_result_arrays(path, result)
+    assert json_shape["posterior_samples"]["G_p"] == {"$hdf5_ref": "posterior_samples/G_p"}
+    assert json_shape["r_hat"] == {"G_p": 1.01, "tau": 1.02}   # no arrays -- stays inline
+    restored = read_result_arrays(path, json_shape)
+    np.testing.assert_array_equal(restored["posterior_samples"]["G_p"], result["posterior_samples"]["G_p"])
+    np.testing.assert_array_equal(restored["sample_stats"]["energy"], result["sample_stats"]["energy"])
+    assert restored["r_hat"] == {"G_p": 1.01, "tau": 1.02}
+
+
+def test_tuple_values_roundtrip_as_tuples(tmp_path):
+    # credible_intervals shape from subprocess_bayesian.py: dict[str, tuple[float, float, float]]
+    path = tmp_path / "ci_result.hdf5"
+    result = {"credible_intervals": {"G_p": (0.9, 1.0, 1.1)}}
+    json_shape = write_result_arrays(path, result)
+    restored = read_result_arrays(path, json_shape)
+    assert restored["credible_intervals"]["G_p"] == (0.9, 1.0, 1.1)
+    assert isinstance(restored["credible_intervals"]["G_p"], tuple)
+
+
+def test_list_of_scalars_stays_a_list(tmp_path):
+    path = tmp_path / "list_result.hdf5"
+    result = {"iterations": [1, 2, 3]}
+    json_shape = write_result_arrays(path, result)
+    restored = read_result_arrays(path, json_shape)
+    assert restored["iterations"] == [1, 2, 3]
+    assert isinstance(restored["iterations"], list)
+
+
+def test_numpy_scalar_normalized_to_python_scalar(tmp_path):
+    path = tmp_path / "npscalar_result.hdf5"
+    result = {"chi_squared": np.float64(3.14)}
+    json_shape = write_result_arrays(path, result)
+    assert isinstance(json_shape["chi_squared"], float)
+    assert json_shape["chi_squared"] == pytest.approx(3.14)
+
+
+def test_unsupported_leaf_type_raises_type_error(tmp_path):
+    path = tmp_path / "bad_result.hdf5"
+
+    class Unsupported:
+        pass
+
+    with pytest.raises(TypeError):
+        write_result_arrays(path, {"bad": Unsupported()})

--- a/tests/gui/foundation/test_project_codec.py
+++ b/tests/gui/foundation/test_project_codec.py
@@ -326,6 +326,28 @@ def test_round_trip_job_history_with_transform_step_output(tmp_path):
     assert step_record["protocol_type"] == "oscillation"
 
 
+def test_job_history_transform_step_output_none_round_trips(tmp_path):
+    # A failed transform pipeline step's record (step_type == "other") may carry
+    # "output": None -- save_project_v2 must not crash trying to save_hdf5(None, ...),
+    # and load_project_v2 must round-trip it back to "output": None (the same "no ref
+    # means no output" convention _restore_result_dict uses for fit/NUTS results).
+    state = AppState()
+    state.job_history.by_id["job1"] = {
+        "dataset_id": "d1", "status": "failed", "error": "transform raised",
+        "step_results": {
+            "s1": {"step_type": "other", "output": None,
+                   "protocol_type": "oscillation", "dataset_id": None},
+        },
+    }
+    path = tmp_path / "project.rheojax"
+    save_project_v2(state, path)  # must not raise
+    loaded = load_project_v2(path)
+
+    step_record = loaded.job_history.by_id["job1"]["step_results"]["s1"]
+    assert step_record["output"] is None
+    assert "output_ref" not in step_record
+
+
 def test_load_rejects_wrong_version(tmp_path):
     path = tmp_path / "v1_style.rheojax"
     with zipfile.ZipFile(path, "w") as zf:

--- a/tests/gui/foundation/test_project_codec.py
+++ b/tests/gui/foundation/test_project_codec.py
@@ -1,9 +1,24 @@
+import json
+import zipfile
 from pathlib import Path
 
 import numpy as np
 import pytest
 
-from rheojax.gui.foundation.project_codec import read_result_arrays, write_result_arrays
+from rheojax.core.data import RheoData
+from rheojax.gui.foundation.library import DatasetRef
+from rheojax.gui.foundation.project_codec import (
+    read_result_arrays,
+    save_project_v2,
+    write_result_arrays,
+)
+from rheojax.gui.foundation.state import (
+    AppState,
+    FitState,
+    PipelineState,
+    PipelineStepConfig,
+    TransformState,
+)
 
 
 def test_flat_scalar_and_array_roundtrip(tmp_path):
@@ -72,3 +87,144 @@ def test_unsupported_leaf_type_raises_type_error(tmp_path):
 
     with pytest.raises(TypeError):
         write_result_arrays(path, {"bad": Unsupported()})
+
+
+def _dataset_ref(id_):
+    return DatasetRef(id=id_, name=id_, protocol_type="oscillation", origin="imported",
+                      units={"x": "rad/s", "y": "Pa"}, row_count=3, hash="h", provenance={},
+                      lineage=[])
+
+
+def test_save_project_v2_writes_expected_archive_members(tmp_path):
+    state = AppState()
+    ref = _dataset_ref("d1")
+    payload = RheoData(x=[1.0, 2.0, 3.0], y=[10.0, 20.0, 30.0], initial_test_mode="oscillation")
+    state.library.add(ref)
+    state.library.store_payload("d1", payload)
+    state.fit = FitState(protocol="oscillation", model_key="maxwell")
+
+    out_path = tmp_path / "project.rheojax"
+    save_project_v2(state, out_path)
+
+    assert out_path.exists()
+    with zipfile.ZipFile(out_path) as zf:
+        names = set(zf.namelist())
+    assert "metadata.json" in names
+    assert "manifest.json" in names
+    assert "library/manifest.json" in names
+    assert "library/d1.hdf5" in names
+    assert "fit.json" in names
+    assert "transform.json" in names
+    assert "pipeline.json" in names
+    assert "job_history.json" in names
+    assert "project.json" in names
+    assert "ui.json" in names
+
+
+def test_save_project_v2_metadata_version(tmp_path):
+    save_project_v2(AppState(), tmp_path / "p.rheojax")
+    with zipfile.ZipFile(tmp_path / "p.rheojax") as zf:
+        meta = json.loads(zf.read("metadata.json"))
+    assert meta["version"] == "2.0"
+
+
+def test_save_project_v2_multi_dataset_multi_slice_archive(tmp_path):
+    """Exercises every non-trivial branch: 2 library datasets (one without a stored
+    payload), a raw NLSQ result dict on FitState, real RheoData under both sides of
+    TransformState.result plus an extra non-RheoData key, and a job_history record with
+    both a 'fit' step (nlsq phase result dict) and a transform-type step ('output' RheoData)."""
+    state = AppState()
+    state.library.add(_dataset_ref("d1"))
+    state.library.add(_dataset_ref("d2"))
+    state.library.store_payload(
+        "d1", RheoData(x=[1.0, 2.0, 3.0], y=[10.0, 20.0, 30.0], initial_test_mode="oscillation")
+    )
+    # d2 intentionally left without a stored payload.
+
+    state.fit = FitState(
+        protocol="oscillation",
+        model_key="maxwell",
+        nlsq_result={"r_squared": 0.97, "params": np.array([1.0, 2.0])},
+    )
+
+    state.transform = TransformState(
+        transform_key="smoothing",
+        result={
+            "input": RheoData(x=[1.0, 2.0], y=[3.0, 4.0], initial_test_mode="oscillation"),
+            "output": RheoData(x=[1.0, 2.0], y=[5.0, 6.0], initial_test_mode="oscillation"),
+            "warnings": ["clipped 2 points"],
+        },
+    )
+
+    state.pipeline = PipelineState(
+        steps=[PipelineStepConfig(id="s1", step_type="transform"),
+               PipelineStepConfig(id="s2", step_type="fit")],
+        selected_dataset_ids=["d1", "d2"],
+        name="batch-a",
+    )
+
+    state.job_history.by_id["job1"] = {
+        "status": "completed",
+        "step_results": {
+            "step-fit-1": {
+                "step_type": "fit",
+                "nlsq": {"result": {"r_squared": 0.9, "params": np.array([1.0, 2.0])},
+                         "duration_s": 1.2},
+                "nuts": None,
+            },
+            "step-transform-1": {
+                "step_type": "other",
+                "output": RheoData(x=[1.0, 2.0], y=[7.0, 8.0], initial_test_mode="oscillation"),
+            },
+        },
+    }
+
+    out_path = tmp_path / "project.rheojax"
+    save_project_v2(state, out_path)
+
+    with zipfile.ZipFile(out_path) as zf:
+        names = set(zf.namelist())
+
+        library_manifest = json.loads(zf.read("library/manifest.json"))
+        assert {e["id"] for e in library_manifest} == {"d1", "d2"}
+        assert "library/d1.hdf5" in names
+        assert "library/d2.hdf5" not in names  # no stored payload -> not written
+
+        fit = json.loads(zf.read("fit.json"))
+        assert fit["nlsq_result_ref"] is not None
+        assert f"fit_results/{fit['nlsq_result_ref']}.hdf5" in names
+        assert fit["nuts_result_ref"] is None
+
+        transform = json.loads(zf.read("transform.json"))
+        input_ref = transform["result_refs"]["input"]
+        output_ref = transform["result_refs"]["output"]
+        assert input_ref is not None and output_ref is not None
+        assert f"transform_results/{input_ref}.hdf5" in names
+        assert f"transform_results/{output_ref}.hdf5" in names
+        assert transform["result_extras"] == {"warnings": ["clipped 2 points"]}
+
+        pipeline = json.loads(zf.read("pipeline.json"))
+        assert pipeline["name"] == "batch-a"
+        assert [s["id"] for s in pipeline["steps"]] == ["s1", "s2"]
+
+        job_history = json.loads(zf.read("job_history.json"))
+        fit_step = job_history["job1"]["step_results"]["step-fit-1"]
+        nlsq_ref = fit_step["nlsq"]["result_ref"]
+        assert nlsq_ref is not None
+        assert f"job_results/{nlsq_ref}.hdf5" in names
+        assert "result" not in fit_step["nlsq"]
+
+        transform_step = job_history["job1"]["step_results"]["step-transform-1"]
+        assert "output" not in transform_step
+        assert f"transform_results/{transform_step['output_ref']}.hdf5" in names
+
+        # manifest.json hashes every archive member and matches the actual bytes.
+        manifest = json.loads(zf.read("manifest.json"))
+        for rel_path in ("metadata.json", "library/manifest.json", "library/d1.hdf5",
+                          f"fit_results/{fit['nlsq_result_ref']}.hdf5"):
+            assert rel_path in manifest["members"]
+            import hashlib
+            assert manifest["members"][rel_path]["sha256"] == hashlib.sha256(zf.read(rel_path)).hexdigest()
+
+    # atomic write: no leftover temp files
+    assert not list(tmp_path.glob(f"{out_path.name}.tmp-*"))

--- a/tests/gui/foundation/test_project_codec.py
+++ b/tests/gui/foundation/test_project_codec.py
@@ -1,4 +1,6 @@
+import hashlib
 import json
+import uuid
 import zipfile
 from pathlib import Path
 
@@ -8,6 +10,7 @@ import pytest
 from rheojax.core.data import RheoData
 from rheojax.gui.foundation.library import DatasetRef
 from rheojax.gui.foundation.project_codec import (
+    _validate_ref_id,
     load_project_v2,
     read_result_arrays,
     save_project_v2,
@@ -366,3 +369,56 @@ def test_load_rejects_checksum_mismatch(tmp_path):
             dst.writestr(item, data)
     with pytest.raises(ValueError, match="checksum"):
         load_project_v2(corrupted)
+
+
+def test_load_rejects_zip_slip_member_name(tmp_path):
+    """Vector 1 (CWE-22): a zip member name like 'library/../../../evil.hdf5' satisfies
+    the pre-fix allowlist (startswith('library/') and endswith('.hdf5')) but resolves
+    outside tmp_root on extraction. _is_allowed_member must reject any '..' path segment
+    before the prefix/suffix check runs, so this never reaches extraction at all."""
+    path = tmp_path / "evil.rheojax"
+    with zipfile.ZipFile(path, "w") as zf:
+        zf.writestr("metadata.json", json.dumps({"version": "2.0", "timestamp": "x"}))
+        zf.writestr("library/../../../evil.hdf5", b"payload")
+    with pytest.raises(ValueError, match="disallowed member"):
+        load_project_v2(path)
+
+
+def test_load_rejects_ref_id_path_traversal_in_manifest(tmp_path):
+    """Vector 2 (CWE-22): a ref id read from JSON *content* (library/manifest.json here)
+    never passes through the zip member allowlist -- it's just a string field -- so a
+    '../'-containing id must be caught separately by _validate_ref_id when building the
+    HDF5 path from it."""
+    members = {
+        "library/manifest.json": json.dumps([{
+            "id": "../../../evil", "name": "d1", "protocol_type": "oscillation",
+            "origin": "imported", "units": {}, "row_count": 1, "hash": "h",
+            "provenance": {}, "lineage": [],
+        }]).encode(),
+        "fit.json": b"{}",
+        "transform.json": json.dumps({"result_refs": {}, "result_extras": {}}).encode(),
+        "pipeline.json": json.dumps({"steps": []}).encode(),
+        "job_history.json": b"{}",
+        "project.json": json.dumps({"path": None, "name": None}).encode(),
+        "ui.json": b"{}",
+    }
+    manifest = {"members": {
+        name: {"sha256": hashlib.sha256(data).hexdigest(), "size": len(data)}
+        for name, data in members.items()
+    }}
+    path = tmp_path / "evil_ref_id.rheojax"
+    with zipfile.ZipFile(path, "w") as zf:
+        zf.writestr("metadata.json", json.dumps({"version": "2.0", "timestamp": "x"}))
+        for name, data in members.items():
+            zf.writestr(name, data)
+        zf.writestr("manifest.json", json.dumps(manifest))
+    with pytest.raises(ValueError, match="invalid archive reference id"):
+        load_project_v2(path)
+
+
+def test_validate_ref_id_rejects_traversal_and_accepts_uuid():
+    good = uuid.uuid4().hex
+    assert _validate_ref_id(good) == good
+    for bad in ("../../etc/passwd", "foo/bar", "foo\\bar", "", None):
+        with pytest.raises(ValueError):
+            _validate_ref_id(bad)

--- a/tests/gui/foundation/test_state.py
+++ b/tests/gui/foundation/test_state.py
@@ -1,5 +1,17 @@
 from rheojax.gui.foundation.invalidation import invalidate_downstream
-from rheojax.gui.foundation.state import FitState, NlsqConfig, NutsConfig, ParameterConfig
+from rheojax.gui.foundation.state import (
+    ActiveJobsState,
+    AppState,
+    FitState,
+    JobHistoryState,
+    JobResultRef,
+    NlsqConfig,
+    NutsConfig,
+    ParameterConfig,
+    PipelineState,
+    PipelineStepConfig,
+    UiState,
+)
 
 
 def test_nlsq_config_defaults():
@@ -66,3 +78,36 @@ def test_changing_columnmap_keeps_data_clears_fits():
     assert new.data_ref == "d1"          # data kept
     assert new.nlsq_result is None       # fit cleared
     assert new.revision == 3
+
+
+def test_pipeline_step_config_fields():
+    step = PipelineStepConfig(id="s1", step_type="fit", config={"run_nuts": True})
+    assert step.step_type == "fit"
+
+
+def test_job_result_ref():
+    ref = JobResultRef(result_id="abc123")
+    assert ref.result_id == "abc123"
+
+
+def test_pipeline_state_defaults():
+    ps = PipelineState()
+    assert ps.steps == []
+    assert ps.selected_dataset_ids == []
+    assert ps.job_id is None
+
+
+def test_ui_state_defaults():
+    ui = UiState()
+    assert ui.mode == "fit"
+    assert ui.theme == "system"
+    assert ui.inspector_tab == "log"
+
+
+def test_app_state_has_pipeline_and_job_slices():
+    state = AppState()
+    assert isinstance(state.pipeline, PipelineState)
+    assert isinstance(state.active_jobs, ActiveJobsState)
+    assert isinstance(state.job_history, JobHistoryState)
+    assert isinstance(state.ui, UiState)
+    assert state.ui.mode == "fit"

--- a/tests/gui/foundation/test_state.py
+++ b/tests/gui/foundation/test_state.py
@@ -1,11 +1,45 @@
 from rheojax.gui.foundation.invalidation import invalidate_downstream
-from rheojax.gui.foundation.state import FitState
+from rheojax.gui.foundation.state import FitState, NlsqConfig, NutsConfig, ParameterConfig
+
+
+def test_nlsq_config_defaults():
+    cfg = NlsqConfig()
+    assert cfg.multi_start is False
+    assert cfg.n_starts == 8
+    assert cfg.parameters == []
+
+
+def test_nuts_config_defaults():
+    cfg = NutsConfig()
+    assert cfg.run_nuts is True
+    assert cfg.num_warmup == 500
+    assert cfg.num_samples == 1000
+    assert cfg.num_chains == 4
+    assert cfg.target_accept == 0.8
+    assert cfg.seed == 0
+    assert cfg.warm_start is True
+    assert cfg.priors == {}
+
+
+def test_parameter_config_fields():
+    p = ParameterConfig(name="G0", value=1.0, lower=0.0, upper=10.0, fixed=False)
+    assert p.name == "G0"
+    assert p.fixed is False
+
+
+def test_fit_state_uses_typed_nlsq_nuts_config():
+    fit = FitState(protocol="oscillation", model_key="maxwell", model_config={},
+                   data_ref="d1", column_map={}, control_vars={},
+                   nlsq_config=NlsqConfig(n_starts=3), nuts_config=NutsConfig(run_nuts=False),
+                   nlsq_result=None, nuts_result=None, step=0, revision=0)
+    assert fit.nlsq_config.n_starts == 3
+    assert fit.nuts_config.run_nuts is False
 
 
 def test_changing_model_clears_downstream():
     fit = FitState(protocol="oscillation", model_key="maxwell", model_config={"n_modes": 3},
                    data_ref="d1", column_map={"x": 0}, control_vars={"gamma_dot": 1.0},
-                   nlsq_config={}, nlsq_result=object(), nuts_result={"rhat": 1.0}, step=4, revision=0)
+                   nlsq_config=NlsqConfig(), nlsq_result=object(), nuts_result={"rhat": 1.0}, step=4, revision=0)
     new = invalidate_downstream(fit, changed="model_key")
     assert new.nlsq_result is None and new.nuts_result is None
     assert new.data_ref is None and new.column_map == {}
@@ -17,7 +51,7 @@ def test_changing_model_clears_downstream():
 def test_changing_protocol_clears_control_vars_and_model_config():
     fit = FitState(protocol="oscillation", model_key="maxwell", model_config={"n_modes": 3},
                    data_ref="d2", column_map={"x": 0}, control_vars={"omega": 1.0},
-                   nlsq_config={}, nlsq_result=object(), nuts_result=None, step=2, revision=0)
+                   nlsq_config=NlsqConfig(), nlsq_result=object(), nuts_result=None, step=2, revision=0)
     new = invalidate_downstream(fit, changed="protocol")
     assert new.control_vars == {}
     assert new.model_config == {}
@@ -26,7 +60,7 @@ def test_changing_protocol_clears_control_vars_and_model_config():
 
 def test_changing_columnmap_keeps_data_clears_fits():
     fit = FitState(protocol="oscillation", model_key="maxwell", model_config={},
-                   data_ref="d1", column_map={"x": 0}, control_vars={}, nlsq_config={},
+                   data_ref="d1", column_map={"x": 0}, control_vars={}, nlsq_config=NlsqConfig(),
                    nlsq_result=object(), nuts_result=None, step=3, revision=2)
     new = invalidate_downstream(fit, changed="column_map")
     assert new.data_ref == "d1"          # data kept

--- a/tests/gui/test_main_cli_wiring.py
+++ b/tests/gui/test_main_cli_wiring.py
@@ -31,3 +31,72 @@ def test_project_alone_still_parses():
     assert args.project == Path("p.rheojax")
     assert args.import_file is None
     assert args.protocol is None
+
+
+def test_no_flags_parses_with_legacy_false():
+    args = parse_args([])
+    assert args.legacy is False
+
+
+def test_legacy_flag_parses():
+    args = parse_args(["--legacy"])
+    assert args.legacy is True
+
+
+def test_workspace_flag_still_parses_for_back_compat():
+    args = parse_args(["--workspace"])
+    assert args.workspace is True
+
+
+def _reuse_qapplication_singleton(monkeypatch):
+    """Qt allows only one QApplication per process; main() unconditionally
+    constructs one, so back-to-back main() calls in the same test session
+    must reuse the existing singleton instead of each trying to create one.
+    Delegates attribute access (e.g. the static QApplication.setAttribute(...)
+    call in main()) to the real class; only the constructor call is intercepted.
+    """
+    import rheojax.gui.compat as compat
+
+    real_qapplication_cls = compat.QApplication
+
+    class _QApplicationProxy:
+        def __getattr__(self, name):
+            return getattr(real_qapplication_cls, name)
+
+        def __call__(self, *args, **kwargs):
+            return real_qapplication_cls.instance() or real_qapplication_cls(*args, **kwargs)
+
+    monkeypatch.setattr(compat, "QApplication", _QApplicationProxy())
+
+
+def test_default_launch_constructs_workspace_window(monkeypatch, tmp_path):
+    import rheojax.gui.main as main_module
+
+    _reuse_qapplication_singleton(monkeypatch)
+    created = {}
+
+    def _fake_create_workspace_window():
+        created["workspace"] = True
+        raise SystemExit(0)  # short-circuit before app.exec() actually blocks
+
+    monkeypatch.setattr(main_module, "_create_workspace_window", _fake_create_workspace_window)
+    with pytest.raises(SystemExit):
+        main_module.main([])
+    assert created.get("workspace") is True
+
+
+def test_legacy_flag_constructs_main_window(monkeypatch):
+    import rheojax.gui.main as main_module
+
+    _reuse_qapplication_singleton(monkeypatch)
+    created = {}
+
+    class _FakeMainWindow:
+        def __init__(self, *a, **k):
+            created["legacy"] = True
+            raise SystemExit(0)
+
+    monkeypatch.setattr("rheojax.gui.app.main_window.RheoJAXMainWindow", _FakeMainWindow)
+    with pytest.raises(SystemExit):
+        main_module.main(["--legacy"])
+    assert created.get("legacy") is True

--- a/tests/gui/test_main_cli_wiring.py
+++ b/tests/gui/test_main_cli_wiring.py
@@ -1,0 +1,33 @@
+from pathlib import Path
+
+import pytest
+
+from rheojax.gui.main import parse_args
+
+
+def test_protocol_required_with_import():
+    with pytest.raises(SystemExit):
+        parse_args(["--import", "data.csv"])  # no --protocol
+
+
+def test_protocol_without_import_is_rejected():
+    with pytest.raises(SystemExit):
+        parse_args(["--protocol", "oscillation"])  # no --import
+
+
+def test_project_and_import_are_mutually_exclusive():
+    with pytest.raises(SystemExit):
+        parse_args(["--project", "p.rheojax", "--import", "data.csv", "--protocol", "oscillation"])
+
+
+def test_import_with_protocol_parses_successfully():
+    args = parse_args(["--import", "data.csv", "--protocol", "oscillation"])
+    assert args.import_file == Path("data.csv")
+    assert args.protocol == "oscillation"
+
+
+def test_project_alone_still_parses():
+    args = parse_args(["--project", "p.rheojax"])
+    assert args.project == Path("p.rheojax")
+    assert args.import_file is None
+    assert args.protocol is None

--- a/tests/gui/test_pipeline_execution_service_execute.py
+++ b/tests/gui/test_pipeline_execution_service_execute.py
@@ -115,3 +115,84 @@ def test_execute_returns_cancelled_when_stop_requested_set(qtbot):
                           library=lib, stop_requested=stop)
     assert result.status == "cancelled"
     assert result.step_results == {}
+
+
+def test_transform_output_persisted_when_export_step_follows(qtbot, tmp_path):
+    lib = DatasetLibrary()
+    lib.add(_ref("d1", "oscillation"))
+    data = RheoData(x=[0.1, 1.0, 10.0], y=[1.0, 2.0, 3.0], initial_test_mode="oscillation")
+    lib.store_payload("d1", data)
+    svc = PipelineExecutionService()
+    steps = [
+        PipelineStepConfig(id="s1", step_type="transform", config={"name": "smooth_derivative"}),
+        PipelineStepConfig(id="s2", step_type="export", config={"path": str(tmp_path / "out.csv"), "format": "csv"}),
+    ]
+    result = svc.execute(steps=steps, initial_context={"data": data, "dataset_id": "d1"},
+                          library=lib, stop_requested=threading.Event())
+    assert result.status == "completed"
+    # exactly one new library entry beyond the original "d1"
+    new_ids = {r.id for r in lib.all()} - {"d1"}
+    assert len(new_ids) == 1
+
+
+def test_transform_output_not_persisted_when_no_later_step_consumes_it(qtbot):
+    lib = DatasetLibrary()
+    lib.add(_ref("d1", "oscillation"))
+    data = RheoData(x=[0.1, 1.0, 10.0], y=[1.0, 2.0, 3.0], initial_test_mode="oscillation")
+    lib.store_payload("d1", data)
+    svc = PipelineExecutionService()
+    steps = [PipelineStepConfig(id="s1", step_type="transform", config={"name": "smooth_derivative"})]
+    svc.execute(steps=steps, initial_context={"data": data, "dataset_id": "d1"},
+                library=lib, stop_requested=threading.Event())
+    assert {r.id for r in lib.all()} == {"d1"}
+
+
+def test_transform_output_persisted_when_a_second_transform_follows(qtbot):
+    # A transform->transform chain must also count as "consumed downstream" -- the first
+    # transform's output is exactly what the second transform reads from context["data"].
+    lib = DatasetLibrary()
+    lib.add(_ref("d1", "oscillation"))
+    data = RheoData(x=[0.1, 1.0, 10.0], y=[1.0, 2.0, 3.0], initial_test_mode="oscillation")
+    lib.store_payload("d1", data)
+    svc = PipelineExecutionService()
+    steps = [
+        PipelineStepConfig(id="s1", step_type="transform", config={"name": "smooth_derivative"}),
+        PipelineStepConfig(id="s2", step_type="transform", config={"name": "smooth_derivative"}),
+    ]
+    result = svc.execute(steps=steps, initial_context={"data": data, "dataset_id": "d1"},
+                          library=lib, stop_requested=threading.Event())
+    assert result.status == "completed"
+    new_ids = {r.id for r in lib.all()} - {"d1"}
+    assert len(new_ids) == 2  # both transforms' outputs persisted
+
+
+def test_second_transform_lineage_points_at_first_transforms_output_not_original(qtbot):
+    # context["dataset_id"] must be updated to the newly-persisted id after each persisted
+    # transform, so a later step's infer_output_protocol() lookup (and any lineage it records)
+    # reflects the immediately-preceding derived dataset, not the original input dataset.
+    lib = DatasetLibrary()
+    lib.add(_ref("d1", "oscillation"))
+    data = RheoData(x=[0.1, 1.0, 10.0], y=[1.0, 2.0, 3.0], initial_test_mode="oscillation")
+    lib.store_payload("d1", data)
+    svc = PipelineExecutionService()
+    steps = [
+        PipelineStepConfig(id="s1", step_type="transform", config={"name": "smooth_derivative"}),
+        PipelineStepConfig(id="s2", step_type="transform", config={"name": "smooth_derivative"}),
+    ]
+    result = svc.execute(steps=steps, initial_context={"data": data, "dataset_id": "d1"},
+                          library=lib, stop_requested=threading.Event())
+    first_new_id = result.step_results["s1"]["dataset_id"]
+    second_ref = lib.get(result.step_results["s2"]["dataset_id"])
+    assert second_ref.lineage == [first_new_id]  # not ["d1"]
+
+
+def test_duplicate_step_ids_rejected(qtbot):
+    lib = DatasetLibrary()
+    svc = PipelineExecutionService()
+    steps = [
+        PipelineStepConfig(id="s1", step_type="export", config={"path": "a.csv"}),
+        PipelineStepConfig(id="s1", step_type="export", config={"path": "b.csv"}),
+    ]
+    with pytest.raises(ValueError, match="duplicate"):
+        svc.execute(steps=steps, initial_context={"data": object(), "dataset_id": "d1"},
+                    library=lib, stop_requested=threading.Event())

--- a/tests/gui/test_pipeline_execution_service_execute.py
+++ b/tests/gui/test_pipeline_execution_service_execute.py
@@ -104,6 +104,30 @@ def test_execute_runs_export_step(qtbot, tmp_path):
     assert (tmp_path / "out.csv").exists()
 
 
+def test_execute_reports_failed_when_export_raises(qtbot, tmp_path, monkeypatch):
+    lib = DatasetLibrary()
+    lib.add(_ref("d1", "oscillation"))
+    data = RheoData(x=[0.1, 1.0, 10.0], y=[1.0, 2.0, 3.0], initial_test_mode="oscillation")
+    lib.store_payload("d1", data)
+    svc = PipelineExecutionService()
+
+    from rheojax.gui.services.export_service import ExportService
+
+    def _raise(*args, **kwargs):
+        raise OSError("disk full")
+
+    monkeypatch.setattr(ExportService, "export_data", _raise)
+
+    out_path = str(tmp_path / "out.csv")
+    steps = [PipelineStepConfig(id="s1", step_type="export", config={"path": out_path, "format": "csv"})]
+    result = svc.execute(steps=steps, initial_context={"data": data, "dataset_id": "d1"},
+                          library=lib, stop_requested=threading.Event())
+    assert result.status == "failed"
+    assert "disk full" in result.error
+    assert "s1" not in result.step_results
+    assert not (tmp_path / "out.csv").exists()
+
+
 def test_execute_returns_cancelled_when_stop_requested_set(qtbot):
     lib = DatasetLibrary()
     data = RheoData(x=[0.1, 1.0], y=[1.0, 2.0], initial_test_mode="oscillation")

--- a/tests/gui/test_pipeline_execution_service_execute.py
+++ b/tests/gui/test_pipeline_execution_service_execute.py
@@ -147,6 +147,27 @@ def test_transform_output_not_persisted_when_no_later_step_consumes_it(qtbot):
     assert {r.id for r in lib.all()} == {"d1"}
 
 
+def test_terminal_transform_after_unrelated_fit_step_is_not_persisted(qtbot):
+    # A terminal transform preceded only by an unrelated fit step (not another transform)
+    # has nothing downstream reading its output -- it must NOT be persisted, even though
+    # len(steps) > 1.
+    lib = DatasetLibrary()
+    lib.add(_ref("d1", "relaxation"))
+    data = RheoData(x=[0.1, 1.0, 10.0], y=[100.0, 50.0, 10.0], initial_test_mode="relaxation")
+    lib.store_payload("d1", data)
+    svc = PipelineExecutionService()
+    steps = [
+        PipelineStepConfig(id="s1", step_type="fit",
+                            config={"model_name": "maxwell", "run_nuts": False}),
+        PipelineStepConfig(id="s2", step_type="transform", config={"name": "smooth_derivative"}),
+    ]
+    result = svc.execute(steps=steps, initial_context={"data": data, "dataset_id": "d1"},
+                          library=lib, stop_requested=threading.Event())
+    assert result.status == "completed"
+    assert result.step_results["s2"]["dataset_id"] is None
+    assert {r.id for r in lib.all()} == {"d1"}
+
+
 def test_transform_output_persisted_when_a_second_transform_follows(qtbot):
     # A transform->transform chain must also count as "consumed downstream" -- the first
     # transform's output is exactly what the second transform reads from context["data"].

--- a/tests/gui/test_pipeline_execution_service_execute.py
+++ b/tests/gui/test_pipeline_execution_service_execute.py
@@ -87,3 +87,31 @@ def test_execute_runs_transform_step(qtbot):
     )
     assert result.status == "completed"
     assert "s1" in result.step_results
+
+
+def test_execute_runs_export_step(qtbot, tmp_path):
+    lib = DatasetLibrary()
+    lib.add(_ref("d1", "oscillation"))
+    data = RheoData(x=[0.1, 1.0, 10.0], y=[1.0, 2.0, 3.0], initial_test_mode="oscillation")
+    lib.store_payload("d1", data)
+    svc = PipelineExecutionService()
+    out_path = str(tmp_path / "out.csv")
+    steps = [PipelineStepConfig(id="s1", step_type="export", config={"path": out_path, "format": "csv"})]
+    result = svc.execute(steps=steps, initial_context={"data": data, "dataset_id": "d1"},
+                          library=lib, stop_requested=threading.Event())
+    assert result.status == "completed"
+    assert result.step_results["s1"]["paths"] == [out_path]
+    assert (tmp_path / "out.csv").exists()
+
+
+def test_execute_returns_cancelled_when_stop_requested_set(qtbot):
+    lib = DatasetLibrary()
+    data = RheoData(x=[0.1, 1.0], y=[1.0, 2.0], initial_test_mode="oscillation")
+    svc = PipelineExecutionService()
+    stop = threading.Event()
+    stop.set()
+    steps = [PipelineStepConfig(id="s1", step_type="export", config={"path": "unused.csv"})]
+    result = svc.execute(steps=steps, initial_context={"data": data, "dataset_id": "d1"},
+                          library=lib, stop_requested=stop)
+    assert result.status == "cancelled"
+    assert result.step_results == {}

--- a/tests/gui/test_pipeline_execution_service_execute.py
+++ b/tests/gui/test_pipeline_execution_service_execute.py
@@ -15,6 +15,62 @@ def _ref(id_, ptype):
                       units={}, row_count=3, hash="h", provenance={}, lineage=[])
 
 
+@pytest.fixture(autouse=True)
+def _subprocess_isolation(monkeypatch):
+    monkeypatch.setenv("RHEOJAX_WORKER_ISOLATION", "subprocess")
+
+
+def test_execute_raises_on_thread_isolation_mode(qtbot, monkeypatch):
+    monkeypatch.setenv("RHEOJAX_WORKER_ISOLATION", "thread")
+    lib = DatasetLibrary()
+    lib.add(_ref("d1", "relaxation"))
+    data = RheoData(x=[0.1, 1.0, 10.0], y=[100.0, 50.0, 10.0], initial_test_mode="relaxation")
+    lib.store_payload("d1", data)
+    svc = PipelineExecutionService()
+    steps = [PipelineStepConfig(id="s1", step_type="fit",
+                                 config={"model_name": "maxwell", "run_nuts": False})]
+    with pytest.raises(RuntimeError, match="subprocess"):
+        svc.execute(steps=steps, initial_context={"data": data, "dataset_id": "d1"},
+                     library=lib, stop_requested=threading.Event())
+
+
+def test_execute_runs_nlsq_only_fit_step(qtbot):
+    lib = DatasetLibrary()
+    lib.add(_ref("d1", "relaxation"))
+    data = RheoData(x=[0.1, 1.0, 10.0], y=[100.0, 50.0, 10.0], initial_test_mode="relaxation")
+    lib.store_payload("d1", data)
+    svc = PipelineExecutionService()
+    steps = [PipelineStepConfig(id="s1", step_type="fit",
+                                 config={"model_name": "maxwell", "run_nuts": False})]
+    result = svc.execute(steps=steps, initial_context={"data": data, "dataset_id": "d1"},
+                          library=lib, stop_requested=threading.Event())
+    assert result.status == "completed"
+    fit_result = result.step_results["s1"]
+    assert fit_result.nlsq.status == "completed"
+    assert fit_result.nuts is None
+
+
+@pytest.mark.slow
+def test_execute_runs_nlsq_then_nuts_fit_step(qtbot):
+    lib = DatasetLibrary()
+    lib.add(_ref("d1", "relaxation"))
+    data = RheoData(x=[0.1, 1.0, 10.0], y=[100.0, 50.0, 10.0], initial_test_mode="relaxation")
+    lib.store_payload("d1", data)
+    svc = PipelineExecutionService()
+    steps = [PipelineStepConfig(id="s1", step_type="fit", config={
+        "model_name": "maxwell", "run_nuts": True,
+        "nuts_config": {"num_warmup": 50, "num_samples": 50, "num_chains": 1},
+    })]
+    result = svc.execute(steps=steps, initial_context={"data": data, "dataset_id": "d1"},
+                          library=lib, stop_requested=threading.Event())
+    fit_result = result.step_results["s1"]
+    assert fit_result.nlsq.status == "completed"
+    assert fit_result.nuts is not None
+    assert fit_result.nuts.status in ("completed", "failed")  # real subprocess MCMC -- allow
+                                                                  # either, just verify it RAN
+                                                                  # independently of nlsq
+
+
 def test_execute_runs_transform_step(qtbot):
     lib = DatasetLibrary()
     lib.add(_ref("d1", "oscillation"))

--- a/tests/gui/test_pipeline_execution_service_execute.py
+++ b/tests/gui/test_pipeline_execution_service_execute.py
@@ -1,0 +1,33 @@
+import threading
+
+import pytest
+
+pytest.importorskip("PySide6")
+
+from rheojax.core.data import RheoData
+from rheojax.gui.foundation.library import DatasetLibrary, DatasetRef
+from rheojax.gui.foundation.state import PipelineStepConfig
+from rheojax.gui.services.pipeline_execution_service import PipelineExecutionService
+
+
+def _ref(id_, ptype):
+    return DatasetRef(id=id_, name=id_, protocol_type=ptype, origin="imported",
+                      units={}, row_count=3, hash="h", provenance={}, lineage=[])
+
+
+def test_execute_runs_transform_step(qtbot):
+    lib = DatasetLibrary()
+    lib.add(_ref("d1", "oscillation"))
+    data = RheoData(x=[0.1, 1.0, 10.0], y=[1.0, 2.0, 3.0], initial_test_mode="oscillation")
+    lib.store_payload("d1", data)
+
+    svc = PipelineExecutionService()
+    steps = [PipelineStepConfig(id="s1", step_type="transform", config={"name": "smooth_derivative"})]
+    result = svc.execute(
+        steps=steps,
+        initial_context={"data": data, "dataset_id": "d1"},
+        library=lib,
+        stop_requested=threading.Event(),
+    )
+    assert result.status == "completed"
+    assert "s1" in result.step_results

--- a/tests/gui/workspace/fit/test_step6.py
+++ b/tests/gui/workspace/fit/test_step6.py
@@ -7,6 +7,42 @@ from rheojax.gui.foundation.state import FitState
 from rheojax.gui.workspace.fit.step6_export import ExportStep
 
 
+def _commit_on_request(step, lib):
+    # Simulates the Task-10 WorkspaceWindow._commit_dataset handler that will
+    # eventually own this: the widget only requests a commit, it no longer
+    # performs one itself.
+    def _handle(ref, payload, overwrite):
+        lib.add(ref, overwrite=overwrite)
+        if payload is not None:
+            lib.store_payload(ref.id, payload)
+
+    step.dataset_commit_requested.connect(_handle)
+
+
+def test_save_emits_dataset_commit_requested_with_overwrite_true(qtbot):
+    st = FitState(
+        protocol="oscillation",
+        model_key="maxwell",
+        model_config={},
+        data_ref="d",
+        nlsq_result={"params": {"G0": 1.0}},
+        nuts_result=None,
+        revision=2,
+    )
+    lib = DatasetLibrary()
+    step = ExportStep(st, lib)
+    qtbot.addWidget(step)
+    assert not hasattr(step, "exported")
+    with qtbot.waitSignal(step.dataset_commit_requested, timeout=1000) as blocker:
+        step.save_to_library()
+    ref, payload, overwrite = blocker.args
+    assert ref.origin == "derived"
+    assert overwrite is True
+    # The library must NOT have been mutated by the widget itself:
+    with pytest.raises(KeyError):
+        step._library.get(ref.id)
+
+
 def test_bundle_and_save(qtbot):
     st = FitState(
         protocol="oscillation",
@@ -20,8 +56,33 @@ def test_bundle_and_save(qtbot):
     lib = DatasetLibrary()
     step = ExportStep(st, lib)
     qtbot.addWidget(step)
+    _commit_on_request(step, lib)
     man = step.bundle_manifest()
     assert "parameters" in man and "posterior_samples" not in man  # no NUTS
     new_id = step.save_to_library()
     assert lib.get(new_id).origin == "derived"
     assert step.provenance()["model_key"] == "maxwell"
+
+
+def test_save_to_library_reruns_at_same_revision_overwrite(qtbot):
+    # step6_export.py's id policy is `{model_key}_fit_{revision}`, reused
+    # across re-saves at the same revision (revision only bumps on an
+    # edit-invalidation, not on every save). overwrite=True lets a repeat
+    # save at the same revision replace the prior entry instead of raising.
+    st = FitState(
+        protocol="oscillation",
+        model_key="maxwell",
+        model_config={},
+        data_ref="d",
+        nlsq_result={"params": {"G0": 1.0}},
+        nuts_result=None,
+        revision=2,
+    )
+    lib = DatasetLibrary()
+    step = ExportStep(st, lib)
+    qtbot.addWidget(step)
+    _commit_on_request(step, lib)
+    id1 = step.save_to_library()
+    id2 = step.save_to_library()
+    assert id1 == id2
+    assert lib.get(id2).origin == "derived"

--- a/tests/gui/workspace/fit/test_step6_store_payload.py
+++ b/tests/gui/workspace/fit/test_step6_store_payload.py
@@ -18,6 +18,13 @@ def test_save_to_library_stores_fitted_curve_payload(qtbot):
     lib = DatasetLibrary()
     step = ExportStep(st, lib)
     qtbot.addWidget(step)
+
+    def _handle(ref, payload, overwrite):
+        lib.add(ref, overwrite=overwrite)
+        if payload is not None:
+            lib.store_payload(ref.id, payload)
+
+    step.dataset_commit_requested.connect(_handle)
     new_id = step.save_to_library()
     payload = lib.load_payload(new_id)  # must not raise KeyError
     assert list(payload.x) == [1.0, 2.0]

--- a/tests/gui/workspace/pipeline/test_batch_runner.py
+++ b/tests/gui/workspace/pipeline/test_batch_runner.py
@@ -1,0 +1,156 @@
+import threading
+
+import pytest
+
+pytest.importorskip("PySide6")
+
+from rheojax.core.data import RheoData
+from rheojax.gui.foundation.library import DatasetLibrary, DatasetRef
+from rheojax.gui.foundation.project_codec import load_project_v2, save_project_v2
+from rheojax.gui.foundation.state import AppState, PipelineStepConfig
+from rheojax.gui.services.pipeline_execution_service import PipelineExecutionService
+from rheojax.gui.workspace.pipeline.batch_runner import PipelineBatchRunner
+
+
+def _ref(id_, ptype):
+    return DatasetRef(id=id_, name=id_, protocol_type=ptype, origin="imported",
+                      units={}, row_count=3, hash="h", provenance={}, lineage=[])
+
+
+def test_batch_runner_processes_each_selected_dataset(qtbot, tmp_path, monkeypatch):
+    monkeypatch.setenv("RHEOJAX_WORKER_ISOLATION", "subprocess")
+    lib = DatasetLibrary()
+    for id_ in ("d1", "d2"):
+        lib.add(_ref(id_, "oscillation"))
+        lib.store_payload(id_, RheoData(x=[0.1, 1.0], y=[1.0, 2.0], initial_test_mode="oscillation"))
+
+    svc = PipelineExecutionService()
+    steps = [PipelineStepConfig(id="s1", step_type="export",
+                                 config={"path": str(tmp_path / "{id}.csv"), "format": "csv"})]
+    runner = PipelineBatchRunner(
+        service=svc, steps=steps, selected_dataset_ids=["d1", "d2"], library=lib,
+        stop_requested=threading.Event(),
+    )
+
+    started, finished = [], []
+    svc.dataset_run_started.connect(lambda dsid: started.append(dsid))
+    svc.dataset_run_finished.connect(lambda dsid, record: finished.append(dsid))
+    with qtbot.waitSignal(svc.dataset_run_finished, timeout=5000):
+        runner.run()
+    assert started == ["d1", "d2"]  # started signal fires per-dataset, in order
+    assert set(finished) == {"d1", "d2"}
+
+
+def test_batch_runner_prepare_job_record_keeps_raw_result_uncompressed(qtbot, tmp_path, monkeypatch):
+    # _prepare_job_record() must NOT write any HDF5 file or split the result -- that's
+    # save_project_v2()'s job at save time, not the batch runner's job at execution time.
+    monkeypatch.setenv("RHEOJAX_WORKER_ISOLATION", "subprocess")
+    lib = DatasetLibrary()
+    lib.add(_ref("d1", "relaxation"))
+    lib.store_payload("d1", RheoData(x=[0.1, 1.0], y=[100.0, 50.0], initial_test_mode="relaxation"))
+    svc = PipelineExecutionService()
+    steps = [PipelineStepConfig(id="s1", step_type="fit",
+                                 config={"model_name": "maxwell", "run_nuts": False})]
+    runner = PipelineBatchRunner(service=svc, steps=steps, selected_dataset_ids=["d1"],
+                                  library=lib, stop_requested=threading.Event())
+    records = []
+    svc.dataset_run_finished.connect(lambda dsid, record: records.append(record))
+    with qtbot.waitSignal(svc.dataset_run_finished, timeout=5000):
+        runner.run()
+    phase = records[0]["step_results"]["s1"]["nlsq"]
+    assert "result_ref" not in phase and "result_meta" not in phase
+    assert isinstance(phase["result"], dict)  # still the raw, unpersisted result dict
+
+
+def test_batch_runner_processes_datasets_in_order_and_skips_after_stop(qtbot, tmp_path, monkeypatch):
+    monkeypatch.setenv("RHEOJAX_WORKER_ISOLATION", "subprocess")
+    lib = DatasetLibrary()
+    for id_ in ("d1", "d2", "d3"):
+        lib.add(_ref(id_, "oscillation"))
+        lib.store_payload(id_, RheoData(x=[0.1, 1.0], y=[1.0, 2.0], initial_test_mode="oscillation"))
+
+    svc = PipelineExecutionService()
+    steps = [PipelineStepConfig(id="s1", step_type="export",
+                                 config={"path": str(tmp_path / "{id}.csv"), "format": "csv"})]
+    stop_requested = threading.Event()
+    runner = PipelineBatchRunner(service=svc, steps=steps,
+                                  selected_dataset_ids=["d1", "d2", "d3"], library=lib,
+                                  stop_requested=stop_requested)
+
+    started = []
+
+    def _on_started(dsid):
+        started.append(dsid)
+        if dsid == "d2":
+            stop_requested.set()
+
+    svc.dataset_run_started.connect(_on_started)
+    runner.run()
+    assert started == ["d1", "d2"]  # d3 never started once stop_requested was set
+
+
+def test_batch_runner_job_record_round_trips_through_save_project_v2(qtbot, tmp_path, monkeypatch):
+    # Cross-plan integration: _prepare_job_record()'s output dict must slot directly into
+    # AppState.job_history.by_id and survive Plan 1's save_project_v2/load_project_v2 round
+    # trip -- the exact shape contract described in project_codec.py's job_history-walking
+    # section (search "job_history_out"/"step_results_out").
+    monkeypatch.setenv("RHEOJAX_WORKER_ISOLATION", "subprocess")
+    lib = DatasetLibrary()
+    lib.add(_ref("d1", "relaxation"))
+    lib.store_payload("d1", RheoData(x=[0.1, 1.0], y=[100.0, 50.0], initial_test_mode="relaxation"))
+    svc = PipelineExecutionService()
+    steps = [PipelineStepConfig(id="s1", step_type="fit",
+                                 config={"model_name": "maxwell", "run_nuts": False})]
+    runner = PipelineBatchRunner(service=svc, steps=steps, selected_dataset_ids=["d1"],
+                                  library=lib, stop_requested=threading.Event())
+    records = []
+    svc.dataset_run_finished.connect(lambda dsid, record: records.append(record))
+    with qtbot.waitSignal(svc.dataset_run_finished, timeout=5000):
+        runner.run()
+    record = records[0]
+    assert record["status"] == "completed"
+
+    state = AppState()
+    state.job_history.by_id["job1"] = record
+    path = tmp_path / "project.rheojax"
+    save_project_v2(state, path)  # must not raise -- proves the shape matches project_codec's
+                                    # expectations (fit phase result_ref/result_meta split)
+    loaded = load_project_v2(path)
+
+    loaded_phase = loaded.job_history.by_id["job1"]["step_results"]["s1"]["nlsq"]
+    assert loaded_phase["status"] == "completed"
+    assert isinstance(loaded_phase["result"], dict)
+    assert "result_ref" not in loaded_phase
+
+
+def test_batch_runner_transform_step_record_round_trips_output_as_rheodata(qtbot, tmp_path, monkeypatch):
+    # A "transform" step's record must carry its RheoData under literally "output" so
+    # save_project_v2's `elif "output" in step_record` branch detects and persists it.
+    monkeypatch.setenv("RHEOJAX_WORKER_ISOLATION", "subprocess")
+    lib = DatasetLibrary()
+    lib.add(_ref("d1", "oscillation"))
+    lib.store_payload("d1", RheoData(x=[0.1, 1.0], y=[1.0, 2.0], initial_test_mode="oscillation"))
+    svc = PipelineExecutionService()
+    steps = [PipelineStepConfig(id="s1", step_type="transform",
+                                 config={"name": "fft"})]
+    runner = PipelineBatchRunner(service=svc, steps=steps, selected_dataset_ids=["d1"],
+                                  library=lib, stop_requested=threading.Event())
+    records = []
+    svc.dataset_run_finished.connect(lambda dsid, record: records.append(record))
+    with qtbot.waitSignal(svc.dataset_run_finished, timeout=5000):
+        runner.run()
+    record = records[0]
+    step_record = record["step_results"]["s1"]
+    assert step_record["step_type"] == "other"
+    assert isinstance(step_record["output"], RheoData)
+
+    state = AppState()
+    state.job_history.by_id["job1"] = record
+    path = tmp_path / "project.rheojax"
+    save_project_v2(state, path)  # must not raise TypeError trying to json.dumps() a RheoData
+    loaded = load_project_v2(path)
+
+    loaded_step = loaded.job_history.by_id["job1"]["step_results"]["s1"]
+    assert "output_ref" not in loaded_step
+    import numpy as np
+    np.testing.assert_array_equal(loaded_step["output"].x, step_record["output"].x)

--- a/tests/gui/workspace/pipeline/test_cancel_runnable.py
+++ b/tests/gui/workspace/pipeline/test_cancel_runnable.py
@@ -1,0 +1,30 @@
+import pytest
+
+pytest.importorskip("PySide6")
+
+from rheojax.gui.workspace.pipeline.cancel_runnable import CancelWorkerRunnable
+
+
+class _FakeWorker:
+    def __init__(self):
+        self.cancel_called = False
+
+    def cancel(self):
+        self.cancel_called = True
+
+
+def test_cancel_worker_runnable_calls_cancel():
+    worker = _FakeWorker()
+    runnable = CancelWorkerRunnable(worker)
+    runnable.run()
+    assert worker.cancel_called is True
+
+
+def test_cancel_worker_runnable_runs_via_threadpool(qtbot):
+    from PySide6.QtCore import QThreadPool
+
+    worker = _FakeWorker()
+    pool = QThreadPool.globalInstance()
+    pool.start(CancelWorkerRunnable(worker))
+    pool.waitForDone(2000)
+    assert worker.cancel_called is True

--- a/tests/gui/workspace/pipeline/test_controller.py
+++ b/tests/gui/workspace/pipeline/test_controller.py
@@ -5,6 +5,7 @@ pytest.importorskip("PySide6")
 from rheojax.gui.foundation.state import AppState
 from rheojax.gui.services.pipeline_execution_service import PipelineExecutionService
 from rheojax.gui.workspace.pipeline.controller import PipelineController
+from rheojax.gui.workspace.window import WorkspaceWindow
 
 
 def test_commit_job_result_moves_active_to_history_and_marks_dirty(qtbot):
@@ -46,3 +47,34 @@ def test_dataset_run_started_registers_active_job(qtbot):
     with qtbot.waitSignal(svc.dataset_run_started, timeout=1000):
         svc.dataset_run_started.emit("d1")
     assert state.active_jobs.by_id["d1"] == {"status": "running"}
+
+
+def test_stale_controller_guarded_after_rebuild_does_not_mutate_discarded_state(qtbot):
+    """Reproduces the Plan 2 Task 11 gap: a PipelineController connected against the
+    persistent PipelineExecutionService must stop mutating its AppState once
+    WorkspaceWindow rebuilds past it, even though Qt keeps the old signal connection
+    alive (only the Python-level self._controllers reference is dropped on rebuild)."""
+    win = WorkspaceWindow(AppState())
+    qtbot.addWidget(win)
+
+    stale_state = win._state
+    stale_ctl = win._controllers["pipeline"]
+    stale_state.active_jobs.by_id["d1"] = {"status": "running"}
+
+    win._rebuild(AppState())  # bumps win._epoch; stale_ctl's connections survive regardless
+    fresh_state = win._state
+    fresh_ctl = win._controllers["pipeline"]
+    assert fresh_ctl is not stale_ctl
+    assert fresh_state is not stale_state
+
+    record = {"dataset_id": "d1", "status": "completed", "error": None, "step_results": {}}
+    with qtbot.waitSignal(win._pipeline_service.dataset_run_finished, timeout=1000):
+        win._pipeline_service.dataset_run_finished.emit("d1", record)
+
+    # Stale controller's handler was a no-op: the discarded state is untouched.
+    assert stale_state.active_jobs.by_id == {"d1": {"status": "running"}}
+    assert stale_state.job_history.by_id == {}
+
+    # Fresh controller still commits normally.
+    assert "d1" not in fresh_state.active_jobs.by_id
+    assert len(fresh_state.job_history.by_id) == 1

--- a/tests/gui/workspace/pipeline/test_controller.py
+++ b/tests/gui/workspace/pipeline/test_controller.py
@@ -1,0 +1,48 @@
+import pytest
+
+pytest.importorskip("PySide6")
+
+from rheojax.gui.foundation.state import AppState
+from rheojax.gui.services.pipeline_execution_service import PipelineExecutionService
+from rheojax.gui.workspace.pipeline.controller import PipelineController
+
+
+def test_commit_job_result_moves_active_to_history_and_marks_dirty(qtbot):
+    state = AppState()
+    state.active_jobs.by_id["d1"] = {"status": "running"}
+    svc = PipelineExecutionService()
+    dirty_calls = []
+    ctl = PipelineController(state, svc, on_dirty=lambda: dirty_calls.append(1))
+
+    record = {"dataset_id": "d1", "status": "completed", "error": None, "step_results": {}}
+    ctl._commit_job_result("d1", record)
+
+    assert "d1" not in state.active_jobs.by_id
+    assert len(state.job_history.by_id) == 1
+    stored = next(iter(state.job_history.by_id.values()))
+    assert stored["status"] == "completed"
+    assert state.pipeline.job_id is not None
+    assert dirty_calls == [1]
+
+
+def test_commit_job_result_connected_to_dataset_run_finished(qtbot):
+    state = AppState()
+    state.active_jobs.by_id["d1"] = {"status": "running"}
+    svc = PipelineExecutionService()
+    ctl = PipelineController(state, svc, on_dirty=lambda: None)
+
+    record = {"dataset_id": "d1", "status": "completed", "error": None, "step_results": {}}
+    with qtbot.waitSignal(svc.dataset_run_finished, timeout=1000):
+        svc.dataset_run_finished.emit("d1", record)
+    assert "d1" not in state.active_jobs.by_id
+
+
+def test_dataset_run_started_registers_active_job(qtbot):
+    state = AppState()
+    svc = PipelineExecutionService()
+    ctl = PipelineController(state, svc, on_dirty=lambda: None)
+    assert "d1" not in state.active_jobs.by_id
+
+    with qtbot.waitSignal(svc.dataset_run_started, timeout=1000):
+        svc.dataset_run_started.emit("d1")
+    assert state.active_jobs.by_id["d1"] == {"status": "running"}

--- a/tests/gui/workspace/pipeline/test_models.py
+++ b/tests/gui/workspace/pipeline/test_models.py
@@ -1,0 +1,44 @@
+from rheojax.gui.workspace.pipeline.models import (
+    DatasetArtifact,
+    FileArtifact,
+    FitArtifact,
+    FitStepResult,
+    PhaseResult,
+    PipelineRunResult,
+)
+
+
+def test_phase_result_defaults():
+    p = PhaseResult(status="pending")
+    assert p.result is None
+    assert p.error is None
+
+
+def test_fit_step_result_nlsq_only():
+    fsr = FitStepResult(nlsq=PhaseResult(status="completed", result={"r_squared": 0.9}), nuts=None)
+    assert fsr.nuts is None
+    assert fsr.nlsq.status == "completed"
+
+
+def test_fit_step_result_nlsq_success_nuts_failure_independent():
+    fsr = FitStepResult(
+        nlsq=PhaseResult(status="completed", result={"r_squared": 0.9}),
+        nuts=PhaseResult(status="failed", error="NUTS divergence"),
+    )
+    assert fsr.nlsq.status == "completed"
+    assert fsr.nuts.status == "failed"
+    assert fsr.nuts.error == "NUTS divergence"
+
+
+def test_pipeline_run_result_error_field():
+    r = PipelineRunResult(step_results={}, status="failed", error="step s1 raised")
+    assert r.error == "step s1 raised"
+
+
+def test_artifact_dataclasses():
+    da = DatasetArtifact(dataset_id="d1", source_step_id="s1", produced_at_revision=0)
+    fa = FitArtifact(step_id="s2", source_dataset_id="d1", result=FitStepResult(nlsq=PhaseResult(status="completed"), nuts=None))
+    fla = FileArtifact(step_id="s3", paths=["/tmp/out.csv"])
+    assert da.dataset_id == "d1"
+    assert fa.result.nlsq.status == "completed"
+    assert fla.paths == ["/tmp/out.csv"]

--- a/tests/gui/workspace/pipeline/test_step1_configure_run.py
+++ b/tests/gui/workspace/pipeline/test_step1_configure_run.py
@@ -1,0 +1,87 @@
+import pytest
+
+pytest.importorskip("PySide6")
+
+from rheojax.gui.foundation.library import DatasetLibrary, DatasetRef
+from rheojax.gui.foundation.state import AppState
+from rheojax.gui.workspace.pipeline.step1_configure_run import PipelineConfigureRunStep
+
+
+def _ref(id_):
+    return DatasetRef(id=id_, name=id_, protocol_type="oscillation", origin="imported",
+                      units={}, row_count=1, hash="h", provenance={}, lineage=[])
+
+
+def test_add_step_appends_to_state(qtbot):
+    state = AppState()
+    step = PipelineConfigureRunStep(state.pipeline, state.library)
+    qtbot.addWidget(step)
+    step.add_step("export", {"path": "out.csv"})
+    assert len(state.pipeline.steps) == 1
+    assert state.pipeline.steps[0].step_type == "export"
+
+
+def test_transform_type_picker_excludes_multi_slot_transforms(qtbot):
+    state = AppState()
+    step = PipelineConfigureRunStep(state.pipeline, state.library)
+    qtbot.addWidget(step)
+    offered = step.available_transform_keys()
+    assert "cox_merz" not in offered
+    assert "mastercurve" not in offered
+    assert "srfs" not in offered
+
+
+def test_is_ready_requires_steps_and_selected_datasets(qtbot):
+    state = AppState()
+    state.library.add(_ref("d1"))
+    step = PipelineConfigureRunStep(state.pipeline, state.library)
+    qtbot.addWidget(step)
+    assert step.is_ready() is False
+    step.add_step("export", {"path": "out.csv"})
+    assert step.is_ready() is False  # steps set, but no dataset selected yet
+    step.set_selected_dataset_ids(["d1"])
+    assert step.is_ready() is True
+
+
+def test_edited_signal_fires_on_add_step(qtbot):
+    state = AppState()
+    step = PipelineConfigureRunStep(state.pipeline, state.library)
+    qtbot.addWidget(step)
+    with qtbot.waitSignal(step.edited, timeout=1000):
+        step.add_step("export", {"path": "out.csv"})
+
+
+def test_add_step_from_ui_collects_fit_config(qtbot):
+    # A user-created fit step must have a real model_name -- an empty {} config (as an earlier
+    # version of this widget produced) fails at execute() time with KeyError: 'model_name'.
+    state = AppState()
+    step = PipelineConfigureRunStep(state.pipeline, state.library)
+    qtbot.addWidget(step)
+    step._step_type_combo.setCurrentText("fit")
+    step._fit_model_combo.setCurrentText("maxwell")
+    step._fit_run_nuts_checkbox.setChecked(False)
+    step._on_add_step_clicked()
+    assert state.pipeline.steps[0].config == {"model_name": "maxwell", "run_nuts": False}
+
+
+def test_add_step_from_ui_collects_export_config(qtbot):
+    state = AppState()
+    step = PipelineConfigureRunStep(state.pipeline, state.library)
+    qtbot.addWidget(step)
+    step._step_type_combo.setCurrentText("export")
+    step._export_path_edit.setText("/tmp/out_{id}.csv")
+    step._export_format_combo.setCurrentText("csv")
+    step._on_add_step_clicked()
+    assert state.pipeline.steps[0].config == {"path": "/tmp/out_{id}.csv", "format": "csv"}
+
+
+def test_is_ready_false_when_a_step_has_incomplete_config(qtbot):
+    # A step added with an empty/incomplete config must not make is_ready() True -- otherwise
+    # "Run All" is enabled against a step that will raise at execute() time.
+    state = AppState()
+    state.library.add(_ref("d1"))
+    step = PipelineConfigureRunStep(state.pipeline, state.library)
+    qtbot.addWidget(step)
+    step.add_step("fit", {})  # incomplete -- no model_name
+    step.set_selected_dataset_ids(["d1"])
+    assert step.is_ready() is False

--- a/tests/gui/workspace/test_widgets.py
+++ b/tests/gui/workspace/test_widgets.py
@@ -136,7 +136,7 @@ def test_window_set_mode_rejects_unknown_mode(qtbot):
 
 def test_window_invalid_persisted_mode_falls_back_to_fit(qtbot):
     state = AppState()
-    state.ui["mode"] = "not-a-real-mode"
+    state.ui.mode = "not-a-real-mode"
     win = WorkspaceWindow(state); qtbot.addWidget(win)
     assert win.mode() == "fit"             # invalid persisted state doesn't crash construction
 

--- a/tests/gui/workspace/test_window_active_jobs_dialog.py
+++ b/tests/gui/workspace/test_window_active_jobs_dialog.py
@@ -1,0 +1,111 @@
+import pytest
+
+pytest.importorskip("PySide6")
+
+from rheojax.gui.foundation.state import AppState
+from rheojax.gui.workspace.window import WorkspaceWindow
+
+
+def test_maybe_confirm_active_jobs_proceeds_immediately_when_empty(qtbot):
+    win = WorkspaceWindow(AppState())
+    qtbot.addWidget(win)
+    calls = []
+    win._maybe_confirm_active_jobs(lambda: calls.append(1))
+    assert calls == [1]
+
+
+def test_maybe_confirm_active_jobs_blocks_when_nonempty(qtbot, monkeypatch):
+    win = WorkspaceWindow(AppState())
+    qtbot.addWidget(win)
+    win._state.active_jobs.by_id["d1"] = {"status": "running"}
+
+    # Simulate the user choosing "Wait" then the job finishing -- monkeypatch the dialog to
+    # avoid a real blocking modal in the test, matching this file's need to control the flow.
+    from PySide6.QtWidgets import QMessageBox
+
+    monkeypatch.setattr(QMessageBox, "question", lambda *a, **k: QMessageBox.StandardButton.Cancel)
+    calls = []
+    win._maybe_confirm_active_jobs(lambda: calls.append(1))
+    assert calls == []  # blocked -- user chose Cancel (the dialog's overall "abort this
+                          # action" option, distinct from "Cancel Jobs")
+
+
+def test_second_action_while_first_is_pending_does_not_double_dialog(qtbot, monkeypatch):
+    win = WorkspaceWindow(AppState())
+    qtbot.addWidget(win)
+    win._state.active_jobs.by_id["d1"] = {"status": "running"}
+
+    from PySide6.QtWidgets import QMessageBox
+
+    call_count = []
+
+    def _counting_question(*a, **k):
+        call_count.append(1)
+        return QMessageBox.StandardButton.Yes
+
+    monkeypatch.setattr(QMessageBox, "question", _counting_question)
+    win._maybe_confirm_active_jobs(lambda: None)
+    win._maybe_confirm_active_jobs(lambda: None)  # fired again before the first poll resolves
+    assert call_count == [1]  # only one dialog shown, not two
+
+
+def test_phase_worker_ready_updates_only_its_own_dataset(qtbot):
+    win = WorkspaceWindow(AppState())
+    qtbot.addWidget(win)
+    win._state.active_jobs.by_id = {"d1": {"status": "running"}, "d2": {"status": "running"}}
+
+    class _FakeWorker:
+        pass
+
+    worker_for_d1 = _FakeWorker()
+    win._pipeline_service.phase_worker_ready.emit("d1", "s1", "nlsq", worker_for_d1)
+    qtbot.wait(50)
+    assert win._state.active_jobs.by_id["d1"].get("worker") is worker_for_d1
+    assert "worker" not in win._state.active_jobs.by_id["d2"]  # NOT overwritten by d1's worker
+
+
+@pytest.mark.parametrize("trigger", ["_on_new", "_on_close"])
+def test_on_new_and_close_do_not_rebuild_while_jobs_active(qtbot, monkeypatch, trigger):
+    # Regression test for the stale-controller scenario Task 10 flagged: rebuilding
+    # window.py's workspace (via _rebuild -> _dispose_workspace/_build_workspace) while a
+    # Pipeline batch is still mid-flight on a worker thread would leave the OLD
+    # PipelineController connected to the persistent _pipeline_service, so it would keep
+    # receiving dataset_run_started/dataset_run_finished and writing into an AppState
+    # that's already been discarded. Blocking the rebuild outright (this task) is what
+    # prevents that -- so _rebuild must never be called while active_jobs is non-empty.
+    win = WorkspaceWindow(AppState())
+    qtbot.addWidget(win)
+    win._state.active_jobs.by_id["d1"] = {"status": "running"}
+
+    from PySide6.QtWidgets import QMessageBox
+
+    monkeypatch.setattr(QMessageBox, "question", lambda *a, **k: QMessageBox.StandardButton.Cancel)
+    rebuild_calls = []
+    monkeypatch.setattr(win, "_rebuild", lambda *a, **k: rebuild_calls.append(1))
+
+    getattr(win, trigger)()
+
+    assert rebuild_calls == []
+
+
+def test_on_open_does_not_rebuild_while_jobs_active(qtbot, monkeypatch):
+    win = WorkspaceWindow(AppState())
+    qtbot.addWidget(win)
+    win._state.active_jobs.by_id["d1"] = {"status": "running"}
+
+    from PySide6.QtWidgets import QFileDialog, QMessageBox
+
+    monkeypatch.setattr(QMessageBox, "question", lambda *a, **k: QMessageBox.StandardButton.Cancel)
+    dialog_calls = []
+    monkeypatch.setattr(
+        QFileDialog,
+        "getOpenFileName",
+        lambda *a, **k: (dialog_calls.append(1), ("", ""))[1],
+    )
+    rebuild_calls = []
+    monkeypatch.setattr(win, "_rebuild", lambda *a, **k: rebuild_calls.append(1))
+
+    win._on_open()
+
+    assert rebuild_calls == []
+    assert dialog_calls == []  # blocked before even reaching the file-open dialog

--- a/tests/gui/workspace/test_window_commit_dataset.py
+++ b/tests/gui/workspace/test_window_commit_dataset.py
@@ -1,0 +1,51 @@
+import pytest
+
+pytest.importorskip("PySide6")
+
+from rheojax.gui.foundation.library import DatasetRef
+from rheojax.gui.foundation.state import AppState
+from rheojax.gui.workspace.window import WorkspaceWindow
+
+
+def _ref(id_):
+    return DatasetRef(id=id_, name=id_, protocol_type="oscillation", origin="derived",
+                      units={}, row_count=1, hash="h", provenance={}, lineage=[])
+
+
+def test_commit_dataset_adds_ref_and_marks_dirty(qtbot):
+    state = AppState()
+    win = WorkspaceWindow(state)
+    qtbot.addWidget(win)
+    assert state.project.dirty is False
+
+    win._commit_dataset(_ref("d1"), payload=None, overwrite=False)
+
+    assert state.library.get("d1").id == "d1"
+    assert state.project.dirty is True
+
+
+def test_commit_dataset_emits_notifier_changed_once(qtbot):
+    state = AppState()
+    win = WorkspaceWindow(state)
+    qtbot.addWidget(win)
+
+    with qtbot.waitSignal(win._notifier.changed, timeout=1000, raising=True):
+        win._commit_dataset(_ref("d1"), payload=None, overwrite=False)
+
+
+def test_commit_dataset_overwrite_false_raises_on_collision(qtbot):
+    state = AppState()
+    win = WorkspaceWindow(state)
+    qtbot.addWidget(win)
+    win._commit_dataset(_ref("d1"), payload=None, overwrite=False)
+    with pytest.raises(ValueError):
+        win._commit_dataset(_ref("d1"), payload=None, overwrite=False)
+
+
+def test_fit_body_dataset_commit_requested_routes_to_commit_dataset(qtbot):
+    state = AppState()
+    win = WorkspaceWindow(state)
+    qtbot.addWidget(win)
+    fit_export_body = next(b for b in win._fit_bodies if hasattr(b, "dataset_commit_requested"))
+    fit_export_body.dataset_commit_requested.emit(_ref("d2"), None, True)
+    assert state.library.get("d2").id == "d2"

--- a/tests/gui/workspace/test_window_file_menu.py
+++ b/tests/gui/workspace/test_window_file_menu.py
@@ -1,0 +1,139 @@
+import pytest
+
+pytest.importorskip("PySide6")
+
+from PySide6.QtWidgets import QFileDialog, QMessageBox
+
+from rheojax.gui.foundation.state import AppState
+from rheojax.gui.workspace.window import WorkspaceWindow
+
+
+def _win(qtbot):
+    win = WorkspaceWindow(AppState())
+    qtbot.addWidget(win)
+    return win
+
+
+def test_maybe_confirm_unsaved_save_cancelled_does_not_proceed(qtbot, monkeypatch):
+    # Simulates the user clicking "Save" but then cancelling the file dialog
+    # inside _on_save/_on_save_as: dirty stays True, so proceed() must not run.
+    win = _win(qtbot)
+    win._state.project.dirty = True
+    monkeypatch.setattr(
+        QMessageBox, "question", lambda *a, **k: QMessageBox.StandardButton.Save
+    )
+    monkeypatch.setattr(win, "_on_save", lambda: None)
+    calls = []
+    win._maybe_confirm_unsaved_changes(lambda: calls.append(1))
+    assert calls == []
+
+
+def test_maybe_confirm_unsaved_save_success_proceeds(qtbot, monkeypatch):
+    win = _win(qtbot)
+    win._state.project.dirty = True
+    monkeypatch.setattr(
+        QMessageBox, "question", lambda *a, **k: QMessageBox.StandardButton.Save
+    )
+
+    def _fake_save():
+        win._state.project.dirty = False
+
+    monkeypatch.setattr(win, "_on_save", _fake_save)
+    calls = []
+    win._maybe_confirm_unsaved_changes(lambda: calls.append(1))
+    assert calls == [1]
+
+
+def test_maybe_confirm_unsaved_discard_still_proceeds(qtbot, monkeypatch):
+    win = _win(qtbot)
+    win._state.project.dirty = True
+    monkeypatch.setattr(
+        QMessageBox, "question", lambda *a, **k: QMessageBox.StandardButton.Discard
+    )
+    calls = []
+    win._maybe_confirm_unsaved_changes(lambda: calls.append(1))
+    assert calls == [1]
+
+
+def test_maybe_confirm_unsaved_clean_state_proceeds_without_dialog(qtbot, monkeypatch):
+    win = _win(qtbot)
+    assert win._state.project.dirty is False
+
+    def _fail(*a, **k):
+        raise AssertionError("dialog should not be shown when not dirty")
+
+    monkeypatch.setattr(QMessageBox, "question", _fail)
+    calls = []
+    win._maybe_confirm_unsaved_changes(lambda: calls.append(1))
+    assert calls == [1]
+
+
+def test_on_save_shows_critical_dialog_on_value_error(qtbot, monkeypatch):
+    win = _win(qtbot)
+    win._state.project.path = "/tmp/whatever.rheojax"
+    win._state.project.dirty = True
+
+    def _raise(*a, **k):
+        raise ValueError("corrupt archive")
+
+    monkeypatch.setattr(
+        "rheojax.gui.foundation.project_codec.save_project_v2", _raise
+    )
+    critical_calls = []
+    monkeypatch.setattr(
+        QMessageBox, "critical", lambda *a, **k: critical_calls.append(a)
+    )
+
+    win._on_save()  # must not raise
+
+    assert len(critical_calls) == 1
+    assert win._state.project.dirty is True
+
+
+def test_on_save_as_shows_critical_dialog_on_os_error(qtbot, monkeypatch):
+    win = _win(qtbot)
+
+    def _raise(*a, **k):
+        raise OSError("disk full")
+
+    monkeypatch.setattr(
+        "rheojax.gui.foundation.project_codec.save_project_v2", _raise
+    )
+    monkeypatch.setattr(
+        QFileDialog,
+        "getSaveFileName",
+        lambda *a, **k: ("/tmp/whatever.rheojax", ""),
+    )
+    critical_calls = []
+    monkeypatch.setattr(
+        QMessageBox, "critical", lambda *a, **k: critical_calls.append(a)
+    )
+
+    win._on_save_as()  # must not raise
+
+    assert len(critical_calls) == 1
+    assert win._state.project.path is None
+
+
+def test_on_open_shows_critical_dialog_on_value_error(qtbot, monkeypatch):
+    win = _win(qtbot)
+
+    def _raise(*a, **k):
+        raise ValueError("unsupported project version")
+
+    monkeypatch.setattr(
+        "rheojax.gui.foundation.project_codec.load_project_v2", _raise
+    )
+    monkeypatch.setattr(
+        QFileDialog,
+        "getOpenFileName",
+        lambda *a, **k: ("/tmp/whatever.rheojax", ""),
+    )
+    critical_calls = []
+    monkeypatch.setattr(
+        QMessageBox, "critical", lambda *a, **k: critical_calls.append(a)
+    )
+
+    win._on_open()  # must not raise
+
+    assert len(critical_calls) == 1

--- a/tests/gui/workspace/test_window_pipeline_mode.py
+++ b/tests/gui/workspace/test_window_pipeline_mode.py
@@ -57,3 +57,24 @@ def test_run_all_populates_active_jobs(qtbot, tmp_path, monkeypatch):
 
     assert "d1" in captured
     assert "d1" in captured["d1"]
+
+
+def test_run_all_ignored_while_batch_already_running(qtbot, monkeypatch):
+    from PySide6.QtCore import QThreadPool
+
+    state = AppState()
+    win = WorkspaceWindow(state)
+    qtbot.addWidget(win)
+    win.set_mode("pipeline")
+
+    start_calls = []
+    monkeypatch.setattr(
+        QThreadPool.globalInstance(), "start", lambda *a, **kw: start_calls.append((a, kw))
+    )
+
+    # Simulate a batch already in flight.
+    state.active_jobs.by_id["d1"] = {"worker": None}
+
+    win._on_pipeline_run_requested()
+
+    assert start_calls == []

--- a/tests/gui/workspace/test_window_pipeline_mode.py
+++ b/tests/gui/workspace/test_window_pipeline_mode.py
@@ -1,0 +1,59 @@
+import pytest
+
+pytest.importorskip("PySide6")
+
+from rheojax.gui.foundation.state import AppState
+from rheojax.gui.workspace.window import WorkspaceWindow
+
+
+def test_pipeline_mode_is_available(qtbot):
+    win = WorkspaceWindow(AppState())
+    qtbot.addWidget(win)
+    assert "pipeline" in win.MODES
+    win.set_mode("pipeline")
+    assert win.mode() == "pipeline"
+
+
+def test_pipeline_toolbar_button_exists(qtbot):
+    win = WorkspaceWindow(AppState())
+    qtbot.addWidget(win)
+    assert win._pipeline_btn.text() == "Pipeline"
+
+
+def test_run_all_populates_active_jobs(qtbot, tmp_path, monkeypatch):
+    monkeypatch.setenv("RHEOJAX_WORKER_ISOLATION", "subprocess")
+    from rheojax.core.data import RheoData
+    from rheojax.gui.foundation.library import DatasetRef
+
+    state = AppState()
+    ref = DatasetRef(id="d1", name="d1", protocol_type="oscillation", origin="imported",
+                      units={}, row_count=1, hash="h", provenance={}, lineage=[])
+    state.library.add(ref)
+    state.library.store_payload("d1", RheoData(x=[0.1, 1.0], y=[1.0, 2.0], initial_test_mode="oscillation"))
+    win = WorkspaceWindow(state)
+    qtbot.addWidget(win)
+    win.set_mode("pipeline")
+    pipeline_body = win._pipeline_bodies[0]
+    pipeline_body.add_step("export", {"path": str(tmp_path / "out.csv"), "format": "csv"})
+    pipeline_body.set_selected_dataset_ids(["d1"])
+
+    # For a single-dataset, single-export-step batch, dataset_run_started and
+    # dataset_run_finished can both land on the GUI thread within the same event-loop
+    # tick -- a fixed post-signal sleep races the batch's real completion and is
+    # flaky-by-construction (it can observe active_jobs after PipelineController's
+    # dataset_run_finished handler has already popped the entry). Capture active_jobs
+    # synchronously inside the dataset_run_started handler instead: Qt delivers
+    # same-signal slots in connection order, and PipelineController's own
+    # dataset_run_started handler (connected in build_pipeline_controller, before this
+    # test connects) always runs first, so by the time this probe fires, active_jobs
+    # is guaranteed to already be populated.
+    captured: dict[str, dict] = {}
+    win._pipeline_service.dataset_run_started.connect(
+        lambda dataset_id: captured.setdefault(dataset_id, dict(state.active_jobs.by_id))
+    )
+
+    with qtbot.waitSignal(win._pipeline_service.dataset_run_finished, timeout=5000):
+        pipeline_body.run_requested.emit()
+
+    assert "d1" in captured
+    assert "d1" in captured["d1"]

--- a/tests/gui/workspace/test_window_rebuild.py
+++ b/tests/gui/workspace/test_window_rebuild.py
@@ -1,0 +1,67 @@
+import pytest
+
+pytest.importorskip("PySide6")
+
+from rheojax.gui.foundation.state import AppState
+from rheojax.gui.workspace.window import WorkspaceWindow
+
+
+def test_rebuild_increments_epoch(qtbot):
+    win = WorkspaceWindow(AppState())
+    qtbot.addWidget(win)
+    epoch_before = win._epoch
+    win._rebuild(AppState())
+    assert win._epoch == epoch_before + 1
+
+
+def test_rebuild_replaces_controllers_with_new_state(qtbot):
+    state_a = AppState()
+    win = WorkspaceWindow(state_a)
+    qtbot.addWidget(win)
+    state_b = AppState()
+    state_b.fit.protocol = "creep"
+    win._rebuild(state_b)
+    assert win._controllers["fit"] is not None
+    assert win._state is state_b
+
+
+def test_toolbar_widgets_are_same_instance_across_rebuild(qtbot):
+    win = WorkspaceWindow(AppState())
+    qtbot.addWidget(win)
+    fit_btn_before = win._fit_btn
+    win._rebuild(AppState())
+    assert win._fit_btn is fit_btn_before
+
+
+def test_notifier_is_same_instance_across_rebuild(qtbot):
+    win = WorkspaceWindow(AppState())
+    qtbot.addWidget(win)
+    notifier_before = win._notifier
+    win._rebuild(AppState())
+    assert win._notifier is notifier_before
+
+
+def test_guard_ignores_callback_after_epoch_changed(qtbot):
+    win = WorkspaceWindow(AppState())
+    qtbot.addWidget(win)
+    calls = []
+    guarded = win._guard(win._epoch, lambda: calls.append(1))
+    win._epoch += 1  # simulate a rebuild happening before the callback fires
+    guarded()
+    assert calls == []
+
+
+def test_guard_runs_callback_when_epoch_unchanged(qtbot):
+    win = WorkspaceWindow(AppState())
+    qtbot.addWidget(win)
+    calls = []
+    guarded = win._guard(win._epoch, lambda: calls.append(1))
+    guarded()
+    assert calls == [1]
+
+
+def test_build_workspace_never_marks_dirty(qtbot):
+    state = AppState()
+    win = WorkspaceWindow(state)
+    qtbot.addWidget(win)
+    assert state.project.dirty is False

--- a/tests/gui/workspace/transform/test_end_to_end_slot_to_library.py
+++ b/tests/gui/workspace/transform/test_end_to_end_slot_to_library.py
@@ -56,6 +56,16 @@ def test_pick_fill_run_save_round_trips_through_library(qapp, monkeypatch):
 
     ctl, bodies = build_transform_controller(app_state)
 
+    # TransformExportStep no longer commits to the library itself -- it only
+    # requests a commit via dataset_commit_requested. Simulate the Task-10
+    # WorkspaceWindow._commit_dataset handler that will perform it.
+    def _handle(ref, payload, overwrite):
+        app_state.library.add(ref, overwrite=overwrite)
+        if payload is not None:
+            app_state.library.store_payload(ref.id, payload)
+
+    bodies[4].dataset_commit_requested.connect(_handle)
+
     # 1. Pick a single-slot transform ("smooth_derivative", not "derivative"
     #    -- the latter is a TransformService-only alias, not a real
     #    TransformRegistry entry).

--- a/tests/gui/workspace/transform/test_infer_output_protocol.py
+++ b/tests/gui/workspace/transform/test_infer_output_protocol.py
@@ -1,0 +1,23 @@
+from rheojax.gui.foundation.library import DatasetLibrary, DatasetRef
+from rheojax.gui.workspace.transform.transform_controller import infer_output_protocol
+
+
+def _ref(id, ptype):
+    return DatasetRef(id=id, name=id, protocol_type=ptype, origin="imported",
+                      units={}, row_count=1, hash="h", provenance={}, lineage=[])
+
+
+def test_infer_output_protocol_same_domain_transform():
+    lib = DatasetLibrary()
+    lib.add(_ref("d1", "oscillation"))
+    # smooth_derivative is same-domain (processing category) -- keeps source protocol
+    result = infer_output_protocol(lib, "smooth_derivative", {"input": "d1"})
+    assert result == "oscillation"
+
+
+def test_infer_output_protocol_domain_changing_transform_returns_empty():
+    lib = DatasetLibrary()
+    lib.add(_ref("d1", "oscillation"))
+    # fft_analysis is domain-changing (spectral category) -- returns ""
+    result = infer_output_protocol(lib, "fft_analysis", {"input": "d1"})
+    assert result == ""

--- a/tests/gui/workspace/transform/test_step5.py
+++ b/tests/gui/workspace/transform/test_step5.py
@@ -6,6 +6,38 @@ from rheojax.gui.foundation.state import TransformState
 from rheojax.gui.workspace.transform.step5_export import TransformExportStep
 
 
+def _commit_on_request(step, lib):
+    # Simulates the Task-10 WorkspaceWindow._commit_dataset handler that will
+    # eventually own this: the widget only requests a commit, it no longer
+    # performs one itself.
+    def _handle(ref, payload, overwrite):
+        lib.add(ref, overwrite=overwrite)
+        if payload is not None:
+            lib.store_payload(ref.id, payload)
+
+    step.dataset_commit_requested.connect(_handle)
+
+
+def test_save_emits_dataset_commit_requested_not_exported(qtbot):
+    st = TransformState(
+        transform_key="prony_conversion",
+        slots={"input": "rel1"},
+        result={"output": "rd", "protocol_type": "oscillation"},
+    )
+    lib = DatasetLibrary()
+    step = TransformExportStep(st, lib)
+    qtbot.addWidget(step)
+    assert not hasattr(step, "exported")
+    with qtbot.waitSignal(step.dataset_commit_requested, timeout=1000) as blocker:
+        step.save_to_library()
+    ref, payload, overwrite = blocker.args
+    assert ref.origin == "derived"
+    assert overwrite is False
+    # The library must NOT have been mutated by the widget itself:
+    with pytest.raises(KeyError):
+        step._library.get(ref.id)
+
+
 def test_save_derived_with_protocol_type(qtbot):
     st = TransformState(
         transform_key="prony_conversion",
@@ -15,6 +47,7 @@ def test_save_derived_with_protocol_type(qtbot):
     lib = DatasetLibrary()
     step = TransformExportStep(st, lib)
     qtbot.addWidget(step)
+    _commit_on_request(step, lib)
     new_id = step.save_to_library()
     assert new_id is not None and lib.get(new_id).origin == "derived"
     assert lib.get(new_id).protocol_type == "oscillation"
@@ -30,6 +63,7 @@ def test_save_to_library_does_not_overwrite_on_repeat_transform_key(qtbot):
     )
     step1 = TransformExportStep(st1, lib)
     qtbot.addWidget(step1)
+    _commit_on_request(step1, lib)
     id1 = step1.save_to_library()
 
     st2 = TransformState(
@@ -39,6 +73,7 @@ def test_save_to_library_does_not_overwrite_on_repeat_transform_key(qtbot):
     )
     step2 = TransformExportStep(st2, lib)
     qtbot.addWidget(step2)
+    _commit_on_request(step2, lib)
     id2 = step2.save_to_library()
 
     assert id1 is not None and id2 is not None
@@ -77,6 +112,7 @@ def test_save_domain_changing_output_with_empty_protocol_type_still_stores(qtbot
     lib = DatasetLibrary()
     step = TransformExportStep(st, lib)
     qtbot.addWidget(step)
+    _commit_on_request(step, lib)
     new_id = step.save_to_library()
     assert new_id is not None
     ref = lib.get(new_id)

--- a/tests/gui/workspace/transform/test_step5_store_payload.py
+++ b/tests/gui/workspace/transform/test_step5_store_payload.py
@@ -24,6 +24,16 @@ def test_save_to_library_stores_payload(qtbot):
     lib = DatasetLibrary()
     step = TransformExportStep(st, lib)
     qtbot.addWidget(step)
+
+    # Widget only requests a commit; simulate the Task-10
+    # WorkspaceWindow._commit_dataset handler that performs it.
+    def _handle(ref, payload, overwrite):
+        lib.add(ref, overwrite=overwrite)
+        if payload is not None:
+            lib.store_payload(ref.id, payload)
+
+    step.dataset_commit_requested.connect(_handle)
+
     new_id = step.save_to_library()
     assert new_id is not None
     payload = lib.load_payload(new_id)  # must not raise KeyError

--- a/tests/gui/workspace/transform/test_transform_controller.py
+++ b/tests/gui/workspace/transform/test_transform_controller.py
@@ -9,8 +9,8 @@ from rheojax.gui.foundation.state import AppState
 from rheojax.gui.widgets.pyqtgraph_canvas import PyQtGraphCanvas
 from rheojax.gui.workspace.transform.slots_spec import SlotSpec
 from rheojax.gui.workspace.transform.transform_controller import (
-    _infer_protocol_type,
     build_transform_controller,
+    infer_output_protocol,
 )
 from rheojax.gui.workspace.window import WorkspaceWindow
 
@@ -195,7 +195,7 @@ def test_infer_protocol_type_returns_empty_string_not_none_for_domain_changing()
             units={}, row_count=3, hash="h", provenance={}, lineage=[],
         )
     )
-    ptype = _infer_protocol_type(lib, "fft_analysis", {"input": "rel1"})
+    ptype = infer_output_protocol(lib, "fft_analysis", {"input": "rel1"})
     assert ptype == ""
     assert ptype is not None
 
@@ -208,5 +208,5 @@ def test_infer_protocol_type_same_domain_still_resolves_real_type():
             units={}, row_count=3, hash="h", provenance={}, lineage=[],
         )
     )
-    ptype = _infer_protocol_type(lib, "smooth_derivative", {"input": "osc1"})
+    ptype = infer_output_protocol(lib, "smooth_derivative", {"input": "osc1"})
     assert ptype == "oscillation"

--- a/tests/gui/workspace/transform/test_transform_controller.py
+++ b/tests/gui/workspace/transform/test_transform_controller.py
@@ -55,8 +55,8 @@ def test_picking_transform_invalidates_downstream_state(qtbot):
 
 
 def test_window_transform_export_step_reachable_without_forced_navigation(qtbot):
-    # Regression: TransformExportStep (index 4) has only an `exported`
-    # signal, not `edited`; TransformVisualizeStep (index 3) is read-only
+    # Regression: TransformExportStep (index 4) has only a
+    # `dataset_commit_requested` signal, not `edited`; TransformVisualizeStep (index 3) is read-only
     # with no signal at all. If window.py only wired `edited` from bodies
     # 0-2 to advance()+refresh with no forward-unlock loop, index 4 would
     # stay permanently unreachable once the workflow lands on Visualize --


### PR DESCRIPTION
## Summary

Cuts the rheojax GUI over from the legacy `RheoJAXMainWindow` to the newer `WorkspaceWindow` shell as the default, executed as three sequential plans (30 tasks total) via subagent-driven development, each individually reviewed and whole-branch reviewed.

- **Plan 1 — Foundation** (13 tasks): typed `AppState` dataclasses, a full versioned `.rheojax` v2 project save/load codec, centralized dataset-commit + dirty tracking, disposal/rebuild machinery, File menu, and `--project`/`--import`/`--protocol` CLI wiring.
- **Plan 2 — Pipeline mode** (13 tasks): a new batch-execution mode running a fit/transform/export pipeline over one or more datasets, with off-thread execution/cancellation, persisted job history, and a third workspace mode alongside Fit/Transform.
- **Plan 3 — Default flip** (4 tasks): go/no-go gate, then flips `rheojax-gui`'s default entry point to the workspace shell, with a `--legacy` flag for instant rollback and a deprecated (still functional) `--workspace` flag.

Design doc: `docs/superpowers/specs/2026-07-02-gui-workspace-parity-and-default-flip-design.md`
Plans: `docs/superpowers/plans/2026-07-02-gui-workspace-parity-{1-foundation,2-pipeline-mode,3-default-flip}.md`

## Notable findings caught and fixed during review

- A Zip Slip / path traversal vulnerability (CWE-22) in the project-load archive extraction, found by automated security scanning.
- A silent Hz→rad/s unit-conversion bug in the CLI `--import` path for oscillation data.
- Silent data-loss paths in the unsaved-changes dialog and File-menu error handling.
- A stale-controller race that could silently write Pipeline job results into a discarded app state after a cancelled-but-still-running batch.
- An export-step exception swallow that reported failed exports as "completed".
- An unguarded concurrent "Run All" race in Pipeline mode.

All of the above are fixed and covered by regression tests.

## Known residual risk

The go/no-go gate's interactive manual soak test (clicking through the live desktop app) could not be performed in this headless environment — automated tests (723 passing) and two independently-reproduced offscreen launches (default + `--legacy`) were used as the strongest available substitute. This gap was surfaced to and explicitly accepted by the user before proceeding.

Three cosmetic Minor items remain, none blocking (see final review): the workspace inspector's log tab isn't wired up yet, a stale comment, and a minor dirty-flag inconsistency in the `--project` CLI path vs. interactive Open.

## Test plan

- [x] Full `tests/gui/` suite: 723 passed, 0 failed
- [x] `ruff check` clean on all touched paths
- [x] `mypy` clean on all touched paths (pre-existing errors elsewhere confirmed untouched by this branch)
- [x] Both launch paths (`rheojax-gui` default, `rheojax-gui --legacy`) independently verified via offscreen Qt with branch-exclusive log-line attribution
- [ ] Interactive manual click-through (not performed — no display in this environment; risk accepted by user)

🤖 Generated with [Claude Code](https://claude.com/claude-code)