### PR TITLE
docs: add workspace shell documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -897,14 +897,17 @@ RheoJAX includes an optional GUI built with PySide6/Qt6 for interactive analysis
 ### Launching
 
 ```bash
-# From command line
+# From command line (launches workspace shell by default)
 rheojax-gui
+
+# Launch the legacy main window instead
+rheojax-gui --legacy
 
 # Start maximized (useful on high-DPI desktops)
 rheojax-gui --maximized
 
-# Preview the new step-wizard workspace shell (experimental)
-rheojax-gui --workspace
+# Open a saved project file
+rheojax-gui --project analysis.rheojax
 
 # Or from Python
 from rheojax.gui import main
@@ -916,9 +919,11 @@ main()
 - **Data Loading**: Import CSV, Excel, TRIOS, and Anton Paar formats with preview
 - **Model Fitting**: Interactive NLSQ curve fitting with real-time visualization
 - **Bayesian Inference**: MCMC sampling with progress tracking
+- **Pipeline Mode**: Batch fit/transform/export workflows over multiple datasets
 - **Diagnostics**: ArviZ plots (trace, forest, pair, energy, ESS, rank, autocorr)
 - **Transforms**: Apply mastercurve, FFT, and derivative transforms
 - **Export**: Save results, figures, and reports in multiple formats
+- **Project Save/Load**: Store and restore complete analysis projects (.rheojax format)
 
 See [GUI Reference Guide](https://rheojax.readthedocs.io/user_guide/06_gui/index.html) for detailed documentation.
 

--- a/docs/source/user_guide/06_gui/getting_started.rst
+++ b/docs/source/user_guide/06_gui/getting_started.rst
@@ -4,7 +4,13 @@
 Getting Started
 ===============
 
-This guide walks you through launching and using the RheoJAX GUI for the first time.
+.. note::
+
+   This guide covers the **Legacy Page-Based Window** (``rheojax-gui --legacy``).
+   By default, ``rheojax-gui`` now launches the modern **Workspace Shell**
+   with Fit, Transform, and Pipeline modes. Workspace documentation is coming soon.
+
+This guide walks you through launching and using the legacy RheoJAX GUI for the first time.
 
 Prerequisites
 =============

--- a/docs/source/user_guide/06_gui/index.rst
+++ b/docs/source/user_guide/06_gui/index.rst
@@ -7,10 +7,19 @@ GUI Reference Guide
 RheoJAX provides an optional graphical user interface (GUI) built with PySide6/Qt6
 for interactive rheological analysis workflows.
 
+.. warning::
+
+   **Workspace Shell is now the default** (as of v0.7.0+): ``rheojax-gui`` launches
+   the modern **Workspace Shell** with Fit, Transform, and Pipeline modes by default.
+   This guide documents the **Legacy Page-Based Window**, which is still available
+   via ``rheojax-gui --legacy`` but no longer the default. See
+   :doc:`workspace_getting_started` for the new default.
+
 .. toctree::
    :maxdepth: 2
    :caption: GUI Documentation
 
+   workspace_getting_started
    getting_started
    data_loading
    model_fitting
@@ -51,10 +60,10 @@ Or from Python::
     from rheojax.gui import main
     main()
 
-Architecture
-============
+Architecture (Legacy Window)
+============================
 
-The GUI follows a modern architecture pattern:
+The legacy page-based window uses the following architecture:
 
 - **State Management**: Redux-like centralized state store with undo/redo
 - **Service Layer**: Business logic abstraction via services (ModelService, etc.)
@@ -64,7 +73,7 @@ The GUI follows a modern architecture pattern:
 Key Components
 --------------
 
-**Pages** (Main Views):
+**Pages** (Main Views, Legacy Only):
 
 - ``DataPage``: Data import and preview
 - ``FitPage``: Model selection and NLSQ fitting

--- a/docs/source/user_guide/06_gui/workspace_getting_started.rst
+++ b/docs/source/user_guide/06_gui/workspace_getting_started.rst
@@ -1,0 +1,123 @@
+.. _gui-workspace-getting-started:
+
+=========================
+Workspace Shell (Default)
+=========================
+
+.. note::
+
+   The Workspace Shell recently became the default RheoJAX GUI. Fuller,
+   per-mode guides (Fit, Transform, Pipeline) are planned; this page covers
+   orientation — launching, the three modes, and the project file model.
+
+This guide covers the **Workspace Shell**, the mode-based GUI that
+``rheojax-gui`` launches by default.
+
+Prerequisites
+=============
+
+Ensure you have RheoJAX installed (GUI dependencies are included)::
+
+    uv sync
+
+Verify the installation::
+
+    python -c "from PySide6.QtWidgets import QApplication; print('PySide6 OK')"
+
+Launching the Application
+==========================
+
+Command Line
+------------
+
+The default launch opens the Workspace Shell::
+
+    rheojax-gui
+
+Other startup options::
+
+    # Launch the legacy page-based window instead (instant rollback if
+    # something isn't working right for you in the workspace shell)
+    rheojax-gui --legacy
+
+    # Open a saved project on startup
+    rheojax-gui --project analysis.rheojax
+
+    # Import raw data into the library on startup (preload only -- this
+    # does not run a fit or transform automatically)
+    rheojax-gui --import data.xlsx --protocol relaxation
+
+    # Start maximized (useful on high-DPI desktops)
+    rheojax-gui --maximized
+
+Python API
+----------
+
+From within a Python script or interactive session::
+
+    from rheojax.gui import main
+    main()
+
+The Workspace Window
+=====================
+
+The Workspace Shell is a single window with a mode toolbar at the top, a
+dataset library on the left, the active mode's step sequence in the center,
+and an inspector panel on the right. A status label in the toolbar shows
+JAX device and float64 status.
+
+Three Modes
+===========
+
+Switching modes (toolbar buttons) swaps the center step sequence. Each mode
+is a linear, forward-unlocking sequence of steps: a step becomes reachable
+once the previous step is both filled in and valid.
+
+Fit
+---
+
+Single-dataset model fitting. Pick a protocol and model, select the
+dataset to fit, run an NLSQ fit, optionally follow up with a Bayesian NUTS
+run, visualize the result, and export it. This mirrors the legacy GUI's
+Data → Fit → Bayesian → Export workflow, but as one guided sequence instead
+of separate pages.
+
+Transform
+---------
+
+Single-dataset transform application. Pick a transform (mastercurve, FFT,
+derivative, etc.), configure its inputs, run it, visualize the transformed
+data, and export the result.
+
+Pipeline
+--------
+
+Batch orchestration across many datasets at once. Assemble a sequence of
+transform, fit, and export steps, select which datasets in the library to
+run them against, and click **Run All**. Pipeline mode has no per-step "run"
+button by design — running a single step interactively is what Fit and
+Transform modes are for; Pipeline mode is for repeating a fixed recipe over
+many datasets in the background.
+
+The File Menu and Projects
+============================
+
+The **File** menu provides **New**, **Open...**, **Save**, **Save As...**,
+and **Close**. Save and Open read and write the ``.rheojax`` v2 project
+format: a single archive file capturing the dataset library, fit/transform/
+pipeline state, and job history, so a full analysis session can be closed
+and reopened later.
+
+The window tracks unsaved changes and prompts you to save before starting a
+new project, opening another one, or closing, if anything is dirty. If
+background jobs (an NLSQ/NUTS fit, a running pipeline batch) are still in
+flight, it will also ask whether to cancel them before proceeding.
+
+Falling Back to the Legacy Window
+====================================
+
+The Workspace Shell recently became the default GUI experience. If you hit
+something that isn't working right for you, ``rheojax-gui --legacy`` is an
+instant rollback to the previous page-based window — see
+:doc:`getting_started` for that guide. The legacy window remains fully
+functional; it is simply no longer the default.

--- a/rheojax/gui/README.md
+++ b/rheojax/gui/README.md
@@ -2,6 +2,16 @@
 
 Qt-based graphical user interface for RheoJAX rheological analysis.
 
+## Architecture Overview
+
+RheoJAX GUI has two main implementations:
+
+1. **Workspace Shell** (Default, new): Modern mode-based interface with Fit, Transform, and Pipeline modes. Launched by `rheojax-gui` with no flags. Located in `foundation/` (core models) and `workspace/` (UI shell). Includes project save/load and batch pipeline execution.
+
+2. **Legacy Main Window** (Page-based, older): Original page-based navigation with sidebar pages. Launched with `rheojax-gui --legacy`. Located in `app/`, `pages/`, `state/`. Still fully functional but no longer the default.
+
+**This document describes the legacy architecture.** For the workspace shell, see `workspace/README.md`.
+
 ## Package Structure
 
 ```

--- a/rheojax/gui/state/USAGE.md
+++ b/rheojax/gui/state/USAGE.md
@@ -2,6 +2,12 @@
 
 Complete state management system for the RheoJAX GUI with immutable updates, undo/redo, and Qt signal integration.
 
+## Note: Legacy Architecture
+
+This document describes the **legacy page-based GUI's state management system**
+(used by `rheojax-gui --legacy`). The default Workspace Shell uses a different
+foundation-based architecture in `rheojax.gui.foundation`.
+
 ## Architecture
 
 ### Core Components

--- a/rheojax/gui/workspace/README.md
+++ b/rheojax/gui/workspace/README.md
@@ -1,0 +1,92 @@
+# RheoJAX Workspace Shell
+
+The default GUI shell for RheoJAX (`rheojax-gui` with no flags). A mode-based
+interface — Fit, Transform, Pipeline — that replaces the legacy page-based
+window (`rheojax/gui/app/`, `pages/`, `state/`, still available via
+`rheojax-gui --legacy`) as the default entry point.
+
+## Relationship to `foundation/`
+
+This package is the UI layer only. All state, persistence, and cross-cutting
+services live in `rheojax/gui/foundation/`:
+
+- `foundation/state.py` — `AppState` and its slices (`FitState`,
+  `TransformState`, `PipelineState`, `ProjectState`, `UiState`,
+  `JobHistoryState`), the single state object each mode's controller reads
+  and mutates.
+- `foundation/library.py` — the in-memory dataset library (`DatasetRef` +
+  payload store) shared across all three modes.
+- `foundation/project_codec.py` — `.rheojax` v2 project file encode/decode.
+- `foundation/import_service.py` — data import shared by CLI `--import` and
+  the in-app import flow.
+- `foundation/notifier.py`, `foundation/invalidation.py`,
+  `foundation/pipeline_bridge.py`, `foundation/metrics.py`,
+  `foundation/priors.py`, `foundation/contract.py` — supporting services
+  (change notification, step invalidation, pipeline execution glue, priors,
+  and the step-controller contract each mode's controller implements).
+
+`workspace/` never talks to the legacy `app/`/`pages/`/`state/` package, and
+vice versa — they are two independent shells over the same `rheojax` core
+API, selected at startup by `rheojax/gui/main.py` based on the `--legacy`
+flag.
+
+## The Three Modes
+
+`WorkspaceWindow` (`window.py`) hosts a toolbar with three mode buttons
+(`WorkspaceWindow.MODES = ("fit", "transform", "pipeline")`) and a central
+splitter of library rail / step canvas / inspector panel. Switching modes
+swaps the step canvas; each mode owns its own controller and step sequence.
+
+- **Fit** (`fit/`) — single-dataset step-by-step model fitting: pick a
+  protocol and model (`step1_protocol_model.py`), select data
+  (`step2_data.py`), run NLSQ (`step3_nlsq.py`), optionally run NUTS
+  (`step4_nuts.py`), visualize (`step5_visualize.py`), export
+  (`step6_export.py`).
+- **Transform** (`transform/`) — single-dataset transform application: pick
+  a transform (`step1_pick.py`), configure its slots (`step2_slots.py`), run
+  it (`step3_run.py`), visualize (`step4_visualize.py`), export
+  (`step5_export.py`).
+- **Pipeline** (`pipeline/`) — batch orchestration across many datasets. A
+  single configure/run step (`step1_configure_run.py`) lets a user assemble
+  a sequence of transform/fit/export steps, select which library datasets to
+  run them against, and hit "Run All". There is deliberately no per-step
+  "Run Step" button — running one step interactively is what Fit/Transform
+  modes are for. `batch_runner.py` executes the queued jobs on a
+  `QThreadPool` worker; `cancel_runnable.py` and `models.py` support
+  cancellation and the pipeline's step/job data model.
+
+Each mode's controller (`fit_controller.py`, `transform_controller.py`,
+`pipeline/controller.py`) drives a `StepperCanvas` (`stepper_canvas.py`) —
+a linear step sequence with forward-only unlocking: a step becomes reachable
+once the previous step is both ready and valid.
+
+## File Menu / Project Model
+
+`WorkspaceWindow._build_file_menu()` adds New / Open / Save / Save As /
+Close under **File**. Save and Open round-trip through
+`foundation/project_codec.py`'s `.rheojax` v2 format: a zip archive with
+JSON metadata/state files (`fit.json`, `transform.json`, `pipeline.json`,
+`job_history.json`, `project.json`, `ui.json`) plus HDF5 payloads for
+dataset and result arrays, an allowlist of archive members, and SHA-256
+checksums verified on load.
+
+`WorkspaceWindow` tracks a `dirty` flag on `AppState.project` (set whenever
+the dataset library changes) and prompts to save unsaved changes before
+New/Open/Close. If jobs are still running in the background (pipeline batch
+or fit/transform steps), it also prompts to cancel them first.
+
+## Package Structure
+
+```
+rheojax/gui/
+├── foundation/                 # State, persistence, and shared services (see above)
+└── workspace/
+    ├── window.py                # WorkspaceWindow: toolbar, File menu, mode switching
+    ├── controller.py            # Shared step-controller base
+    ├── stepper_canvas.py        # Linear step UI shared by all three modes
+    ├── library_rail.py          # Dataset library panel (left)
+    ├── inspector.py             # Inspector panel (right)
+    ├── fit/                     # Fit mode: steps 1-6
+    ├── transform/                # Transform mode: steps 1-5, transform slot specs
+    └── pipeline/                 # Pipeline mode: configure/run step, batch runner, models
+```


### PR DESCRIPTION
## Summary
- Adds `rheojax/gui/workspace/README.md`, a package-level overview of the WorkspaceWindow shell (default GUI entry point since #31): its relationship to `foundation/`, the three modes (Fit/Transform/Pipeline), the File menu / `.rheojax` v2 project model, and package structure.
- Adds `docs/source/user_guide/06_gui/workspace_getting_started.rst`, a real Sphinx user guide page covering launching (`rheojax-gui`, `--legacy`, `--project`, `--import --protocol`), the three modes, and the File menu/project model, matching the style of the sibling legacy `getting_started.rst`.
- Wires the new page into the `06_gui` toctree and replaces the "coming soon" language in `index.rst`'s warning box with a `:doc:` cross-reference.
- Drops the "(when available)" hedge in `rheojax/gui/README.md`'s forward reference now that `workspace/README.md` exists.
- Also commits a prior documentation pass that was sitting uncommitted in this worktree (root `README.md`, legacy `getting_started.rst`/`index.rst`, `state/USAGE.md` — `--workspace` flag corrections and "workspace docs are coming soon" notices).

## Scoped out (follow-up work)
- Per-mode deep-dive guides (separate pages for Fit, Transform, Pipeline workflows) — the new page is orientation only, matching the level of detail in the legacy `getting_started.rst`.

## Test plan
- [x] `cd docs && make html` (via `sphinx-build`) — build succeeded, no new errors or warnings; `user_guide/06_gui/workspace_getting_started` reads/writes cleanly and the toctree `:doc:` reference resolves.
- [ ] `make linkcheck` not run (network-dependent full-site crawl; html build already validates the internal toctree wiring).

🤖 Generated with [Claude Code](https://claude.com/claude-code)