### PR TITLE
fix(gui): finish default-flip help text + stale test naming from workspace-parity cutover

### DIFF
--- a/rheojax/gui/main.py
+++ b/rheojax/gui/main.py
@@ -59,7 +59,7 @@ logger = get_logger(__name__)
 
 
 def _create_workspace_window() -> "WorkspaceWindow":  # noqa: F821
-    """Construct the Plan 2 workspace shell window (preview, ``--workspace``).
+    """Construct the workspace shell window (now the default entry point).
 
     Kept as a standalone import point so it can be unit-tested without
     entering the Qt event loop.
@@ -145,11 +145,13 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
         formatter_class=argparse.RawDescriptionHelpFormatter,
         epilog="""
 Examples:
-  rheojax-gui                              # Launch GUI
+  rheojax-gui                              # Launch GUI (workspace shell, now the default)
+  rheojax-gui --legacy                     # Launch the legacy main window
   rheojax-gui --project analysis.rheojax     # Open project file
-  rheojax-gui --import data.xlsx          # Import data on startup
+  rheojax-gui --import data.xlsx --protocol relaxation  # Import data on startup
   rheojax-gui --maximized                 # Start maximized (per-window manager)
   rheojax-gui --verbose                   # Enable verbose logging
+  rheojax-gui --workspace                 # Deprecated no-op alias (workspace is now default)
 
 For more information, visit: https://github.com/imewei/rheojax
         """,

--- a/tests/gui/workspace/transform/test_step5.py
+++ b/tests/gui/workspace/transform/test_step5.py
@@ -97,7 +97,7 @@ def test_scalar_output_not_saved(qtbot):
 
 
 def test_save_domain_changing_output_with_empty_protocol_type_still_stores(qtbot):
-    # Regression: transform_controller._infer_protocol_type() deliberately
+    # Regression: transform_controller.infer_output_protocol() deliberately
     # returns "" (not None) for domain-changing transforms (spectral/
     # decomposition) whose output has a real payload but no determinable
     # rheological protocol. save_to_library() used to no-op on ANY falsy

--- a/tests/gui/workspace/transform/test_transform_controller.py
+++ b/tests/gui/workspace/transform/test_transform_controller.py
@@ -182,7 +182,7 @@ def test_run_finish_refreshes_visualize_step(qtbot):
     assert "n_peaks" in result_tab.text()
 
 
-def test_infer_protocol_type_returns_empty_string_not_none_for_domain_changing():
+def test_infer_output_protocol_returns_empty_string_not_none_for_domain_changing():
     # Regression: domain-changing transforms (spectral/decomposition) must
     # still return a real `str` ("", not None) so save_to_library() can tell
     # "genuinely unresolvable" apart from "known but typeless" -- per design
@@ -200,7 +200,7 @@ def test_infer_protocol_type_returns_empty_string_not_none_for_domain_changing()
     assert ptype is not None
 
 
-def test_infer_protocol_type_same_domain_still_resolves_real_type():
+def test_infer_output_protocol_same_domain_still_resolves_real_type():
     lib = DatasetLibrary()
     lib.add(
         DatasetRef(


### PR DESCRIPTION
## Summary

Ran a full verification pass of the three GUI workspace-parity implementation plans (state foundation, Pipeline mode, default flip) against the approved design spec (`docs/superpowers/specs/2026-07-02-gui-workspace-parity-and-default-flip-design.md`) and the already-merged implementation (PRs #31-33), using three parallel audit agents plus targeted test runs.

**Result: the implementation is essentially complete and correct.** All dataclasses, the recursive result codec (`write_result_arrays`/`read_result_arrays`), the full `.rheojax` v2 archive round-trip (including the previously-tricky nested RheoData round-trips in `transform.json`/`job_history.json`), the export-signal rewiring (`dataset_commit_requested`), dirty tracking, `import_dataset()`, Pipeline mode's `execute()`/cancellation/job-lifecycle split, and the default-flip launch gate all match the spec and pass their tests.

Two small completeness gaps were found and fixed here:

- `rheojax/gui/main.py`'s argparse `--help` epilog ("Examples" block) still described pre-cutover behavior (no mention of `--legacy` or `--workspace` deprecation) even though Plan 3 Task 2 Step 3 explicitly required updating it, and the module docstring *was* correctly updated. Also updated a stale docstring on `_create_workspace_window()` still calling it a "preview" behind `--workspace`.
- Two test function names and one comment in `tests/gui/workspace/transform/` still referenced the old private `_infer_protocol_type` name (renamed to public `infer_output_protocol` in Plan 1 Task 4); the actual test bodies already called the new name, so this was cosmetic-only.

No functional bugs were found in Pipeline mode or the project codec; test suite is 520 passed / 10 failed, with all 10 failures being a pre-existing environmental FreeType/matplotlib glyph-rendering issue (`FT_Render_Glyph ... raster overflow`) unrelated to this spec, reproducible before this change too.

## Test plan
- [x] `uv run pytest tests/gui/test_main_cli_wiring.py tests/gui/workspace/transform/test_transform_controller.py tests/gui/workspace/transform/test_step5.py -q` — 23 passed
- [x] `rheojax-gui --help` — epilog now shows `--legacy` and `--workspace` deprecation examples
- [x] `RHEOJAX_WORKER_ISOLATION=subprocess uv run pytest tests/gui/ -q` — 520 passed, 10 failed (pre-existing FreeType rendering issue, unrelated)

🤖 Generated with [Claude Code](https://claude.com/claude-code)