### PR TITLE
docs: fix 7 genuine linkcheck failures

### DIFF
--- a/docs/source/models/ikh/mikh.rst
+++ b/docs/source/models/ikh/mikh.rst
@@ -1332,10 +1332,6 @@ References
    viscoplastic model." *Journal of Non-Newtonian Fluid Mechanics*, 158, 154-161
    (2009). https://doi.org/10.1016/j.jnnfm.2008.12.001
 
-.. [4] de Souza Mendes, P. R. and Thompson, R. L. "Time-dependent yield stress
-   materials." *Annual Review of Fluid Mechanics*, 51, 421-449 (2019).
-   https://doi.org/10.1146/annurev-fluid-010518-040305
-
 .. [5] Armstrong, P. J. and Frederick, C. O. "A mathematical representation of the
    multiaxial Bauschinger effect." *CEGB Report RD/B/N731* (1966).
    https://doi.org/10.3184/096034007X207589

--- a/docs/source/models/ikh/ml_ikh.rst
+++ b/docs/source/models/ikh/ml_ikh.rst
@@ -1640,8 +1640,8 @@ References
    DOI: `10.1122/1.4978259 <https://doi.org/10.1122/1.4978259>`_
    :download:`PDF <../../../reference/geri_2017_thermokinematic_memory.pdf>`
 
-.. [4] Fielding, S. M., et al. "Aging and rheology in soft materials."
-   *Journal of Rheology*, 53(1), 39-64 (2009). https://doi.org/10.1122/1.3018902
+.. [4] Fielding, S. M., Sollich, P., and Cates, M. E. "Aging and rheology in soft materials."
+   *Journal of Rheology*, 44(2), 323-369 (2000). https://doi.org/10.1122/1.551088
 
 .. [5] Mewis, J. and Wagner, N. J. "Thixotropy." *Advances in Colloid and Interface
    Science*, 147-148, 214-227 (2009). https://doi.org/10.1016/j.cis.2008.09.005

--- a/docs/source/user_guide/03_advanced_topics/dense_suspensions_glasses.rst
+++ b/docs/source/user_guide/03_advanced_topics/dense_suspensions_glasses.rst
@@ -762,4 +762,4 @@ See Also
 - :doc:`/models/fluidity/index` — Fluidity models
 
 .. note::
-   For questions or issues with ITT-MCT models, consult the `RheoJAX GitHub Issues <https://github.com/username/rheojax/issues>`_ or refer to the original publications above.
+   For questions or issues with ITT-MCT models, consult the `RheoJAX GitHub Issues <https://github.com/imewei/rheojax/issues>`_ or refer to the original publications above.

--- a/docs/verification/dmt_literature_verification.md
+++ b/docs/verification/dmt_literature_verification.md
@@ -220,7 +220,7 @@ Dullaert-Mewis model specifically, it would require a new model family with:
 - [Dullaert & Mewis 2006 (ScienceDirect)](https://www.sciencedirect.com/science/article/abs/pii/S0377025706001431)
 - [Dullaert & Mewis 2005 (J. Rheol.)](https://sor.scitation.org/doi/10.1122/1.2039868)
 - [Larson & Wei 2019 Review](https://pubs.aip.org/sor/jor/article/63/3/477/241126/A-review-of-thixotropy-and-its-rheological)
-- [Armstrong et al. LAOS study (UDel)](https://bpb-us-w2.wpmucdn.com/sites.udel.edu/dist/8/715/files/2014/11/Armstrong-et-al-Thixotropy-of-Transient-and-LAOS-08152015-1zaa32b.pdf)
+- [Armstrong et al. 2016 LAOS study (J. Rheol.)](https://doi.org/10.1122/1.4943986)
 - [de Souza Mendes & Thompson 2013 (Rheol. Acta)](https://link.springer.com/article/10.1007/s00397-013-0699-1)
 - [Gas Bubbles in Dullaert-Mewis Fluid (ResearchGate)](https://www.researchgate.net/publication/270432311_Dynamic_of_Gas_Bubbles_Surrounded_by_a_Dullaert-Mewis_Thixotropic_Fluid)
 - [Turbulent Pipe Flow of Thixotropic Fluids (arXiv)](https://arxiv.org/abs/2501.01597)

--- a/docs/verification/epm_validation_report_2026-03-29.md
+++ b/docs/verification/epm_validation_report_2026-03-29.md
@@ -149,7 +149,7 @@ The lattice EPM is correctly described as a spatial generalization of HL (1998).
 |-------|--------|
 | Secrets in code | None found |
 | Input sanitization | N/A (numerical library) |
-| `assert` usage | 18 instances in base.py/tensor.py — parameter guards, not security-critical |
+| `assert` usage | 18 instances in `base.py`/`tensor.py` — parameter guards, not security-critical |
 | Dependency vulnerabilities | Not applicable (JAX/NumPy/SciPy stack) |
 | Code injection | No string eval/exec, no user-supplied code paths |
 

--- a/docs/verification/ikh_literature_verification.md
+++ b/docs/verification/ikh_literature_verification.md
@@ -241,7 +241,7 @@ Representative values from the paper (for model waxy crude):
 - C = 70 Pa
 - m = 0.25
 
-**RheoJAX (mikh.py):** Parameters are: G, eta, C, gamma_dyn (=q for m=1), m, sigma_y0, delta_sigma_y (=k3), tau_thix (=1/k1), Gamma (=k2), eta_inf, mu_p — **11 parameters** vs 9 in the paper. The extra parameters are eta_inf (background viscosity, distinct from mu_p) and sigma_y0 (the paper implicitly includes this as part of the steady-state balance).
+**RheoJAX (`mikh.py`):** Parameters are: G, eta, C, gamma_dyn (=q for m=1), m, sigma_y0, delta_sigma_y (=k3), tau_thix (=1/k1), Gamma (=k2), eta_inf, mu_p — **11 parameters** vs 9 in the paper. The extra parameters are eta_inf (background viscosity, distinct from mu_p) and sigma_y0 (the paper implicitly includes this as part of the steady-state balance).
 
 ---
 

--- a/rheojax/utils/prony.py
+++ b/rheojax/utils/prony.py
@@ -17,7 +17,7 @@ References:
     - Park, S. W., & Schapery, R. A. (1999). Methods of interconversion between
       linear viscoelastic material functions. Part I—A numerical method based on
       Prony series. International Journal of Solids and Structures, 36(11), 1653-1675.
-    - pyvisco: https://github.com/saintsfan342000/pyvisco
+    - pyvisco: https://github.com/NatLabRockies/pyvisco
 """
 
 from __future__ import annotations


### PR DESCRIPTION
## Summary

Filtered a full `make linkcheck` run for genuine problems, excluding ~125 academic-publisher 403s that are bot-blocking (Sphinx's crawler gets rejected by ScienceDirect/JSTOR/MDPI/AIP regardless of whether the link works for a real reader). Fixed the 7 real issues found:

- **`dense_suspensions_glasses.rst`** — `github.com/username/rheojax` was a literal unreplaced template placeholder → `imewei/rheojax`.
- **`rheojax/utils/prony.py`** docstring — dead pyvisco GitHub link (`saintsfan342000/pyvisco`, 404) → the correct repo (`NatLabRockies/pyvisco`), found via web search and verified with a direct fetch.
- **`ml_ikh.rst`** — the Fielding et al. citation had both a dead DOI *and* wrong volume/pages/year; corrected to the real paper with the full author list.
- **`mikh.rst`** — removed a "de Souza Mendes & Thompson, *Time-dependent yield stress materials*, Annual Review of Fluid Mechanics 51, 421-449 (2019)" reference. Could not verify this publication exists across three independent searches, and it wasn't cited anywhere in the document body — left as a numbering gap rather than invent a replacement DOI.
- **`dmt_literature_verification.md`** — replaced a dead personal-lab-hosted PDF (404, server reorganized) with the paper's actual published DOI, which is more durable.
- **`ikh_literature_verification.md`**, **`epm_validation_report_2026-03-29.md`** — wrapped `mikh.py` and `base.py`/`tensor.py` in code spans; MyST's linkify was mistaking these bare filenames for domain names and auto-generating dead `http://mikh.py` / `http://base.py/tensor.py` links.

## Test plan

- [x] `sphinx-build -b html` — clean, 0 new warnings
- [x] Re-ran `make linkcheck` after the fixes and confirmed each one individually — 5 of 7 now resolve cleanly (`ok` or fully removed); the other 2 (Fielding DOI, Armstrong DOI) now correctly redirect to the right published article but hit the same AIP/Scitation bot-blocking 403 as ~125 other legitimate citations already in this doc tree — expected, not a regression, and a clear improvement over the prior dead 404s.
- [x] Every replacement URL independently verified with a direct `curl`/web search before use — no guessed URLs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)