### PR TITLE
fix(gui): close 6 bugs found by codex/agy audit of workspace-parity plans

### DIFF
--- a/rheojax/gui/foundation/project_codec.py
+++ b/rheojax/gui/foundation/project_codec.py
@@ -132,7 +132,7 @@ def save_project_v2(state, path: Path) -> None:
             persisted -- fit.json's nlsq_result/nuts_result AND every job_history.json
             fit-step phase result both route through this helper, so there is exactly one
             persistence path for this value shape, not two independently-maintained ones."""
-            if not raw:
+            if raw is None:
                 return None, None
             result_id = uuid.uuid4().hex
             rel = f"{result_dir}/{result_id}.hdf5"
@@ -338,11 +338,19 @@ def load_project_v2(path: Path):
 
         manifest = json.loads(zf.read("manifest.json"))
         checksums = manifest["members"]
-        for name in seen_names:
-            if name in ("manifest.json", "metadata.json"):
-                continue
+        # manifest.json can't hash itself (chicken-and-egg -- its own content includes
+        # every OTHER member's hash), but metadata.json IS written and hashed before
+        # manifest.json at save time, so it belongs in this set, not skipped alongside it.
+        hashable_names = seen_names - {"manifest.json"}
+        if set(checksums) != hashable_names:
+            raise ValueError(
+                "Archive manifest does not exactly match its members "
+                f"(manifest-only: {sorted(set(checksums) - hashable_names)}, "
+                f"archive-only: {sorted(hashable_names - set(checksums))})"
+            )
+        for name in hashable_names:
             data = zf.read(name)
-            expected = checksums.get(name, {}).get("sha256")
+            expected = checksums[name].get("sha256")
             actual = hashlib.sha256(data).hexdigest()
             if expected != actual:
                 raise ValueError(f"checksum mismatch for archive member: {name}")

--- a/rheojax/gui/services/pipeline_execution_service.py
+++ b/rheojax/gui/services/pipeline_execution_service.py
@@ -275,7 +275,20 @@ class PipelineExecutionService(QObject):
                         step, context, library, persist=consumed_downstream
                     )
                 elif step.step_type == "fit":
-                    step_results[step.id] = self._execute_pipeline_fit(step, context)
+                    fit_result = self._execute_pipeline_fit(step, context)
+                    step_results[step.id] = fit_result
+                    # A fit step's outcome is its LAST phase that actually ran (nuts if
+                    # requested and reached, else nlsq) -- a failed/cancelled phase must not
+                    # be reported as an overall "completed" pipeline run just because the
+                    # per-step call itself didn't raise.
+                    terminal_phase = fit_result.nuts if fit_result.nuts is not None else fit_result.nlsq
+                    if terminal_phase.status != "completed":
+                        self.step_failed.emit(step.id, terminal_phase.error or "")
+                        return PipelineRunResult(
+                            step_results=step_results,
+                            status=terminal_phase.status,
+                            error=terminal_phase.error,
+                        )
                 elif step.step_type == "export":
                     step_results[step.id] = self._execute_pipeline_export(step, context)
                 else:

--- a/rheojax/gui/workspace/pipeline/batch_runner.py
+++ b/rheojax/gui/workspace/pipeline/batch_runner.py
@@ -27,18 +27,43 @@ class PipelineBatchRunner(QRunnable):
         self._stop_requested = stop_requested
 
     def run(self) -> None:
+        from rheojax.gui.services.pipeline_execution_service import (
+            WorkerIsolationRequiredError,
+        )
+
         for dataset_id in self._selected_dataset_ids:
             if self._stop_requested.is_set():
                 break
             self._service.dataset_run_started.emit(dataset_id)
             ctx = pipeline_context_from_library(self._library, [dataset_id])
             steps_for_dataset = self._substitute_dataset_id(self._steps, dataset_id)
-            result = self._service.execute(
-                steps=steps_for_dataset, initial_context=ctx, library=self._library,
-                stop_requested=self._stop_requested,
-            )
-            record = self._prepare_job_record(dataset_id, result)
+            fatal = False
+            try:
+                result = self._service.execute(
+                    steps=steps_for_dataset, initial_context=ctx, library=self._library,
+                    stop_requested=self._stop_requested,
+                )
+                record = self._prepare_job_record(dataset_id, result)
+            except WorkerIsolationRequiredError as exc:
+                # Misconfigured environment -- would fail identically for every
+                # remaining dataset, so this is the batch's last iteration too.
+                record = self._failed_record(dataset_id, str(exc))
+                fatal = True
+            except Exception as exc:  # pragma: no cover - defensive backstop
+                # execute() already converts ordinary step failures into a
+                # status="failed" PipelineRunResult internally; this only catches an
+                # unexpected bug elsewhere in the call chain (e.g. context/record
+                # construction). Without this, such an exception would propagate out
+                # of run() with dataset_run_finished never emitted, leaving this
+                # dataset's active_jobs entry stuck forever (nothing else clears it).
+                record = self._failed_record(dataset_id, str(exc))
             self._service.dataset_run_finished.emit(dataset_id, record)
+            if fatal:
+                break
+
+    @staticmethod
+    def _failed_record(dataset_id: str, error: str) -> dict:
+        return {"dataset_id": dataset_id, "status": "failed", "error": error, "step_results": {}}
 
     @staticmethod
     def _substitute_dataset_id(steps, dataset_id: str) -> list:

--- a/rheojax/gui/workspace/pipeline/controller.py
+++ b/rheojax/gui/workspace/pipeline/controller.py
@@ -26,10 +26,12 @@ class PipelineController(WorkflowController):
         on_dirty: Callable[[], None],
         epoch: int = 0,
         guard: Callable[[int, Callable], Callable] | None = None,
+        notify: Callable[[], None] | None = None,
     ) -> None:
         self._state = app_state
         self._service = service
         self._on_dirty = on_dirty
+        self._notify = notify
         super().__init__(steps=[])
         on_started = self._on_dataset_run_started
         on_finished = self._commit_job_result
@@ -58,9 +60,18 @@ class PipelineController(WorkflowController):
         self._state.job_history.by_id[job_id] = record
         self._state.pipeline.job_id = job_id
         self._on_dirty()
+        if self._notify is not None:
+            # Pipeline transform steps add/store into the library directly on the
+            # worker thread (PipelineExecutionService._execute_pipeline_transform),
+            # bypassing WorkspaceWindow._commit_dataset()'s notifier emission. By the
+            # time this GUI-thread slot runs, that thread's execute() call has already
+            # returned (dataset_run_finished fires after it), so the library mutation
+            # has already happened -- reading/notifying about it here is safe and is
+            # what makes a pipeline-produced dataset show up in LibraryRail at all.
+            self._notify()
 
 
-def build_pipeline_controller(app_state, service, epoch: int = 0, guard=None):
+def build_pipeline_controller(app_state, service, epoch: int = 0, guard=None, notify=None):
     from rheojax.gui.workspace.controller import Step
     from rheojax.gui.workspace.pipeline.step1_configure_run import (
         PipelineConfigureRunStep,
@@ -73,6 +84,7 @@ def build_pipeline_controller(app_state, service, epoch: int = 0, guard=None):
         on_dirty=lambda: setattr(app_state.project, "dirty", True),
         epoch=epoch,
         guard=guard,
+        notify=notify,
     )
     ctl.steps = [Step(id="configure_run", title="Configure & Run", is_ready=body.is_ready, validate=lambda: True)]
     ctl.reached = {0}

--- a/rheojax/gui/workspace/window.py
+++ b/rheojax/gui/workspace/window.py
@@ -81,7 +81,8 @@ class WorkspaceWindow(QMainWindow):
         fit_ctl, self._fit_bodies = build_fit_controller(state)
         transform_ctl, self._transform_bodies = build_transform_controller(state)
         pipeline_ctl, self._pipeline_bodies = build_pipeline_controller(
-            state, self._pipeline_service, epoch=self._epoch, guard=self._guard
+            state, self._pipeline_service, epoch=self._epoch, guard=self._guard,
+            notify=self._notifier.changed.emit,
         )
         self._controllers = {
             "fit": fit_ctl,
@@ -119,6 +120,11 @@ class WorkspaceWindow(QMainWindow):
         self._refresh_status_label()
 
         self._rail = LibraryRail(state.library, self)
+        # LibraryRail otherwise only ever renders the snapshot present at construction
+        # time -- nothing else calls .refresh() -- so without this, a dataset added by
+        # any commit path (interactive export or a Pipeline job) never appears until the
+        # next full _rebuild() (Open/New/Close).
+        self._notifier.changed.connect(self._rail.refresh)
         self._inspector = InspectorPanel(self)
         self._canvas = StepperCanvas(self._controllers[self._mode], self)
         self._wire_canvas(self._canvas)
@@ -160,6 +166,10 @@ class WorkspaceWindow(QMainWindow):
                 except (RuntimeError, TypeError):
                     pass
             body.deleteLater()
+        try:
+            self._notifier.changed.disconnect(self._rail.refresh)
+        except (RuntimeError, TypeError):
+            pass
         for widget in (self._canvas, self._rail, self._inspector, self._splitter):
             widget.deleteLater()
         self._controllers = {}
@@ -211,7 +221,26 @@ class WorkspaceWindow(QMainWindow):
             lambda: self._maybe_confirm_unsaved_changes(_open)
         )
 
+    def _blocked_by_active_jobs(self, action: str) -> bool:
+        # Spec §3.3: "Save snapshots job_history only; blocked while active_jobs is
+        # non-empty" -- a running Pipeline batch mutates DatasetLibrary/job_history from
+        # a worker thread, so a concurrent Save could serialize a torn, inconsistent
+        # snapshot. Unlike Close/New/Open (which offer to cancel jobs and proceed), Save
+        # is a hard block: there is no safe "discard the running job" option here.
+        if not self._state.active_jobs.by_id:
+            return False
+        from PySide6.QtWidgets import QMessageBox
+
+        QMessageBox.information(
+            self, "Jobs Running",
+            f"Cannot {action} while {len(self._state.active_jobs.by_id)} job(s) are still "
+            "running. Wait for them to finish, or cancel them via Close/New/Open first.",
+        )
+        return True
+
     def _on_save(self) -> None:
+        if self._blocked_by_active_jobs("save"):
+            return
         if self._state.project.path is None:
             self._on_save_as()
             return
@@ -227,6 +256,8 @@ class WorkspaceWindow(QMainWindow):
         self._state.project.dirty = False
 
     def _on_save_as(self) -> None:
+        if self._blocked_by_active_jobs("save"):
+            return
         from PySide6.QtWidgets import QFileDialog, QMessageBox
 
         path, _ = QFileDialog.getSaveFileName(
@@ -428,13 +459,19 @@ class WorkspaceWindow(QMainWindow):
             self._canvas.refresh()
 
     def _on_fit_body_edited(self) -> None:
+        # `edited`/`config_edited` fire on real content changes (model/protocol/prior/
+        # NLSQ-option edits) that persist into fit.json -- distinct from navigation,
+        # which spec §5.2 explicitly excludes from dirty tracking.
+        self._mark_dirty()
         self._advance_and_unlock("fit")
 
     def _on_transform_body_edited(self) -> None:
+        self._mark_dirty()
         self._advance_and_unlock("transform")
 
     def _on_pipeline_body_edited(self) -> None:
-        pass  # mirrors _on_fit_body_edited/_on_transform_body_edited's advance-eligibility recheck
+        # Pipeline step-list edits persist into pipeline.json, same rationale as above.
+        self._mark_dirty()
 
     def _on_pipeline_run_requested(self) -> None:
         if self._state.active_jobs.by_id:

--- a/rheojax/gui/workspace/window.py
+++ b/rheojax/gui/workspace/window.py
@@ -346,6 +346,21 @@ class WorkspaceWindow(QMainWindow):
             | QMessageBox.StandardButton.Cancel,
         )
         if choice == QMessageBox.StandardButton.Save:
+            if self._state.active_jobs.by_id:
+                # Reachable when _maybe_confirm_active_jobs gave up waiting for jobs to
+                # finish cancelling (its 30s poll timeout) with active_jobs still
+                # non-empty -- Save is unconditionally blocked in that state
+                # (_blocked_by_active_jobs), so calling it here would silently leave
+                # `proceed()` never called with no indication that the Close/New/Open
+                # the user already confirmed was itself aborted. Tell them directly
+                # instead of showing only the generic "Cannot save" dialog.
+                QMessageBox.warning(
+                    self, "Cannot Save",
+                    "Some jobs are still finishing cancellation, so the project can't "
+                    "be saved yet. This action was cancelled -- try again shortly, or "
+                    "choose Discard to proceed without saving.",
+                )
+                return
             self._on_save()
             if not self._state.project.dirty:
                 proceed()

--- a/tests/gui/foundation/test_project_codec.py
+++ b/tests/gui/foundation/test_project_codec.py
@@ -411,7 +411,9 @@ def test_load_rejects_ref_id_path_traversal_in_manifest(tmp_path):
     never passes through the zip member allowlist -- it's just a string field -- so a
     '../'-containing id must be caught separately by _validate_ref_id when building the
     HDF5 path from it."""
+    metadata_bytes = json.dumps({"version": "2.0", "timestamp": "x"}).encode()
     members = {
+        "metadata.json": metadata_bytes,
         "library/manifest.json": json.dumps([{
             "id": "../../../evil", "name": "d1", "protocol_type": "oscillation",
             "origin": "imported", "units": {}, "row_count": 1, "hash": "h",
@@ -424,18 +426,83 @@ def test_load_rejects_ref_id_path_traversal_in_manifest(tmp_path):
         "project.json": json.dumps({"path": None, "name": None}).encode(),
         "ui.json": b"{}",
     }
+    # manifest.json must declare every OTHER member exactly (load_project_v2 now
+    # verifies membership, not just per-file hashes -- see test_load_rejects_
+    # manifest_membership_mismatch below).
     manifest = {"members": {
         name: {"sha256": hashlib.sha256(data).hexdigest(), "size": len(data)}
         for name, data in members.items()
     }}
     path = tmp_path / "evil_ref_id.rheojax"
     with zipfile.ZipFile(path, "w") as zf:
-        zf.writestr("metadata.json", json.dumps({"version": "2.0", "timestamp": "x"}))
         for name, data in members.items():
             zf.writestr(name, data)
         zf.writestr("manifest.json", json.dumps(manifest))
     with pytest.raises(ValueError, match="invalid archive reference id"):
         load_project_v2(path)
+
+
+def test_round_trip_job_history_empty_fit_result_dict_stays_empty_dict(tmp_path):
+    # _persist_result_dict used `if not raw` (truthiness), so a legitimate empty dict
+    # `{}` was silently indistinguishable from "no result" and restored as None.
+    state = AppState()
+    state.job_history.by_id["job1"] = {
+        "dataset_id": "d1", "status": "completed", "error": None,
+        "step_results": {
+            "s1": {"step_type": "fit", "nlsq": {"status": "completed", "error": None,
+                                                 "result": {}}, "nuts": None},
+        },
+    }
+    path = tmp_path / "project.rheojax"
+    save_project_v2(state, path)
+    loaded = load_project_v2(path)
+    phase = loaded.job_history.by_id["job1"]["step_results"]["s1"]["nlsq"]
+    assert phase["result"] == {}
+    assert phase["result"] is not None
+
+
+def test_load_rejects_manifest_membership_mismatch(tmp_path):
+    # A manifest declaring an entry for a member that isn't actually in the archive
+    # (or vice versa) must be rejected -- not silently skipped -- even if every entry
+    # that IS present in both happens to hash-match.
+    state = AppState()
+    path = tmp_path / "project.rheojax"
+    save_project_v2(state, path)
+
+    with zipfile.ZipFile(path) as src:
+        manifest = json.loads(src.read("manifest.json"))
+        manifest["members"]["phantom/not_real.hdf5"] = {"sha256": "0" * 64, "size": 0}
+        tampered = tmp_path / "tampered.rheojax"
+        with zipfile.ZipFile(tampered, "w") as dst:
+            for item in src.infolist():
+                data = src.read(item.filename)
+                if item.filename == "manifest.json":
+                    data = json.dumps(manifest).encode()
+                dst.writestr(item, data)
+
+    with pytest.raises(ValueError, match="does not exactly match"):
+        load_project_v2(tampered)
+
+
+def test_load_rejects_metadata_checksum_tampering(tmp_path):
+    # metadata.json IS hashed at save time (registered via _write_json like every other
+    # JSON member) -- the loader must actually verify it, not exempt it the way it
+    # legitimately exempts manifest.json's own unhashable self-reference.
+    state = AppState()
+    path = tmp_path / "project.rheojax"
+    save_project_v2(state, path)
+
+    with zipfile.ZipFile(path) as src:
+        tampered = tmp_path / "tampered_meta.rheojax"
+        with zipfile.ZipFile(tampered, "w") as dst:
+            for item in src.infolist():
+                data = src.read(item.filename)
+                if item.filename == "metadata.json":
+                    data = json.dumps({"version": "2.0", "timestamp": "TAMPERED"}).encode()
+                dst.writestr(item, data)
+
+    with pytest.raises(ValueError, match="checksum"):
+        load_project_v2(tampered)
 
 
 def test_validate_ref_id_rejects_traversal_and_accepts_uuid():

--- a/tests/gui/test_pipeline_execution_service_execute.py
+++ b/tests/gui/test_pipeline_execution_service_execute.py
@@ -231,6 +231,40 @@ def test_second_transform_lineage_points_at_first_transforms_output_not_original
     assert second_ref.lineage == [first_new_id]  # not ["d1"]
 
 
+def test_execute_reports_failed_when_nlsq_phase_fails(qtbot, monkeypatch):
+    # A failed NLSQ phase must not be swallowed into an overall "completed" run just
+    # because _execute_pipeline_fit() itself didn't raise.
+    from PySide6.QtCore import QObject, Signal
+
+    class _FakeSignals(QObject):
+        completed = Signal(object)
+        failed = Signal(str)
+        cancelled = Signal()
+
+    class _FakeFailingWorker:
+        def __init__(self):
+            self.signals = _FakeSignals()
+
+        def run(self):
+            self.signals.failed.emit("boom: nlsq blew up")
+
+    import rheojax.gui.jobs.process_adapter as process_adapter
+
+    monkeypatch.setattr(process_adapter, "make_fit_worker", lambda **kwargs: _FakeFailingWorker())
+
+    lib = DatasetLibrary()
+    lib.add(_ref("d1", "relaxation"))
+    data = RheoData(x=[0.1, 1.0, 10.0], y=[100.0, 50.0, 10.0], initial_test_mode="relaxation")
+    lib.store_payload("d1", data)
+    svc = PipelineExecutionService()
+    steps = [PipelineStepConfig(id="s1", step_type="fit",
+                                 config={"model_name": "maxwell", "run_nuts": False})]
+    result = svc.execute(steps=steps, initial_context={"data": data, "dataset_id": "d1"},
+                          library=lib, stop_requested=threading.Event())
+    assert result.status == "failed"
+    assert "boom" in result.error
+
+
 def test_duplicate_step_ids_rejected(qtbot):
     lib = DatasetLibrary()
     svc = PipelineExecutionService()

--- a/tests/gui/workspace/pipeline/test_batch_runner.py
+++ b/tests/gui/workspace/pipeline/test_batch_runner.py
@@ -123,6 +123,37 @@ def test_batch_runner_job_record_round_trips_through_save_project_v2(qtbot, tmp_
     assert "result_ref" not in loaded_phase
 
 
+def test_batch_runner_emits_finished_with_failed_record_on_fatal_precondition_error(
+    qtbot, monkeypatch
+):
+    # A WorkerIsolationRequiredError (misconfigured environment) escaping execute() must
+    # still result in dataset_run_finished being emitted with a terminal "failed" record
+    # -- otherwise this dataset's active_jobs entry (registered by dataset_run_started,
+    # which already fired) is never cleared by PipelineController._commit_job_result(),
+    # leaving it stuck "running" forever. The batch must also stop rather than repeat the
+    # identical fatal error for every remaining dataset.
+    monkeypatch.setenv("RHEOJAX_WORKER_ISOLATION", "thread")
+    lib = DatasetLibrary()
+    for id_ in ("d1", "d2"):
+        lib.add(_ref(id_, "relaxation"))
+        lib.store_payload(id_, RheoData(x=[0.1, 1.0], y=[100.0, 50.0], initial_test_mode="relaxation"))
+    svc = PipelineExecutionService()
+    steps = [PipelineStepConfig(id="s1", step_type="fit",
+                                 config={"model_name": "maxwell", "run_nuts": False})]
+    runner = PipelineBatchRunner(service=svc, steps=steps, selected_dataset_ids=["d1", "d2"],
+                                  library=lib, stop_requested=threading.Event())
+    started, records = [], []
+    svc.dataset_run_started.connect(lambda dsid: started.append(dsid))
+    svc.dataset_run_finished.connect(lambda dsid, record: records.append(record))
+    with qtbot.waitSignal(svc.dataset_run_finished, timeout=5000):
+        runner.run()
+    assert started == ["d1"]  # fatal precondition error stops the batch -- d2 never started
+    assert len(records) == 1
+    assert records[0]["status"] == "failed"
+    assert "subprocess" in records[0]["error"]
+    assert records[0]["step_results"] == {}
+
+
 def test_batch_runner_transform_step_record_round_trips_output_as_rheodata(qtbot, tmp_path, monkeypatch):
     # A "transform" step's record must carry its RheoData under literally "output" so
     # save_project_v2's `elif "output" in step_record` branch detects and persists it.

--- a/tests/gui/workspace/pipeline/test_controller.py
+++ b/tests/gui/workspace/pipeline/test_controller.py
@@ -49,6 +49,55 @@ def test_dataset_run_started_registers_active_job(qtbot):
     assert state.active_jobs.by_id["d1"] == {"status": "running"}
 
 
+def test_commit_job_result_calls_notify_when_provided(qtbot):
+    # Pipeline transform steps add/store into the library directly on the worker thread
+    # (bypassing WorkspaceWindow._commit_dataset()'s notifier emission), so this GUI-
+    # thread commit slot is what tells the notifier (and therefore LibraryRail) that
+    # something changed, once the mutation has already safely happened.
+    state = AppState()
+    state.active_jobs.by_id["d1"] = {"status": "running"}
+    svc = PipelineExecutionService()
+    notify_calls = []
+    ctl = PipelineController(state, svc, on_dirty=lambda: None, notify=lambda: notify_calls.append(1))
+
+    record = {"dataset_id": "d1", "status": "completed", "error": None, "step_results": {}}
+    ctl._commit_job_result("d1", record)
+
+    assert notify_calls == [1]
+
+
+def test_commit_job_result_tolerates_missing_notify(qtbot):
+    state = AppState()
+    state.active_jobs.by_id["d1"] = {"status": "running"}
+    svc = PipelineExecutionService()
+    ctl = PipelineController(state, svc, on_dirty=lambda: None)  # notify defaults to None
+
+    record = {"dataset_id": "d1", "status": "completed", "error": None, "step_results": {}}
+    ctl._commit_job_result("d1", record)  # must not raise
+
+
+def test_pipeline_produced_dataset_visible_in_rail_after_job_commits(qtbot):
+    # End-to-end wiring check for WorkspaceWindow: a dataset added directly to the
+    # library (simulating what _execute_pipeline_transform does on the worker thread)
+    # must appear in LibraryRail once the job commit fires on the GUI thread.
+    from rheojax.gui.foundation.library import DatasetRef
+
+    win = WorkspaceWindow(AppState())
+    qtbot.addWidget(win)
+    assert win._rail.count() == 0
+
+    win._state.library.add(DatasetRef(
+        id="derived1", name="derived1", protocol_type="oscillation", origin="derived",
+        units={}, row_count=0, hash="", provenance={}, lineage=["d1"],
+    ))
+    win._state.active_jobs.by_id["d1"] = {"status": "running"}
+    record = {"dataset_id": "d1", "status": "completed", "error": None, "step_results": {}}
+    with qtbot.waitSignal(win._pipeline_service.dataset_run_finished, timeout=1000):
+        win._pipeline_service.dataset_run_finished.emit("d1", record)
+
+    assert win._rail.count() == 1
+
+
 def test_stale_controller_guarded_after_rebuild_does_not_mutate_discarded_state(qtbot):
     """Reproduces the Plan 2 Task 11 gap: a PipelineController connected against the
     persistent PipelineExecutionService must stop mutating its AppState once

--- a/tests/gui/workspace/test_window_active_jobs_dialog.py
+++ b/tests/gui/workspace/test_window_active_jobs_dialog.py
@@ -88,6 +88,33 @@ def test_on_new_and_close_do_not_rebuild_while_jobs_active(qtbot, monkeypatch, t
     assert rebuild_calls == []
 
 
+@pytest.mark.parametrize("trigger", ["_on_save", "_on_save_as"])
+def test_save_and_save_as_blocked_while_jobs_active(qtbot, monkeypatch, trigger, tmp_path):
+    # Spec §3.3: "Save snapshots job_history only; blocked while active_jobs is
+    # non-empty" -- a running Pipeline batch mutates the library/job_history from a
+    # worker thread, so a concurrent Save could serialize a torn snapshot.
+    win = WorkspaceWindow(AppState())
+    qtbot.addWidget(win)
+    win._state.project.path = str(tmp_path / "p.rheojax")
+    win._state.active_jobs.by_id["d1"] = {"status": "running"}
+
+    from PySide6.QtWidgets import QFileDialog, QMessageBox
+
+    info_calls = []
+    monkeypatch.setattr(QMessageBox, "information", lambda *a, **k: info_calls.append(1))
+    save_calls = []
+    monkeypatch.setattr(
+        "rheojax.gui.foundation.project_codec.save_project_v2",
+        lambda *a, **k: save_calls.append(1),
+    )
+    monkeypatch.setattr(QFileDialog, "getSaveFileName", lambda *a, **k: (str(tmp_path / "x.rheojax"), ""))
+
+    getattr(win, trigger)()
+
+    assert info_calls == [1]  # blocked -- user was told, not silently ignored
+    assert save_calls == []  # save_project_v2 never invoked
+
+
 def test_on_open_does_not_rebuild_while_jobs_active(qtbot, monkeypatch):
     win = WorkspaceWindow(AppState())
     qtbot.addWidget(win)

--- a/tests/gui/workspace/test_window_commit_dataset.py
+++ b/tests/gui/workspace/test_window_commit_dataset.py
@@ -49,3 +49,34 @@ def test_fit_body_dataset_commit_requested_routes_to_commit_dataset(qtbot):
     fit_export_body = next(b for b in win._fit_bodies if hasattr(b, "dataset_commit_requested"))
     fit_export_body.dataset_commit_requested.emit(_ref("d2"), None, True)
     assert state.library.get("d2").id == "d2"
+
+
+def test_commit_dataset_refreshes_library_rail(qtbot):
+    # LibraryRail.refresh() is otherwise never called after construction -- without the
+    # notifier -> rail.refresh wiring, a newly committed dataset would render nowhere
+    # until the next full _rebuild() (Open/New/Close).
+    state = AppState()
+    win = WorkspaceWindow(state)
+    qtbot.addWidget(win)
+    assert win._rail.count() == 0
+
+    win._commit_dataset(_ref("d1"), payload=None, overwrite=False)
+
+    assert win._rail.count() == 1
+
+
+@pytest.mark.parametrize("edited_signal", [
+    "_on_fit_body_edited", "_on_transform_body_edited", "_on_pipeline_body_edited",
+])
+def test_body_edited_marks_project_dirty(qtbot, edited_signal):
+    # Fit/Transform/Pipeline step config edits (nlsq_config, priors, pipeline steps) are
+    # all persisted into the project archive -- silently NOT dirtying on edit means a
+    # user can Close/New/Open without a save prompt and lose those changes.
+    state = AppState()
+    win = WorkspaceWindow(state)
+    qtbot.addWidget(win)
+    assert state.project.dirty is False
+
+    getattr(win, edited_signal)()
+
+    assert state.project.dirty is True

--- a/tests/gui/workspace/test_window_file_menu.py
+++ b/tests/gui/workspace/test_window_file_menu.py
@@ -44,6 +44,30 @@ def test_maybe_confirm_unsaved_save_success_proceeds(qtbot, monkeypatch):
     assert calls == [1]
 
 
+def test_maybe_confirm_unsaved_save_blocked_by_active_jobs_warns_and_aborts(qtbot, monkeypatch):
+    # Reachable when _maybe_confirm_active_jobs gave up waiting (30s poll timeout) with
+    # active_jobs still non-empty: Save is unconditionally blocked in that state, so
+    # picking "Save" here must not silently no-op -- it must warn the user that the
+    # whole Close/New/Open action was aborted, not just fail to save.
+    win = _win(qtbot)
+    win._state.project.dirty = True
+    win._state.active_jobs.by_id["d1"] = {"status": "running"}
+    monkeypatch.setattr(
+        QMessageBox, "question", lambda *a, **k: QMessageBox.StandardButton.Save
+    )
+    warning_calls = []
+    monkeypatch.setattr(QMessageBox, "warning", lambda *a, **k: warning_calls.append(1))
+    save_calls = []
+    monkeypatch.setattr(win, "_on_save", lambda: save_calls.append(1))
+
+    calls = []
+    win._maybe_confirm_unsaved_changes(lambda: calls.append(1))
+
+    assert warning_calls == [1]  # user told the action was aborted
+    assert save_calls == []      # _on_save (and its own separate dialog) never invoked
+    assert calls == []           # proceed() never called -- Close/New/Open did not happen
+
+
 def test_maybe_confirm_unsaved_discard_still_proceeds(qtbot, monkeypatch):
     win = _win(qtbot)
     win._state.project.dirty = True


### PR DESCRIPTION
## Summary
Independent `codex exec` and `agy` CLI reviews of the GUI workspace-parity cutover (plans 1-3 vs `docs/superpowers/specs/2026-07-02-gui-workspace-parity-and-default-flip-design.md`) surfaced implementation bugs beyond the 99%-complete audit already merged in PR #34. Each finding was independently verified against the actual source before fixing (a couple of the reviewers' claims were re-scoped: e.g. the "AutoConnection vs QueuedConnection" deviation is already intentional and documented in-code; the transform-persistence "violation" is actually the more sensible behavior and the spec text is what's stale — those are being corrected as doc-only fixes separately, not code changes).

- **Pipeline fit-phase status swallowed**: a failed/cancelled NLSQ or NUTS phase inside a Pipeline fit step was still reported as an overall `"completed"` run.
- **Stuck active job on fatal error**: `WorkerIsolationRequiredError` (or any unexpected exception) escaping `PipelineBatchRunner.run()` skipped `dataset_run_finished` entirely, leaving that dataset's `active_jobs` entry "running" forever with no way to clear it.
- **Save/Save As unguarded during active jobs**: spec §3.3 requires Save to be blocked while `active_jobs` is non-empty (a worker thread may be mid-mutation of the library/job history); this was never checked.
- **Missing dirty-tracking on step edits**: Fit/Transform/Pipeline body edits (`nlsq_config`, priors, pipeline steps — all persisted) never called `_mark_dirty()`, so a user could lose those changes silently on Close/New/Open.
- **LibraryRail never refreshes**: `LibraryRail.refresh()` was never called anywhere after construction — newly committed datasets (interactive *or* Pipeline-produced) never appeared in the sidebar until the next full project reload. Wired the persistent notifier to `rail.refresh`, and threaded a `notify` callback into `PipelineController` so Pipeline-produced datasets (added on a worker thread, bypassing the notifier) become visible once their job commits on the GUI thread.
- **project_codec edge cases**: an empty result dict `{}` was silently turned into `None` on save (`if not raw` truthiness bug); the archive loader exempted `metadata.json` from checksum verification even though it IS hashed at save time, and never verified the manifest declared *exactly* the members present in the archive (phantom/missing entries went undetected).

## Test plan
- [x] Added targeted regression tests for every fix (pipeline fit-phase failure propagation, batch-runner fatal-error cleanup, Save/Save-As blocking, dirty-on-edit, rail-refresh wiring, empty-dict round-trip, manifest-membership/metadata-checksum tampering)
- [x] `uv run ruff check` clean on all touched files
- [x] Full GUI suite: `RHEOJAX_WORKER_ISOLATION=subprocess uv run pytest tests/gui/` — 723 passed, 1 failed (pre-existing FreeType/matplotlib `raster overflow` glyph-rendering bug in this environment, confirmed via isolated rerun with the identical error signature across multiple unrelated visual-regression tests — not caused by this change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)