### PR TITLE
fix(gui): wire LibraryRail's Import data button to an actual import

### DIFF
--- a/graphify-out/GRAPH_REPORT.md
+++ b/graphify-out/GRAPH_REPORT.md
@@ -1,938 +1,884 @@
-# Graph Report - rheojax  (2026-07-03)
+# Graph Report - purring-popping-sedgewick  (2026-07-04)
 
 ## Corpus Check
-- 810 files · ~1,749,103 words
+- 812 files · ~1,752,771 words
 - Verdict: corpus is large enough that graph structure adds value.
 
 ## Summary
-- 24609 nodes · 43818 edges · 2791 communities (2570 shown, 221 thin omitted)
-- Extraction: 89% EXTRACTED · 11% INFERRED · 0% AMBIGUOUS · INFERRED: 4703 edges (avg confidence: 0.61)
+- 24640 nodes · 43922 edges · 2737 communities (2612 shown, 125 thin omitted)
+- Extraction: 89% EXTRACTED · 11% INFERRED · 0% AMBIGUOUS · INFERRED: 4708 edges (avg confidence: 0.61)
 - Token cost: 0 input · 0 output
 
 ## Graph Freshness
-- Built from commit: `e980ea46`
+- Built from commit: `0a294a78`
 - Run `git rev-parse HEAD` and compare to check if the graph is stale.
 - Run `graphify update .` after code changes (no API cost).
 
 ## Community Hubs (Navigation)
-- [[_COMMUNITY_Core NLSQ & Bayesian Base|Core NLSQ & Bayesian Base]]
-- [[_COMMUNITY_RheoData & Data Layer|RheoData & Data Layer]]
-- [[_COMMUNITY_BaseModel API & Methods|BaseModel API & Methods]]
-- [[_COMMUNITY_GUI Bayesian Page & Jobs|GUI Bayesian Page & Jobs]]
-- [[_COMMUNITY_GUI App & Main Window|GUI App & Main Window]]
-- [[_COMMUNITY_Model Registry & Inventory|Model Registry & Inventory]]
-- [[_COMMUNITY_VLB Viscoelastic Models|VLB Viscoelastic Models]]
-- [[_COMMUNITY_Anton Paar IO Reader|Anton Paar IO Reader]]
-- [[_COMMUNITY_CLI SPP Analysis|CLI SPP Analysis]]
-- [[_COMMUNITY_Import Wizard Dialog|Import Wizard Dialog]]
-- [[_COMMUNITY_GUI Import Worker & Drop Zone|GUI Import Worker & Drop Zone]]
-- [[_COMMUNITY_Saramito Fluidity Models|Saramito Fluidity Models]]
-- [[_COMMUNITY_ArviZ Utils & Bayesian Results|ArviZ Utils & Bayesian Results]]
-- [[_COMMUNITY_GUI Icons & Utils|GUI Icons & Utils]]
-- [[_COMMUNITY_Initialization Base|Initialization Base]]
-- [[_COMMUNITY_Transform Page & Worker|Transform Page & Worker]]
-- [[_COMMUNITY_Bayesian Pipeline|Bayesian Pipeline]]
-- [[_COMMUNITY_Giesekus Single-Mode Model|Giesekus Single-Mode Model]]
-- [[_COMMUNITY_CSV Reader & IO|CSV Reader & IO]]
-- [[_COMMUNITY_Qt Widgets|Qt Widgets]]
-- [[_COMMUNITY_Community 20|Community 20]]
-- [[_COMMUNITY_Community 21|Community 21]]
-- [[_COMMUNITY_Community 22|Community 22]]
-- [[_COMMUNITY_Community 23|Community 23]]
-- [[_COMMUNITY_Community 24|Community 24]]
-- [[_COMMUNITY_Community 25|Community 25]]
-- [[_COMMUNITY_Community 26|Community 26]]
-- [[_COMMUNITY_Community 27|Community 27]]
-- [[_COMMUNITY_Community 28|Community 28]]
-- [[_COMMUNITY_Community 29|Community 29]]
-- [[_COMMUNITY_Community 30|Community 30]]
-- [[_COMMUNITY_Community 31|Community 31]]
-- [[_COMMUNITY_Community 32|Community 32]]
-- [[_COMMUNITY_Community 33|Community 33]]
-- [[_COMMUNITY_Community 34|Community 34]]
-- [[_COMMUNITY_Community 35|Community 35]]
-- [[_COMMUNITY_Community 36|Community 36]]
-- [[_COMMUNITY_Community 37|Community 37]]
-- [[_COMMUNITY_Community 38|Community 38]]
-- [[_COMMUNITY_Community 39|Community 39]]
-- [[_COMMUNITY_Community 40|Community 40]]
-- [[_COMMUNITY_Community 41|Community 41]]
-- [[_COMMUNITY_Community 42|Community 42]]
-- [[_COMMUNITY_Community 43|Community 43]]
-- [[_COMMUNITY_Community 44|Community 44]]
-- [[_COMMUNITY_Community 45|Community 45]]
-- [[_COMMUNITY_Community 46|Community 46]]
-- [[_COMMUNITY_Community 47|Community 47]]
-- [[_COMMUNITY_Community 48|Community 48]]
-- [[_COMMUNITY_Community 49|Community 49]]
-- [[_COMMUNITY_Community 50|Community 50]]
-- [[_COMMUNITY_Community 51|Community 51]]
-- [[_COMMUNITY_Community 52|Community 52]]
-- [[_COMMUNITY_Community 53|Community 53]]
-- [[_COMMUNITY_Community 54|Community 54]]
-- [[_COMMUNITY_Community 55|Community 55]]
-- [[_COMMUNITY_Community 56|Community 56]]
-- [[_COMMUNITY_Community 57|Community 57]]
-- [[_COMMUNITY_Community 58|Community 58]]
-- [[_COMMUNITY_Community 59|Community 59]]
-- [[_COMMUNITY_Community 60|Community 60]]
-- [[_COMMUNITY_Community 61|Community 61]]
-- [[_COMMUNITY_Community 62|Community 62]]
-- [[_COMMUNITY_Community 63|Community 63]]
-- [[_COMMUNITY_Community 64|Community 64]]
-- [[_COMMUNITY_Community 65|Community 65]]
-- [[_COMMUNITY_Community 66|Community 66]]
-- [[_COMMUNITY_Community 67|Community 67]]
-- [[_COMMUNITY_Community 68|Community 68]]
-- [[_COMMUNITY_Community 69|Community 69]]
-- [[_COMMUNITY_Community 70|Community 70]]
-- [[_COMMUNITY_Community 71|Community 71]]
-- [[_COMMUNITY_Community 72|Community 72]]
-- [[_COMMUNITY_Community 73|Community 73]]
-- [[_COMMUNITY_Community 74|Community 74]]
-- [[_COMMUNITY_Community 75|Community 75]]
-- [[_COMMUNITY_Community 76|Community 76]]
-- [[_COMMUNITY_Community 77|Community 77]]
-- [[_COMMUNITY_Community 78|Community 78]]
-- [[_COMMUNITY_Community 79|Community 79]]
-- [[_COMMUNITY_Community 80|Community 80]]
-- [[_COMMUNITY_Community 81|Community 81]]
-- [[_COMMUNITY_Community 82|Community 82]]
-- [[_COMMUNITY_Community 83|Community 83]]
-- [[_COMMUNITY_Community 84|Community 84]]
-- [[_COMMUNITY_Community 85|Community 85]]
-- [[_COMMUNITY_Community 86|Community 86]]
-- [[_COMMUNITY_Community 87|Community 87]]
-- [[_COMMUNITY_Community 88|Community 88]]
-- [[_COMMUNITY_Community 89|Community 89]]
-- [[_COMMUNITY_Community 90|Community 90]]
-- [[_COMMUNITY_Community 91|Community 91]]
-- [[_COMMUNITY_Community 92|Community 92]]
-- [[_COMMUNITY_Community 93|Community 93]]
-- [[_COMMUNITY_Community 94|Community 94]]
-- [[_COMMUNITY_Community 95|Community 95]]
-- [[_COMMUNITY_Community 96|Community 96]]
-- [[_COMMUNITY_Community 97|Community 97]]
-- [[_COMMUNITY_Community 98|Community 98]]
-- [[_COMMUNITY_Community 99|Community 99]]
-- [[_COMMUNITY_Community 100|Community 100]]
-- [[_COMMUNITY_Community 101|Community 101]]
-- [[_COMMUNITY_Community 102|Community 102]]
-- [[_COMMUNITY_Community 103|Community 103]]
-- [[_COMMUNITY_Community 104|Community 104]]
-- [[_COMMUNITY_Community 105|Community 105]]
-- [[_COMMUNITY_Community 106|Community 106]]
-- [[_COMMUNITY_Community 107|Community 107]]
-- [[_COMMUNITY_Community 108|Community 108]]
-- [[_COMMUNITY_Community 109|Community 109]]
-- [[_COMMUNITY_Community 110|Community 110]]
-- [[_COMMUNITY_Community 111|Community 111]]
-- [[_COMMUNITY_Community 112|Community 112]]
-- [[_COMMUNITY_Community 113|Community 113]]
-- [[_COMMUNITY_Community 114|Community 114]]
-- [[_COMMUNITY_Community 115|Community 115]]
-- [[_COMMUNITY_Community 116|Community 116]]
-- [[_COMMUNITY_Community 117|Community 117]]
-- [[_COMMUNITY_Community 118|Community 118]]
-- [[_COMMUNITY_Community 119|Community 119]]
-- [[_COMMUNITY_Community 120|Community 120]]
-- [[_COMMUNITY_Community 121|Community 121]]
-- [[_COMMUNITY_Community 122|Community 122]]
-- [[_COMMUNITY_Community 123|Community 123]]
-- [[_COMMUNITY_Community 124|Community 124]]
-- [[_COMMUNITY_Community 125|Community 125]]
-- [[_COMMUNITY_Community 126|Community 126]]
-- [[_COMMUNITY_Community 127|Community 127]]
-- [[_COMMUNITY_Community 128|Community 128]]
-- [[_COMMUNITY_Community 129|Community 129]]
-- [[_COMMUNITY_Community 130|Community 130]]
-- [[_COMMUNITY_Community 131|Community 131]]
-- [[_COMMUNITY_Community 132|Community 132]]
-- [[_COMMUNITY_Community 133|Community 133]]
-- [[_COMMUNITY_Community 134|Community 134]]
-- [[_COMMUNITY_Community 135|Community 135]]
-- [[_COMMUNITY_Community 136|Community 136]]
-- [[_COMMUNITY_Community 137|Community 137]]
-- [[_COMMUNITY_Community 138|Community 138]]
-- [[_COMMUNITY_Community 139|Community 139]]
-- [[_COMMUNITY_Community 140|Community 140]]
-- [[_COMMUNITY_Community 141|Community 141]]
-- [[_COMMUNITY_Community 142|Community 142]]
-- [[_COMMUNITY_Community 143|Community 143]]
-- [[_COMMUNITY_Community 144|Community 144]]
-- [[_COMMUNITY_Community 145|Community 145]]
-- [[_COMMUNITY_Community 146|Community 146]]
-- [[_COMMUNITY_Community 147|Community 147]]
-- [[_COMMUNITY_Community 148|Community 148]]
-- [[_COMMUNITY_Community 149|Community 149]]
-- [[_COMMUNITY_Community 150|Community 150]]
-- [[_COMMUNITY_Community 151|Community 151]]
-- [[_COMMUNITY_Community 152|Community 152]]
-- [[_COMMUNITY_Community 153|Community 153]]
-- [[_COMMUNITY_Community 154|Community 154]]
-- [[_COMMUNITY_Community 155|Community 155]]
-- [[_COMMUNITY_Community 156|Community 156]]
-- [[_COMMUNITY_Community 157|Community 157]]
-- [[_COMMUNITY_Community 158|Community 158]]
-- [[_COMMUNITY_Community 159|Community 159]]
-- [[_COMMUNITY_Community 160|Community 160]]
-- [[_COMMUNITY_Community 161|Community 161]]
-- [[_COMMUNITY_Community 162|Community 162]]
-- [[_COMMUNITY_Community 163|Community 163]]
-- [[_COMMUNITY_Community 164|Community 164]]
-- [[_COMMUNITY_Community 165|Community 165]]
-- [[_COMMUNITY_Community 166|Community 166]]
-- [[_COMMUNITY_Community 167|Community 167]]
-- [[_COMMUNITY_Community 168|Community 168]]
-- [[_COMMUNITY_Community 169|Community 169]]
-- [[_COMMUNITY_Community 170|Community 170]]
-- [[_COMMUNITY_Community 171|Community 171]]
-- [[_COMMUNITY_Community 172|Community 172]]
-- [[_COMMUNITY_Community 173|Community 173]]
-- [[_COMMUNITY_Community 174|Community 174]]
-- [[_COMMUNITY_Community 175|Community 175]]
-- [[_COMMUNITY_Community 176|Community 176]]
-- [[_COMMUNITY_Community 177|Community 177]]
-- [[_COMMUNITY_Community 178|Community 178]]
-- [[_COMMUNITY_Community 179|Community 179]]
-- [[_COMMUNITY_Community 180|Community 180]]
-- [[_COMMUNITY_Community 181|Community 181]]
-- [[_COMMUNITY_Community 182|Community 182]]
-- [[_COMMUNITY_Community 183|Community 183]]
-- [[_COMMUNITY_Community 184|Community 184]]
-- [[_COMMUNITY_Community 185|Community 185]]
-- [[_COMMUNITY_Community 186|Community 186]]
-- [[_COMMUNITY_Community 187|Community 187]]
-- [[_COMMUNITY_Community 188|Community 188]]
-- [[_COMMUNITY_Community 189|Community 189]]
-- [[_COMMUNITY_Community 190|Community 190]]
-- [[_COMMUNITY_Community 191|Community 191]]
-- [[_COMMUNITY_Community 192|Community 192]]
-- [[_COMMUNITY_Community 193|Community 193]]
-- [[_COMMUNITY_Community 194|Community 194]]
-- [[_COMMUNITY_Community 195|Community 195]]
-- [[_COMMUNITY_Community 196|Community 196]]
-- [[_COMMUNITY_Community 197|Community 197]]
-- [[_COMMUNITY_Community 198|Community 198]]
-- [[_COMMUNITY_Community 199|Community 199]]
-- [[_COMMUNITY_Community 200|Community 200]]
-- [[_COMMUNITY_Community 201|Community 201]]
-- [[_COMMUNITY_Community 202|Community 202]]
-- [[_COMMUNITY_Community 203|Community 203]]
-- [[_COMMUNITY_Community 204|Community 204]]
-- [[_COMMUNITY_Community 205|Community 205]]
-- [[_COMMUNITY_Community 206|Community 206]]
-- [[_COMMUNITY_Community 207|Community 207]]
-- [[_COMMUNITY_Community 208|Community 208]]
-- [[_COMMUNITY_Community 209|Community 209]]
-- [[_COMMUNITY_Community 210|Community 210]]
-- [[_COMMUNITY_Community 211|Community 211]]
-- [[_COMMUNITY_Community 212|Community 212]]
-- [[_COMMUNITY_Community 213|Community 213]]
-- [[_COMMUNITY_Community 214|Community 214]]
-- [[_COMMUNITY_Community 215|Community 215]]
-- [[_COMMUNITY_Community 216|Community 216]]
-- [[_COMMUNITY_Community 217|Community 217]]
-- [[_COMMUNITY_Community 218|Community 218]]
-- [[_COMMUNITY_Community 219|Community 219]]
-- [[_COMMUNITY_Community 220|Community 220]]
-- [[_COMMUNITY_Community 221|Community 221]]
-- [[_COMMUNITY_Community 222|Community 222]]
-- [[_COMMUNITY_Community 223|Community 223]]
-- [[_COMMUNITY_Community 224|Community 224]]
-- [[_COMMUNITY_Community 225|Community 225]]
-- [[_COMMUNITY_Community 226|Community 226]]
-- [[_COMMUNITY_Community 227|Community 227]]
-- [[_COMMUNITY_Community 228|Community 228]]
-- [[_COMMUNITY_Community 229|Community 229]]
-- [[_COMMUNITY_Community 230|Community 230]]
-- [[_COMMUNITY_Community 231|Community 231]]
-- [[_COMMUNITY_Community 232|Community 232]]
-- [[_COMMUNITY_Community 233|Community 233]]
-- [[_COMMUNITY_Community 234|Community 234]]
-- [[_COMMUNITY_Community 235|Community 235]]
-- [[_COMMUNITY_Community 236|Community 236]]
-- [[_COMMUNITY_Community 237|Community 237]]
-- [[_COMMUNITY_Community 238|Community 238]]
-- [[_COMMUNITY_Community 239|Community 239]]
-- [[_COMMUNITY_Community 240|Community 240]]
-- [[_COMMUNITY_Community 241|Community 241]]
-- [[_COMMUNITY_Community 242|Community 242]]
-- [[_COMMUNITY_Community 243|Community 243]]
-- [[_COMMUNITY_Community 244|Community 244]]
-- [[_COMMUNITY_Community 245|Community 245]]
-- [[_COMMUNITY_Community 246|Community 246]]
-- [[_COMMUNITY_Community 247|Community 247]]
-- [[_COMMUNITY_Community 248|Community 248]]
-- [[_COMMUNITY_Community 249|Community 249]]
-- [[_COMMUNITY_Community 250|Community 250]]
-- [[_COMMUNITY_Community 251|Community 251]]
-- [[_COMMUNITY_Community 252|Community 252]]
-- [[_COMMUNITY_Community 253|Community 253]]
-- [[_COMMUNITY_Community 254|Community 254]]
-- [[_COMMUNITY_Community 255|Community 255]]
-- [[_COMMUNITY_Community 256|Community 256]]
-- [[_COMMUNITY_Community 257|Community 257]]
-- [[_COMMUNITY_Community 258|Community 258]]
-- [[_COMMUNITY_Community 259|Community 259]]
-- [[_COMMUNITY_Community 260|Community 260]]
-- [[_COMMUNITY_Community 261|Community 261]]
-- [[_COMMUNITY_Community 262|Community 262]]
-- [[_COMMUNITY_Community 263|Community 263]]
-- [[_COMMUNITY_Community 264|Community 264]]
-- [[_COMMUNITY_Community 265|Community 265]]
-- [[_COMMUNITY_Community 266|Community 266]]
-- [[_COMMUNITY_Community 267|Community 267]]
-- [[_COMMUNITY_Community 268|Community 268]]
-- [[_COMMUNITY_Community 269|Community 269]]
-- [[_COMMUNITY_Community 270|Community 270]]
-- [[_COMMUNITY_Community 271|Community 271]]
-- [[_COMMUNITY_Community 272|Community 272]]
-- [[_COMMUNITY_Community 273|Community 273]]
-- [[_COMMUNITY_Community 274|Community 274]]
-- [[_COMMUNITY_Community 275|Community 275]]
-- [[_COMMUNITY_Community 276|Community 276]]
-- [[_COMMUNITY_Community 277|Community 277]]
-- [[_COMMUNITY_Community 278|Community 278]]
-- [[_COMMUNITY_Community 279|Community 279]]
-- [[_COMMUNITY_Community 280|Community 280]]
-- [[_COMMUNITY_Community 281|Community 281]]
-- [[_COMMUNITY_Community 282|Community 282]]
-- [[_COMMUNITY_Community 283|Community 283]]
-- [[_COMMUNITY_Community 284|Community 284]]
-- [[_COMMUNITY_Community 285|Community 285]]
-- [[_COMMUNITY_Community 286|Community 286]]
-- [[_COMMUNITY_Community 287|Community 287]]
-- [[_COMMUNITY_Community 288|Community 288]]
-- [[_COMMUNITY_Community 289|Community 289]]
-- [[_COMMUNITY_Community 290|Community 290]]
-- [[_COMMUNITY_Community 291|Community 291]]
-- [[_COMMUNITY_Community 292|Community 292]]
-- [[_COMMUNITY_Community 293|Community 293]]
-- [[_COMMUNITY_Community 294|Community 294]]
-- [[_COMMUNITY_Community 295|Community 295]]
-- [[_COMMUNITY_Community 296|Community 296]]
-- [[_COMMUNITY_Community 297|Community 297]]
-- [[_COMMUNITY_Community 298|Community 298]]
-- [[_COMMUNITY_Community 299|Community 299]]
-- [[_COMMUNITY_Community 300|Community 300]]
-- [[_COMMUNITY_Community 301|Community 301]]
-- [[_COMMUNITY_Community 302|Community 302]]
-- [[_COMMUNITY_Community 303|Community 303]]
-- [[_COMMUNITY_Community 304|Community 304]]
-- [[_COMMUNITY_Community 305|Community 305]]
-- [[_COMMUNITY_Community 306|Community 306]]
-- [[_COMMUNITY_Community 307|Community 307]]
-- [[_COMMUNITY_Community 308|Community 308]]
-- [[_COMMUNITY_Community 309|Community 309]]
-- [[_COMMUNITY_Community 310|Community 310]]
-- [[_COMMUNITY_Community 311|Community 311]]
-- [[_COMMUNITY_Community 312|Community 312]]
-- [[_COMMUNITY_Community 313|Community 313]]
-- [[_COMMUNITY_Community 314|Community 314]]
-- [[_COMMUNITY_Community 315|Community 315]]
-- [[_COMMUNITY_Community 316|Community 316]]
-- [[_COMMUNITY_Community 317|Community 317]]
-- [[_COMMUNITY_Community 318|Community 318]]
-- [[_COMMUNITY_Community 319|Community 319]]
-- [[_COMMUNITY_Community 320|Community 320]]
-- [[_COMMUNITY_Community 321|Community 321]]
-- [[_COMMUNITY_Community 322|Community 322]]
-- [[_COMMUNITY_Community 323|Community 323]]
-- [[_COMMUNITY_Community 324|Community 324]]
-- [[_COMMUNITY_Community 325|Community 325]]
-- [[_COMMUNITY_Community 326|Community 326]]
-- [[_COMMUNITY_Community 327|Community 327]]
-- [[_COMMUNITY_Community 328|Community 328]]
-- [[_COMMUNITY_Community 329|Community 329]]
-- [[_COMMUNITY_Community 330|Community 330]]
-- [[_COMMUNITY_Community 331|Community 331]]
-- [[_COMMUNITY_Community 332|Community 332]]
-- [[_COMMUNITY_Community 333|Community 333]]
-- [[_COMMUNITY_Community 334|Community 334]]
-- [[_COMMUNITY_Community 335|Community 335]]
-- [[_COMMUNITY_Community 336|Community 336]]
-- [[_COMMUNITY_Community 337|Community 337]]
-- [[_COMMUNITY_Community 338|Community 338]]
-- [[_COMMUNITY_Community 339|Community 339]]
-- [[_COMMUNITY_Community 340|Community 340]]
-- [[_COMMUNITY_Community 341|Community 341]]
-- [[_COMMUNITY_Community 342|Community 342]]
-- [[_COMMUNITY_Community 343|Community 343]]
-- [[_COMMUNITY_Community 344|Community 344]]
-- [[_COMMUNITY_Community 345|Community 345]]
-- [[_COMMUNITY_Community 346|Community 346]]
-- [[_COMMUNITY_Community 347|Community 347]]
-- [[_COMMUNITY_Community 348|Community 348]]
-- [[_COMMUNITY_Community 349|Community 349]]
-- [[_COMMUNITY_Community 350|Community 350]]
-- [[_COMMUNITY_Community 351|Community 351]]
-- [[_COMMUNITY_Community 352|Community 352]]
-- [[_COMMUNITY_Community 353|Community 353]]
-- [[_COMMUNITY_Community 354|Community 354]]
-- [[_COMMUNITY_Community 355|Community 355]]
-- [[_COMMUNITY_Community 356|Community 356]]
-- [[_COMMUNITY_Community 357|Community 357]]
-- [[_COMMUNITY_Community 358|Community 358]]
-- [[_COMMUNITY_Community 359|Community 359]]
-- [[_COMMUNITY_Community 360|Community 360]]
-- [[_COMMUNITY_Community 361|Community 361]]
-- [[_COMMUNITY_Community 362|Community 362]]
-- [[_COMMUNITY_Community 363|Community 363]]
-- [[_COMMUNITY_Community 364|Community 364]]
-- [[_COMMUNITY_Community 365|Community 365]]
-- [[_COMMUNITY_Community 366|Community 366]]
-- [[_COMMUNITY_Community 367|Community 367]]
-- [[_COMMUNITY_Community 368|Community 368]]
-- [[_COMMUNITY_Community 369|Community 369]]
-- [[_COMMUNITY_Community 370|Community 370]]
-- [[_COMMUNITY_Community 371|Community 371]]
-- [[_COMMUNITY_Community 372|Community 372]]
-- [[_COMMUNITY_Community 373|Community 373]]
-- [[_COMMUNITY_Community 374|Community 374]]
-- [[_COMMUNITY_Community 375|Community 375]]
-- [[_COMMUNITY_Community 376|Community 376]]
-- [[_COMMUNITY_Community 377|Community 377]]
-- [[_COMMUNITY_Community 378|Community 378]]
-- [[_COMMUNITY_Community 379|Community 379]]
-- [[_COMMUNITY_Community 380|Community 380]]
-- [[_COMMUNITY_Community 381|Community 381]]
-- [[_COMMUNITY_Community 382|Community 382]]
-- [[_COMMUNITY_Community 383|Community 383]]
-- [[_COMMUNITY_Community 384|Community 384]]
-- [[_COMMUNITY_Community 385|Community 385]]
-- [[_COMMUNITY_Community 386|Community 386]]
-- [[_COMMUNITY_Community 387|Community 387]]
-- [[_COMMUNITY_Community 388|Community 388]]
-- [[_COMMUNITY_Community 389|Community 389]]
-- [[_COMMUNITY_Community 390|Community 390]]
-- [[_COMMUNITY_Community 391|Community 391]]
-- [[_COMMUNITY_Community 392|Community 392]]
-- [[_COMMUNITY_Community 393|Community 393]]
-- [[_COMMUNITY_Community 394|Community 394]]
-- [[_COMMUNITY_Community 395|Community 395]]
-- [[_COMMUNITY_Community 396|Community 396]]
-- [[_COMMUNITY_Community 397|Community 397]]
-- [[_COMMUNITY_Community 398|Community 398]]
-- [[_COMMUNITY_Community 399|Community 399]]
-- [[_COMMUNITY_Community 400|Community 400]]
-- [[_COMMUNITY_Community 401|Community 401]]
-- [[_COMMUNITY_Community 402|Community 402]]
-- [[_COMMUNITY_Community 403|Community 403]]
-- [[_COMMUNITY_Community 404|Community 404]]
-- [[_COMMUNITY_Community 405|Community 405]]
-- [[_COMMUNITY_Community 406|Community 406]]
-- [[_COMMUNITY_Community 407|Community 407]]
-- [[_COMMUNITY_Community 408|Community 408]]
-- [[_COMMUNITY_Community 409|Community 409]]
-- [[_COMMUNITY_Community 410|Community 410]]
-- [[_COMMUNITY_Community 411|Community 411]]
-- [[_COMMUNITY_Community 412|Community 412]]
-- [[_COMMUNITY_Community 413|Community 413]]
-- [[_COMMUNITY_Community 414|Community 414]]
-- [[_COMMUNITY_Community 415|Community 415]]
-- [[_COMMUNITY_Community 416|Community 416]]
-- [[_COMMUNITY_Community 417|Community 417]]
-- [[_COMMUNITY_Community 418|Community 418]]
-- [[_COMMUNITY_Community 419|Community 419]]
-- [[_COMMUNITY_Community 420|Community 420]]
-- [[_COMMUNITY_Community 421|Community 421]]
-- [[_COMMUNITY_Community 422|Community 422]]
-- [[_COMMUNITY_Community 423|Community 423]]
-- [[_COMMUNITY_Community 424|Community 424]]
-- [[_COMMUNITY_Community 425|Community 425]]
-- [[_COMMUNITY_Community 426|Community 426]]
-- [[_COMMUNITY_Community 427|Community 427]]
-- [[_COMMUNITY_Community 428|Community 428]]
-- [[_COMMUNITY_Community 429|Community 429]]
-- [[_COMMUNITY_Community 430|Community 430]]
-- [[_COMMUNITY_Community 431|Community 431]]
-- [[_COMMUNITY_Community 432|Community 432]]
-- [[_COMMUNITY_Community 433|Community 433]]
-- [[_COMMUNITY_Community 434|Community 434]]
-- [[_COMMUNITY_Community 435|Community 435]]
-- [[_COMMUNITY_Community 436|Community 436]]
-- [[_COMMUNITY_Community 437|Community 437]]
-- [[_COMMUNITY_Community 438|Community 438]]
-- [[_COMMUNITY_Community 439|Community 439]]
-- [[_COMMUNITY_Community 440|Community 440]]
-- [[_COMMUNITY_Community 441|Community 441]]
-- [[_COMMUNITY_Community 442|Community 442]]
-- [[_COMMUNITY_Community 443|Community 443]]
-- [[_COMMUNITY_Community 444|Community 444]]
-- [[_COMMUNITY_Community 445|Community 445]]
-- [[_COMMUNITY_Community 446|Community 446]]
-- [[_COMMUNITY_Community 447|Community 447]]
-- [[_COMMUNITY_Community 448|Community 448]]
-- [[_COMMUNITY_Community 449|Community 449]]
-- [[_COMMUNITY_Community 450|Community 450]]
-- [[_COMMUNITY_Community 451|Community 451]]
-- [[_COMMUNITY_Community 452|Community 452]]
-- [[_COMMUNITY_Community 453|Community 453]]
-- [[_COMMUNITY_Community 454|Community 454]]
-- [[_COMMUNITY_Community 455|Community 455]]
-- [[_COMMUNITY_Community 456|Community 456]]
-- [[_COMMUNITY_Community 457|Community 457]]
-- [[_COMMUNITY_Community 458|Community 458]]
-- [[_COMMUNITY_Community 459|Community 459]]
-- [[_COMMUNITY_Community 460|Community 460]]
-- [[_COMMUNITY_Community 461|Community 461]]
-- [[_COMMUNITY_Community 462|Community 462]]
-- [[_COMMUNITY_Community 463|Community 463]]
-- [[_COMMUNITY_Community 464|Community 464]]
-- [[_COMMUNITY_Community 465|Community 465]]
-- [[_COMMUNITY_Community 466|Community 466]]
-- [[_COMMUNITY_Community 467|Community 467]]
-- [[_COMMUNITY_Community 468|Community 468]]
-- [[_COMMUNITY_Community 469|Community 469]]
-- [[_COMMUNITY_Community 470|Community 470]]
-- [[_COMMUNITY_Community 471|Community 471]]
-- [[_COMMUNITY_Community 472|Community 472]]
-- [[_COMMUNITY_Community 473|Community 473]]
-- [[_COMMUNITY_Community 474|Community 474]]
-- [[_COMMUNITY_Community 475|Community 475]]
-- [[_COMMUNITY_Community 476|Community 476]]
-- [[_COMMUNITY_Community 477|Community 477]]
-- [[_COMMUNITY_Community 478|Community 478]]
-- [[_COMMUNITY_Community 479|Community 479]]
-- [[_COMMUNITY_Community 480|Community 480]]
-- [[_COMMUNITY_Community 481|Community 481]]
-- [[_COMMUNITY_Community 482|Community 482]]
-- [[_COMMUNITY_Community 483|Community 483]]
-- [[_COMMUNITY_Community 484|Community 484]]
-- [[_COMMUNITY_Community 485|Community 485]]
-- [[_COMMUNITY_Community 486|Community 486]]
-- [[_COMMUNITY_Community 487|Community 487]]
-- [[_COMMUNITY_Community 488|Community 488]]
-- [[_COMMUNITY_Community 489|Community 489]]
-- [[_COMMUNITY_Community 490|Community 490]]
-- [[_COMMUNITY_Community 491|Community 491]]
-- [[_COMMUNITY_Community 492|Community 492]]
-- [[_COMMUNITY_Community 493|Community 493]]
-- [[_COMMUNITY_Community 494|Community 494]]
-- [[_COMMUNITY_Community 495|Community 495]]
-- [[_COMMUNITY_Community 496|Community 496]]
-- [[_COMMUNITY_Community 497|Community 497]]
-- [[_COMMUNITY_Community 498|Community 498]]
-- [[_COMMUNITY_Community 499|Community 499]]
-- [[_COMMUNITY_Community 500|Community 500]]
-- [[_COMMUNITY_Community 501|Community 501]]
-- [[_COMMUNITY_Community 502|Community 502]]
-- [[_COMMUNITY_Community 503|Community 503]]
-- [[_COMMUNITY_Community 504|Community 504]]
-- [[_COMMUNITY_Community 505|Community 505]]
-- [[_COMMUNITY_Community 506|Community 506]]
-- [[_COMMUNITY_Community 507|Community 507]]
-- [[_COMMUNITY_Community 508|Community 508]]
-- [[_COMMUNITY_Community 509|Community 509]]
-- [[_COMMUNITY_Community 510|Community 510]]
-- [[_COMMUNITY_Community 511|Community 511]]
-- [[_COMMUNITY_Community 512|Community 512]]
-- [[_COMMUNITY_Community 513|Community 513]]
-- [[_COMMUNITY_Community 514|Community 514]]
-- [[_COMMUNITY_Community 515|Community 515]]
-- [[_COMMUNITY_Community 516|Community 516]]
-- [[_COMMUNITY_Community 517|Community 517]]
-- [[_COMMUNITY_Community 518|Community 518]]
-- [[_COMMUNITY_Community 519|Community 519]]
-- [[_COMMUNITY_Community 520|Community 520]]
-- [[_COMMUNITY_Community 521|Community 521]]
-- [[_COMMUNITY_Community 522|Community 522]]
-- [[_COMMUNITY_Community 523|Community 523]]
-- [[_COMMUNITY_Community 524|Community 524]]
-- [[_COMMUNITY_Community 525|Community 525]]
-- [[_COMMUNITY_Community 526|Community 526]]
-- [[_COMMUNITY_Community 527|Community 527]]
-- [[_COMMUNITY_Community 528|Community 528]]
-- [[_COMMUNITY_Community 529|Community 529]]
-- [[_COMMUNITY_Community 530|Community 530]]
-- [[_COMMUNITY_Community 531|Community 531]]
-- [[_COMMUNITY_Community 532|Community 532]]
-- [[_COMMUNITY_Community 533|Community 533]]
-- [[_COMMUNITY_Community 534|Community 534]]
-- [[_COMMUNITY_Community 535|Community 535]]
-- [[_COMMUNITY_Community 536|Community 536]]
-- [[_COMMUNITY_Community 537|Community 537]]
-- [[_COMMUNITY_Community 538|Community 538]]
-- [[_COMMUNITY_Community 539|Community 539]]
-- [[_COMMUNITY_Community 540|Community 540]]
-- [[_COMMUNITY_Community 541|Community 541]]
-- [[_COMMUNITY_Community 542|Community 542]]
-- [[_COMMUNITY_Community 543|Community 543]]
-- [[_COMMUNITY_Community 544|Community 544]]
-- [[_COMMUNITY_Community 545|Community 545]]
-- [[_COMMUNITY_Community 546|Community 546]]
-- [[_COMMUNITY_Community 547|Community 547]]
-- [[_COMMUNITY_Community 548|Community 548]]
-- [[_COMMUNITY_Community 549|Community 549]]
-- [[_COMMUNITY_Community 550|Community 550]]
-- [[_COMMUNITY_Community 551|Community 551]]
-- [[_COMMUNITY_Community 552|Community 552]]
-- [[_COMMUNITY_Community 553|Community 553]]
-- [[_COMMUNITY_Community 554|Community 554]]
-- [[_COMMUNITY_Community 555|Community 555]]
-- [[_COMMUNITY_Community 556|Community 556]]
-- [[_COMMUNITY_Community 557|Community 557]]
-- [[_COMMUNITY_Community 558|Community 558]]
-- [[_COMMUNITY_Community 559|Community 559]]
-- [[_COMMUNITY_Community 560|Community 560]]
-- [[_COMMUNITY_Community 561|Community 561]]
-- [[_COMMUNITY_Community 562|Community 562]]
-- [[_COMMUNITY_Community 563|Community 563]]
-- [[_COMMUNITY_Community 564|Community 564]]
-- [[_COMMUNITY_Community 565|Community 565]]
-- [[_COMMUNITY_Community 566|Community 566]]
-- [[_COMMUNITY_Community 567|Community 567]]
-- [[_COMMUNITY_Community 568|Community 568]]
-- [[_COMMUNITY_Community 569|Community 569]]
-- [[_COMMUNITY_Community 570|Community 570]]
-- [[_COMMUNITY_Community 571|Community 571]]
-- [[_COMMUNITY_Community 572|Community 572]]
-- [[_COMMUNITY_Community 573|Community 573]]
-- [[_COMMUNITY_Community 574|Community 574]]
-- [[_COMMUNITY_Community 575|Community 575]]
-- [[_COMMUNITY_Community 576|Community 576]]
-- [[_COMMUNITY_Community 577|Community 577]]
-- [[_COMMUNITY_Community 578|Community 578]]
-- [[_COMMUNITY_Community 579|Community 579]]
-- [[_COMMUNITY_Community 580|Community 580]]
-- [[_COMMUNITY_Community 581|Community 581]]
-- [[_COMMUNITY_Community 582|Community 582]]
-- [[_COMMUNITY_Community 583|Community 583]]
-- [[_COMMUNITY_Community 584|Community 584]]
-- [[_COMMUNITY_Community 585|Community 585]]
-- [[_COMMUNITY_Community 586|Community 586]]
-- [[_COMMUNITY_Community 587|Community 587]]
-- [[_COMMUNITY_Community 588|Community 588]]
-- [[_COMMUNITY_Community 589|Community 589]]
-- [[_COMMUNITY_Community 590|Community 590]]
-- [[_COMMUNITY_Community 591|Community 591]]
-- [[_COMMUNITY_Community 592|Community 592]]
-- [[_COMMUNITY_Community 593|Community 593]]
-- [[_COMMUNITY_Community 594|Community 594]]
-- [[_COMMUNITY_Community 595|Community 595]]
-- [[_COMMUNITY_Community 596|Community 596]]
-- [[_COMMUNITY_Community 597|Community 597]]
-- [[_COMMUNITY_Community 598|Community 598]]
-- [[_COMMUNITY_Community 599|Community 599]]
-- [[_COMMUNITY_Community 600|Community 600]]
-- [[_COMMUNITY_Community 601|Community 601]]
-- [[_COMMUNITY_Community 602|Community 602]]
-- [[_COMMUNITY_Community 603|Community 603]]
-- [[_COMMUNITY_Community 604|Community 604]]
-- [[_COMMUNITY_Community 605|Community 605]]
-- [[_COMMUNITY_Community 606|Community 606]]
-- [[_COMMUNITY_Community 607|Community 607]]
-- [[_COMMUNITY_Community 608|Community 608]]
-- [[_COMMUNITY_Community 609|Community 609]]
-- [[_COMMUNITY_Community 610|Community 610]]
-- [[_COMMUNITY_Community 611|Community 611]]
-- [[_COMMUNITY_Community 612|Community 612]]
-- [[_COMMUNITY_Community 613|Community 613]]
-- [[_COMMUNITY_Community 614|Community 614]]
-- [[_COMMUNITY_Community 615|Community 615]]
-- [[_COMMUNITY_Community 616|Community 616]]
-- [[_COMMUNITY_Community 617|Community 617]]
-- [[_COMMUNITY_Community 618|Community 618]]
-- [[_COMMUNITY_Community 619|Community 619]]
-- [[_COMMUNITY_Community 620|Community 620]]
-- [[_COMMUNITY_Community 621|Community 621]]
-- [[_COMMUNITY_Community 622|Community 622]]
-- [[_COMMUNITY_Community 623|Community 623]]
-- [[_COMMUNITY_Community 624|Community 624]]
-- [[_COMMUNITY_Community 625|Community 625]]
-- [[_COMMUNITY_Community 626|Community 626]]
-- [[_COMMUNITY_Community 627|Community 627]]
-- [[_COMMUNITY_Community 628|Community 628]]
-- [[_COMMUNITY_Community 629|Community 629]]
-- [[_COMMUNITY_Community 630|Community 630]]
-- [[_COMMUNITY_Community 631|Community 631]]
-- [[_COMMUNITY_Community 632|Community 632]]
-- [[_COMMUNITY_Community 633|Community 633]]
-- [[_COMMUNITY_Community 634|Community 634]]
-- [[_COMMUNITY_Community 635|Community 635]]
-- [[_COMMUNITY_Community 636|Community 636]]
-- [[_COMMUNITY_Community 637|Community 637]]
-- [[_COMMUNITY_Community 638|Community 638]]
-- [[_COMMUNITY_Community 639|Community 639]]
-- [[_COMMUNITY_Community 640|Community 640]]
-- [[_COMMUNITY_Community 641|Community 641]]
-- [[_COMMUNITY_Community 642|Community 642]]
-- [[_COMMUNITY_Community 643|Community 643]]
-- [[_COMMUNITY_Community 644|Community 644]]
-- [[_COMMUNITY_Community 645|Community 645]]
-- [[_COMMUNITY_Community 646|Community 646]]
-- [[_COMMUNITY_Community 647|Community 647]]
-- [[_COMMUNITY_Community 648|Community 648]]
-- [[_COMMUNITY_Community 649|Community 649]]
-- [[_COMMUNITY_Community 650|Community 650]]
-- [[_COMMUNITY_Community 651|Community 651]]
-- [[_COMMUNITY_Community 652|Community 652]]
-- [[_COMMUNITY_Community 653|Community 653]]
-- [[_COMMUNITY_Community 654|Community 654]]
-- [[_COMMUNITY_Community 655|Community 655]]
-- [[_COMMUNITY_Community 656|Community 656]]
-- [[_COMMUNITY_Community 657|Community 657]]
-- [[_COMMUNITY_Community 658|Community 658]]
-- [[_COMMUNITY_Community 659|Community 659]]
-- [[_COMMUNITY_Community 660|Community 660]]
-- [[_COMMUNITY_Community 661|Community 661]]
-- [[_COMMUNITY_Community 662|Community 662]]
-- [[_COMMUNITY_Community 663|Community 663]]
-- [[_COMMUNITY_Community 664|Community 664]]
-- [[_COMMUNITY_Community 665|Community 665]]
-- [[_COMMUNITY_Community 666|Community 666]]
-- [[_COMMUNITY_Community 667|Community 667]]
-- [[_COMMUNITY_Community 668|Community 668]]
-- [[_COMMUNITY_Community 669|Community 669]]
-- [[_COMMUNITY_Community 670|Community 670]]
-- [[_COMMUNITY_Community 671|Community 671]]
-- [[_COMMUNITY_Community 672|Community 672]]
-- [[_COMMUNITY_Community 673|Community 673]]
-- [[_COMMUNITY_Community 674|Community 674]]
-- [[_COMMUNITY_Community 675|Community 675]]
-- [[_COMMUNITY_Community 676|Community 676]]
-- [[_COMMUNITY_Community 677|Community 677]]
-- [[_COMMUNITY_Community 678|Community 678]]
-- [[_COMMUNITY_Community 679|Community 679]]
-- [[_COMMUNITY_Community 680|Community 680]]
-- [[_COMMUNITY_Community 681|Community 681]]
-- [[_COMMUNITY_Community 682|Community 682]]
-- [[_COMMUNITY_Community 683|Community 683]]
-- [[_COMMUNITY_Community 684|Community 684]]
-- [[_COMMUNITY_Community 685|Community 685]]
-- [[_COMMUNITY_Community 686|Community 686]]
-- [[_COMMUNITY_Community 687|Community 687]]
-- [[_COMMUNITY_Community 688|Community 688]]
-- [[_COMMUNITY_Community 689|Community 689]]
-- [[_COMMUNITY_Community 690|Community 690]]
-- [[_COMMUNITY_Community 691|Community 691]]
-- [[_COMMUNITY_Community 692|Community 692]]
-- [[_COMMUNITY_Community 693|Community 693]]
-- [[_COMMUNITY_Community 694|Community 694]]
-- [[_COMMUNITY_Community 695|Community 695]]
-- [[_COMMUNITY_Community 696|Community 696]]
-- [[_COMMUNITY_Community 697|Community 697]]
-- [[_COMMUNITY_Community 698|Community 698]]
-- [[_COMMUNITY_Community 699|Community 699]]
-- [[_COMMUNITY_Community 700|Community 700]]
-- [[_COMMUNITY_Community 701|Community 701]]
-- [[_COMMUNITY_Community 702|Community 702]]
-- [[_COMMUNITY_Community 703|Community 703]]
-- [[_COMMUNITY_Community 704|Community 704]]
-- [[_COMMUNITY_Community 705|Community 705]]
-- [[_COMMUNITY_Community 706|Community 706]]
-- [[_COMMUNITY_Community 707|Community 707]]
-- [[_COMMUNITY_Community 708|Community 708]]
-- [[_COMMUNITY_Community 709|Community 709]]
-- [[_COMMUNITY_Community 710|Community 710]]
-- [[_COMMUNITY_Community 711|Community 711]]
-- [[_COMMUNITY_Community 712|Community 712]]
-- [[_COMMUNITY_Community 713|Community 713]]
-- [[_COMMUNITY_Community 714|Community 714]]
-- [[_COMMUNITY_Community 715|Community 715]]
-- [[_COMMUNITY_Community 716|Community 716]]
-- [[_COMMUNITY_Community 717|Community 717]]
-- [[_COMMUNITY_Community 718|Community 718]]
-- [[_COMMUNITY_Community 719|Community 719]]
-- [[_COMMUNITY_Community 720|Community 720]]
-- [[_COMMUNITY_Community 721|Community 721]]
-- [[_COMMUNITY_Community 722|Community 722]]
-- [[_COMMUNITY_Community 723|Community 723]]
-- [[_COMMUNITY_Community 724|Community 724]]
-- [[_COMMUNITY_Community 725|Community 725]]
-- [[_COMMUNITY_Community 726|Community 726]]
-- [[_COMMUNITY_Community 727|Community 727]]
-- [[_COMMUNITY_Community 728|Community 728]]
-- [[_COMMUNITY_Community 729|Community 729]]
-- [[_COMMUNITY_Community 731|Community 731]]
-- [[_COMMUNITY_Community 732|Community 732]]
-- [[_COMMUNITY_Community 733|Community 733]]
-- [[_COMMUNITY_Community 734|Community 734]]
-- [[_COMMUNITY_Community 735|Community 735]]
-- [[_COMMUNITY_Community 736|Community 736]]
-- [[_COMMUNITY_Community 737|Community 737]]
-- [[_COMMUNITY_Community 738|Community 738]]
-- [[_COMMUNITY_Community 739|Community 739]]
-- [[_COMMUNITY_Community 740|Community 740]]
-- [[_COMMUNITY_Community 741|Community 741]]
-- [[_COMMUNITY_Community 742|Community 742]]
-- [[_COMMUNITY_Community 743|Community 743]]
-- [[_COMMUNITY_Community 744|Community 744]]
-- [[_COMMUNITY_Community 745|Community 745]]
-- [[_COMMUNITY_Community 746|Community 746]]
-- [[_COMMUNITY_Community 747|Community 747]]
-- [[_COMMUNITY_Community 748|Community 748]]
-- [[_COMMUNITY_Community 749|Community 749]]
-- [[_COMMUNITY_Community 750|Community 750]]
-- [[_COMMUNITY_Community 751|Community 751]]
-- [[_COMMUNITY_Community 752|Community 752]]
-- [[_COMMUNITY_Community 754|Community 754]]
-- [[_COMMUNITY_Community 755|Community 755]]
-- [[_COMMUNITY_Community 756|Community 756]]
-- [[_COMMUNITY_Community 757|Community 757]]
-- [[_COMMUNITY_Community 758|Community 758]]
-- [[_COMMUNITY_Community 759|Community 759]]
-- [[_COMMUNITY_Community 760|Community 760]]
-- [[_COMMUNITY_Community 761|Community 761]]
-- [[_COMMUNITY_Community 762|Community 762]]
-- [[_COMMUNITY_Community 763|Community 763]]
-- [[_COMMUNITY_Community 764|Community 764]]
-- [[_COMMUNITY_Community 765|Community 765]]
-- [[_COMMUNITY_Community 766|Community 766]]
-- [[_COMMUNITY_Community 767|Community 767]]
-- [[_COMMUNITY_Community 768|Community 768]]
-- [[_COMMUNITY_Community 769|Community 769]]
-- [[_COMMUNITY_Community 770|Community 770]]
-- [[_COMMUNITY_Community 771|Community 771]]
-- [[_COMMUNITY_Community 772|Community 772]]
-- [[_COMMUNITY_Community 773|Community 773]]
-- [[_COMMUNITY_Community 774|Community 774]]
-- [[_COMMUNITY_Community 775|Community 775]]
-- [[_COMMUNITY_Community 776|Community 776]]
-- [[_COMMUNITY_Community 777|Community 777]]
-- [[_COMMUNITY_Community 778|Community 778]]
-- [[_COMMUNITY_Community 779|Community 779]]
-- [[_COMMUNITY_Community 780|Community 780]]
-- [[_COMMUNITY_Community 781|Community 781]]
-- [[_COMMUNITY_Community 782|Community 782]]
-- [[_COMMUNITY_Community 783|Community 783]]
-- [[_COMMUNITY_Community 784|Community 784]]
-- [[_COMMUNITY_Community 785|Community 785]]
-- [[_COMMUNITY_Community 786|Community 786]]
-- [[_COMMUNITY_Community 787|Community 787]]
-- [[_COMMUNITY_Community 788|Community 788]]
-- [[_COMMUNITY_Community 789|Community 789]]
-- [[_COMMUNITY_Community 790|Community 790]]
-- [[_COMMUNITY_Community 791|Community 791]]
-- [[_COMMUNITY_Community 792|Community 792]]
-- [[_COMMUNITY_Community 793|Community 793]]
-- [[_COMMUNITY_Community 794|Community 794]]
-- [[_COMMUNITY_Community 795|Community 795]]
-- [[_COMMUNITY_Community 796|Community 796]]
-- [[_COMMUNITY_Community 797|Community 797]]
-- [[_COMMUNITY_Community 798|Community 798]]
-- [[_COMMUNITY_Community 799|Community 799]]
-- [[_COMMUNITY_Community 800|Community 800]]
-- [[_COMMUNITY_Community 801|Community 801]]
-- [[_COMMUNITY_Community 802|Community 802]]
-- [[_COMMUNITY_Community 803|Community 803]]
-- [[_COMMUNITY_Community 804|Community 804]]
-- [[_COMMUNITY_Community 805|Community 805]]
-- [[_COMMUNITY_Community 806|Community 806]]
-- [[_COMMUNITY_Community 807|Community 807]]
-- [[_COMMUNITY_Community 808|Community 808]]
-- [[_COMMUNITY_Community 809|Community 809]]
-- [[_COMMUNITY_Community 810|Community 810]]
-- [[_COMMUNITY_Community 811|Community 811]]
-- [[_COMMUNITY_Community 812|Community 812]]
-- [[_COMMUNITY_Community 813|Community 813]]
-- [[_COMMUNITY_Community 814|Community 814]]
-- [[_COMMUNITY_Community 815|Community 815]]
-- [[_COMMUNITY_Community 816|Community 816]]
-- [[_COMMUNITY_Community 817|Community 817]]
-- [[_COMMUNITY_Community 818|Community 818]]
-- [[_COMMUNITY_Community 819|Community 819]]
-- [[_COMMUNITY_Community 820|Community 820]]
-- [[_COMMUNITY_Community 821|Community 821]]
-- [[_COMMUNITY_Community 822|Community 822]]
-- [[_COMMUNITY_Community 823|Community 823]]
-- [[_COMMUNITY_Community 824|Community 824]]
-- [[_COMMUNITY_Community 825|Community 825]]
-- [[_COMMUNITY_Community 826|Community 826]]
-- [[_COMMUNITY_Community 827|Community 827]]
-- [[_COMMUNITY_Community 828|Community 828]]
-- [[_COMMUNITY_Community 829|Community 829]]
-- [[_COMMUNITY_Community 830|Community 830]]
-- [[_COMMUNITY_Community 831|Community 831]]
-- [[_COMMUNITY_Community 832|Community 832]]
-- [[_COMMUNITY_Community 833|Community 833]]
-- [[_COMMUNITY_Community 834|Community 834]]
-- [[_COMMUNITY_Community 835|Community 835]]
-- [[_COMMUNITY_Community 836|Community 836]]
-- [[_COMMUNITY_Community 839|Community 839]]
-- [[_COMMUNITY_Community 840|Community 840]]
-- [[_COMMUNITY_Community 841|Community 841]]
-- [[_COMMUNITY_Community 842|Community 842]]
-- [[_COMMUNITY_Community 843|Community 843]]
-- [[_COMMUNITY_Community 844|Community 844]]
-- [[_COMMUNITY_Community 845|Community 845]]
-- [[_COMMUNITY_Community 846|Community 846]]
-- [[_COMMUNITY_Community 847|Community 847]]
-- [[_COMMUNITY_Community 848|Community 848]]
-- [[_COMMUNITY_Community 849|Community 849]]
-- [[_COMMUNITY_Community 850|Community 850]]
-- [[_COMMUNITY_.test_saos_magnitude|.test_saos_magnitude]]
-- [[_COMMUNITY_Community 852|Community 852]]
-- [[_COMMUNITY_Community 853|Community 853]]
-- [[_COMMUNITY_.test_laos_periodicity|.test_laos_periodicity]]
-- [[_COMMUNITY_.test_equilibrium_conformation_multimode|.test_equilibrium_conformation_multimode]]
-- [[_COMMUNITY_.test_model_function_laos_uses_kwargs|.test_model_function_laos_uses_kwargs]]
-- [[_COMMUNITY_temp_variable_length_files|temp_variable_length_files]]
-- [[_COMMUNITY_temp_batch_files|temp_batch_files]]
-- [[_COMMUNITY_.test_fit_bayesian_no_model_raises|.test_fit_bayesian_no_model_raises]]
-- [[_COMMUNITY_.test_plot_bayesian_no_result_raises|.test_plot_bayesian_no_result_raises]]
-- [[_COMMUNITY_Community 861|Community 861]]
-- [[_COMMUNITY_.test_plot_diagnostics_no_result_raises|.test_plot_diagnostics_no_result_raises]]
-- [[_COMMUNITY_Community 863|Community 863]]
-- [[_COMMUNITY_test_numerical_derivative_second_order_sinusoid|test_numerical_derivative_second_order_sinusoid]]
-- [[_COMMUNITY_test_numerical_derivative_periodic_matches_analytic|test_numerical_derivative_periodic_matches_analytic]]
-- [[_COMMUNITY_test_spp_numerical_analysis_linear_material|test_spp_numerical_analysis_linear_material]]
-- [[_COMMUNITY_test_numerical_derivative_step_size_smoothing|test_numerical_derivative_step_size_smoothing]]
-- [[_COMMUNITY_test_numerical_derivative_4th_order_third_derivative|test_numerical_derivative_4th_order_third_derivative]]
-- [[_COMMUNITY_test_compute_phase_offset_zero_for_pure_sine|test_compute_phase_offset_zero_for_pure_sine]]
-- [[_COMMUNITY_test_spp_numerical_analysis_includes_moduli_rates|test_spp_numerical_analysis_includes_moduli_rates]]
-- [[_COMMUNITY_Community 871|Community 871]]
-- [[_COMMUNITY_test_frenet_serret_frame_unit_vectors|test_frenet_serret_frame_unit_vectors]]
-- [[_COMMUNITY_test_frenet_serret_frame_standalone_function|test_frenet_serret_frame_standalone_function]]
-- [[_COMMUNITY_Community 874|Community 874]]
-- [[_COMMUNITY_Community 875|Community 875]]
-- [[_COMMUNITY_Community 876|Community 876]]
-- [[_COMMUNITY_Community 877|Community 877]]
-- [[_COMMUNITY_Community 878|Community 878]]
-- [[_COMMUNITY_Community 879|Community 879]]
-- [[_COMMUNITY_Community 880|Community 880]]
-- [[_COMMUNITY_Community 882|Community 882]]
-- [[_COMMUNITY_Community 883|Community 883]]
-- [[_COMMUNITY_Community 884|Community 884]]
-- [[_COMMUNITY_Community 885|Community 885]]
-- [[_COMMUNITY_Community 886|Community 886]]
-- [[_COMMUNITY_Community 887|Community 887]]
-- [[_COMMUNITY_Community 888|Community 888]]
-- [[_COMMUNITY_Community 889|Community 889]]
-- [[_COMMUNITY_Community 890|Community 890]]
-- [[_COMMUNITY_Community 891|Community 891]]
-- [[_COMMUNITY_test_yield_from_displacement_stress_basic|test_yield_from_displacement_stress_basic]]
-- [[_COMMUNITY_Community 893|Community 893]]
-- [[_COMMUNITY_test_convert_units_stress|test_convert_units_stress]]
-- [[_COMMUNITY_test_convert_units_angle|test_convert_units_angle]]
-- [[_COMMUNITY_test_differentiate_rate_from_strain_wrapped_matches_cosine|test_differentiate_rate_from_strain_wrapped_matches_cosine]]
-- [[_COMMUNITY_test_numerical_derivative_first_order_sinusoid|test_numerical_derivative_first_order_sinusoid]]
-- [[_COMMUNITY_Community 1001|Community 1001]]
-- [[_COMMUNITY_Community 1038|Community 1038]]
-- [[_COMMUNITY_Community 1051|Community 1051]]
-- [[_COMMUNITY_Community 1053|Community 1053]]
-- [[_COMMUNITY_Community 1055|Community 1055]]
-- [[_COMMUNITY_Community 1059|Community 1059]]
-- [[_COMMUNITY_Community 1076|Community 1076]]
-- [[_COMMUNITY_Community 1235|Community 1235]]
-- [[_COMMUNITY_Community 1236|Community 1236]]
-- [[_COMMUNITY_Community 1237|Community 1237]]
-- [[_COMMUNITY_Community 1238|Community 1238]]
-- [[_COMMUNITY_Community 1271|Community 1271]]
-- [[_COMMUNITY_Community 1795|Community 1795]]
-- [[_COMMUNITY_Community 1796|Community 1796]]
-- [[_COMMUNITY_Community 1797|Community 1797]]
-- [[_COMMUNITY_Community 1798|Community 1798]]
-- [[_COMMUNITY_Community 1799|Community 1799]]
-- [[_COMMUNITY_Community 1814|Community 1814]]
-- [[_COMMUNITY_Community 2461|Community 2461]]
-- [[_COMMUNITY_Community 2805|Community 2805]]
-- [[_COMMUNITY_Community 2806|Community 2806]]
-- [[_COMMUNITY_Community 2807|Community 2807]]
+- [[_COMMUNITY_ModelRegistry|ModelRegistry]]
+- [[_COMMUNITY_ParameterSet|ParameterSet]]
+- [[_COMMUNITY_StateStore|StateStore]]
+- [[_COMMUNITY_QWidget|QWidget]]
+- [[_COMMUNITY_test_visual_pipeline_state.py|test_visual_pipeline_state.py]]
+- [[_COMMUNITY_Parameter|Parameter]]
+- [[_COMMUNITY_RheoData|RheoData]]
+- [[_COMMUNITY_test_io_fixes.py|test_io_fixes.py]]
+- [[_COMMUNITY_Pipeline|Pipeline]]
+- [[_COMMUNITY_IconProvider|IconProvider]]
+- [[_COMMUNITY_.create|.create]]
+- [[_COMMUNITY_GiesekusSingleMode|GiesekusSingleMode]]
+- [[_COMMUNITY_ValueError|ValueError]]
+- [[_COMMUNITY_device.py|device.py]]
+- [[_COMMUNITY_._predict|._predict]]
+- [[_COMMUNITY_load_csv|load_csv]]
+- [[_COMMUNITY_TestCoerceBayesianInt|TestCoerceBayesianInt]]
+- [[_COMMUNITY_SGRGeneric|SGRGeneric]]
+- [[_COMMUNITY_test_fractional_initializers.py|test_fractional_initializers.py]]
+- [[_COMMUNITY_STZConventional|STZConventional]]
+- [[_COMMUNITY_test_trios_auto_chunk.py|test_trios_auto_chunk.py]]
+- [[_COMMUNITY_json.py|json.py]]
+- [[_COMMUNITY_test_kernels.py|test_kernels.py]]
+- [[_COMMUNITY_txt.py|txt.py]]
+- [[_COMMUNITY_TensorialEPM|TensorialEPM]]
+- [[_COMMUNITY_Maxwell|Maxwell]]
+- [[_COMMUNITY_PipelineBuilder|PipelineBuilder]]
+- [[_COMMUNITY_test_project_structure.py|test_project_structure.py]]
+- [[_COMMUNITY_SpringPot|SpringPot]]
+- [[_COMMUNITY_ArvizCanvas|ArvizCanvas]]
+- [[_COMMUNITY__kernels.py|_kernels.py]]
+- [[_COMMUNITY_mittag_leffler_e|mittag_leffler_e]]
+- [[_COMMUNITY_FIKH|FIKH]]
+- [[_COMMUNITY_HVNMLocal|HVNMLocal]]
+- [[_COMMUNITY_FractionalMaxwellModel|FractionalMaxwellModel]]
+- [[_COMMUNITY_validate_prony_parameters|validate_prony_parameters]]
+- [[_COMMUNITY_DataService|DataService]]
+- [[_COMMUNITY__kernels.py|_kernels.py]]
+- [[_COMMUNITY__kernels_diffrax.py|_kernels_diffrax.py]]
+- [[_COMMUNITY__translate_y2_col|_translate_y2_col]]
+- [[_COMMUNITY_FluiditySaramitoLocal|FluiditySaramitoLocal]]
+- [[_COMMUNITY_ndarray|ndarray]]
+- [[_COMMUNITY_FMLIKH|FMLIKH]]
+- [[_COMMUNITY_ColumnMappingPage|ColumnMappingPage]]
+- [[_COMMUNITY_FitPage|FitPage]]
+- [[_COMMUNITY_from_yaml|from_yaml]]
+- [[_COMMUNITY_FractionalMaxwellLiquid|FractionalMaxwellLiquid]]
+- [[_COMMUNITY_TransformState|TransformState]]
+- [[_COMMUNITY__make_mock_spp_results|_make_mock_spp_results]]
+- [[_COMMUNITY_._init_state|._init_state]]
+- [[_COMMUNITY_FitPlotter|FitPlotter]]
+- [[_COMMUNITY_FractionalModelMixin|FractionalModelMixin]]
+- [[_COMMUNITY_CreepToRelaxationPipeline|CreepToRelaxationPipeline]]
+- [[_COMMUNITY___init__.py|__init__.py]]
+- [[_COMMUNITY_test_multi_file.py|test_multi_file.py]]
+- [[_COMMUNITY_FluidityNonlocal|FluidityNonlocal]]
+- [[_COMMUNITY_test_fractional_zener_family.py|test_fractional_zener_family.py]]
+- [[_COMMUNITY__execute_notebook|_execute_notebook]]
+- [[_COMMUNITY_TestMenuBarActionConnections|TestMenuBarActionConnections]]
+- [[_COMMUNITY_FitResult|FitResult]]
+- [[_COMMUNITY___init__.py|__init__.py]]
+- [[_COMMUNITY_PipelineSidebar|PipelineSidebar]]
+- [[_COMMUNITY_TransformService|TransformService]]
+- [[_COMMUNITY__kernels.py|_kernels.py]]
+- [[_COMMUNITY_RheoJAXMainWindow|RheoJAXMainWindow]]
+- [[_COMMUNITY_HVNMBase|HVNMBase]]
+- [[_COMMUNITY_test_transform_plotter.py|test_transform_plotter.py]]
+- [[_COMMUNITY_SmoothDerivative|SmoothDerivative]]
+- [[_COMMUNITY_local.py|local.py]]
+- [[_COMMUNITY_test_fikh_caputo.py|test_fikh_caputo.py]]
+- [[_COMMUNITY_conftest.py|conftest.py]]
+- [[_COMMUNITY_ModelComparisonPipeline|ModelComparisonPipeline]]
+- [[_COMMUNITY_DatasetLibrary|DatasetLibrary]]
+- [[_COMMUNITY_check_model_compatibility|check_model_compatibility]]
+- [[_COMMUNITY_.predict_rheo|.predict_rheo]]
+- [[_COMMUNITY_MLIKH|MLIKH]]
+- [[_COMMUNITY_PersistentProcessPool|PersistentProcessPool]]
+- [[_COMMUNITY_TestKernelProperties|TestKernelProperties]]
+- [[_COMMUNITY_._transform|._transform]]
+- [[_COMMUNITY_WorkerPool|WorkerPool]]
+- [[_COMMUNITY__kernels.py|_kernels.py]]
+- [[_COMMUNITY_get_default_workers|get_default_workers]]
+- [[_COMMUNITY_PipelineConfig|PipelineConfig]]
+- [[_COMMUNITY_ITTMCTSchematic|ITTMCTSchematic]]
+- [[_COMMUNITY_.navigate_to|.navigate_to]]
+- [[_COMMUNITY_plot_model_fit|plot_model_fit]]
+- [[_COMMUNITY_MIKH|MIKH]]
+- [[_COMMUNITY_conftest.py|conftest.py]]
+- [[_COMMUNITY__kernels_diffrax.py|_kernels_diffrax.py]]
+- [[_COMMUNITY__kernels.py|_kernels.py]]
+- [[_COMMUNITY_ndarray|ndarray]]
+- [[_COMMUNITY_DMTLocal|DMTLocal]]
+- [[_COMMUNITY_FluidityLocal|FluidityLocal]]
+- [[_COMMUNITY___init__.py|__init__.py]]
+- [[_COMMUNITY_TransformPlotter|TransformPlotter]]
+- [[_COMMUNITY_FFTAnalysis|FFTAnalysis]]
+- [[_COMMUNITY_TestFrequencyDependentModulus|TestFrequencyDependentModulus]]
+- [[_COMMUNITY_PreviewWorker|PreviewWorker]]
+- [[_COMMUNITY_BatchPipeline|BatchPipeline]]
+- [[_COMMUNITY_._predict|._predict]]
+- [[_COMMUNITY_ITTMCTBase|ITTMCTBase]]
+- [[_COMMUNITY_TNTLoopBridge|TNTLoopBridge]]
+- [[_COMMUNITY_test_physics.py|test_physics.py]]
+- [[_COMMUNITY_BayesianWorker|BayesianWorker]]
+- [[_COMMUNITY_MockBayesianModel|MockBayesianModel]]
+- [[_COMMUNITY_test_epm_kernels_tensorial.py|test_epm_kernels_tensorial.py]]
+- [[_COMMUNITY_PreprocessingResult|PreprocessingResult]]
+- [[_COMMUNITY_TestSTZIntegration|TestSTZIntegration]]
+- [[_COMMUNITY_test_column_mapping.py|test_column_mapping.py]]
+- [[_COMMUNITY_schematic.py|schematic.py]]
+- [[_COMMUNITY_main|main]]
+- [[_COMMUNITY_test_hvm.py|test_hvm.py]]
+- [[_COMMUNITY_spp_kernels.py|spp_kernels.py]]
+- [[_COMMUNITY_TestLAOSAnalysis|TestLAOSAnalysis]]
+- [[_COMMUNITY_.connect_signals|.connect_signals]]
+- [[_COMMUNITY_get_template|get_template]]
+- [[_COMMUNITY_load_trios_chunked|load_trios_chunked]]
+- [[_COMMUNITY_AnalysisExporter|AnalysisExporter]]
+- [[_COMMUNITY_StatusBar|StatusBar]]
+- [[_COMMUNITY_HVMLocal|HVMLocal]]
+- [[_COMMUNITY_ndarray|ndarray]]
+- [[_COMMUNITY_FitResult|FitResult]]
+- [[_COMMUNITY_HVMBase|HVMBase]]
+- [[_COMMUNITY__yaml_runner.py|_yaml_runner.py]]
+- [[_COMMUNITY_Envelope|Envelope]]
+- [[_COMMUNITY_PipelineChips|PipelineChips]]
+- [[_COMMUNITY_FitState|FitState]]
+- [[_COMMUNITY_PronyConversion|PronyConversion]]
+- [[_COMMUNITY_SPPYieldStress|SPPYieldStress]]
+- [[_COMMUNITY_get_stylesheet|get_stylesheet]]
+- [[_COMMUNITY_RheoJaxValidationWarning|RheoJaxValidationWarning]]
+- [[_COMMUNITY_VLBLocal|VLBLocal]]
+- [[_COMMUNITY_test_bayesian.py|test_bayesian.py]]
+- [[_COMMUNITY_main|main]]
+- [[_COMMUNITY_Common Patterns|Common Patterns]]
+- [[_COMMUNITY_Properties|Properties]]
+- [[_COMMUNITY_._simulate_transient|._simulate_transient]]
+- [[_COMMUNITY_.model_function|.model_function]]
+- [[_COMMUNITY_test_fluidity_nlsq_nuts_pipeline.py|test_fluidity_nlsq_nuts_pipeline.py]]
+- [[_COMMUNITY_ProcessCancellationToken|ProcessCancellationToken]]
+- [[_COMMUNITY_ResidualsPanel|ResidualsPanel]]
+- [[_COMMUNITY_library.py|library.py]]
+- [[_COMMUNITY_WorkspaceWindow|WorkspaceWindow]]
+- [[_COMMUNITY_.copy|.copy]]
+- [[_COMMUNITY_generate_diagnostic_suite|generate_diagnostic_suite]]
+- [[_COMMUNITY_test_physics.py|test_physics.py]]
+- [[_COMMUNITY_TestFractionalZenerSolidLiquid|TestFractionalZenerSolidLiquid]]
+- [[_COMMUNITY_test_schematic.py|test_schematic.py]]
+- [[_COMMUNITY_main.py|main.py]]
+- [[_COMMUNITY_load_anton_paar|load_anton_paar]]
+- [[_COMMUNITY_UnsupportedDataError|UnsupportedDataError]]
+- [[_COMMUNITY_test_trios_chunked_integrity.py|test_trios_chunked_integrity.py]]
+- [[_COMMUNITY_ndarray|ndarray]]
+- [[_COMMUNITY_ExportPage|ExportPage]]
+- [[_COMMUNITY_.export_data|.export_data]]
+- [[_COMMUNITY_LogConfig|LogConfig]]
+- [[_COMMUNITY_extract_frequency_features|extract_frequency_features]]
+- [[_COMMUNITY_ArrayLike|ArrayLike]]
+- [[_COMMUNITY_ITTMCTIsotropic|ITTMCTIsotropic]]
+- [[_COMMUNITY_TNTSingleMode|TNTSingleMode]]
+- [[_COMMUNITY_ExportOptionsDialog|ExportOptionsDialog]]
+- [[_COMMUNITY_test_sgr_parity.py|test_sgr_parity.py]]
+- [[_COMMUNITY_physics_checks.py|physics_checks.py]]
+- [[_COMMUNITY_FluiditySaramitoNonlocal|FluiditySaramitoNonlocal]]
+- [[_COMMUNITY_hebraud_lequeux.py|hebraud_lequeux.py]]
+- [[_COMMUNITY_GeneralizedMaxwell|GeneralizedMaxwell]]
+- [[_COMMUNITY_MastercurvePipeline|MastercurvePipeline]]
+- [[_COMMUNITY_SPPAmplitudeSweepPipeline|SPPAmplitudeSweepPipeline]]
+- [[_COMMUNITY_auto_p0.py|auto_p0.py]]
+- [[_COMMUNITY_VLB Model Equation Verification|VLB Model Equation Verification]]
+- [[_COMMUNITY_test_priors.py|test_priors.py]]
+- [[_COMMUNITY_ITT-MCT Literature Review Key Equations|ITT-MCT Literature Review: Key Equations]]
+- [[_COMMUNITY_formatters.py|formatters.py]]
+- [[_COMMUNITY_layout_helpers.py|layout_helpers.py]]
+- [[_COMMUNITY_SPPDecomposer|SPPDecomposer]]
+- [[_COMMUNITY_RheoJAX GUI Smoke Tests|RheoJAX GUI Smoke Tests]]
+- [[_COMMUNITY__make_fit_result|_make_fit_result]]
+- [[_COMMUNITY_SGRConventional|SGRConventional]]
+- [[_COMMUNITY__coerce_ndarray|_coerce_ndarray]]
+- [[_COMMUNITY_transform_controller.py|transform_controller.py]]
+- [[_COMMUNITY_MultiView|MultiView]]
+- [[_COMMUNITY_PriorsEditor|PriorsEditor]]
+- [[_COMMUNITY_ndarray|ndarray]]
+- [[_COMMUNITY_ndarray|ndarray]]
+- [[_COMMUNITY_TNTMultiSpecies|TNTMultiSpecies]]
+- [[_COMMUNITY_test_notebook_execution_consistency.py|test_notebook_execution_consistency.py]]
+- [[_COMMUNITY_TestAdvancedNotebooks|TestAdvancedNotebooks]]
+- [[_COMMUNITY_run_fit_isolated|run_fit_isolated]]
+- [[_COMMUNITY_ndarray|ndarray]]
+- [[_COMMUNITY_TestHVMStartup|TestHVMStartup]]
+- [[_COMMUNITY_BaseArviZWidget|BaseArviZWidget]]
+- [[_COMMUNITY_TestDMTRegistry|TestDMTRegistry]]
+- [[_COMMUNITY_test_epm_kernels.py|test_epm_kernels.py]]
+- [[_COMMUNITY_FractionalPoyntingThomson|FractionalPoyntingThomson]]
+- [[_COMMUNITY_._transform|._transform]]
+- [[_COMMUNITY_ndarray|ndarray]]
+- [[_COMMUNITY_mct_kernels.py|mct_kernels.py]]
+- [[_COMMUNITY_Test Data Fixtures for RheoJAX v0.4.0|Test Data Fixtures for RheoJAX v0.4.0]]
+- [[_COMMUNITY_RheoJAX Architecture Overview|RheoJAX Architecture Overview]]
+- [[_COMMUNITY_BatchPanel|BatchPanel]]
+- [[_COMMUNITY_FractionalMaxwellGel|FractionalMaxwellGel]]
+- [[_COMMUNITY_ndarray|ndarray]]
+- [[_COMMUNITY_TestBaseModelEdgeCases|TestBaseModelEdgeCases]]
+- [[_COMMUNITY_check_r_hat|check_r_hat]]
+- [[_COMMUNITY_TestFrameworkSmoke|TestFrameworkSmoke]]
+- [[_COMMUNITY_test_migrated_notebooks.py|test_migrated_notebooks.py]]
+- [[_COMMUNITY_BayesianPipeline|BayesianPipeline]]
+- [[_COMMUNITY_sgr_population_balance.py|sgr_population_balance.py]]
+- [[_COMMUNITY_test_visual_regression.py|test_visual_regression.py]]
+- [[_COMMUNITY_Hebraud-Lequeux (HL) Model Equations and Physics|Hebraud-Lequeux (HL) Model: Equations and Physics]]
+- [[_COMMUNITY_Background Job System - Implementation Summary|Background Job System - Implementation Summary]]
+- [[_COMMUNITY_FractionalBurgersModel|FractionalBurgersModel]]
+- [[_COMMUNITY_test_protocols.py|test_protocols.py]]
+- [[_COMMUNITY_test_nlsq_numpyro_workflow.py|test_nlsq_numpyro_workflow.py]]
+- [[_COMMUNITY_FIKH (Fractional Isotropic-Kinematic Hardening) Comprehensive Validation Report|FIKH (Fractional Isotropic-Kinematic Hardening) Comprehensive Validation Report]]
+- [[_COMMUNITY_ndarray|ndarray]]
+- [[_COMMUNITY_main|main]]
+- [[_COMMUNITY_apply_overrides|apply_overrides]]
+- [[_COMMUNITY_Registry|Registry]]
+- [[_COMMUNITY_EPM (Elasto-Plastic Models) Comprehensive Validation Report|EPM (Elasto-Plastic Models) Comprehensive Validation Report]]
+- [[_COMMUNITY_FractionalKelvinVoigt|FractionalKelvinVoigt]]
+- [[_COMMUNITY_VLBVariant|VLBVariant]]
+- [[_COMMUNITY_run_profiling.py|run_profiling.py]]
+- [[_COMMUNITY_._predict|._predict]]
+- [[_COMMUNITY_RheoJAX v0.4.0 Task Group 1 - Baseline Test Report|RheoJAX v0.4.0 Task Group 1 - Baseline Test Report]]
+- [[_COMMUNITY_RheoJAX Tech Stack|RheoJAX Tech Stack]]
+- [[_COMMUNITY_ProcessWorkerAdapter|ProcessWorkerAdapter]]
+- [[_COMMUNITY_ModelComparison|ModelComparison]]
+- [[_COMMUNITY_test_dmta_removal.py|test_dmta_removal.py]]
+- [[_COMMUNITY_DMTNonlocal|DMTNonlocal]]
+- [[_COMMUNITY_ArrayLike|ArrayLike]]
+- [[_COMMUNITY_TNTStickyRouse|TNTStickyRouse]]
+- [[_COMMUNITY_compute_fit_quality|compute_fit_quality]]
+- [[_COMMUNITY_solve_linear_creep_compliance|solve_linear_creep_compliance]]
+- [[_COMMUNITY_.get_diagnostics|.get_diagnostics]]
+- [[_COMMUNITY_TestBayesianNotebooks|TestBayesianNotebooks]]
+- [[_COMMUNITY_.__init__|.__init__]]
+- [[_COMMUNITY_handlers.py|handlers.py]]
+- [[_COMMUNITY_main|main]]
+- [[_COMMUNITY_cmd_transform.py|cmd_transform.py]]
+- [[_COMMUNITY_RheoJAX GUI Stylesheets|RheoJAX GUI Stylesheets]]
+- [[_COMMUNITY_PreferencesDialog|PreferencesDialog]]
+- [[_COMMUNITY_test_unit_conversion.py|test_unit_conversion.py]]
+- [[_COMMUNITY_FractionalJeffreysModel|FractionalJeffreysModel]]
+- [[_COMMUNITY_detect_data_range_decades|detect_data_range_decades]]
+- [[_COMMUNITY_.predict_rheo|.predict_rheo]]
+- [[_COMMUNITY_ProtocolModelStep|ProtocolModelStep]]
+- [[_COMMUNITY_DMTBase|DMTBase]]
+- [[_COMMUNITY_test_single_mode.py|test_single_mode.py]]
+- [[_COMMUNITY_plot_lissajous|plot_lissajous]]
+- [[_COMMUNITY_fikh_scan_kernel_thermal|fikh_scan_kernel_thermal]]
+- [[_COMMUNITY_HebraudLequeux|HebraudLequeux]]
+- [[_COMMUNITY_Capability Matrix|Capability Matrix]]
+- [[_COMMUNITY_Functional Requirements|Functional Requirements]]
+- [[_COMMUNITY_BayesianOptionsDialog|BayesianOptionsDialog]]
+- [[_COMMUNITY_FitStepResult|FitStepResult]]
+- [[_COMMUNITY_FractionalZenerLiquidLiquid|FractionalZenerLiquidLiquid]]
+- [[_COMMUNITY_TestParameterClass|TestParameterClass]]
+- [[_COMMUNITY_._process_file|._process_file]]
+- [[_COMMUNITY_test_spp_golden_parity.py|test_spp_golden_parity.py]]
+- [[_COMMUNITY_validate_model_doc|validate_model_doc]]
+- [[_COMMUNITY_test_gmm_element_search.py|test_gmm_element_search.py]]
+- [[_COMMUNITY_.calculate|.calculate]]
+- [[_COMMUNITY_._fit|._fit]]
+- [[_COMMUNITY_compute_plastic_strain_rate|compute_plastic_strain_rate]]
+- [[_COMMUNITY_PlotService|PlotService]]
+- [[_COMMUNITY_TestFromYaml|TestFromYaml]]
+- [[_COMMUNITY_ndarray|ndarray]]
+- [[_COMMUNITY_._transform|._transform]]
+- [[_COMMUNITY_TestInstantiation|TestInstantiation]]
+- [[_COMMUNITY_TestParameterSet|TestParameterSet]]
+- [[_COMMUNITY_epm_plots.py|epm_plots.py]]
+- [[_COMMUNITY_run_single_notebook_96h.py|run_single_notebook_96h.py]]
+- [[_COMMUNITY_TestDynamicX|TestDynamicX]]
+- [[_COMMUNITY_TestOptimizationResultStatistics|TestOptimizationResultStatistics]]
+- [[_COMMUNITY_create_global_parser|create_global_parser]]
+- [[_COMMUNITY_DatasetTree|DatasetTree]]
+- [[_COMMUNITY_Background Job System|Background Job System]]
+- [[_COMMUNITY_JAXStatusWidget|JAXStatusWidget]]
+- [[_COMMUNITY_Hybrid Vitrimer Model (HVM) -- Literature Review & Equations|Hybrid Vitrimer Model (HVM) -- Literature Review & Equations]]
+- [[_COMMUNITY_TestMittagLefflerConvergence|TestMittagLefflerConvergence]]
+- [[_COMMUNITY_FractionalKelvinVoigtZener|FractionalKelvinVoigtZener]]
+- [[_COMMUNITY_f12_memory_kernel|f12_memory_kernel]]
+- [[_COMMUNITY_initialize_equilibrium|initialize_equilibrium]]
+- [[_COMMUNITY_test_dmt.py|test_dmt.py]]
+- [[_COMMUNITY_ndarray|ndarray]]
+- [[_COMMUNITY_MenuBar|MenuBar]]
+- [[_COMMUNITY_._predict|._predict]]
+- [[_COMMUNITY_ColumnMapperDialog|ColumnMapperDialog]]
+- [[_COMMUNITY_AppState|AppState]]
+- [[_COMMUNITY_ModelService|ModelService]]
+- [[_COMMUNITY_RheoData|RheoData]]
+- [[_COMMUNITY_test_base_initializer.py|test_base_initializer.py]]
+- [[_COMMUNITY_TestHebraudLequeux|TestHebraudLequeux]]
+- [[_COMMUNITY_TestVLBMultiNetworkAnalytical|TestVLBMultiNetworkAnalytical]]
+- [[_COMMUNITY__VizTestTransform|_VizTestTransform]]
+- [[_COMMUNITY__SpyModel|_SpyModel]]
+- [[_COMMUNITY_TestTensorialAnimation|TestTensorialAnimation]]
+- [[_COMMUNITY_main|main]]
+- [[_COMMUNITY_test_performance_f9.py|test_performance_f9.py]]
+- [[_COMMUNITY_._handle_transform_result|._handle_transform_result]]
+- [[_COMMUNITY_.result|.result]]
+- [[_COMMUNITY_GiesekusMultiMode|GiesekusMultiMode]]
+- [[_COMMUNITY_ml_ikh.py|ml_ikh.py]]
+- [[_COMMUNITY_ndarray|ndarray]]
+- [[_COMMUNITY_TestBasicNotebooks|TestBasicNotebooks]]
+- [[_COMMUNITY_1. Dullaert-Mewis Model (2006) -- Literature Equations|1. Dullaert-Mewis Model (2006) -- Literature Equations]]
+- [[_COMMUNITY_test_transform_page_redesign.py|test_transform_page_redesign.py]]
+- [[_COMMUNITY_create_parser|create_parser]]
+- [[_COMMUNITY_TestPhysicalConstraints|TestPhysicalConstraints]]
+- [[_COMMUNITY_Module Breakdown|Module Breakdown]]
+- [[_COMMUNITY_fit_controller.py|fit_controller.py]]
+- [[_COMMUNITY_TestFluidityLocalModelFunction|TestFluidityLocalModelFunction]]
+- [[_COMMUNITY_TestHVNMLimitingCases|TestHVNMLimitingCases]]
+- [[_COMMUNITY_TNTCates|TNTCates]]
+- [[_COMMUNITY_lve_envelope|lve_envelope]]
+- [[_COMMUNITY_plot_harmonic_spectrum|plot_harmonic_spectrum]]
+- [[_COMMUNITY_TestFluidityNonlocalModelFunction|TestFluidityNonlocalModelFunction]]
+- [[_COMMUNITY_test_sgr_generic_extended.py|test_sgr_generic_extended.py]]
+- [[_COMMUNITY_test_trios_memory_profiling.py|test_trios_memory_profiling.py]]
+- [[_COMMUNITY_test_generalized_maxwell_warm_start.py|test_generalized_maxwell_warm_start.py]]
+- [[_COMMUNITY_test_loop_bridge.py|test_loop_bridge.py]]
+- [[_COMMUNITY_TestHessianCI|TestHessianCI]]
+- [[_COMMUNITY_TestSTZFlowTransient|TestSTZFlowTransient]]
+- [[_COMMUNITY_spp.py|spp.py]]
+- [[_COMMUNITY_.fit_bayesian|.fit_bayesian]]
+- [[_COMMUNITY_test_spp_kernels.py|test_spp_kernels.py]]
+- [[_COMMUNITY_TestBinghamPredictions|TestBinghamPredictions]]
+- [[_COMMUNITY_HerschelBulkley|HerschelBulkley]]
+- [[_COMMUNITY_PipelineConfigureRunStep|PipelineConfigureRunStep]]
+- [[_COMMUNITY_TestPlotModuliEvolution|TestPlotModuliEvolution]]
+- [[_COMMUNITY_RheoJAX Architecture Review — 2026-04-06|RheoJAX Architecture Review — 2026-04-06]]
+- [[_COMMUNITY_PipelineTemplateDialog|PipelineTemplateDialog]]
+- [[_COMMUNITY_FitOrchestrator|FitOrchestrator]]
+- [[_COMMUNITY_RheoJAX GUI Package|RheoJAX GUI Package]]
+- [[_COMMUNITY_ThemeDemo|ThemeDemo]]
+- [[_COMMUNITY_vlb_fene_factor|vlb_fene_factor]]
+- [[_COMMUNITY_.get_fit_result|.get_fit_result]]
+- [[_COMMUNITY_TestSTZOscillatory|TestSTZOscillatory]]
+- [[_COMMUNITY_test_optimization_validation.py|test_optimization_validation.py]]
+- [[_COMMUNITY_test_ikh_fitting.py|test_ikh_fitting.py]]
+- [[_COMMUNITY_ndarray|ndarray]]
+- [[_COMMUNITY_test_cates.py|test_cates.py]]
+- [[_COMMUNITY_test_multi_species.py|test_multi_species.py]]
+- [[_COMMUNITY_TestInstantiation|TestInstantiation]]
+- [[_COMMUNITY_TestPhysicalConsistency|TestPhysicalConsistency]]
+- [[_COMMUNITY_TestVLBVariantCreation|TestVLBVariantCreation]]
+- [[_COMMUNITY_TestVLBBellPhysics|TestVLBBellPhysics]]
+- [[_COMMUNITY_test_jobs.py|test_jobs.py]]
+- [[_COMMUNITY_.predict|.predict]]
+- [[_COMMUNITY_apply_globals|apply_globals]]
+- [[_COMMUNITY_._transform|._transform]]
+- [[_COMMUNITY_FractionalZenerSolidLiquid|FractionalZenerSolidLiquid]]
+- [[_COMMUNITY_get_worker_isolation_mode|get_worker_isolation_mode]]
+- [[_COMMUNITY_test_trios_chunked.py|test_trios_chunked.py]]
+- [[_COMMUNITY_VLBNonlocal|VLBNonlocal]]
+- [[_COMMUNITY_._optimized_wavelet_transform|._optimized_wavelet_transform]]
+- [[_COMMUNITY_TestCarreauPredictions|TestCarreauPredictions]]
+- [[_COMMUNITY_test_identifiability.py|test_identifiability.py]]
+- [[_COMMUNITY_TestVLBVariantRegression|TestVLBVariantRegression]]
+- [[_COMMUNITY_Mastercurve|Mastercurve]]
+- [[_COMMUNITY_TestMLIKH|TestMLIKH]]
+- [[_COMMUNITY_.step|.step]]
+- [[_COMMUNITY_TRIOSDataSet|TRIOSDataSet]]
+- [[_COMMUNITY_TestThermodynamicConsistency|TestThermodynamicConsistency]]
+- [[_COMMUNITY_TestMaterialTypeDetection|TestMaterialTypeDetection]]
+- [[_COMMUNITY_.predict_rheo|.predict_rheo]]
+- [[_COMMUNITY_TestThixotropy|TestThixotropy]]
+- [[_COMMUNITY_.predict_rheo|.predict_rheo]]
+- [[_COMMUNITY_G0|G0]]
+- [[_COMMUNITY_vlb_arrhenius_shift|vlb_arrhenius_shift]]
+- [[_COMMUNITY_TestBaseTransform|TestBaseTransform]]
+- [[_COMMUNITY_Giesekus Model Mathematical Verification Report|Giesekus Model Mathematical Verification Report]]
+- [[_COMMUNITY_TestModelCompatibility|TestModelCompatibility]]
+- [[_COMMUNITY_TestFMLIKHPredictions|TestFMLIKHPredictions]]
+- [[_COMMUNITY_TestComposedVariants|TestComposedVariants]]
+- [[_COMMUNITY_TRIOSExperiment|TRIOSExperiment]]
+- [[_COMMUNITY_Fractional Viscoelastic Models Equation Verification Report|Fractional Viscoelastic Models: Equation Verification Report]]
+- [[_COMMUNITY_TestShearBandingDetection|TestShearBandingDetection]]
+- [[_COMMUNITY_.apply_transform|.apply_transform]]
+- [[_COMMUNITY_style_helpers.py|style_helpers.py]]
+- [[_COMMUNITY_Zener|Zener]]
+- [[_COMMUNITY_FluidityBase|FluidityBase]]
+- [[_COMMUNITY_._predict|._predict]]
+- [[_COMMUNITY_._transform|._transform]]
+- [[_COMMUNITY_TestPlotPipkinDiagram|TestPlotPipkinDiagram]]
+- [[_COMMUNITY_create_spp_report|create_spp_report]]
+- [[_COMMUNITY_TestBaseModel|TestBaseModel]]
+- [[_COMMUNITY_.from_json|.from_json]]
+- [[_COMMUNITY_TestDMTBayesian|TestDMTBayesian]]
+- [[_COMMUNITY_Notebook Validation Tests - Tiered Testing Strategy|Notebook Validation Tests - Tiered Testing Strategy]]
+- [[_COMMUNITY_._model_function_scalar|._model_function_scalar]]
+- [[_COMMUNITY_build_numpyro_model|build_numpyro_model]]
+- [[_COMMUNITY_._model_function_general|._model_function_general]]
+- [[_COMMUNITY_Carreau|Carreau]]
+- [[_COMMUNITY_giesekus_saos_moduli|giesekus_saos_moduli]]
+- [[_COMMUNITY_rho_trap|rho_trap]]
+- [[_COMMUNITY_TestFluidityLocalOscillation|TestFluidityLocalOscillation]]
+- [[_COMMUNITY_plot_cole_cole|plot_cole_cole]]
+- [[_COMMUNITY_test_arviz_utils.py|test_arviz_utils.py]]
+- [[_COMMUNITY_SimpleBayesianModel|SimpleBayesianModel]]
+- [[_COMMUNITY_TestLogOperation|TestLogOperation]]
+- [[_COMMUNITY_TestLoggerMethods|TestLoggerMethods]]
+- [[_COMMUNITY_test_logging_integration.py|test_logging_integration.py]]
+- [[_COMMUNITY_TestDMTLocalCreation|TestDMTLocalCreation]]
+- [[_COMMUNITY_TestDMTLocalCreep|TestDMTLocalCreep]]
+- [[_COMMUNITY_test_parameter_schema.py|test_parameter_schema.py]]
+- [[_COMMUNITY_TestHVNMSAOS|TestHVNMSAOS]]
+- [[_COMMUNITY_When Analytical SAOS Breaks Down for Transient Network Models and Vitrimers|When Analytical SAOS Breaks Down for Transient Network Models and Vitrimers]]
+- [[_COMMUNITY_TestFluidityLocalFitting|TestFluidityLocalFitting]]
+- [[_COMMUNITY_.get_instance|.get_instance]]
+- [[_COMMUNITY_TestSTZCoverage|TestSTZCoverage]]
+- [[_COMMUNITY_TestPhysicalConsistency|TestPhysicalConsistency]]
+- [[_COMMUNITY_test_sticky_rouse.py|test_sticky_rouse.py]]
+- [[_COMMUNITY_TestModelFunctionCompleteness|TestModelFunctionCompleteness]]
+- [[_COMMUNITY_TestInstantiation|TestInstantiation]]
+- [[_COMMUNITY_TestKwargsCaching|TestKwargsCaching]]
+- [[_COMMUNITY_.confidence_intervals|.confidence_intervals]]
+- [[_COMMUNITY_TestHVMFlowCurve|TestHVMFlowCurve]]
+- [[_COMMUNITY_TestHVMRelaxation|TestHVMRelaxation]]
+- [[_COMMUNITY_TestPlotRheoData|TestPlotRheoData]]
+- [[_COMMUNITY_FIKHBase|FIKHBase]]
+- [[_COMMUNITY_TestPlot3DTrajectory|TestPlot3DTrajectory]]
+- [[_COMMUNITY_micro_benchmarks.py|micro_benchmarks.py]]
+- [[_COMMUNITY_TestFitResultSerialization|TestFitResultSerialization]]
+- [[_COMMUNITY_percus_yevick_sk|percus_yevick_sk]]
+- [[_COMMUNITY_TestFluidityNonlocalShearBanding|TestFluidityNonlocalShearBanding]]
+- [[_COMMUNITY_TestGMMBayesianInference|TestGMMBayesianInference]]
+- [[_COMMUNITY_TestIdentifiabilityAPI|TestIdentifiabilityAPI]]
+- [[_COMMUNITY_TestFluidityPredictWithoutFit|TestFluidityPredictWithoutFit]]
+- [[_COMMUNITY_._predict_stress|._predict_stress]]
+- [[_COMMUNITY_TestHVNMStartup|TestHVNMStartup]]
+- [[_COMMUNITY_TestVLBNonlocalCreation|TestVLBNonlocalCreation]]
+- [[_COMMUNITY_TestHVMCreep|TestHVMCreep]]
+- [[_COMMUNITY_is_monotonic_decreasing|is_monotonic_decreasing]]
+- [[_COMMUNITY_ndarray|ndarray]]
+- [[_COMMUNITY_laplacian_1d_neumann_vlb|laplacian_1d_neumann_vlb]]
+- [[_COMMUNITY_TestHVMLAOS|TestHVMLAOS]]
+- [[_COMMUNITY_TestInstantiation|TestInstantiation]]
+- [[_COMMUNITY_parallel_load|parallel_load]]
+- [[_COMMUNITY_plot_moduli_evolution|plot_moduli_evolution]]
+- [[_COMMUNITY__modulus_labels|_modulus_labels]]
+- [[_COMMUNITY_TestHVNMInterphase|TestHVNMInterphase]]
+- [[_COMMUNITY_TestDMTLocalStartup|TestDMTLocalStartup]]
+- [[_COMMUNITY_TestF002KwargsCache|TestF002KwargsCache]]
+- [[_COMMUNITY_TestRheoDataSerialization|TestRheoDataSerialization]]
+- [[_COMMUNITY_test_local.py|test_local.py]]
+- [[_COMMUNITY_TestDataIntegrity|TestDataIntegrity]]
+- [[_COMMUNITY_TestRheoDataDomainConsistency|TestRheoDataDomainConsistency]]
+- [[_COMMUNITY_TestFluidityNonlocalSmoke|TestFluidityNonlocalSmoke]]
+- [[_COMMUNITY_TestNormalStresses|TestNormalStresses]]
+- [[_COMMUNITY_CancelWorkerRunnable|CancelWorkerRunnable]]
+- [[_COMMUNITY_TestBinghamStability|TestBinghamStability]]
+- [[_COMMUNITY_TestGMMRelaxationMode|TestGMMRelaxationMode]]
+- [[_COMMUNITY_TestGMMCreepMode|TestGMMCreepMode]]
+- [[_COMMUNITY_TestGMMElementMinimization|TestGMMElementMinimization]]
+- [[_COMMUNITY_.model_function|.model_function]]
+- [[_COMMUNITY_TestInstantiation|TestInstantiation]]
+- [[_COMMUNITY_TestPhysicalConsistency|TestPhysicalConsistency]]
+- [[_COMMUNITY_test_single_mode.py|test_single_mode.py]]
+- [[_COMMUNITY_TestStartupSimulation|TestStartupSimulation]]
+- [[_COMMUNITY_TestPhysicalConsistency|TestPhysicalConsistency]]
+- [[_COMMUNITY_TestBellVariant|TestBellVariant]]
+- [[_COMMUNITY_TestFENEVariant|TestFENEVariant]]
+- [[_COMMUNITY_TestCreepSimulation|TestCreepSimulation]]
+- [[_COMMUNITY_TestStressOvershoot|TestStressOvershoot]]
+- [[_COMMUNITY_TestVLBVariantProtocols|TestVLBVariantProtocols]]
+- [[_COMMUNITY_TestDecayTypeDetection|TestDecayTypeDetection]]
+- [[_COMMUNITY_TestEdgeCases|TestEdgeCases]]
+- [[_COMMUNITY_Material Classification|Material Classification]]
+- [[_COMMUNITY_NamedTuple|NamedTuple]]
+- [[_COMMUNITY_TestMittagLefflerEdgeCases|TestMittagLefflerEdgeCases]]
+- [[_COMMUNITY_.from_registry|.from_registry]]
+- [[_COMMUNITY_TestConfiguration|TestConfiguration]]
+- [[_COMMUNITY_TestShearBandingMetrics|TestShearBandingMetrics]]
+- [[_COMMUNITY_.create_mastercurve|.create_mastercurve]]
+- [[_COMMUNITY_TestTensorialFieldPlots|TestTensorialFieldPlots]]
+- [[_COMMUNITY_TestNormalStressPlots|TestNormalStressPlots]]
+- [[_COMMUNITY_TestTensorialAutoDetection|TestTensorialAutoDetection]]
+- [[_COMMUNITY_TestGetLogger|TestGetLogger]]
+- [[_COMMUNITY_.has_message|.has_message]]
+- [[_COMMUNITY_TestParameterManagement|TestParameterManagement]]
+- [[_COMMUNITY_TestHVNMFlowCurve|TestHVNMFlowCurve]]
+- [[_COMMUNITY_TestHVNMRelaxation|TestHVNMRelaxation]]
+- [[_COMMUNITY_TestVLBUtilities|TestVLBUtilities]]
+- [[_COMMUNITY_MockBayesianModel|MockBayesianModel]]
+- [[_COMMUNITY_TestExportFormats|TestExportFormats]]
+- [[_COMMUNITY_compute_diagnostics|compute_diagnostics]]
+- [[_COMMUNITY_Migration Guide|Migration Guide]]
+- [[_COMMUNITY_Classical Linear Viscoelastic Model Equations -- Verification Reference|Classical Linear Viscoelastic Model Equations -- Verification Reference]]
+- [[_COMMUNITY_RheoJAX Documentation Structure|RheoJAX Documentation Structure]]
+- [[_COMMUNITY__process_remaining_rows|_process_remaining_rows]]
+- [[_COMMUNITY_TestTransformPlotterDispatch|TestTransformPlotterDispatch]]
+- [[_COMMUNITY_load_trios|load_trios]]
+- [[_COMMUNITY_run_all_notebooks.py|run_all_notebooks.py]]
+- [[_COMMUNITY_Array|Array]]
+- [[_COMMUNITY_.predict_rheo|.predict_rheo]]
+- [[_COMMUNITY_.test_mode|.test_mode]]
+- [[_COMMUNITY_create_prony_parameter_set|create_prony_parameter_set]]
+- [[_COMMUNITY_TestCrossPredictions|TestCrossPredictions]]
+- [[_COMMUNITY_TestDMTLocalLAOS|TestDMTLocalLAOS]]
+- [[_COMMUNITY_TestDMTNonlocal|TestDMTNonlocal]]
+- [[_COMMUNITY_test_fikh.py|test_fikh.py]]
+- [[_COMMUNITY_TestHerschelBulkleyNumericalStability|TestHerschelBulkleyNumericalStability]]
+- [[_COMMUNITY_._sync_fit_step_config|._sync_fit_step_config]]
+- [[_COMMUNITY_TestNormalStressScaling|TestNormalStressScaling]]
+- [[_COMMUNITY_Cross|Cross]]
+- [[_COMMUNITY_format_compatibility_message|format_compatibility_message]]
+- [[_COMMUNITY_test_window_file_menu.py|test_window_file_menu.py]]
+- [[_COMMUNITY_TestCascadeProvenance|TestCascadeProvenance]]
+- [[_COMMUNITY_TestTriosChunkedBasic|TestTriosChunkedBasic]]
+- [[_COMMUNITY_TestSteadyShearAnalytical|TestSteadyShearAnalytical]]
+- [[_COMMUNITY_TestFluidityLocalFlowCurve|TestFluidityLocalFlowCurve]]
+- [[_COMMUNITY_TestFluidityNonlocalTransient|TestFluidityNonlocalTransient]]
+- [[_COMMUNITY_TestBinghamBasics|TestBinghamBasics]]
+- [[_COMMUNITY_TestBinghamFitting|TestBinghamFitting]]
+- [[_COMMUNITY_TestDiffraxCompilation|TestDiffraxCompilation]]
+- [[_COMMUNITY_TestTieredPriorConstruction|TestTieredPriorConstruction]]
+- [[_COMMUNITY_TestFIKHParameters|TestFIKHParameters]]
+- [[_COMMUNITY_TestCatesMaxwellLimit|TestCatesMaxwellLimit]]
+- [[_COMMUNITY_TestBinghamPhysicalBehavior|TestBinghamPhysicalBehavior]]
+- [[_COMMUNITY_TestStartupSimulation|TestStartupSimulation]]
+- [[_COMMUNITY_TestCreepSimulation|TestCreepSimulation]]
+- [[_COMMUNITY_TestLAOSSimulation|TestLAOSSimulation]]
+- [[_COMMUNITY_TestPhysicalConsistency|TestPhysicalConsistency]]
+- [[_COMMUNITY_TestFlowCurve|TestFlowCurve]]
+- [[_COMMUNITY_TestStartupSimulation|TestStartupSimulation]]
+- [[_COMMUNITY_TestFluidityNonlocalGrid|TestFluidityNonlocalGrid]]
+- [[_COMMUNITY_TestPlasticityAlpha|TestPlasticityAlpha]]
+- [[_COMMUNITY_TestMaxwellLimit|TestMaxwellLimit]]
+- [[_COMMUNITY_TestFlowCurve|TestFlowCurve]]
+- [[_COMMUNITY_TestCreepSimulation|TestCreepSimulation]]
+- [[_COMMUNITY_TestBayesianInterface|TestBayesianInterface]]
+- [[_COMMUNITY_TestNonAffineVariant|TestNonAffineVariant]]
+- [[_COMMUNITY_TestMaxwellLimits|TestMaxwellLimits]]
+- [[_COMMUNITY_TestFlowCurve|TestFlowCurve]]
+- [[_COMMUNITY_TestInstantiation|TestInstantiation]]
+- [[_COMMUNITY_TestLAOSSimulation|TestLAOSSimulation]]
+- [[_COMMUNITY_TestFlowCurve|TestFlowCurve]]
+- [[_COMMUNITY_TestStartupSimulation|TestStartupSimulation]]
+- [[_COMMUNITY_TestRelaxationSimulation|TestRelaxationSimulation]]
+- [[_COMMUNITY_TestBayesianInterface|TestBayesianInterface]]
+- [[_COMMUNITY_TestDerivedProperties|TestDerivedProperties]]
+- [[_COMMUNITY_TestVLBNonlocalProtocols|TestVLBNonlocalProtocols]]
+- [[_COMMUNITY_TestVLBLocalFlowCurve|TestVLBLocalFlowCurve]]
+- [[_COMMUNITY_TestVLBLocalStartup|TestVLBLocalStartup]]
+- [[_COMMUNITY_TestVLBLocalSAOS|TestVLBLocalSAOS]]
+- [[_COMMUNITY_TestVLBCrossProtocol|TestVLBCrossProtocol]]
+- [[_COMMUNITY_TestStartupSimulation|TestStartupSimulation]]
+- [[_COMMUNITY_TestMittagLefflerJAXCompatibility|TestMittagLefflerJAXCompatibility]]
+- [[_COMMUNITY_TestCompareModels|TestCompareModels]]
+- [[_COMMUNITY_TestFlowCurve|TestFlowCurve]]
+- [[_COMMUNITY_test_spp_plots.py|test_spp_plots.py]]
+- [[_COMMUNITY_RheoJAX Documentation|RheoJAX Documentation]]
+- [[_COMMUNITY_📖 Documentation Structure|📖 Documentation Structure]]
+- [[_COMMUNITY_TestPlotPair|TestPlotPair]]
+- [[_COMMUNITY_TestPlotForest|TestPlotForest]]
+- [[_COMMUNITY_DatasetRef|DatasetRef]]
+- [[_COMMUNITY_TestPlotAutocorr|TestPlotAutocorr]]
+- [[_COMMUNITY_TestSAOS|TestSAOS]]
+- [[_COMMUNITY_TestPlotRank|TestPlotRank]]
+- [[_COMMUNITY_._predict_viscosity|._predict_viscosity]]
+- [[_COMMUNITY_.predict_normal_stresses|.predict_normal_stresses]]
+- [[_COMMUNITY_TestPlotESS|TestPlotESS]]
+- [[_COMMUNITY_TestCreepSimulation|TestCreepSimulation]]
+- [[_COMMUNITY_TestVonMisesPlots|TestVonMisesPlots]]
+- [[_COMMUNITY_TestPlotTimeDomain|TestPlotTimeDomain]]
+- [[_COMMUNITY_TestPlotFrequencyDomain|TestPlotFrequencyDomain]]
+- [[_COMMUNITY_TestLogFit|TestLogFit]]
+- [[_COMMUNITY_TestPowerLawPredictions|TestPowerLawPredictions]]
+- [[_COMMUNITY_GiesekusBase|GiesekusBase]]
+- [[_COMMUNITY_TestHVNMLAOS|TestHVNMLAOS]]
+- [[_COMMUNITY_TestBatchVectorization|TestBatchVectorization]]
+- [[_COMMUNITY_TestPlotFlowCurve|TestPlotFlowCurve]]
+- [[_COMMUNITY_SPP Parity Reference (MATLAB SPPplus v2.1, R oreo, RheoJAX)|SPP Parity Reference (MATLAB SPPplus v2.1, R oreo, RheoJAX)]]
+- [[_COMMUNITY_TestPlotResiduals|TestPlotResiduals]]
+- [[_COMMUNITY_TestBayesianInterface|TestBayesianInterface]]
+- [[_COMMUNITY_TestPublicationQuality|TestPublicationQuality]]
+- [[_COMMUNITY_PowerLaw|PowerLaw]]
+- [[_COMMUNITY_IKHBase|IKHBase]]
+- [[_COMMUNITY_TestCreepSimulation|TestCreepSimulation]]
+- [[_COMMUNITY_TestModulusFrequencyTemplate|TestModulusFrequencyTemplate]]
+- [[_COMMUNITY_TestMittagLefflerAccuracy|TestMittagLefflerAccuracy]]
+- [[_COMMUNITY_TestPartitionFunction|TestPartitionFunction]]
+- [[_COMMUNITY_TestTrapDistribution|TestTrapDistribution]]
+- [[_COMMUNITY_TestJAXCompatibility|TestJAXCompatibility]]
+- [[_COMMUNITY_TestPhysicalBehavior|TestPhysicalBehavior]]
+- [[_COMMUNITY_._run_nuts_sampling|._run_nuts_sampling]]
+- [[_COMMUNITY_.update_metadata|.update_metadata]]
+- [[_COMMUNITY_.get_dataframe|.get_dataframe]]
+- [[_COMMUNITY_._get_initial_stress_state|._get_initial_stress_state]]
+- [[_COMMUNITY_TestEquilibriumStructure|TestEquilibriumStructure]]
+- [[_COMMUNITY_TestDMTLocalFlowCurve|TestDMTLocalFlowCurve]]
+- [[_COMMUNITY_TestDMTLocalSAOS|TestDMTLocalSAOS]]
+- [[_COMMUNITY_main|main]]
+- [[_COMMUNITY_TRIOSResult|TRIOSResult]]
+- [[_COMMUNITY_TestDialogIntegration|TestDialogIntegration]]
+- [[_COMMUNITY_TestHerschelBulkleyRheoData|TestHerschelBulkleyRheoData]]
+- [[_COMMUNITY_TestPowerLawRheoData|TestPowerLawRheoData]]
+- [[_COMMUNITY_TestPowerLawBasics|TestPowerLawBasics]]
+- [[_COMMUNITY_TestPowerLawNumericalStability|TestPowerLawNumericalStability]]
+- [[_COMMUNITY_TestSteadyStateFlowCurve|TestSteadyStateFlowCurve]]
+- [[_COMMUNITY_TestPhaseRegimes|TestPhaseRegimes]]
+- [[_COMMUNITY_TestNonlocalCreep|TestNonlocalCreep]]
+- [[_COMMUNITY_test_multi_mode.py|test_multi_mode.py]]
+- [[_COMMUNITY_TestNumericalStability|TestNumericalStability]]
+- [[_COMMUNITY_TestCarreauNumericalStability|TestCarreauNumericalStability]]
+- [[_COMMUNITY_TestCreepBifurcation|TestCreepBifurcation]]
+- [[_COMMUNITY_TestFractionalMaxwellLiquidOscillation|TestFractionalMaxwellLiquidOscillation]]
+- [[_COMMUNITY_TestGMMBayesianPipelineBugs|TestGMMBayesianPipelineBugs]]
+- [[_COMMUNITY_TestConvergenceClassification|TestConvergenceClassification]]
+- [[_COMMUNITY_TestSAOS|TestSAOS]]
+- [[_COMMUNITY_TestBayesianInterface|TestBayesianInterface]]
+- [[_COMMUNITY_TestStressTensorProduct|TestStressTensorProduct]]
+- [[_COMMUNITY_TestStartupSimulation|TestStartupSimulation]]
+- [[_COMMUNITY_TestFluidityEvolution|TestFluidityEvolution]]
+- [[_COMMUNITY_TestSAOS|TestSAOS]]
+- [[_COMMUNITY_TestSAOSPredictions|TestSAOSPredictions]]
+- [[_COMMUNITY_TestBayesianInterface|TestBayesianInterface]]
+- [[_COMMUNITY_TestStickerFloorPhysics|TestStickerFloorPhysics]]
+- [[_COMMUNITY_TestSAOS|TestSAOS]]
+- [[_COMMUNITY_TestLAOSSimulation|TestLAOSSimulation]]
+- [[_COMMUNITY_TestVonMisesStress|TestVonMisesStress]]
+- [[_COMMUNITY_test_vlb_nonlocal.py|test_vlb_nonlocal.py]]
+- [[_COMMUNITY_TestVLBNonlocalBanding|TestVLBNonlocalBanding]]
+- [[_COMMUNITY_TestVLBLocalLAOS|TestVLBLocalLAOS]]
+- [[_COMMUNITY_TestFlowCurvePredictions|TestFlowCurvePredictions]]
+- [[_COMMUNITY_TestModelFunction|TestModelFunction]]
+- [[_COMMUNITY_TestYieldStressEmergence|TestYieldStressEmergence]]
+- [[_COMMUNITY_TestInferenceDataConversion|TestInferenceDataConversion]]
+- [[_COMMUNITY_TestNonexponentialRelaxation|TestNonexponentialRelaxation]]
+- [[_COMMUNITY_TestVLBBellFeneCombined|TestVLBBellFeneCombined]]
+- [[_COMMUNITY_TestModelFunction|TestModelFunction]]
+- [[_COMMUNITY_TestShearThinning|TestShearThinning]]
+- [[_COMMUNITY_TestMittagLefflerComplexArguments|TestMittagLefflerComplexArguments]]
+- [[_COMMUNITY_🚀 Key Features|🚀 Key Features]]
+- [[_COMMUNITY_.plot_data|.plot_data]]
+- [[_COMMUNITY_Bingham|Bingham]]
+- [[_COMMUNITY_._fit|._fit]]
+- [[_COMMUNITY_TestFlowCurveProtocol|TestFlowCurveProtocol]]
+- [[_COMMUNITY_TestMittagLefflerRheologicalApplications|TestMittagLefflerRheologicalApplications]]
+- [[_COMMUNITY_TestRSquaredComputation|TestRSquaredComputation]]
+- [[_COMMUNITY_Any|Any]]
+- [[_COMMUNITY_.__init__|.__init__]]
+- [[_COMMUNITY_.predict_rheo|.predict_rheo]]
+- [[_COMMUNITY_vlb_stress_fene_xy|vlb_stress_fene_xy]]
+- [[_COMMUNITY_TestNumericalStability|TestNumericalStability]]
+- [[_COMMUNITY_generate_synthetic_trios_file|generate_synthetic_trios_file]]
+- [[_COMMUNITY_.closeEvent|.closeEvent]]
+- [[_COMMUNITY_.get_posterior_summary|.get_posterior_summary]]
+- [[_COMMUNITY_TestNonlocalModelFunction|TestNonlocalModelFunction]]
+- [[_COMMUNITY_._on_state_changed|._on_state_changed]]
+- [[_COMMUNITY_percus_yevick_sk_jax|percus_yevick_sk_jax]]
+- [[_COMMUNITY_TestVLBLocalRelaxation|TestVLBLocalRelaxation]]
+- [[_COMMUNITY_TestVLBLocalCreep|TestVLBLocalCreep]]
+- [[_COMMUNITY_TestFractionalMaxwellLiquidRelaxation|TestFractionalMaxwellLiquidRelaxation]]
+- [[_COMMUNITY_TestFractionalMaxwellModelNumericalStability|TestFractionalMaxwellModelNumericalStability]]
+- [[_COMMUNITY_RheoJAX Workspace Shell|RheoJAX Workspace Shell]]
+- [[_COMMUNITY_SPP Parity Status (MATLAB SPPplus v2.1  R oreo  RheoJAX)|SPP Parity Status (MATLAB SPPplus v2.1 / R oreo / RheoJAX)]]
+- [[_COMMUNITY__LazyModule|_LazyModule]]
+- [[_COMMUNITY_.__init__|.__init__]]
+- [[_COMMUNITY__read_segment_chunked|_read_segment_chunked]]
+- [[_COMMUNITY_.__init__|.__init__]]
+- [[_COMMUNITY_.__init__|.__init__]]
+- [[_COMMUNITY_.__init__|.__init__]]
+- [[_COMMUNITY_TestModeEnum|TestModeEnum]]
+- [[_COMMUNITY_._model_relaxation_jit|._model_relaxation_jit]]
+- [[_COMMUNITY_TestYAMLInjection|TestYAMLInjection]]
+- [[_COMMUNITY_conftest.py|conftest.py]]
+- [[_COMMUNITY_.__init__|.__init__]]
+- [[_COMMUNITY_TestLogBayesian|TestLogBayesian]]
+- [[_COMMUNITY_._model_startup_jit|._model_startup_jit]]
+- [[_COMMUNITY_.__init__|.__init__]]
+- [[_COMMUNITY_TestUpperConvected|TestUpperConvected]]
+- [[_COMMUNITY_TestYieldStressCoupling|TestYieldStressCoupling]]
+- [[_COMMUNITY_TestHerschelBulkleyViscosity|TestHerschelBulkleyViscosity]]
+- [[_COMMUNITY_TestNormalStresses|TestNormalStresses]]
+- [[_COMMUNITY_test_herschel_bulkley.py|test_herschel_bulkley.py]]
+- [[_COMMUNITY_TestHerschelBulkleyBasics|TestHerschelBulkleyBasics]]
+- [[_COMMUNITY_TestHerschelBulkleyFitting|TestHerschelBulkleyFitting]]
+- [[_COMMUNITY_TestHerschelBulkleyPhysicalBehavior|TestHerschelBulkleyPhysicalBehavior]]
+- [[_COMMUNITY_TestPowerLawFitting|TestPowerLawFitting]]
+- [[_COMMUNITY_TestPowerLawPerformance|TestPowerLawPerformance]]
+- [[_COMMUNITY_TestPowerLawModelFunction|TestPowerLawModelFunction]]
+- [[_COMMUNITY_TestLaplacian|TestLaplacian]]
+- [[_COMMUNITY_TestCredibleIntervals|TestCredibleIntervals]]
+- [[_COMMUNITY_TestNonlocalFlowCurve|TestNonlocalFlowCurve]]
+- [[_COMMUNITY_spp_analyze|spp_analyze]]
+- [[_COMMUNITY_capture_golden_screens.py|capture_golden_screens.py]]
+- [[_COMMUNITY_TestPowerLawScaling|TestPowerLawScaling]]
+- [[_COMMUNITY_TestFitCreep|TestFitCreep]]
+- [[_COMMUNITY_TestCarreauBasics|TestCarreauBasics]]
+- [[_COMMUNITY_TestCarreauRheoData|TestCarreauRheoData]]
+- [[_COMMUNITY_TestCrossBasics|TestCrossBasics]]
+- [[_COMMUNITY_TestVLBNonlocalFene|TestVLBNonlocalFene]]
+- [[_COMMUNITY_TestCrossStability|TestCrossStability]]
+- [[_COMMUNITY_TestPublicAPI|TestPublicAPI]]
+- [[_COMMUNITY_TestFractionalZenerANSYS|TestFractionalZenerANSYS]]
+- [[_COMMUNITY_TestPronySeries|TestPronySeries]]
+- [[_COMMUNITY_TestFractionalMaxwellLiquidCreep|TestFractionalMaxwellLiquidCreep]]
+- [[_COMMUNITY_TestRelaxation|TestRelaxation]]
+- [[_COMMUNITY_TestLAOSKwargsRegression|TestLAOSKwargsRegression]]
+- [[_COMMUNITY_TestAnalysisMethods|TestAnalysisMethods]]
+- [[_COMMUNITY_TestRegistryIntegration|TestRegistryIntegration]]
+- [[_COMMUNITY_TestBatchVectorizationSmoke|TestBatchVectorizationSmoke]]
+- [[_COMMUNITY_TestSoftmaxPenalty|TestSoftmaxPenalty]]
+- [[_COMMUNITY_TestUncertaintyBand|TestUncertaintyBand]]
+- [[_COMMUNITY_🎓 Learning Paths|🎓 Learning Paths]]
+- [[_COMMUNITY_🎯 Quick Navigation|🎯 Quick Navigation]]
+- [[_COMMUNITY_💡 Quick Examples|💡 Quick Examples]]
+- [[_COMMUNITY_📚 Key References|📚 Key References]]
+- [[_COMMUNITY_._inverse_transform|._inverse_transform]]
+- [[_COMMUNITY_._transform|._transform]]
+- [[_COMMUNITY_.shape|.shape]]
+- [[_COMMUNITY_._on_batch_requested|._on_batch_requested]]
+- [[_COMMUNITY_.plot|.plot]]
+- [[_COMMUNITY_evolve_thixotropy_lambda|evolve_thixotropy_lambda]]
+- [[_COMMUNITY_.get_initial_state|.get_initial_state]]
+- [[_COMMUNITY_test_spp_integration.py|test_spp_integration.py]]
+- [[_COMMUNITY_🛠️ Building the Documentation Locally|🛠️ Building the Documentation Locally]]
+- [[_COMMUNITY_📊 Documentation Statistics|📊 Documentation Statistics]]
+- [[_COMMUNITY_TestFractionalMaxwellLiquidLimitCases|TestFractionalMaxwellLiquidLimitCases]]
+- [[_COMMUNITY_TestFractionalMaxwellLiquidNumericalStability|TestFractionalMaxwellLiquidNumericalStability]]
+- [[_COMMUNITY_._get_inventory_stats|._get_inventory_stats]]
+- [[_COMMUNITY_TestCrossValidation|TestCrossValidation]]
+- [[_COMMUNITY_.precompile|.precompile]]
+- [[_COMMUNITY_.test_conventional_generic_oscillation_match|.test_conventional_generic_oscillation_match]]
+- [[_COMMUNITY_conftest.py|conftest.py]]
+- [[_COMMUNITY_.__init__|.__init__]]
+- [[_COMMUNITY_clean_notebook|clean_notebook]]
+- [[_COMMUNITY_test_visual_regression_spec_scaffold.py|test_visual_regression_spec_scaffold.py]]
+- [[_COMMUNITY_.bounds|.bounds]]
+- [[_COMMUNITY_.teardown_method|.teardown_method]]
+- [[_COMMUNITY_.setup_method|.setup_method]]
+- [[_COMMUNITY_.set_fit_result|.set_fit_result]]
+- [[_COMMUNITY_.to_dataframe|.to_dataframe]]
+- [[_COMMUNITY_.teardown_method|.teardown_method]]
+- [[_COMMUNITY_TestGMMBayesianPriorSafetyIntegration|TestGMMBayesianPriorSafetyIntegration]]
+- [[_COMMUNITY_TestBayesianIntegration|TestBayesianIntegration]]
+- [[_COMMUNITY_TestNLSQDiagnostics|TestNLSQDiagnostics]]
+- [[_COMMUNITY_TestPlotEnergy|TestPlotEnergy]]
+- [[_COMMUNITY_.setup_method|.setup_method]]
+- [[_COMMUNITY_.teardown_method|.teardown_method]]
+- [[_COMMUNITY_._init_hb_from_data|._init_hb_from_data]]
+- [[_COMMUNITY_.__init__|.__init__]]
+- [[_COMMUNITY_.teardown_method|.teardown_method]]
+- [[_COMMUNITY_.setup_method|.setup_method]]
+- [[_COMMUNITY_.teardown_method|.teardown_method]]
+- [[_COMMUNITY_.setup_method|.setup_method]]
+- [[_COMMUNITY_.teardown_method|.teardown_method]]
+- [[_COMMUNITY_.setup_method|.setup_method]]
+- [[_COMMUNITY_.setup_method|.setup_method]]
+- [[_COMMUNITY_test_fit_subprocess_exits_cleanly|test_fit_subprocess_exits_cleanly]]
+- [[_COMMUNITY_.__init__|.__init__]]
+- [[_COMMUNITY___init__.py|__init__.py]]
+- [[_COMMUNITY_.setup_method|.setup_method]]
+- [[_COMMUNITY_.teardown_method|.teardown_method]]
+- [[_COMMUNITY_.__init__|.__init__]]
+- [[_COMMUNITY_.teardown_method|.teardown_method]]
+- [[_COMMUNITY_.setup_method|.setup_method]]
+- [[_COMMUNITY_.teardown_method|.teardown_method]]
+- [[_COMMUNITY_.setup_method|.setup_method]]
+- [[_COMMUNITY_.teardown_method|.teardown_method]]
+- [[_COMMUNITY_.test_registry_singleton_pattern|.test_registry_singleton_pattern]]
+- [[_COMMUNITY_.setup_method|.setup_method]]
+- [[_COMMUNITY_.teardown_method|.teardown_method]]
+- [[_COMMUNITY_._on_finished|._on_finished]]
+- [[_COMMUNITY___init__.py|__init__.py]]
+- [[_COMMUNITY_.setup_method|.setup_method]]
+- [[_COMMUNITY_.teardown_method|.teardown_method]]
+- [[_COMMUNITY_.setup_method|.setup_method]]
+- [[_COMMUNITY_.__init__|.__init__]]
+- [[_COMMUNITY_.teardown_method|.teardown_method]]
+- [[_COMMUNITY_.__init__|.__init__]]
+- [[_COMMUNITY_TestFlowCurve|TestFlowCurve]]
+- [[_COMMUNITY_.reset|.reset]]
+- [[_COMMUNITY_.test_plot_forest_without_bayesian_fit_raises_error|.test_plot_forest_without_bayesian_fit_raises_error]]
+- [[_COMMUNITY_.test_plot_autocorr_without_bayesian_fit_raises_error|.test_plot_autocorr_without_bayesian_fit_raises_error]]
+- [[_COMMUNITY_.test_plot_rank_without_bayesian_fit_raises_error|.test_plot_rank_without_bayesian_fit_raises_error]]
+- [[_COMMUNITY_TestRelaxationSimulation|TestRelaxationSimulation]]
+- [[_COMMUNITY_.test_fit_bayesian_after_nlsq|.test_fit_bayesian_after_nlsq]]
+- [[_COMMUNITY_.test_get_diagnostics_returns_correct_structure|.test_get_diagnostics_returns_correct_structure]]
+- [[_COMMUNITY___init__.py|__init__.py]]
+- [[_COMMUNITY_TestJAXSupport|TestJAXSupport]]
+- [[_COMMUNITY_.test_complete_workflow|.test_complete_workflow]]
+- [[_COMMUNITY_.test_workflow_warm_start_converges_faster|.test_workflow_warm_start_converges_faster]]
+- [[_COMMUNITY_.test_error_handling_when_methods_called_out_of_order|.test_error_handling_when_methods_called_out_of_order]]
+- [[_COMMUNITY_.test_single_chain_still_works|.test_single_chain_still_works]]
+- [[_COMMUNITY___init__.py|__init__.py]]
+- [[_COMMUNITY___init__.py|__init__.py]]
+- [[_COMMUNITY___init__.py|__init__.py]]
+- [[_COMMUNITY___init__.py|__init__.py]]
+- [[_COMMUNITY_TestRelaxationSimulation|TestRelaxationSimulation]]
+- [[_COMMUNITY_TestPipelineExport|TestPipelineExport]]
+- [[_COMMUNITY_TestAnalysisMethods|TestAnalysisMethods]]
+- [[_COMMUNITY___init__.py|__init__.py]]
+- [[_COMMUNITY___init__.py|__init__.py]]
+- [[_COMMUNITY___init__.py|__init__.py]]
+- [[_COMMUNITY___init__.py|__init__.py]]
+- [[_COMMUNITY___init__.py|__init__.py]]
+- [[_COMMUNITY___init__.py|__init__.py]]
+- [[_COMMUNITY___init__.py|__init__.py]]
+- [[_COMMUNITY___init__.py|__init__.py]]
+- [[_COMMUNITY___init__.py|__init__.py]]
+- [[_COMMUNITY___init__.py|__init__.py]]
+- [[_COMMUNITY___init__.py|__init__.py]]
+- [[_COMMUNITY___init__.py|__init__.py]]
+- [[_COMMUNITY___init__.py|__init__.py]]
+- [[_COMMUNITY___init__.py|__init__.py]]
+- [[_COMMUNITY___init__.py|__init__.py]]
+- [[_COMMUNITY___init__.py|__init__.py]]
+- [[_COMMUNITY___init__.py|__init__.py]]
+- [[_COMMUNITY___init__.py|__init__.py]]
+- [[_COMMUNITY_TestRelaxationSimulation|TestRelaxationSimulation]]
+- [[_COMMUNITY_TestLAOSSimulation|TestLAOSSimulation]]
+- [[_COMMUNITY_TestSAOS|TestSAOS]]
+- [[_COMMUNITY___init__.py|__init__.py]]
+- [[_COMMUNITY___init__.py|__init__.py]]
+- [[_COMMUNITY_TestLAOSKwargsRegression|TestLAOSKwargsRegression]]
+- [[_COMMUNITY_.test_discover_swallows_already_registered|.test_discover_swallows_already_registered]]
+- [[_COMMUNITY___init__.py|__init__.py]]
+- [[_COMMUNITY___init__.py|__init__.py]]
+- [[_COMMUNITY_BaseArviZWidget|BaseArviZWidget]]
+- [[_COMMUNITY_BaseInitializer|BaseInitializer]]
+- [[_COMMUNITY_BaseModel|BaseModel]]
+- [[_COMMUNITY_BaseTransform|BaseTransform]]
+- [[_COMMUNITY_BayesianMixin|BayesianMixin]]
+- [[_COMMUNITY_DMTBase|DMTBase]]
+- [[_COMMUNITY_EPMBase|EPMBase]]
+- [[_COMMUNITY_FIKHBase|FIKHBase]]
+- [[_COMMUNITY_FluidityBase|FluidityBase]]
+- [[_COMMUNITY_FluiditySaramitoBase|FluiditySaramitoBase]]
+- [[_COMMUNITY_FractionalModelMixin|FractionalModelMixin]]
+- [[_COMMUNITY_GiesekusBase|GiesekusBase]]
+- [[_COMMUNITY_HVMBase|HVMBase]]
+- [[_COMMUNITY_HVNMBase|HVNMBase]]
+- [[_COMMUNITY_IKHBase|IKHBase]]
+- [[_COMMUNITY_ITTMCTBase|ITTMCTBase]]
+- [[_COMMUNITY_Pipeline|Pipeline]]
+- [[_COMMUNITY_QTableWidgetItem|QTableWidgetItem]]
+- [[_COMMUNITY_.set_bayesian_result|.set_bayesian_result]]
+- [[_COMMUNITY_Models Lazy Loader|Models Lazy Loader]]
+- [[_COMMUNITY_Version Information|Version Information]]
+- [[_COMMUNITY_CANONICAL_FIELDS|CANONICAL_FIELDS]]
+- [[_COMMUNITY_TRIOS_COLUMN_MAPPINGS|TRIOS_COLUMN_MAPPINGS]]
+- [[_COMMUNITY_detect_deformation_mode_from_columns|detect_deformation_mode_from_columns]]
+- [[_COMMUNITY_BatchPipeline Re-export|BatchPipeline Re-export]]
+- [[_COMMUNITY_BayesianPipeline|BayesianPipeline]]
+- [[_COMMUNITY_Pipeline|Pipeline]]
+- [[_COMMUNITY_PipelineBuilder|PipelineBuilder]]
+- [[_COMMUNITY_STZBase|STZBase]]
+- [[_COMMUNITY_Test @timed decorator with actual model fitting.|Test @timed decorator with actual model fitting.]]
+- [[_COMMUNITY_Test log_array_info with actual JAX arrays.|Test log_array_info with actual JAX arrays.]]
+- [[_COMMUNITY_Test iteration logging with actual optimization loops.|Test iteration logging with actual optimization loops.]]
+- [[_COMMUNITY_Test IterationLogger with simulated optimization.|Test IterationLogger with simulated optimization.]]
+- [[_COMMUNITY_Test ConvergenceTracker with realistic cost sequence.|Test ConvergenceTracker with realistic cost sequence.]]
+- [[_COMMUNITY_TestIterationLoggingWithOptimization|TestIterationLoggingWithOptimization]]
+- [[_COMMUNITY_Bayesian inference on Bell shear-thinning flow curve.|Bayesian inference on Bell shear-thinning flow curve.]]
+- [[_COMMUNITY_TNTBase|TNTBase]]
+- [[_COMMUNITY_load_trios (Facade)|load_trios (Facade)]]
+- [[_COMMUNITY_VLBBase|VLBBase]]
 
 ## God Nodes (most connected - your core abstractions)
-1. `RheoData` - 1177 edges
+1. `RheoData` - 1182 edges
 2. `ModelRegistry` - 554 edges
 3. `ParameterSet` - 398 edges
 4. `safe_import_jax()` - 309 edges
@@ -946,2810 +892,2978 @@
 ## Surprising Connections (you probably didn't know these)
 - `test_base_signatures_clean()` --indirect_call--> `BaseModel`  [INFERRED]
   tests/refactor/test_dmta_removal.py → rheojax/core/base.py
+- `test_removed_options_are_rejected()` --calls--> `Maxwell`  [INFERRED]
+  tests/refactor/test_dmta_removal.py → rheojax/models/classical/maxwell.py
 - `TestApplyOverrides` --uses--> `PipelineConfig`  [INFERRED]
   tests/cli/test_yaml_runner.py → rheojax/cli/_yaml_schema.py
 - `TestCoerceValue` --uses--> `PipelineConfig`  [INFERRED]
   tests/cli/test_yaml_runner.py → rheojax/cli/_yaml_schema.py
 - `TestConfigToBuilder` --uses--> `PipelineConfig`  [INFERRED]
   tests/cli/test_yaml_runner.py → rheojax/cli/_yaml_schema.py
-- `TestDryRunPipeline` --uses--> `PipelineConfig`  [INFERRED]
-  tests/cli/test_yaml_runner.py → rheojax/cli/_yaml_schema.py
 
 ## Import Cycles
 - 1-file cycle: `rheojax/logging/handlers.py -> rheojax/logging/handlers.py`
 
-## Communities (2791 total, 221 thin omitted)
+## Communities (2737 total, 125 thin omitted)
 
-### Community 0 - "Core NLSQ & Bayesian Base"
+### Community 0 - "ModelRegistry"
 Cohesion: 0.01
-Nodes (399): ABC, main(), CLI subcommand for Bayesian inference with NUTS sampling.  Usage:     rheojax, Run Bayesian inference from CLI., BaseModel, BaseTransform, Base classes for models and transforms with JAX support.  This module provides a, Standard NLSQ fitting pipeline for models with a stateless model_fn.          Ha (+391 more)
+Nodes (495): ABC, CLI subcommand for Bayesian inference with NUTS sampling.  Usage:     rheojax, BaseModel, BaseTransform, Base classes for models and transforms with JAX support.  This module provides a, Standard NLSQ fitting pipeline for models with a stateless model_fn.          Ha, Abstract base class for all data transforms.      This class defines the standar, Initialize base transform. (+487 more)
 
-### Community 1 - "RheoData & Data Layer"
+### Community 1 - "ParameterSet"
 Cohesion: 0.01
-Nodes (282): Initialize base model., Number of data points used in the fit., ParameterSet, Collection of parameters for a model or transform.      A ParameterSet manages m, Initialize empty parameter set., Number of parameters., Check if parameter exists., Iterate over parameter names. (+274 more)
+Nodes (315): Initialize base model., Number of data points used in the fit., ParameterSet, Collection of parameters for a model or transform.      A ParameterSet manages m, Initialize empty parameter set., Number of parameters., Check if parameter exists., Iterate over parameter names. (+307 more)
 
-### Community 2 - "BaseModel API & Methods"
+### Community 2 - "StateStore"
 Cohesion: 0.01
-Nodes (225): Bayesian Page ============  Bayesian inference interface with prior specificatio, Pipeline execution service for GUI.  Orchestrates sequential execution of visual, add_transform_record(), bayesian_completed(), bayesian_failed(), fitting_completed(), fitting_failed(), load_dataset() (+217 more)
+Nodes (319): Enum, Application Core Components ===========================  Main window, menu bar,, Main Application Window =======================  Central window coordinating pag, # TODO: Implement project serialization (state → JSON/HDF5)., # NOTE: This guard assumes single-threaded (GUI main thread) access., Menu Bar ========  Application menu bar with File, Edit, View, Data, Models, Tra, Status Bar ==========  Application status bar with progress indicators, JAX devi, Toolbars ========  Main toolbar and related utilities. (+311 more)
 
-### Community 3 - "GUI Bayesian Page & Jobs"
+### Community 3 - "QWidget"
+Cohesion: 0.02
+Nodes (82): QFrame, QGroupBox, QPushButton, QSplitter, QTableWidget, QVBoxLayout, QWidget, QWizard (+74 more)
+
+### Community 4 - "test_visual_pipeline_state.py"
+Cohesion: 0.02
+Nodes (153): add_pipeline_step(), cache_step_result(), load_pipeline(), Any, Load a visual pipeline state (e.g., restored from YAML/project file).      Param, Add a step to the visual pipeline.      Parameters     ----------     step_type, Remove a step from the visual pipeline.      Parameters     ----------     step_, Move a pipeline step to a new position.      Parameters     ----------     step_ (+145 more)
+
+### Community 5 - "Parameter"
+Cohesion: 0.01
+Nodes (138): Create model from dictionary.          Args:             data: Dictionary repres, _import_numpyro(), Lazy-import NumPyro and its submodules.      Returns all NumPyro symbols needed, Parameter, ParameterConstraint, ParameterOptimizer, Any, Convert to dictionary representation. (+130 more)
+
+### Community 6 - "RheoData"
+Cohesion: 0.01
+Nodes (280): Auto-detect optimization strategy based on data range.          Args:, Get storage modulus label. Always returns "G'" (shear)., Get loss modulus label. Always returns 'G"' (shear)., JAX-native container for rheological data with NumPy/JAX array support.      Thi, RheoData, NumPy .npz writer/reader for RheoData objects., CarreauYasuda, Carreau-Yasuda model for non-Newtonian flow (ROTATION only).      The Carreau-Ya (+272 more)
+
+### Community 7 - "test_io_fixes.py"
+Cohesion: 0.02
+Nodes (109): ImportWizard, Any, Multi-step data import wizard.      Steps:         1. File selection         2., Handle wizard finished., Get import configuration.          Returns         -------         dict[str, Any, _create_parameters_dataframe(), _create_predictions_dataframe(), _create_quality_dataframe() (+101 more)
+
+### Community 8 - "Pipeline"
 Cohesion: 0.03
-Nodes (66): FigureCanvasQTAgg, QGroupBox, QLayout, QPushButton, QSplitter, QTableWidget, QVBoxLayout, QWidget (+58 more)
+Nodes (39): Pipeline, Get the last fitted model.          Returns:             Last fitted BaseModel o, Get all fitted models from pipeline.          Returns:             List of all f, Get fitted parameters from the last model as a dictionary.          This is a co, Create a copy of the pipeline.          Returns:             New Pipeline with c, Reset pipeline to initial state.          Returns:             self for method c, String representation of pipeline., Apply a transform to the data.          Args:             transform: Transform n (+31 more)
 
-### Community 4 - "GUI App & Main Window"
-Cohesion: 0.01
-Nodes (208): add_pipeline_step(), cache_step_result(), clear_pipeline(), load_pipeline(), Any, Clear the entire visual pipeline (steps, results, selection)., Load a visual pipeline state (e.g., restored from YAML/project file).      Param, Add a step to the visual pipeline.      Parameters     ----------     step_type (+200 more)
-
-### Community 5 - "Model Registry & Inventory"
-Cohesion: 0.06
-Nodes (26): Regression tests for Bayesian diagnostics RCA fixes (2026-02-13).  These tests, Result diagnostics should include diagnostics_valid flag., Verify protocol kwargs survive NLSQ→Bayesian without being cleared., _last_fit_kwargs from NLSQ should not be cleared by fit_bayesian., Verify precompiled cache is per-instance, not shared., Two model instances should have independent precompile caches., Verify unknown divergences are reported as -1, not 0., Valid MCMC should report actual divergence count (>= 0). (+18 more)
-
-### Community 6 - "VLB Viscoelastic Models"
-Cohesion: 0.01
-Nodes (217): Any, Invalidate JAX cache when x or y data is reassigned., Convert arrays to JAX arrays.          Returns cached result on subsequent calls, Convert arrays to NumPy arrays.          Uses np.asarray() for zero-copy convers, Create a copy of the RheoData.          Returns:             Copy of the RheoDat, Update metadata dictionary.          Args:             metadata: Dictionary of m, Convert to dictionary representation.          Returns:             Dictionary w, Create from dictionary representation.          Args:             data_dict: Dic (+209 more)
-
-### Community 7 - "Anton Paar IO Reader"
+### Community 9 - "IconProvider"
 Cohesion: 0.02
-Nodes (110): ImportWizard, Any, Multi-step data import wizard.      Steps:         1. File selection         2., Handle wizard finished., Get import configuration.          Returns         -------         dict[str, Any, DataService, Any, Path (+102 more)
+Nodes (111): Config, Any, Path, Configuration Management =======================  Application configuration and, Application configuration manager.      Features:         - Persistent settings, Initialize configuration manager.          Parameters         ----------, Get configuration value.          Parameters         ----------         key : st, Set configuration value.          Parameters         ----------         key : st (+103 more)
 
-### Community 8 - "CLI SPP Analysis"
-Cohesion: 0.02
-Nodes (44): Pipeline, Generate ArviZ MCMC diagnostic suite (6 plots).          Requires a prior call t, Get the last fitted model.          Returns:             Last fitted BaseModel o, Get all fitted models from pipeline.          Returns:             List of all f, Get fitted parameters from the last model as a dictionary.          This is a co, Create a copy of the pipeline.          Returns:             New Pipeline with c, Reset pipeline to initial state.          Returns:             self for method c, Export the full analysis to a directory or file.          This bundles data, par (+36 more)
-
-### Community 9 - "Import Wizard Dialog"
-Cohesion: 0.07
-Nodes (24): IconProvider, Platform-safe icon provider for Qt widgets.      This class provides text-based, Initialize icon provider.          Parameters         ----------         allow_e, Check if this provider uses emoji icons.          Returns         -------, Get icon for a model category.          Parameters         ----------         ca, Get icon for a status indicator.          Parameters         ----------, Get icon for a file type.          Parameters         ----------         file_ty, Format text with a prepended icon.          Parameters         ---------- (+16 more)
-
-### Community 10 - "GUI Import Worker & Drop Zone"
+### Community 10 - ".create"
 Cohesion: 0.01
-Nodes (155): Unregister a transform.          Args:             name: Name of the transform t, Get list of all registered model names.          Returns:             List of mo, Get list of all registered transform names.          Returns:             List o, Find plugins matching certain criteria.          Args:             protocol: Fil, Check if metadata matches all criteria.          Args:             metadata: Plu, Decorator for registering a model.          Args:             name: Name for the, Create a model instance by name (factory method).          Args:             nam, List all registered model names (discovery).          Returns:             List (+147 more)
+Nodes (173): BayesianResult, Perform Bayesian inference using NumPyro NUTS sampler.          This method dele, Get stored Bayesian inference result.          Returns:             BayesianResu, Unregister a transform.          Args:             name: Name of the transform t, Get list of all registered model names.          Returns:             List of mo, Get list of all registered transform names.          Returns:             List o, Find plugins matching certain criteria.          Args:             protocol: Fil, Check if metadata matches all criteria.          Args:             metadata: Plu (+165 more)
 
-### Community 11 - "Saramito Fluidity Models"
+### Community 11 - "GiesekusSingleMode"
+Cohesion: 0.03
+Nodes (30): GiesekusSingleMode, Initialize single-mode Giesekus model., Single-mode Giesekus nonlinear viscoelastic model.      The Giesekus model exten, Test SAOS prediction., Test G' = G'' at crossover frequency., Test complex G* prediction via test_mode='oscillation'.          predict() ret, Test N1 and N2 predictions., Test predicted N₂/N₁ ≈ -α/2 at low Wi. (+22 more)
+
+### Community 12 - "ValueError"
 Cohesion: 0.02
-Nodes (44): GiesekusSingleMode, Initialize single-mode Giesekus model., Single-mode Giesekus nonlinear viscoelastic model.      The Giesekus model exten, Test direct predict_flow_curve method., Test flow curve with viscosity and N1., Test viscosity decreases with shear rate., Test SAOS prediction., Test G' = G'' at crossover frequency. (+36 more)
+Nodes (142): _fit_single(), Load, fit, and return a result dict for a single file.      Returns a dict with, Check if value satisfies the constraint.          Args:             value: Value, Any, Path, Extract a scalar temperature from a column in *file_path*.          Reads up to, Load data from file using rheojax.io.auto_load.          Parameters         ----, Extract temperature from a filename like ``foam_dma_-5C.csv``.          Recognis (+134 more)
 
-### Community 12 - "ArviZ Utils & Bayesian Results"
-Cohesion: 0.01
-Nodes (159): create_parser(), main(), ArgumentParser, CLI subcommand for NLSQ model fitting.  Usage:     rheojax fit data.csv --mod, Run NLSQ fit from CLI., Create argument parser for fit subcommand., Data Service ===========  Service for loading, validating, and managing rheologi, Raised when no reader can parse a file.      Subclasses ValueError so downstream (+151 more)
-
-### Community 13 - "GUI Icons & Utils"
+### Community 13 - "device.py"
 Cohesion: 0.12
 Nodes (23): check_gpu_availability(), check_plugin_conflicts(), get_device_info(), get_gpu_info(), get_gpu_memory_info(), get_recommended_package(), get_system_cuda_version(), print_device_summary() (+15 more)
 
-### Community 14 - "Initialization Base"
+### Community 14 - "._predict"
+Cohesion: 0.08
+Nodes (17): Array, JIT-compiled relaxation prediction: G(t).          Computes relaxation modulus w, JIT-compiled creep prediction: J(t).          Computes creep compliance as appro, JIT-compiled steady shear prediction: eta(gamma_dot).          Computes viscosit, Predict based on fitted test mode.          Routes to appropriate prediction met, Predict complex modulus in oscillation mode.          Args:             omega: A, Predict relaxation modulus in relaxation mode.          Args:             t: Tim, Predict creep compliance in creep mode.          Args:             t: Time array (+9 more)
+
+### Community 15 - "load_csv"
 Cohesion: 0.03
-Nodes (59): Array, JIT-compiled relaxation prediction: G(t).          Computes relaxation modulus w, JIT-compiled creep prediction: J(t).          Computes creep compliance as appro, JIT-compiled steady shear prediction: eta(gamma_dot).          Computes viscosit, Predict based on fitted test mode.          Routes to appropriate prediction met, Predict complex modulus in oscillation mode.          Args:             omega: A, Predict relaxation modulus in relaxation mode.          Args:             t: Tim, Predict creep compliance in creep mode.          Args:             t: Time array (+51 more)
+Nodes (99): complexfloating, Index, _detect_delimiter(), _get_column_data(), _get_column_header(), load_csv(), DataFrame, ndarray (+91 more)
 
-### Community 15 - "Transform Page & Worker"
-Cohesion: 0.02
-Nodes (105): complexfloating, Index, _detect_delimiter(), _get_column_data(), _get_column_header(), load_csv(), DataFrame, ndarray (+97 more)
+### Community 16 - "TestCoerceBayesianInt"
+Cohesion: 0.17
+Nodes (4): _coerce_bayesian_int(), Coerce a Bayesian config value to int with range validation.      The per-key li, Unit tests for _coerce_bayesian_int helper., TestCoerceBayesianInt
 
-### Community 16 - "Bayesian Pipeline"
-Cohesion: 0.14
-Nodes (5): _coerce_bayesian_int(), Coerce a Bayesian config value to int with range validation.      The per-key li, Execute a Bayesian inference step via BayesianService.run_mcmc.          Recogni, Unit tests for _coerce_bayesian_int helper., TestCoerceBayesianInt
+### Community 17 - "SGRGeneric"
+Cohesion: 0.05
+Nodes (26): Initialize SGR GENERIC Model.          Creates ParameterSet with:         - x (n, Initialize parameters for dynamic noise temperature evolution.          Adds par, Enable thixotropy modeling with structural parameter lambda(t).          Adds th, Evolve structural parameter lambda(t) for given shear history.          Integrat, Predict stress response with thixotropic modulus.          The effective modulus, Predict stress transient (overshoot/undershoot) for shear step protocol., Evolve noise temperature x(t) for aging/rejuvenation dynamics.          Evolutio, Soft Glassy Rheology (SGR) GENERIC Thermodynamic Framework Model.      This mode (+18 more)
 
-### Community 17 - "Giesekus Single-Mode Model"
-Cohesion: 0.03
-Nodes (61): Array, ndarray, Full Monte Carlo-based LAOS fitting.          Runs MC simulations within optimiz, JIT-compiled creep prediction: J(t).          Theory: J(t) ~ t^(x-1) for x > 1 (, JIT-compiled steady shear prediction: sigma(gamma_dot).          Theory:, JIT-compiled startup flow prediction: eta_plus(t).          Computes stress grow, JIT-compiled oscillation prediction: G'(omega), G''(omega).          Uses same k, JIT-compiled relaxation prediction: G(t).          Uses power-law form consisten (+53 more)
-
-### Community 18 - "CSV Reader & IO"
+### Community 18 - "test_fractional_initializers.py"
 Cohesion: 0.02
 Nodes (107): BaseInitializer, Base initializer abstract class for fractional model initialization.  This modul, Abstract base class for fractional model parameter initialization.      Implemen, Safely set a parameter if it exists in ParameterSet.          This helper method, FractionalBurgersInitializer, Initializer for FractionalBurgers model from oscillation data.  Model equation (, Set FractionalBurgers parameters in ParameterSet.          Parameters         --, Smart initialization for FractionalBurgers from oscillation data. (+99 more)
 
-### Community 19 - "Qt Widgets"
-Cohesion: 0.02
-Nodes (70): VariantType, Base class for Shear Transformation Zone (STZ) models.      Implements the core, Initialize STZ Base Model.          Args:             variant: Complexity varian, Initialize ParameterSet based on selected variant., STZBase, Any, ndarray, VariantType (+62 more)
+### Community 19 - "STZConventional"
+Cohesion: 0.04
+Nodes (64): VariantType, Base class for Shear Transformation Zone (STZ) models.      Implements the core, Initialize STZ Base Model.          Args:             variant: Complexity varian, Initialize ParameterSet based on selected variant., STZBase, Any, ndarray, Fit steady-state flow curve (stress vs shear rate).          Args:             g (+56 more)
 
-### Community 20 - "Community 20"
+### Community 20 - "test_trios_auto_chunk.py"
 Cohesion: 0.17
 Nodes (19): cleanup_temp_files(), Unit tests for TRIOS auto-chunking detection and behavior.  This test module val, Cleanup temporary files after each test., Test that files < 5 MB do NOT trigger auto-chunking., Test that files > 5 MB automatically trigger chunked loading., Test that files at exactly 5 MB threshold trigger chunked loading., Test that auto_chunk=False disables auto-detection for large files., Test that progress callback works when auto-chunking is triggered. (+11 more)
 
-### Community 21 - "Community 21"
-Cohesion: 0.07
-Nodes (57): File readers for rheological data formats.  This module provides readers for var, ColumnMapping, construct_complex_modulus(), convert_unit(), DataSegment, detect_step_column(), detect_test_type(), map_columns_to_canonical() (+49 more)
+### Community 21 - "json.py"
+Cohesion: 0.04
+Nodes (98): Shared JSON encoder for numpy/JAX types.  Used by both analysis_exporter and npz, File readers for rheological data formats.  This module provides readers for var, ColumnMapping, construct_complex_modulus(), convert_unit(), DataSegment, detect_step_column(), detect_test_type() (+90 more)
 
-### Community 22 - "Community 22"
+### Community 22 - "test_kernels.py"
 Cohesion: 0.09
 Nodes (40): banding_ratio(), detect_shear_bands(), fluidity_evolution_saramito(), herschel_bulkley_viscosity(), laplacian_1d_neumann(), ndarray, JAX-accelerated physics kernels for Fluidity-Saramito EVP models.  This module i, Detect shear banding from fluidity profile.      Args:         f_field: Fluidity (+32 more)
 
-### Community 23 - "Community 23"
-Cohesion: 0.03
-Nodes (88): _add_sample_to_buffers(), _build_segment_metadata(), convert_units(), _create_rheodata_chunk(), _detect_txt_encoding(), _determine_xy_columns(), _extract_metadata(), _extract_step_temperature() (+80 more)
+### Community 23 - "txt.py"
+Cohesion: 0.11
+Nodes (28): _add_sample_to_buffers(), _build_segment_metadata(), convert_units(), _determine_xy_columns(), _infer_domain_and_mode(), _parse_headers_and_units(), _parse_segment(), _parse_total_points() (+20 more)
 
-### Community 24 - "Community 24"
-Cohesion: 0.03
-Nodes (76): Check if this is a scalar (not tensorial) EPM.          Returns False for Tensor, 3-Component Tensorial Lattice EPM.      A mesoscopic model for amorphous solids, Fit tensorial-EPM parameters to shear-stress data.          Currently supports *, Initialize the Tensorial EPM.          Args:             L: Lattice size (LxL gr, TensorialEPM, Test that TensorialEPM is constructable and its forward / fit paths work.      T, test_tensorial_epm_scaffold(), Tests for Tensorial EPM model.  This module tests the full tensorial (3-componen (+68 more)
-
-### Community 25 - "Community 25"
+### Community 24 - "TensorialEPM"
 Cohesion: 0.01
-Nodes (138): Maxwell, Estimate G0 and eta from relaxation data for faster convergence., Maxwell viscoelastic model (spring and dashpot in series).      The Maxwell mode, Get characteristic relaxation time tau = eta/G0.          Returns:             R, String representation of Maxwell model., Initialize Maxwell model with default parameters., Edge case tests using Maxwell as a concrete model., Predict before fit should use default parameters. (+130 more)
+Nodes (184): Enumeration of rheological test modes.      Note: Named TestModeEnum (not TestMo, Return string representation., Convert inventory Protocol to TestModeEnum., TestModeEnum, Elasto-Plastic Models (EPM) for amorphous solids., LatticeEPM, 2D Lattice Elasto-Plastic Model (EPM).      A mesoscopic model for amorphous sol, Check if this is a scalar (not tensorial) EPM.          Returns False for Tensor (+176 more)
 
-### Community 26 - "Community 26"
-Cohesion: 0.02
-Nodes (63): PipelineBuilder, Any, Path, Add prediction step.          Args:             store_as: Optional name to store, Add plotting step.          Args:             show: Whether to display plot, Add Bayesian inference step (NUTS sampling).          Args:             num_warm, Add analysis export step.          Args:             output_path: Output directo, Add data saving step.          Args:             file_path: Output file path (+55 more)
+### Community 25 - "Maxwell"
+Cohesion: 0.01
+Nodes (169): Maxwell, ndarray, Fit Maxwell model to data.          Args:             X: RheoData object or inde, Estimate G0 and eta from relaxation data for faster convergence., Predict response based on input data.          Args:             X: RheoData obj, Model function for Bayesian inference.          This method is required by Bayes, Maxwell viscoelastic model (spring and dashpot in series).      The Maxwell mode, Predict relaxation modulus G(t).          Theory: G(t) = G0 * exp(-t/tau) where (+161 more)
 
-### Community 27 - "Community 27"
-Cohesion: 0.04
-Nodes (34): Project structure validation tests for rheojax package.  These tests verify that, Test that JAX is installed and accessible., Test that py.typed marker file exists for type checking support., Test suite for documentation setup., Test that documentation directory exists., Test that Sphinx configuration exists., Test that Sphinx index.rst exists., Test suite for validating project structure and setup. (+26 more)
-
-### Community 28 - "Community 28"
+### Community 26 - "PipelineBuilder"
 Cohesion: 0.03
-Nodes (50): Classical rheological models.  Contains fundamental spring-dashpot models: - Max, ndarray, Predict response based on input data.          Args:             X: RheoData obj, Model function for Bayesian inference.          This method is required by Bayes, Predict relaxation modulus G(t).          Theory: G(t) = c_alpha * t^(-alpha) /, Predict creep compliance J(t).          Theory: J(t) = (1/c_alpha) * t^alpha / G, Predict complex modulus G*(omega).          Theory: G*(omega) = c_alpha * (i*ome, Get characteristic time scale for the material.          For SpringPot, there's (+42 more)
+Nodes (44): PipelineBuilder, Any, Path, Add prediction step.          Args:             store_as: Optional name to store, Add plotting step.          Args:             show: Whether to display plot, Add Bayesian inference step (NUTS sampling).          Args:             num_warm, Add analysis export step.          Args:             output_path: Output directo, Add data saving step.          Args:             file_path: Output file path (+36 more)
 
-### Community 29 - "Community 29"
-Cohesion: 0.05
-Nodes (38): ArvizCanvas, _filter_degenerate_vars(), Any, Figure, Connect internal signals., Scale the figure to the viewport width, preserving aspect ratio.          Instea, Handle plot type change.          Parameters         ----------         index :, Refresh the current plot with performance tracking. (+30 more)
-
-### Community 30 - "Community 30"
+### Community 27 - "test_project_structure.py"
 Cohesion: 0.03
-Nodes (61): banding_ratio(), f_loc_herschel_bulkley(), fluidity_local_creep_ode_rhs(), fluidity_local_ode_rhs(), fluidity_nonlocal_creep_pde_rhs(), fluidity_nonlocal_pde_rhs(), fluidity_nonlocal_steady_state(), laplacian_1d_neumann() (+53 more)
+Nodes (37): Project structure validation tests for rheojax package.  These tests verify that, Test that JAX is installed and accessible., Test that py.typed marker file exists for type checking support., Test suite for documentation setup., Test that documentation directory exists., Test that Sphinx configuration exists., Test that Sphinx index.rst exists., Test suite for validating project structure and setup. (+29 more)
 
-### Community 31 - "Community 31"
+### Community 28 - "SpringPot"
 Cohesion: 0.03
-Nodes (67): mittag_leffler_e(), mittag_leffler_e2(), _mittag_leffler_hybrid(), _ml_asymptotic_neg(), _ml_asymptotic_pos(), _ml_taylor(), _ml_taylor_complex(), ndarray (+59 more)
+Nodes (61): ndarray, Fit SpringPot model to data.          Args:             X: RheoData object or in, Predict response based on input data.          Args:             X: RheoData obj, Model function for Bayesian inference.          This method is required by Bayes, Predict relaxation modulus G(t).          Theory: G(t) = c_alpha * t^(-alpha) /, Predict creep compliance J(t).          Theory: J(t) = (1/c_alpha) * t^alpha / G, Predict complex modulus G*(omega).          Theory: G*(omega) = c_alpha * (i*ome, Get characteristic time scale for the material.          For SpringPot, there's (+53 more)
 
-### Community 32 - "Community 32"
+### Community 29 - "ArvizCanvas"
+Cohesion: 0.06
+Nodes (31): ArvizCanvas, _filter_degenerate_vars(), Any, Figure, Set up the user interface.          The toolbar stays fixed at the top.  The mat, Connect internal signals., Scale the figure to the viewport width, preserving aspect ratio.          Instea, Handle plot type change.          Parameters         ----------         index : (+23 more)
+
+### Community 30 - "_kernels.py"
 Cohesion: 0.04
-Nodes (52): FIKH, Any, ArrayLike, ndarray, Initialize FIKH model.          Args:             include_thermal: Enable thermo, Fit model parameters using protocol-aware optimization.          Args:, Fit to steady-state flow curve data., Fit using ODE formulation (creep/relaxation). (+44 more)
+Nodes (54): banding_ratio(), f_loc_herschel_bulkley(), fluidity_local_creep_ode_rhs(), fluidity_local_ode_rhs(), fluidity_nonlocal_creep_pde_rhs(), fluidity_nonlocal_pde_rhs(), fluidity_nonlocal_steady_state(), laplacian_1d_neumann() (+46 more)
 
-### Community 33 - "Community 33"
-Cohesion: 0.05
-Nodes (29): HVNM (Hybrid Vitrimer Nanocomposite Model) package.  Constitutive models for n, HVNMLocal, ndarray, Create partial vitrimer nanocomposite (G_D=0).          Parameters         -----, Create conventional filled rubber (no E-network, frozen interphase).          Pa, Get parameters as dict with defaults for optional params., Build complete ODE args dict with derived quantities., Predict steady-state flow curve.          At steady state, mu^E -> mu^E_nat and (+21 more)
+### Community 31 - "mittag_leffler_e"
+Cohesion: 0.06
+Nodes (32): mittag_leffler_e(), mittag_leffler_e2(), _mittag_leffler_hybrid(), _ml_asymptotic_neg(), _ml_asymptotic_pos(), _ml_taylor(), _ml_taylor_complex(), ndarray (+24 more)
 
-### Community 34 - "Community 34"
+### Community 32 - "FIKH"
+Cohesion: 0.04
+Nodes (51): FIKH, Any, ArrayLike, ndarray, Initialize FIKH model.          Args:             include_thermal: Enable thermo, Fit model parameters using protocol-aware optimization.          Args:, Fit to steady-state flow curve data., Fit using ODE formulation (creep/relaxation). (+43 more)
+
+### Community 33 - "HVNMLocal"
 Cohesion: 0.03
-Nodes (68): Emitted when auto_p0 estimation partially fails.      Some parameters may have b, RheoJaxInitWarning, FractionalMaxwellModel, Fractional Maxwell Model: Two SpringPots in series with independent orders., Initialize Fractional Maxwell Model., FractionalZenerSolidSolid, ndarray, Predict relaxation modulus G(t) using JAX.          G(t) = G_e + G_m * E_α(-(t/τ (+60 more)
+Nodes (36): HVNM (Hybrid Vitrimer Nanocomposite Model) package.  Constitutive models for n, HVNMLocal, Create unfilled vitrimer (phi=0, recovers HVM exactly).          Parameters, Create partial vitrimer nanocomposite (G_D=0).          Parameters         -----, Create conventional filled rubber (no E-network, frozen interphase).          Pa, Get parameters as dict with defaults for optional params., Predict steady-state flow curve.          At steady state, mu^E -> mu^E_nat and, Predict steady-state normal stress differences.          At steady state, E and (+28 more)
 
-### Community 35 - "Community 35"
+### Community 34 - "FractionalMaxwellModel"
+Cohesion: 0.03
+Nodes (66): Emitted when auto_p0 estimation partially fails.      Some parameters may have b, RheoJaxInitWarning, FractionalMaxwellModel, Fractional Maxwell Model: Two SpringPots in series with independent orders., Initialize Fractional Maxwell Model., FractionalZenerSolidSolid, Derive heuristic starting values from relaxation data., Fractional Zener Solid-Solid model.      A fractional viscoelastic model with bo (+58 more)
+
+### Community 35 - "validate_prony_parameters"
+Cohesion: 0.06
+Nodes (29): iterative_n_reduction(), log_tau_to_tau(), ArrayLike, Transform relaxation times to log-space.      Useful for optimization over wide, Transform log-space relaxation times back to linear space.      Inverse of tau_t, Track R² vs N for element minimization visualization.      Args:         fit_res, Validate Prony series parameters for physical consistency.      Checks:     - E_, Extract warm-start parameters for reduced-mode fit from N-mode solution.      Us (+21 more)
+
+### Community 36 - "DataService"
+Cohesion: 0.01
+Nodes (234): QDragEnterEvent, QDropEvent, BayesianPage, Handle bayesian_failed signal from state store.          This slot catches Bayes, Handle Bayesian started signal from state., Handle Bayesian completed signal from state., Apply sampler/prior presets derived from example notebooks., Export Bayesian results to JSON or HDF5 format. (+226 more)
+
+### Community 37 - "_kernels.py"
 Cohesion: 0.04
-Nodes (53): Apply element minimization with padded arrays to avoid JIT recompilation., compute_r_squared(), create_prony_parameter_set(), iterative_n_reduction(), log_tau_to_tau(), ArrayLike, Prony series utilities for Generalized Maxwell Model parameter identification., Create ParameterSet for N-mode Prony series.      Dynamically generates paramete (+45 more)
+Nodes (69): Update history buffer with new value using ring buffer pattern.      Shifts buff, update_history_buffer(), fikh_return_step_isothermal(), fikh_return_step_thermal(), fractional_structure_rhs(), macaulay(), _make_fikh_creep_ode_rhs(), _make_fikh_maxwell_ode_rhs() (+61 more)
 
-### Community 36 - "Community 36"
-Cohesion: 0.02
-Nodes (74): QDragEnterEvent, QDropEvent, QFrame, DropZone, Drag-and-drop zone for file import., Handle drag enter event., HomePage, Populate header stat pills after event loop starts. (+66 more)
+### Community 38 - "_kernels_diffrax.py"
+Cohesion: 0.03
+Nodes (112): _make_creep_vector_field(), _make_k_ber_fn(), _make_laos_vector_field(), _make_relaxation_vector_field(), _make_startup_vector_field(), Create ODE vector field for startup shear.      gamma_dot is constant, passed vi, Create ODE vector field for stress relaxation.      After step strain, gamma_dot, Create ODE vector field for LAOS.      Oscillatory shear: gamma(t) = gamma_0 * s (+104 more)
 
-### Community 37 - "Community 37"
-Cohesion: 0.04
-Nodes (70): Simulate transient response using Diffrax ODE integration.          Args:, Update history buffer with new value using ring buffer pattern.      Shifts buff, update_history_buffer(), fikh_return_step_isothermal(), fikh_return_step_thermal(), fractional_structure_rhs(), macaulay(), _make_fikh_creep_ode_rhs() (+62 more)
+### Community 39 - "_translate_y2_col"
+Cohesion: 0.06
+Nodes (22): Any, Translate GUI-layer ``y2_col`` to reader-layer ``y_cols``.      The GUI passes `, _translate_y2_col(), F-IO-R4-001: y2_col must not be stripped before reaching _try_excel., auto_load must translate y2_col → y_cols before format dispatch., Excel file loaded via auto_load with y2_col produces complex y., Double-translation of y2_col must be idempotent., F-IO-R2-001: y2_col must be translated to y_cols for generic readers. (+14 more)
 
-### Community 38 - "Community 38"
+### Community 40 - "FluiditySaramitoLocal"
+Cohesion: 0.03
+Nodes (43): FluiditySaramitoLocal, Any, ndarray, Simulate LAOS response using Diffrax.          Parameters         ----------, Simulate LAOS response.          Parameters         ----------         gamma_0 :, Extract Fourier harmonics from LAOS stress response.          Parameters, NumPyro/BayesianMixin model function.          Routes to appropriate prediction, Predict based on fitted state.          Parameters         ----------         X (+35 more)
+
+### Community 41 - "ndarray"
 Cohesion: 0.08
-Nodes (49): hvm_damage_rhs(), hvm_exchangeable_rhs_shear(), ODE RHS for exchangeable network distribution + natural state.      E-network di, Damage evolution with cooperative shielding.      dD/dt = Gamma_0 * (1 - D) * ma, _compute_k_ber_interphase(), _compute_k_ber_matrix(), _default_hvnm_args(), _hvnm_initial_state() (+41 more)
+Nodes (19): ndarray, Detect shear banding from constitutive curve.          Computes the steady-state, Predict flow in shear banding regime with lever rule.          When shear bandin, Compute Helmholtz free energy F(z) = U(z) - T*S(z).          The free energy fun, Extract Fourier harmonics from LAOS stress response.          Performs FFT analy, Compute Chebyshev decomposition of LAOS response.          Decomposes stress int, Compute internal energy U(z) from elastic storage.          The internal energy, Compute 3D Poisson bracket operator L(z) for dynamic x mode.          The 3x3 Po (+11 more)
 
-### Community 39 - "Community 39"
-Cohesion: 0.03
-Nodes (82): initialize_fractional_burgers(), initialize_fractional_jeffreys(), initialize_fractional_kelvin_voigt(), initialize_fractional_kv_zener(), initialize_fractional_maxwell_gel(), initialize_fractional_maxwell_liquid(), initialize_fractional_maxwell_model(), initialize_fractional_zener_ll() (+74 more)
-
-### Community 40 - "Community 40"
-Cohesion: 0.03
-Nodes (48): FluiditySaramitoLocal, Any, ndarray, Simulate LAOS response using Diffrax.          Parameters         ----------, Simulate LAOS response.          Parameters         ----------         gamma_0 :, Extract Fourier harmonics from LAOS stress response.          Parameters, NumPyro/BayesianMixin model function.          Routes to appropriate prediction, Predict based on fitted state.          Parameters         ----------         X (+40 more)
-
-### Community 41 - "Community 41"
-Cohesion: 0.03
-Nodes (61): LatticeEPM, RheoData, Simulate the model for the given protocol.          Args:             X: Input d, 2D Lattice Elasto-Plastic Model (EPM).      A mesoscopic model for amorphous sol, Test that LatticeEPM can be instantiated and has correct defaults., Test the Flow Curve protocol (steady state shear)., Test Creep protocol with Adaptive Controller., Test that smooth mode is differentiable (for NLSQ/NUTS). (+53 more)
-
-### Community 42 - "Community 42"
+### Community 42 - "FMLIKH"
 Cohesion: 0.04
 Nodes (48): FMLIKH, Any, ArrayLike, ndarray, TestMode, Initialize FMLIKH model.          Args:             n_modes: Number of viscoelas, Setup per-mode parameters, replacing single-mode defaults., Number of viscoelastic modes. (+40 more)
 
-### Community 43 - "Community 43"
+### Community 43 - "ColumnMappingPage"
+Cohesion: 0.07
+Nodes (20): QWizardPage, ColumnMappingPage, PreviewConfirmPage, DataFrame, Handle x column change., Handle y column change., Handle y2 column change., Handle temp column change. (+12 more)
+
+### Community 44 - "FitPage"
+Cohesion: 0.03
+Nodes (47): FitPage, Any, Figure, ndarray, Update the Fit page status from a stored FitResult., Replace the plot canvas figure.          Delegates to PlotCanvas.replace_figure(, Forward residuals to the residuals panel., Connect internal signals. (+39 more)
+
+### Community 45 - "from_yaml"
 Cohesion: 0.05
-Nodes (27): QWizardPage, ColumnMappingPage, FileSelectionPage, PreviewConfirmPage, DataFrame, QWidget, Check if page is complete., Handle drag enter event. (+19 more)
+Nodes (57): _display_name(), from_pipeline_builder(), from_yaml(), _get_yaml(), _make_step(), Any, PipelineStepConfig, Pipeline serialization for GUI <-> CLI YAML round-trip.  Provides bidirectional (+49 more)
 
-### Community 44 - "Community 44"
+### Community 46 - "FractionalMaxwellLiquid"
+Cohesion: 0.09
+Nodes (12): FractionalMaxwellLiquid, Provide custom priors that stay near realistic data-informed scales., Prefer conservative NUTS settings for the stiff Mittag-Leffler kernel., Fractional Maxwell Liquid model: Spring in series with SpringPot.      This mode, Initialize Fractional Maxwell Liquid model., Test model initialization and parameters., Test JAX functionality., Test RheoData integration. (+4 more)
+
+### Community 47 - "TransformState"
 Cohesion: 0.04
-Nodes (42): FitPage, Any, Figure, ndarray, Update the Fit page status from a stored FitResult., Replace the plot canvas figure.          Delegates to PlotCanvas.replace_figure(, Forward residuals to the residuals panel., Load available models into browser. (+34 more)
+Nodes (57): TransformState, is_pyqtgraph_available(), PyQtGraphCanvas, PyQtGraph Canvas Widget for GPU-Accelerated Plotting.  This module provides GPU-, Handle scale selection change., Set logarithmic scale for axes.          Parameters         ----------         x, Set axis labels and title.          Parameters         ----------         x_labe, Handle mouse movement for crosshair and coordinates. (+49 more)
 
-### Community 45 - "Community 45"
-Cohesion: 0.06
-Nodes (46): from_pipeline_builder(), Convert GUI pipeline steps to a YAML string.      The resulting string is compat, Convert GUI pipeline steps to a PipelineBuilder.      Uses the same field mappin, Convert a :class:`~rheojax.pipeline.builder.PipelineBuilder` to a GUI state., to_pipeline_builder(), to_yaml(), _basic_steps(), _make_bayesian_step() (+38 more)
-
-### Community 46 - "Community 46"
-Cohesion: 0.04
-Nodes (32): FractionalMaxwellLiquid, ndarray, RheoData, Provide custom priors that stay near realistic data-informed scales., Tighten tau bounds based on data scale to avoid pathological samples., Prefer conservative NUTS settings for the stiff Mittag-Leffler kernel., Predict relaxation modulus G(t) using JAX.          G(t) = G_m E_{α,1}(-(t/τ)^α), Predict creep compliance J(t) using JAX.          J(t) = (1/G_m) + (t^α)/(G_m τ^ (+24 more)
-
-### Community 47 - "Community 47"
-Cohesion: 0.06
-Nodes (40): TransformState, Apply uniform margins to a panel or section layout.      Sets identical margins, set_panel_margins(), is_pyqtgraph_available(), PyQtGraph Canvas Widget for GPU-Accelerated Plotting.  This module provides GPU-, Check if PyQtGraph is available.      Returns     -------     bool         True, TransformPickStep, # NOTE: TransformService has no .run() method. The real implementation must: (+32 more)
-
-### Community 48 - "Community 48"
+### Community 48 - "_make_mock_spp_results"
 Cohesion: 0.05
 Nodes (49): export_spp_csv(), export_spp_hdf5(), export_spp_txt(), _extract_spp_arrays(), ndarray, Path, SPP (Sequence of Physical Processes) data export module.  This module provides e, Export SPP results to MATLAB-compatible text format.      Creates output files m (+41 more)
 
-### Community 49 - "Community 49"
-Cohesion: 0.05
-Nodes (44): EPMBase, _jit_creep_kernel(), _jit_flow_curve_batch(), _jit_flow_curve_single(), _jit_oscillation_kernel(), _jit_relaxation_kernel(), _jit_startup_kernel(), Array (+36 more)
+### Community 49 - "._init_state"
+Cohesion: 0.12
+Nodes (10): RheoData, Stress relaxation: G(t) after step strain.          Args:             data: Rheo, Creep: Strain(t) at constant stress using Adaptive P-Controller.          The co, SAOS/LAOS: Stress(t) for sinusoidal strain.          Args:             data: Rhe, JAX-pure creep simulation with P-controller., Initialize yield thresholds from Gaussian distribution.          Args:, Initialize stress field (subclass-specific shape).          Args:             ke, Initialize full simulation state.          Args:             key: PRNG key for r (+2 more)
 
-### Community 50 - "Community 50"
+### Community 50 - "FitPlotter"
 Cohesion: 0.03
 Nodes (53): FitPlotter, Unified plotting for NLSQ and Bayesian fit results.      Provides methods for cr, complex_data(), mock_bayesian_result(), mock_fit_result(), mock_model(), plotter(), Tests for the FitPlotter class and Bayesian visualization primitives. (+45 more)
 
-### Community 51 - "Community 51"
+### Community 51 - "FractionalModelMixin"
 Cohesion: 0.07
-Nodes (33): build_fit_controller(), _make_fit_fn(), _make_sample_fn(), AppState, Build the real fit_fn NlsqStep.run() calls., Build the real sample_fn NutsStep.run() calls., NlsqStep, Sync the result label to current state.          Called both after a run and whe (+25 more)
+Nodes (30): FractionalModelMixin, ndarray, TestMode, Convert class name to module name.          Examples:             FractionalZene, Validate fractional model parameters.          Checks:         - Fractional orde, Mixin providing common functionality for fractional viscoelastic models.      Th, Apply smart initialization for oscillation mode.          This method provides c, MockFractionalModel (+22 more)
 
-### Community 52 - "Community 52"
-Cohesion: 0.05
-Nodes (43): CreepToRelaxationPipeline, FrequencyToTimePipeline, ModelComparisonPipeline, Pipeline for comparing multiple models on the same data.      This pipeline fits, Get comparison table of all models.          Returns:             Dictionary of, Convert creep compliance data to relaxation modulus.      This pipeline performs, Convert frequency domain data to time domain.      This pipeline converts dynami, MockMaxwell (+35 more)
+### Community 52 - "CreepToRelaxationPipeline"
+Cohesion: 0.06
+Nodes (37): CreepToRelaxationPipeline, FrequencyToTimePipeline, Convert creep compliance data to relaxation modulus.      This pipeline performs, Convert frequency domain data to time domain.      This pipeline converts dynami, creep_data(), frequency_data(), MockMaxwell, MockZener (+29 more)
 
-### Community 53 - "Community 53"
-Cohesion: 0.07
-Nodes (63): Any, AppState, Bayesian action reducers.  Handles: START_BAYESIAN, BAYESIAN_COMPLETED, BAYESIAN, reduce_bayesian_completed(), reduce_bayesian_failed(), reduce_start_bayesian(), reduce_store_bayesian_result(), Any (+55 more)
+### Community 53 - "__init__.py"
+Cohesion: 0.08
+Nodes (62): Any, AppState, reduce_bayesian_completed(), reduce_bayesian_failed(), reduce_start_bayesian(), reduce_store_bayesian_result(), Any, AppState (+54 more)
 
-### Community 54 - "Community 54"
-Cohesion: 0.05
-Nodes (64): _expand_glob(), _flatten_result(), load_series(), load_srfs(), load_tts(), Any, Path, RheoData (+56 more)
+### Community 54 - "test_multi_file.py"
+Cohesion: 0.08
+Nodes (48): _expand_glob(), _flatten_result(), load_series(), load_srfs(), load_tts(), Any, Path, RheoData (+40 more)
 
-### Community 55 - "Community 55"
-Cohesion: 0.03
-Nodes (59): FluidityNonlocal, Any, ndarray, NumPyro/BayesianMixin model function.          Accepts protocol-specific kwargs, Predict based on fitted state., Fit Non-Local Fluidity model to data.          Args:             X: Independent, Get grid-related arguments for PDE solver.          Args:             params: Op, Get initial fluidity field (uniform across gap).          Args:             f_in (+51 more)
-
-### Community 56 - "Community 56"
+### Community 55 - "FluidityNonlocal"
 Cohesion: 0.04
-Nodes (25): Comprehensive tests for Fractional Zener Family and Advanced Fractional Models (, Test parameter initialization., Test relaxation modulus., Test creep compliance., Test complex modulus., Tests for FZLL model., Test parameter initialization., Test complex modulus (primary mode for FZLL). (+17 more)
+Nodes (42): FluidityNonlocal, Any, ndarray, NumPyro/BayesianMixin model function.          Accepts protocol-specific kwargs, Predict based on fitted state., Add non-local specific parameters., Fit Non-Local Fluidity model to data.          Args:             X: Independent, Get grid-related arguments for PDE solver.          Args:             params: Op (+34 more)
 
-### Community 57 - "Community 57"
+### Community 56 - "test_fractional_zener_family.py"
+Cohesion: 0.05
+Nodes (20): Comprehensive tests for Fractional Zener Family and Advanced Fractional Models (, Test parameter initialization., Test relaxation modulus., Test creep compliance., Test complex modulus., Test parameter initialization., Test creep compliance., Test relaxation modulus. (+12 more)
+
+### Community 57 - "_execute_notebook"
 Cohesion: 0.04
 Nodes (37): _execute_notebook(), Validate that WLF parameters (C1, C2) are defined., Validate that shift factors are calculated for all temperatures., Execute a Jupyter notebook and return the executed notebook object.      Paramet, Validate that multi-temperature data is loaded., Validate that Mastercurve transform is applied., Validate that mastercurve quality metrics are computed., Validate that key visualizations are present. (+29 more)
 
-### Community 58 - "Community 58"
-Cohesion: 0.12
-Nodes (13): Unit tests for SPP JAX kernels.  These tests exercise the lightweight analytical, num_mode=2 (periodic) should smooth boundary artifacts compared to mode 1., Phase offset should be nonzero for pure cosine wave., Fourier analysis should compute Frenet-Serret frame., T, N, B vectors should be mutually orthogonal., Test unit conversion for strain., Numerical analysis should accept per-sample omega and keep shapes stable., test_compute_phase_offset_nonzero_for_pure_cosine() (+5 more)
+### Community 58 - "TestMenuBarActionConnections"
+Cohesion: 0.08
+Nodes (21): action_has_receivers(), RheoJAX GUI Menu Actions Tests.  Regression tests ensuring all menu bar actions, Verify all Data menu actions have handlers., Verify all Models menu actions have handlers., Check if a QAction has any receivers connected to its triggered signal.      In, Verify all Transforms menu actions have handlers., Verify all Analysis menu actions have handlers., Verify all Pipeline menu actions have handlers. (+13 more)
 
-### Community 59 - "Community 59"
+### Community 59 - "FitResult"
 Cohesion: 0.04
-Nodes (65): BayesianWorkerSignals, Any, QObject, QRunnable, Bayesian Worker ==============  Background worker for Bayesian inference with NU, Initialize Bayesian worker.          Parameters         ----------         model, Signals for BayesianWorker.      Signals     -------     progress : Signal(int,, Slot: relay staged elapsed-time message on the GUI thread.          Called exclu (+57 more)
+Nodes (64): BayesianWorkerSignals, Any, QObject, QRunnable, Bayesian Worker ==============  Background worker for Bayesian inference with NU, Initialize Bayesian worker.          Parameters         ----------         model, Signals for BayesianWorker.      Signals     -------     progress : Signal(int,, Slot: relay staged elapsed-time message on the GUI thread.          Called exclu (+56 more)
 
-### Community 60 - "Community 60"
+### Community 60 - "__init__.py"
 Cohesion: 0.06
 Nodes (50): RheoJAX Logging Configuration.  Centralized configuration management for the Rhe, Reset logging configuration to defaults.      Primarily useful for testing., reset_config(), log_bayesian(), log_gui_action(), log_io(), log_operation(), log_pipeline_stage() (+42 more)
 
-### Community 61 - "Community 61"
+### Community 61 - "PipelineSidebar"
 Cohesion: 0.04
-Nodes (38): QPainter, QSize, QStyledItemDelegate, get_icon(), QIcon, QWidget, Get an icon by name from the icons directory.      Parameters     ----------, Initialize main toolbar.          Parameters         ----------         parent : (+30 more)
+Nodes (39): QPainter, QSize, QStyledItemDelegate, QToolBar, get_icon(), MainToolBar, QIcon, QWidget (+31 more)
 
-### Community 62 - "Community 62"
+### Community 62 - "TransformService"
+Cohesion: 0.03
+Nodes (71): _PreviewWorker, Signals for cross-thread preview result delivery., QRunnable that computes a transform preview off the main thread., _WorkerSignals, Data Service ===========  Service for loading, validating, and managing rheologi, Service for rheological transform operations.      Transforms:         - Masterc, Get list of available transforms.          Returns         -------         list[, Return the transform class for a registry key or legacy alias.          Paramete (+63 more)
+
+### Community 63 - "_kernels.py"
 Cohesion: 0.04
-Nodes (54): Raised when a Pipeline-mode fit step runs under thread-mode worker isolation., WorkerIsolationRequiredError, Service for rheological transform operations.      Transforms:         - Masterc, Get list of available transforms.          Returns         -------         list[, Return the transform class for a registry key or legacy alias.          Paramete, TransformService, apply_transform accepts unified key 'fft_analysis' without raising., apply_transform accepts unified key 'smooth_derivative' without raising. (+46 more)
+Nodes (59): build_vlb_creep_ode_rhs(), build_vlb_laos_ode_rhs(), build_vlb_nonlocal_pde_rhs(), build_vlb_ode_rhs(), build_vlb_relaxation_ode_rhs(), build_vlb_stress_fn(), ndarray, JAX-accelerated physics kernels for VLB transient network models.  This module p (+51 more)
 
-### Community 63 - "Community 63"
-Cohesion: 0.02
-Nodes (113): build_vlb_creep_ode_rhs(), build_vlb_laos_ode_rhs(), build_vlb_nonlocal_pde_rhs(), build_vlb_ode_rhs(), build_vlb_relaxation_ode_rhs(), build_vlb_stress_fn(), laplacian_1d_neumann_vlb(), ndarray (+105 more)
+### Community 64 - "RheoJAXMainWindow"
+Cohesion: 0.04
+Nodes (33): Handle open file action., Handle save as action., Handle preferences action., Handle zoom in action., Handle zoom out action., Handle reset zoom action., Clear the current visual pipeline state., Called on the main thread when a single pipeline step completes. (+25 more)
 
-### Community 64 - "Community 64"
-Cohesion: 0.01
-Nodes (147): QCloseEvent, Any, AppState, FitResult, Path, QToolBar, QWidget, Handle new file action. (+139 more)
+### Community 65 - "HVNMBase"
+Cohesion: 0.03
+Nodes (36): HVNMBase, ndarray, Interphase reinforcement ratio G_I/G_E., Interfacial TST attempt frequency (1/s)., Interfacial activation energy (J/mol)., Interfacial activation volume (m^3/mol)., Mobile interphase thickness (m)., Interfacial damage rate (1/s). (+28 more)
 
-### Community 65 - "Community 65"
-Cohesion: 0.17
-Nodes (5): HVNMBase, Strain amplification for I-network X(phi_eff)., Base class for Hybrid Vitrimer Nanocomposite Models.      Extends HVMBase with, Estimate matrix and interfacial vitrimer topology freezing temperatures., Whether interfacial damage is active.
-
-### Community 66 - "Community 66"
+### Community 66 - "test_transform_plotter.py"
 Cohesion: 0.04
 Nodes (39): complex_data(), freq_data(), plotter(), Tests for the TransformPlotter class., Tests for mastercurve visualization., Mastercurve plot with shift factors dict., Mastercurve plot without input datasets., Mutation number plot shows bar with value. (+31 more)
 
-### Community 67 - "Community 67"
-Cohesion: 0.05
-Nodes (35): DerivativeMethod, JaxArray, RheoData, Initialize Smooth Derivative transform.          Parameters         ----------, Apply moving average smoothing.          Parameters         ----------         y, Compute derivative using Savitzky-Golay filter.          Parameters         ----, Compute derivative using finite differences.          Parameters         -------, Compute derivative using JIT-safe cubic splines via interpax.          Parameter (+27 more)
+### Community 67 - "SmoothDerivative"
+Cohesion: 0.07
+Nodes (23): Smooth noise-robust numerical differentiation.      This transform computes deri, SmoothDerivative, Tests for batch transform vectorization., TestBatchSmoothDerivative, Test derivative on noisy data., Test different differentiation methods., Test suite for Smooth Derivative transform., Test inverse transform (integration). (+15 more)
 
-### Community 68 - "Community 68"
-Cohesion: 0.06
-Nodes (47): DMTBase, Initialize ParameterSet with model parameters.          Parameters are added con, Get initial structure parameter value (fully structured).          Returns, Get all parameters as a dictionary.          Returns         -------         dic, Build base args dictionary for ODE integration.          Parameters         ----, Get human-readable description of the closure.          Returns         -------, Base class for DMT (de Souza Mendes-Thompson) thixotropic models.      Implement, Get human-readable description of elasticity setting.          Returns         - (+39 more)
+### Community 68 - "local.py"
+Cohesion: 0.09
+Nodes (39): consistency(), elastic_modulus(), equilibrium_structure(), invert_stress_for_gamma_dot_exponential(), invert_stress_for_gamma_dot_hb(), maxwell_stress_evolution(), ndarray, JIT-compiled kernels for DMT (de Souza Mendes-Thompson) models.  This module pro (+31 more)
 
-### Community 69 - "Community 69"
+### Community 69 - "test_fikh_caputo.py"
 Cohesion: 0.05
 Nodes (43): caputo_derivative_l1(), compute_gl_weights(), compute_l1_coefficients(), create_history_buffer(), fractional_derivative_with_short_memory(), fractional_structure_derivative(), initialize_history_with_value(), ndarray (+35 more)
 
-### Community 70 - "Community 70"
+### Community 70 - "conftest.py"
 Cohesion: 0.02
-Nodes (80): Reset validation state (for testing purposes only).      This function is intend, Verify that JAX is operating in float64 mode.      This function checks that JAX, reset_validation(), verify_float64(), RheoJAX: Unified Rheological Analysis Framework.  A comprehensive rheological an, _ensure_all_registered(), __getattr__(), Rheological models package.  This package contains 53 rheological models organiz (+72 more)
+Nodes (89): Reset validation state (for testing purposes only).      This function is intend, Verify that JAX is operating in float64 mode.      This function checks that JAX, reset_validation(), verify_float64(), RheoJAX: Unified Rheological Analysis Framework.  A comprehensive rheological an, _ensure_all_registered(), __getattr__(), Rheological models package.  This package contains 53 rheological models organiz (+81 more)
 
-### Community 71 - "Community 71"
+### Community 71 - "ModelComparisonPipeline"
 Cohesion: 0.07
-Nodes (16): Test transform method returns RheoData., Test average relaxation time calculation., Test equilibrium modulus estimation., Test suite for Mutation Number transform., Test extrapolation to infinite time (exponential)., Test error for non-relaxation data., Test basic mutation number initialization., Test handling of complex data. (+8 more)
+Nodes (16): ModelComparisonPipeline, Pipeline for comparing multiple models on the same data.      This pipeline fits, Return name of best-fitting model.          Args:             metric: Metric to, Get comparison table of all models.          Returns:             Dictionary of, Tests for parallel model comparison., With only 1 model, parallel=True should not use pool., TestModelComparisonParallel, Test model comparison pipeline initialization. (+8 more)
 
-### Community 72 - "Community 72"
-Cohesion: 0.08
-Nodes (44): QObject, DatasetLibrary, Any, PipelineStepConfig, PipelineExecutionService, Any, Execute all pipeline steps sequentially.          This method runs synchronously, Execute a single step with the given context.          Wraps the step in the sam (+36 more)
+### Community 72 - "DatasetLibrary"
+Cohesion: 0.06
+Nodes (60): QObject, DatasetLibrary, Any, pipeline_context_from_library(), Any, Seed a PipelineExecutionService.execute_single_step context from a     Workspace, PipelineStepConfig, PipelineExecutionService (+52 more)
 
-### Community 73 - "Community 73"
-Cohesion: 0.03
-Nodes (66): Enum, RuntimeError, Check model-data compatibility and return result.          Args:             X:, Enhance optimization error with compatibility information.          Args:, _compute_relaxation_compatibility(), Fit model to data using NLSQ TRF optimization.          Parameters         -----, Return True when compatibility analysis flags obvious mismatches., Best-effort compatibility evaluation for relaxation data. (+58 more)
+### Community 73 - "check_model_compatibility"
+Cohesion: 0.14
+Nodes (22): check_model_compatibility(), DecayType, detect_decay_type(), _detect_from_oscillation(), _detect_from_relaxation(), detect_material_type(), MaterialType, Any (+14 more)
 
-### Community 74 - "Community 74"
-Cohesion: 0.04
-Nodes (44): Carreau, ndarray, RheoData, TestMode, Fit Carreau parameters to data.          Args:             X: Shear rate data (g, Predict viscosity for given shear rates.          Args:             X: Shear rat, Model function for Bayesian inference.          This method is required by Bayes, Compute viscosity using Carreau model.          Args:             gamma_dot: She (+36 more)
+### Community 74 - ".predict_rheo"
+Cohesion: 0.15
+Nodes (10): ndarray, RheoData, TestMode, Fit Carreau parameters to data.          Args:             X: Shear rate data (g, Predict viscosity for given shear rates.          Args:             X: Shear rat, Model function for Bayesian inference.          This method is required by Bayes, Compute viscosity using Carreau model.          Args:             gamma_dot: She, Compute shear stress using Carreau model.          Args:             gamma_dot: (+2 more)
 
-### Community 75 - "Community 75"
+### Community 75 - "MLIKH"
 Cohesion: 0.05
-Nodes (29): MLIKH, Number of structural modes., Yield formulation mode ('per_mode' or 'weighted_sum')., Initialize parameters based on yield_mode., Create parameters for per-mode yield formulation., Create parameters for weighted-sum yield formulation., Multi-Lambda Isotropic-Kinematic Hardening (ML-IKH) Model.      Extends MIKH to, Tests for the ML-IKH model. (+21 more)
+Nodes (30): MLIKH, Number of structural modes., Yield formulation mode ('per_mode' or 'weighted_sum')., Initialize parameters based on yield_mode., Create parameters for per-mode yield formulation., Create parameters for weighted-sum yield formulation., Multi-Lambda Isotropic-Kinematic Hardening (ML-IKH) Model.      Extends MIKH to, Tests for ML-IKH protocol-specific fitting. (+22 more)
 
-### Community 76 - "Community 76"
-Cohesion: 0.13
-Nodes (13): PersistentProcessPool, Process pool with long-lived workers for JAX-safe parallel execution.      Each, _add_one(), _raise_error(), Tests for PersistentProcessPool., Futures submitted but not completed before shutdown get an error., Test persistent process pool lifecycle and task execution., _slow_add() (+5 more)
+### Community 76 - "PersistentProcessPool"
+Cohesion: 0.12
+Nodes (15): __getattr__(), Lazy import for PersistentProcessPool (avoids multiprocessing import at package, PersistentProcessPool, Process pool with long-lived workers for JAX-safe parallel execution.      Each, _add_one(), _raise_error(), Tests for PersistentProcessPool., Futures submitted but not completed before shutdown get an error. (+7 more)
 
-### Community 77 - "Community 77"
-Cohesion: 0.05
-Nodes (29): _G0_compute(), _G0_integrand(), _Gp_integrand_imag(), _Gp_integrand_real(), _Gp_quadrature(), Integrand for G0(x) equilibrium modulus integral.      G0(x) = integral_0^inf rh, Compute G0(x) using numerical quadrature (internal).      Parameters     -------, Real part of Gp integrand for storage modulus G'(omega).      Parameters     --- (+21 more)
+### Community 77 - "TestKernelProperties"
+Cohesion: 0.09
+Nodes (12): Trap distribution rho(E) >= 0 for all E >= 0., Trap distribution rho(E) <= 1 for all E >= 0., Trap distribution rho(E) = 0 for E < 0., Equilibrium modulus G0(x) > 0 for all x > 0., Equilibrium modulus G0(x) is finite for all valid x., G0(x) decreases monotonically with increasing x (more fluid-like)., G'(x, omega) >= 0 and G''(x, omega) >= 0 for all valid inputs., G' and G'' are finite for all valid inputs. (+4 more)
 
-### Community 78 - "Community 78"
-Cohesion: 0.04
-Nodes (41): Fit SpringPot model to data.          Args:             X: RheoData object or in, Initialize EPM base with common parameters.          The `fluidity_form` argumen, Extract parameters as dictionary for kernel calls.          Returns:, TestMode, Validate and convert test mode.          Args:             test_mode: Test mode, Report which parameters are identifiable for a given protocol.          Fluidity, Add non-local specific parameters., Initialize Non-Local Fluidity Model.          Args:             N_y: Number of s (+33 more)
+### Community 78 - "._transform"
+Cohesion: 0.29
+Nodes (6): RheoData, Compute SRFS shift factor from SGR theory.          For SGR materials, the shift, Apply SRFS shift to a single dataset.          Parameters         ----------, Apply SRFS transformation.          Parameters         ----------         data :, Apply SRFS transformation (public interface).          Parameters         ------, Create SRFS master curve from multiple flow curve datasets.          Parameters
 
-### Community 79 - "Community 79"
+### Community 79 - "WorkerPool"
 Cohesion: 0.06
 Nodes (28): Any, QObject, QRunnable, Qt, QThreadPool, Worker Pool ==========  Thread pool for executing background jobs with progress, Create or return singleton instance., Reset the singleton instance (useful for testing). (+20 more)
 
-### Community 80 - "Community 80"
-Cohesion: 0.05
-Nodes (49): Giesekus Nonlinear Viscoelastic Models.  This package implements the Giesekus, _compute_steady_dimensionless_stresses(), giesekus_creep_ode_rhs(), giesekus_multimode_ode_rhs(), giesekus_multimode_saos_moduli(), giesekus_ode_rhs(), giesekus_ode_rhs_laos(), giesekus_relaxation_ode_rhs() (+41 more)
+### Community 80 - "_kernels.py"
+Cohesion: 0.07
+Nodes (42): _compute_steady_dimensionless_stresses(), giesekus_creep_ode_rhs(), giesekus_multimode_ode_rhs(), giesekus_multimode_saos_moduli(), giesekus_ode_rhs(), giesekus_ode_rhs_laos(), giesekus_relaxation_ode_rhs(), giesekus_steady_normal_stresses() (+34 more)
 
-### Community 81 - "Community 81"
-Cohesion: 0.10
-Nodes (19): configure(), get_default_workers(), get_worker_isolation(), Override default parallel configuration.      Call once at application startup., Optimal worker count for the current system.      Priority: sequential mode (ret, Get worker isolation mode: 'subprocess' or 'thread'., _clean_parallel_config(), Shared fixtures for parallel module tests. (+11 more)
+### Community 81 - "get_default_workers"
+Cohesion: 0.08
+Nodes (27): Public API for parallel execution.  High-level convenience functions that hide p, configure(), get_default_workers(), get_parallel_config(), get_worker_isolation(), is_sequential_mode(), Any, Adaptive parallelism configuration.  Auto-detects optimal worker count based on (+19 more)
 
-### Community 82 - "Community 82"
+### Community 82 - "PipelineConfig"
 Cohesion: 0.07
 Nodes (27): Namespace, CLI subcommand for pipeline management (init, validate, show).  Provides utiliti, Validate a pipeline YAML config against the schema., Print a human-readable summary of a pipeline config., run_show(), run_validate(), load_config(), PipelineConfig (+19 more)
 
-### Community 83 - "Community 83"
-Cohesion: 0.05
-Nodes (28): ITTMCTSchematic, Get the strain decorrelation function form., Get the memory kernel form.          Returns         -------         str, Get the stress computation form.          Returns         -------         str, Initialize F₁₂ Schematic Model.          Parameters         ----------         e, Initialize F₁₂ model parameters., Get critical v₂ value for glass transition.          Parameters         --------, Get separation parameter ε = (v₂ - v₂_c)/v₂_c. (+20 more)
+### Community 83 - "ITTMCTSchematic"
+Cohesion: 0.03
+Nodes (55): ITTMCTSchematic, Get the strain decorrelation function form., Get the memory kernel form.          Returns         -------         str, Get the stress computation form.          Returns         -------         str, Initialize F₁₂ Schematic Model.          Parameters         ----------         e, Initialize F₁₂ model parameters., Get critical v₂ value for glass transition.          Parameters         --------, Get separation parameter ε = (v₂ - v₂_c)/v₂_c. (+47 more)
 
-### Community 84 - "Community 84"
-Cohesion: 0.04
-Nodes (25): Test creating mastercurve without merging., Test vertical shifting for modulus., Test suite for Mastercurve transform., Test setting manual shift factors., Test error when temperature is missing., Test basic mastercurve initialization., Test overlap error computation., Test WLF parameter optimization. (+17 more)
+### Community 84 - ".navigate_to"
+Cohesion: 0.07
+Nodes (16): Path, Handle opening a recent project from the home page., Handle import data action., Perform the deferred file import (blocking I/O)., Handle export action., Navigate to the workspace page matching the sidebar step selection.          The, Open a pipeline from a YAML file., Save the current pipeline to a YAML file. (+8 more)
 
-### Community 85 - "Community 85"
+### Community 85 - "plot_model_fit"
 Cohesion: 0.06
 Nodes (36): apply_template_style(), plot_mastercurve(), plot_model_fit(), plot_stress_strain(), Any, Array, Axes, Figure (+28 more)
 
-### Community 86 - "Community 86"
+### Community 86 - "MIKH"
 Cohesion: 0.05
 Nodes (33): MIKH, r"""Maxwell-Isotropic-Kinematic Hardening (MIKH) Model.      A thixotropic elast, Test NLSQ fitting for MIKH., NLSQ fitting for flow curve should converge., NLSQ fitting for startup should converge., NLSQ should recover parameters within reasonable bounds., Test Bayesian inference for MIKH., Smoke test for Bayesian inference on MIKH. (+25 more)
 
-### Community 87 - "Community 87"
+### Community 87 - "conftest.py"
+Cohesion: 0.04
+Nodes (45): PlotMetrics, Clear all collected metrics., Track plot rendering performance metrics.      This class collects timing data f, Get statistics for a plot type.          Parameters         ----------         p, Get statistics for all plot types.          Returns         -------         dict, app_state_instance(), ascii_checker(), contains_emoji() (+37 more)
+
+### Community 88 - "_kernels_diffrax.py"
 Cohesion: 0.06
-Nodes (31): PlotMetrics, Any, Clear all collected metrics., Track plot rendering performance metrics.      This class collects timing data f, Execute a render function with timing.          Parameters         ----------, Record a plot rendering duration.          Parameters         ----------, Get statistics for a plot type.          Parameters         ----------         p, Get statistics for all plot types.          Returns         -------         dict (+23 more)
+Nodes (49): _hvm_initial_state(), hvm_solve_creep(), hvm_solve_laos(), hvm_solve_relaxation(), hvm_solve_startup(), _mask_failed_solution_ys(), ndarray, Solution (+41 more)
 
-### Community 88 - "Community 88"
-Cohesion: 0.07
-Nodes (40): _hvm_initial_state(), hvm_solve_creep(), hvm_solve_laos(), hvm_solve_relaxation(), hvm_solve_startup(), _make_creep_vector_field(), _make_k_ber_fn(), _make_laos_vector_field() (+32 more)
+### Community 89 - "_kernels.py"
+Cohesion: 0.04
+Nodes (61): breakage_bell(), breakage_constant(), breakage_power_law(), build_tnt_creep_ode_rhs(), build_tnt_laos_ode_rhs(), build_tnt_ode_rhs(), build_tnt_relaxation_ode_rhs(), gordon_schowalter_2d() (+53 more)
 
-### Community 89 - "Community 89"
-Cohesion: 0.05
-Nodes (53): breakage_bell(), breakage_constant(), breakage_power_law(), build_tnt_creep_ode_rhs(), build_tnt_laos_ode_rhs(), build_tnt_ode_rhs(), build_tnt_relaxation_ode_rhs(), gordon_schowalter_2d() (+45 more)
+### Community 90 - "ndarray"
+Cohesion: 0.15
+Nodes (7): ndarray, Initialize parameters from SAOS data.          Uses the crossover frequency and, Initialize parameters from flow curve data.          Parameters         --------, Initialize parameters from stress relaxation data G(t) = G₀ exp(-k_d·t)., Initialize parameters from startup shear data.          Uses the steady-state st, Initialize parameters from creep data γ(t) = σ₀·(1 + k_d·t)/G₀.          Paramet, Return equilibrium distribution tensor mu_eq = I.          In the absence of flo
 
-### Community 90 - "Community 90"
+### Community 91 - "DMTLocal"
 Cohesion: 0.06
-Nodes (20): ndarray, Compute stretch ratio from distribution tensor.          stretch = sqrt(tr(mu)/3, Compute Weissenberg number Wi = t_R * gamma_dot.          Parameters         ---, Compute Deborah number De = t_R * omega.          Parameters         ----------, Get all parameters as a dictionary.          Returns         -------         dic, Set parameters from a dictionary.          Parameters         ----------, Initialize parameters from SAOS data.          Uses the crossover frequency and, Initialize parameters from flow curve data.          Parameters         -------- (+12 more)
+Nodes (36): DMTLocal, ndarray, Predict creep strain., Fit to SAOS data G*(ω) = G'(ω) + jG''(ω).          Requires include_elasticity=T, Initialize DMTLocal model., Predict complex modulus., Simulate LAOS (Large Amplitude Oscillatory Shear).          Parameters         -, Fit model to data.          Dispatches to protocol-specific fitting method based (+28 more)
 
-### Community 91 - "Community 91"
-Cohesion: 0.06
-Nodes (33): de Souza Mendes-Thompson (DMT) thixotropic models.  This module provides DMT mod, DMTLocal, ndarray, Predict creep strain., Fit to SAOS data G*(ω) = G'(ω) + jG''(ω).          Requires include_elasticity=T, Initialize DMTLocal model., Predict complex modulus., Simulate LAOS (Large Amplitude Oscillatory Shear).          Parameters         - (+25 more)
+### Community 92 - "FluidityLocal"
+Cohesion: 0.03
+Nodes (45): fluidity_local_steady_state(), Compute steady-state flow curve for Local Fluidity model.      At steady state:, FluidityLocal, Any, ndarray, Predict steady-state flow curve (compatibility wrapper)., Simulate transient response using Diffrax ODE integration.          Args:, Predict transient response.          Protocol inputs (``gamma_dot`` for startup, (+37 more)
 
-### Community 92 - "Community 92"
-Cohesion: 0.02
-Nodes (68): fluidity_local_steady_state(), Compute steady-state flow curve for Local Fluidity model.      At steady state:, FluidityLocal, Any, ndarray, Predict steady-state flow curve (compatibility wrapper)., Simulate transient response using Diffrax ODE integration.          Args:, Predict transient response.          Protocol inputs (``gamma_dot`` for startup, (+60 more)
-
-### Community 93 - "Community 93"
+### Community 93 - "__init__.py"
 Cohesion: 0.09
 Nodes (48): Unified fit visualization for NLSQ and Bayesian results.  This module provides t, configure_matplotlib(), Unified plotting and visualization utilities for rheological data.  This module, Configure matplotlib for rheological plotting with proper font handling.      Th, _apply_style(), compute_uncertainty_band(), _filter_positive(), plot_fit_with_uncertainty() (+40 more)
 
-### Community 94 - "Community 94"
+### Community 94 - "TransformPlotter"
 Cohesion: 0.11
 Nodes (31): _ensure_numpy(), Ensure data is a NumPy array for plotting.      Args:         data: Input data a, Any, Axes, Figure, ndarray, RheoData, Generic before/after plot for unrecognized transforms. (+23 more)
 
-### Community 95 - "Community 95"
-Cohesion: 0.06
-Nodes (28): FFTAnalysis, JaxArray, RheoData, Get window function of length n.          Parameters         ----------, Remove linear trend from data.          Parameters         ----------         y, Apply FFT transform to time-domain data.          Parameters         ----------, Apply inverse FFT to return to time domain.          Parameters         --------, Transform time-domain rheological data to frequency domain using FFT.      This (+20 more)
+### Community 95 - "FFTAnalysis"
+Cohesion: 0.08
+Nodes (20): FFTAnalysis, Transform time-domain rheological data to frequency domain using FFT.      This, Initialize FFT Analysis transform.          Parameters         ----------, TestBatchFFT, Test round-trip FFT → inverse FFT., Test detrending functionality., Test suite for FFT Analysis transform., Test peak finding in FFT spectrum. (+12 more)
 
-### Community 96 - "Community 96"
-Cohesion: 0.03
-Nodes (52): Gp(), Frequency-dependent complex modulus for SGR model.      Computes the dimensionle, Partition function for SGR model normalization.      Computes the normalization, Z(), Property-based tests for SGR (Soft Glassy Rheology) models using Hypothesis.  Th, Property-based tests for numerical stability near edge cases., G0 and Gp are numerically stable near x = 1., Gp is numerically stable at extreme frequencies. (+44 more)
+### Community 96 - "TestFrequencyDependentModulus"
+Cohesion: 0.14
+Nodes (8): Test Gp(x, z) frequency-dependent complex modulus., Test SGR Gp physical behavior for 1 < x < 2.          With the corrected Sollich, Test power-law scaling for different x values., Test G''(omega) > G'(omega) at low frequencies (viscous dominance)., Test G'(omega) approaches G0(x) at high frequencies (elastic plateau)., Test vectorized evaluation over frequency array., Test that G' >= 0 and G'' >= 0 for all frequencies., TestFrequencyDependentModulus
 
-### Community 97 - "Community 97"
-Cohesion: 0.15
-Nodes (11): PreviewWorker, Any, Path, QObject, QRunnable, Preview Worker =============  Background worker for data file preview loading, Execute file preview in background thread., # NOTE: Cancellation is not implemented for PreviewWorker — the file (+3 more)
+### Community 97 - "PreviewWorker"
+Cohesion: 0.14
+Nodes (13): PreviewWorker, PreviewWorkerSignals, Any, Path, QObject, QRunnable, Preview Worker =============  Background worker for data file preview loading, Execute file preview in background thread. (+5 more)
 
-### Community 98 - "Community 98"
+### Community 98 - "BatchPipeline"
 Cohesion: 0.03
 Nodes (35): BatchPipeline, Apply pipeline to multiple datasets.      This class enables batch processing of, Initialize batch pipeline.          Args:             template_pipeline: Templat, Set template pipeline.          Args:             pipeline: Pipeline to use as t, Clear all results and errors.          Returns:             self for method chai, Get number of processed results., String representation., csv_files() (+27 more)
 
-### Community 99 - "Community 99"
-Cohesion: 0.07
-Nodes (34): hvnm_ber_rate_constant_matrix(), hvnm_creep_compliance_linear(), hvnm_effective_phi(), hvnm_guth_gold(), hvnm_interphase_fraction(), hvnm_interphase_modulus(), hvnm_interphase_stress(), hvnm_permanent_stress_shear() (+26 more)
+### Community 99 - "._predict"
+Cohesion: 0.08
+Nodes (16): Array, JIT-compiled creep prediction: J(t).          Theory: J(t) ~ t^(x-1) for x > 1 (, JIT-compiled steady shear prediction: sigma(gamma_dot).          Theory:, JIT-compiled startup flow prediction: eta_plus(t).          Computes stress grow, JIT-compiled oscillation prediction: G'(omega), G''(omega).          Uses same k, JIT-compiled relaxation prediction: G(t).          Uses power-law form consisten, JIT-compiled viscosity prediction: eta(gamma_dot).          Computes viscosity a, Predict based on fitted test mode.          Routes to appropriate prediction met (+8 more)
 
-### Community 100 - "Community 100"
+### Community 100 - "ITTMCTBase"
 Cohesion: 0.06
-Nodes (28): ITTMCTBase, Any, ndarray, Initialize ITT-MCT base model.          Parameters         ----------         in, Initialize model parameters.          Subclasses must implement this to add para, Compute equilibrium (quiescent) correlator Φ_eq(t).          Parameters, Compute memory kernel m(Φ) from correlator values.          Parameters         -, Internal fit implementation.          Parameters         ----------         X : (+20 more)
+Nodes (29): ITTMCTBase, Any, ndarray, Initialize ITT-MCT base model.          Parameters         ----------         in, Initialize model parameters.          Subclasses must implement this to add para, Compute equilibrium (quiescent) correlator Φ_eq(t).          Parameters, Compute memory kernel m(Φ) from correlator values.          Parameters         -, Internal fit implementation.          Parameters         ----------         X : (+21 more)
 
-### Community 101 - "Community 101"
-Cohesion: 0.04
-Nodes (27): Loop-bridge kinetics model for telechelic polymer networks.      Implements reve, Get network modulus G (Pa)., Get bridge detachment time τ_b (s)., Get loop attachment time τ_a (s)., Get Bell force sensitivity ν (dimensionless)., Get equilibrium bridge fraction f_B_eq (dimensionless)., Get solvent viscosity η_s (Pa·s)., Get effective modulus G_eff = f_B_eq·G (Pa).          This is the linearized mod (+19 more)
+### Community 101 - "TNTLoopBridge"
+Cohesion: 0.10
+Nodes (12): Loop-bridge kinetics model for telechelic polymer networks.      Implements reve, Initialize TNT loop-bridge model., Initialize ParameterSet with loop-bridge parameters.          Parameters:, Get network modulus G (Pa)., Get bridge detachment time τ_b (s)., Get loop attachment time τ_a (s)., Get Bell force sensitivity ν (dimensionless)., Get equilibrium bridge fraction f_B_eq (dimensionless). (+4 more)
 
-### Community 102 - "Community 102"
+### Community 102 - "test_physics.py"
 Cohesion: 0.07
-Nodes (19): Physical validation tests for Giesekus model.  Tests verify that the implement, Tests for physical diagnostic relationships., Test N₂/N₁ → -α/2 at low Wi (zero-shear limit).          In the zero-shear lim, Tests for stress relaxation physics., Test stress decays to zero during relaxation., Test Giesekus relaxes faster than pure exponential.          The quadratic τ·τ, Tests for normal stress physics., Test N₁ increases with shear rate (roughly quadratically at low Wi). (+11 more)
+Nodes (19): Physical validation tests for Giesekus model.  Tests verify that the implement, Tests for physical diagnostic relationships., Test N₂/N₁ → -α/2 at low Wi (zero-shear limit).          In the zero-shear lim, Tests for normal stress physics., Test N₁ increases with shear rate (roughly quadratically at low Wi)., Test N₁ > 0 always (Weissenberg effect)., Tests comparing to literature values., Test α > 0 shows some shear-thinning behavior.          The Giesekus model pre (+11 more)
 
-### Community 103 - "Community 103"
-Cohesion: 0.05
-Nodes (69): BayesianWorker, Worker for running MCMC sampling in background.      Features:         - NUTS sa, Check if job should be cancelled.          Raises         ------         Cancell, FitWorker, Check if job should be cancelled.          Raises         ------         Cancell, Worker for running NLSQ fitting in background.      Features:         - NLSQ opt, _bayesian_work_entry(), _extract_data() (+61 more)
+### Community 103 - "BayesianWorker"
+Cohesion: 0.09
+Nodes (25): BayesianWorker, Worker for running MCMC sampling in background.      Features:         - NUTS sa, Check if job should be cancelled.          Raises         ------         Cancell, _bayesian_work_entry(), _extract_data(), make_bayesian_worker(), Any, Extract x, y, y2, test_mode, metadata from RheoData or DatasetState.      Parame (+17 more)
 
-### Community 104 - "Community 104"
-Cohesion: 0.07
-Nodes (15): MockBayesianModel, Test fit_nlsq with model instance., Test that fit_nlsq stores NLSQ result., Test fit_bayesian with warm-start from NLSQ., Test get_diagnostics returns correct structure., Test complete workflow with method chaining., Test complete workflow: load → fit_nlsq → fit_bayesian → diagnostics., Simple mock model for testing Bayesian pipeline. (+7 more)
+### Community 104 - "MockBayesianModel"
+Cohesion: 0.12
+Nodes (9): MockBayesianModel, Test fit_nlsq with model instance., Test that fit_nlsq stores NLSQ result., Test complete workflow with method chaining., Simple mock model for testing Bayesian pipeline., Test that state is properly managed across method calls., Test that num_chains parameter is exposed and works correctly., Test that multi-chain sampling provides better R-hat estimates. (+1 more)
 
-### Community 105 - "Community 105"
+### Community 105 - "test_epm_kernels_tensorial.py"
 Cohesion: 0.07
 Nodes (51): apply_tensorial_propagator(), compute_hill_stress(), compute_von_mises_stress(), get_yield_criterion(), make_tensorial_propagator_q(), Array, Tensorial kernels for Elasto-Plastic Models (EPM).  This module implements the f, Compute von Mises effective stress for plane strain.      For plane strain: σ_zz (+43 more)
 
-### Community 106 - "Community 106"
+### Community 106 - "PreprocessingResult"
 Cohesion: 0.08
 Nodes (36): check_kramers_kronig(), estimate_eta0(), fit_gel_point(), _preprocess_creep(), _preprocess_flow_curve(), preprocess_for_protocol(), _preprocess_laos(), _preprocess_oscillation() (+28 more)
 
-### Community 107 - "Community 107"
-Cohesion: 0.22
-Nodes (6): get_worker_isolation_mode(), Return the configured worker isolation mode.      Reads the ``RHEOJAX_WORKER_ISO, Run one Pipeline-mode fit step: synchronous NLSQ, then optional NUTS.          N, get_worker_isolation_mode reads RHEOJAX_WORKER_ISOLATION env var., RHEOJAX_WORKER_ISOLATION=thread uses FitWorker directly., TestWorkerIsolationConfig
+### Community 107 - "TestSTZIntegration"
+Cohesion: 0.07
+Nodes (16): Test model_function uses sigma_0 for relaxation initial condition., Test model_function routes creep mode with sigma_applied kwarg., Test model_function routes LAOS mode with gamma_0 and omega., Test model_function raises when test_mode is not set., Test _predict works after setting test_mode., Test that model maintains float64 precision., Test SAOS prediction returns 2-column output., Test that parameter bounds are enforced. (+8 more)
 
-### Community 108 - "Community 108"
+### Community 108 - "test_column_mapping.py"
 Cohesion: 0.08
 Nodes (42): CanonicalField, match_column(), match_columns(), Consolidated canonical column field registry for all I/O readers.  Merges patter, Canonical field descriptor for a rheological measurement column., Match a column header string to a CanonicalField.      Uses :func:`~rheojax.io.r, Match a list of column headers to canonical fields.      Parameters     --------, Tests for the consolidated canonical column field registry. (+34 more)
 
-### Community 109 - "Community 109"
+### Community 109 - "schematic.py"
 Cohesion: 0.07
-Nodes (53): compute_complex_modulus_from_correlator(), clear_solver_cache(), compute_adaptive_t_max(), FlowCurveParams, is_diffrax_available(), _make_batched_solver(), make_flow_curve_vector_field(), make_flow_curve_with_stress_vector_field() (+45 more)
+Nodes (51): compute_complex_modulus_from_correlator(), clear_solver_cache(), compute_adaptive_t_max(), FlowCurveParams, is_diffrax_available(), _make_batched_solver(), make_flow_curve_vector_field(), make_flow_curve_with_stress_vector_field() (+43 more)
 
-### Community 110 - "Community 110"
+### Community 110 - "main"
 Cohesion: 0.13
 Nodes (10): create_parser(), main(), ArgumentParser, Dispatch pipeline management subcommands., Create argument parser for pipeline subcommand., Tests for rheojax.cli.cmd_pipeline — pipeline management subcommand., TestCreateParser, TestMainInit (+2 more)
 
-### Community 111 - "Community 111"
-Cohesion: 0.06
-Nodes (22): Create Zener/SLS model (G_E=0).          Parameters         ----------         G, Create pure vitrimer (G_P=0, G_D=0).          Parameters         ----------, Create partial vitrimer (G_D=0, Meng 2019).          Parameters         --------, Create neo-Hookean elastic solid (G_E=0, G_D=0).          Parameters         ---, Create single Maxwell fluid (G_P=0, G_E=0).          Parameters         --------, hvm_maxwell(), hvm_partial(), hvm_zener() (+14 more)
-
-### Community 112 - "Community 112"
-Cohesion: 0.05
-Nodes (47): Array, Compute mask for selected cycles from time series data.          Parameters, Apply SPP decomposition to LAOS stress data.          Parameters         -------, apparent_cage_modulus(), build_spp_exports(), calculate_loop_energy(), compute_phase_offset(), convert_units() (+39 more)
-
-### Community 113 - "Community 113"
+### Community 111 - "test_hvm.py"
 Cohesion: 0.04
-Nodes (32): dynamic_x_model(), fluid_model(), glass_model(), model(), Extended tests for SGRGeneric model with advanced features.  This module conta, Test eig(M) >= 0 for 2D state., Test W >= 0 for 2D state., Test full thermodynamic verification for 2D state. (+24 more)
+Nodes (36): Create Zener/SLS model (G_E=0).          Parameters         ----------         G, Create pure vitrimer (G_P=0, G_D=0).          Parameters         ----------, Create partial vitrimer (G_D=0, Meng 2019).          Parameters         --------, Create neo-Hookean elastic solid (G_E=0, G_D=0).          Parameters         ---, Create single Maxwell fluid (G_P=0, G_E=0).          Parameters         --------, hvm_default(), hvm_maxwell(), hvm_partial() (+28 more)
 
-### Community 114 - "Community 114"
-Cohesion: 0.27
-Nodes (6): FIKHBase, Setup base FIKH parameters (mechanical + fractional)., Setup thermal coupling parameters., Setup isotropic hardening parameters., Base class for Fractional Isotropic-Kinematic Hardening models.      FIKH models, Initialize FIKHBase model.          Args:             include_thermal: Whether t
+### Community 112 - "spp_kernels.py"
+Cohesion: 0.08
+Nodes (29): calculate_loop_energy(), compute_phase_offset(), convert_units(), differentiate_rate_from_strain(), frenet_serret_frame(), harmonic_reconstruction_full(), harmonic_truncation_robustness(), numerical_derivative_4th_order() (+21 more)
 
-### Community 115 - "Community 115"
+### Community 113 - "TestLAOSAnalysis"
+Cohesion: 0.11
+Nodes (10): Tests for Large Amplitude Oscillatory Shear (LAOS) analysis., Test simulate_laos() returns correct shapes., Test that LAOS output is periodic., Test extract_laos_harmonics() returns required keys., Test that harmonic amplitudes are physically reasonable., Test compute_chebyshev_coefficients() returns required keys., Test Chebyshev coefficients are physically reasonable., Test get_lissajous_curve() output shape and normalization. (+2 more)
+
+### Community 114 - ".connect_signals"
 Cohesion: 0.07
-Nodes (27): Write a template YAML pipeline config., run_init(), get_template(), list_templates(), Path, YAML pipeline templates for ``rheojax pipeline init``.  Each template is a compl, Return the YAML string for a named template.      Args:         name: Template i, Return metadata for all available templates.      Returns:         List of dicts (+19 more)
+Nodes (14): Update the selected pipeline step's config when transform selection changes., Handle set test mode action., Handle model selection., Handle model change from the quick-fit toolbar., Connect state signals to UI updates., Connect File menu actions., Connect Edit menu actions., Connect Data menu actions. (+6 more)
 
-### Community 116 - "Community 116"
-Cohesion: 0.04
-Nodes (46): get_compatible_test_modes(), TestMode, Enumeration of rheological test modes.      Note: Named TestModeEnum (not TestMo, Validate and convert test mode to TestMode enum.      Args:         test_mode: T, Get compatible test modes for a given model.      Queries the ModelRegistry to d, Suggest appropriate models for a given test mode.      Queries the ModelRegistry, Return string representation., Convert inventory Protocol to TestModeEnum. (+38 more)
+### Community 115 - "get_template"
+Cohesion: 0.06
+Nodes (31): Write a template YAML pipeline config., run_init(), get_template(), list_templates(), Path, YAML pipeline templates for ``rheojax pipeline init``.  Each template is a compl, Return the YAML string for a named template.      Args:         name: Template i, Return metadata for all available templates.      Returns:         List of dicts (+23 more)
 
-### Community 117 - "Community 117"
+### Community 116 - "load_trios_chunked"
+Cohesion: 0.10
+Nodes (17): load_trios_chunked(), Load TRIOS file in memory-efficient chunks (generator).      This function reads, Advanced chunked reading tests., Test chunked reading with simulated large file (1000 points)., Test that chunked reading produces same data as full load., Test chunked reading with multiple procedure segments., Test reading only specific segment., Test that NaN values are properly filtered in chunks. (+9 more)
+
+### Community 117 - "AnalysisExporter"
 Cohesion: 0.05
 Nodes (35): AnalysisExporter, Any, Path, Export analysis to a single Excel workbook.          Creates sheets:         - S, Collect all exportable state from a Pipeline., List which sections were populated., Write summary.json and summary.txt., Export pipeline analysis results to structured output.      Supports three expor (+27 more)
 
-### Community 118 - "Community 118"
-Cohesion: 0.10
-Nodes (15): configure_logging(), Configure the RheoJAX logging system.      This function should be called once a, Tests for rheojax.logging.config module., Tests for configuration functions., Test basic configure_logging call., Test configure_logging with file output., Test is_configured returns False initially., Test reset_config clears configuration. (+7 more)
+### Community 118 - "StatusBar"
+Cohesion: 0.07
+Nodes (16): QStatusBar, __getattr__(), Lazy import for application components., Create all UI elements., Register application-wide shortcuts and command palette., Update JAX device and memory status in status bar., QWidget, Update JAX device and memory status.          Parameters         ---------- (+8 more)
 
-### Community 119 - "Community 119"
+### Community 119 - "HVMLocal"
 Cohesion: 0.05
-Nodes (21): HVM (Hybrid Vitrimer Model) package.  Constitutive models for vitrimers with p, HVMLocal, Compute zero-stress BER rate from current parameters., Predict steady-state flow curve.          At steady state, mu^E → mu^E_nat, so s, Predict SAOS storage and loss moduli.          Two Maxwell modes (E, D) plus per, Predict steady-state normal stress differences.          At steady state, E-netw, Extract Fourier harmonics from LAOS simulation.          Parameters         ----, Local (0D) Hybrid Vitrimer Model.      A constitutive model for vitrimers combin (+13 more)
+Nodes (25): HVM (Hybrid Vitrimer Model) package.  Constitutive models for vitrimers with p, HVMLocal, Resolve test_mode from kwarg, cached value, or HVM default.          This is HVM, Compute zero-stress BER rate from current parameters., Predict steady-state flow curve.          At steady state, mu^E → mu^E_nat, so s, Predict SAOS storage and loss moduli.          Two Maxwell modes (E, D) plus per, Predict steady-state normal stress differences.          At steady state, E-netw, Extract Fourier harmonics from LAOS simulation.          Parameters         ---- (+17 more)
 
-### Community 120 - "Community 120"
-Cohesion: 0.08
-Nodes (18): ndarray, Internal LAOS simulation for model_function.          Returns (strain, stress) a, Simulate startup flow at constant shear rate.          Parameters         ------, Simulate stress relaxation after cessation of steady shear.          For constan, Simulate creep deformation under constant stress.          Parameters         --, Simulate Large-Amplitude Oscillatory Shear (LAOS).          Parameters         -, Compute stress overshoot ratio in startup flow.          For constant breakage,, Get relaxation modulus G(t).          For single-mode TNT: G(t) = G·exp(-t/τ_b) (+10 more)
+### Community 120 - "ndarray"
+Cohesion: 0.07
+Nodes (23): ndarray, Internal relaxation simulation for model_function.          For constant breakag, Internal creep simulation for model_function.          Returns accumulated strai, Internal LAOS simulation for model_function.          Returns (strain, stress) a, Simulate startup flow at constant shear rate.          Parameters         ------, Simulate stress relaxation after cessation of steady shear.          For constan, Simulate creep deformation under constant stress.          Parameters         --, Simulate Large-Amplitude Oscillatory Shear (LAOS).          Parameters         - (+15 more)
 
-### Community 121 - "Community 121"
+### Community 121 - "FitResult"
 Cohesion: 0.05
 Nodes (25): Exception, Build a :class:`FitResult` that records a failed fit attempt., FitResult, Any, Root mean squared error, delegated to OptimizationResult., Mean absolute error, delegated to OptimizationResult., Akaike Information Criterion, delegated to OptimizationResult., Bayesian Information Criterion, delegated to OptimizationResult. (+17 more)
 
-### Community 122 - "Community 122"
+### Community 122 - "HVMBase"
 Cohesion: 0.05
-Nodes (24): HVMBase, ndarray, Whether D-network is present., Permanent network modulus (Pa)., Exchangeable network modulus (Pa)., TST attempt frequency (1/s)., Activation energy for BER (J/mol)., Activation volume (m^3/mol). (+16 more)
+Nodes (22): HVMBase, ndarray, Whether D-network is present., Permanent network modulus (Pa)., Exchangeable network modulus (Pa)., TST attempt frequency (1/s)., Activation energy for BER (J/mol)., Activation volume (m^3/mol). (+14 more)
 
-### Community 123 - "Community 123"
+### Community 123 - "_yaml_runner.py"
 Cohesion: 0.08
 Nodes (28): Console, Progress, create_progress(), get_console(), print_error(), print_result(), print_success(), print_table() (+20 more)
 
-### Community 124 - "Community 124"
+### Community 124 - "Envelope"
 Cohesion: 0.08
 Nodes (19): create_data_envelope(), create_fit_envelope(), Envelope, _get_version(), Any, JSON envelope dataclass for stdin/stdout piping between CLI commands.  RheoJAX C, Read an envelope from stdin if stdin is not a terminal.          Returns:, Write the envelope as JSON to stdout.          The newline ensures downstream pr (+11 more)
 
-### Community 125 - "Community 125"
-Cohesion: 0.06
-Nodes (31): Reset the singleton instance (useful for testing)., setup_function(), setup_function(), Any, QApplication, Reset StateStore singleton before each test., Test full workflow integration with Qt widgets., Get or create QApplication instance. (+23 more)
-
-### Community 126 - "Community 126"
-Cohesion: 0.04
-Nodes (64): FitState, DataStep, Shape/NaN/monotonicity checks against a loaded RheoData. Empty = valid., Execute the Hz -> rad/s (x2pi) conversion flagged by needs_hz_conversion()., Derive (contract, label text) from the current state's protocol/model_key., Rebuild contract/label/combo from current state (call after Step 1 edits)., _validate_shape_and_values(), _diagnostics_verdict() (+56 more)
-
-### Community 127 - "Community 127"
-Cohesion: 0.05
-Nodes (37): Any, RheoData, Validate data for transform.          Parameters         ----------         name, Get configurable parameters for transform.          Parameters         ---------, Return display metadata for all transforms.          Returns         -------, Apply transform and return new data.          Parameters         ----------, Compute transform and return plot data for preview.          Parameters, _fit_prony_oscillation() (+29 more)
-
-### Community 128 - "Community 128"
+### Community 125 - "PipelineChips"
 Cohesion: 0.11
-Nodes (15): Distribution, Sequence of Physical Processes (SPP) models.  Contains models for LAOS (Large Am, Array, RheoData, Initialize SPP yield stress model., Predict stress using fitted parameters.          Parameters         ----------, Model function for predictions and Bayesian inference.          This is the NumP, Predict static yield stress for amplitude sweep.          σ_sy(γ_0) = sigma_sy_s (+7 more)
+Nodes (14): PipelineChips, QLabel, Create a chip button for a pipeline step.          Parameters         ----------, Handle chip click.          Parameters         ----------         step : Pipelin, Create an arrow connector between chips.          Returns         -------, Set the status of a pipeline step.          Parameters         ----------, Reset all chips to pending status., Reset all chips to pending status.          Convenience alias for ``reset_all()` (+6 more)
 
-### Community 129 - "Community 129"
+### Community 126 - "FitState"
+Cohesion: 0.04
+Nodes (62): FitState, _make_fit_fn(), Build the real fit_fn NlsqStep.run() calls., NlsqStep, Sync the result label to current state.          Called both after a run and whe, # NOTE: `data_ref` is a str id — the real implementation must:, _diagnostics_verdict(), NutsStep (+54 more)
+
+### Community 127 - "PronyConversion"
 Cohesion: 0.07
-Nodes (28): available_plot_styles(), load_plot_style(), GUI Resources ============  Loader helpers for stylesheets, plot styles, and ico, Return the list of bundled matplotlib style names., Load a matplotlib style file bundled with the GUI.      Falls back to the defaul, _generate_qss(), get_dark_stylesheet(), get_light_stylesheet() (+20 more)
+Nodes (33): _fit_prony_oscillation(), _fit_prony_relaxation(), _prony_to_frequency(), _prony_to_frequency_jax(), _prony_to_time(), _prony_to_time_jax(), PronyConversion, PronyResult (+25 more)
 
-### Community 130 - "Community 130"
+### Community 128 - "SPPYieldStress"
+Cohesion: 0.07
+Nodes (26): Distribution, Sequence of Physical Processes (SPP) models.  Contains models for LAOS (Large Am, Array, ndarray, RheoData, TestMode, Initialize SPP yield stress model., Fit SPP yield stress model to data.          The fitting strategy depends on the (+18 more)
+
+### Community 129 - "get_stylesheet"
+Cohesion: 0.08
+Nodes (22): _generate_qss(), get_dark_stylesheet(), get_light_stylesheet(), get_stylesheet(), _parse_tokens(), RheoJAX GUI Stylesheets.  Provides light and dark themes for the application, al, Generate a complete QSS stylesheet by substituting Python token dicts.      This, Load and return the light theme stylesheet.      Returns     -------     str (+14 more)
+
+### Community 130 - "RheoJaxValidationWarning"
 Cohesion: 0.10
 Nodes (47): Emitted for data quality issues detected during loading or validation.      Subc, Emitted when an optimizer converges but with caveats.      Examples: maximum ite, RheoJaxConvergenceWarning, RheoJaxValidationWarning, _check_creep(), _check_oscillation(), _check_relaxation(), _check_rotation() (+39 more)
 
-### Community 131 - "Community 131"
-Cohesion: 0.04
-Nodes (39): ndarray, Single transient network VLB model (2 params: G0, k_d).      Implements the VLB, Initialize single-network VLB model., Initialize ParameterSet with VLB local parameters.          Parameters:, Get network modulus G0 (Pa)., Get dissociation rate k_d (1/s)., Get relaxation time t_R = 1/k_d (s)., Get zero-shear viscosity eta_0 = G0/k_d (Pa*s). (+31 more)
+### Community 131 - "VLBLocal"
+Cohesion: 0.02
+Nodes (78): Temperature scaling of network modulus.      G0(T) = G0_ref · (T/T_ref)      Bas, Vectorized SAOS moduli over frequency array.      Parameters     ----------, vlb_saos_moduli_vec(), vlb_thermal_modulus(), ndarray, Single transient network VLB model (2 params: G0, k_d).      Implements the VLB, Initialize single-network VLB model., Initialize ParameterSet with VLB local parameters.          Parameters: (+70 more)
 
-### Community 132 - "Community 132"
-Cohesion: 0.08
-Nodes (18): Tests for Giesekus Bayesian inference pipeline.  Tests cover: - NLSQ fitting, Test Bayesian fitting on SAOS data., Tests for NLSQ fitting as Bayesian warm-start., Tests for mode-aware Bayesian inference (v0.4.0 fix)., Test that test_mode is correctly captured for Bayesian., Test NLSQ fitting on flow curve data., Tests for multi-mode Bayesian fitting., Test multi-mode Bayesian on SAOS data. (+10 more)
+### Community 132 - "test_bayesian.py"
+Cohesion: 0.06
+Nodes (22): Tests for Giesekus Bayesian inference pipeline.  Tests cover: - NLSQ fitting, Test Bayesian fitting on SAOS data., Tests for NLSQ fitting as Bayesian warm-start., Tests for mode-aware Bayesian inference (v0.4.0 fix)., Test that test_mode is correctly captured for Bayesian., Test NLSQ fitting on flow curve data., Tests for multi-mode Bayesian fitting., Test multi-mode Bayesian on SAOS data. (+14 more)
 
-### Community 133 - "Community 133"
-Cohesion: 0.09
-Nodes (20): cli_entry(), create_main_parser(), main(), ArgumentParser, RheoJAX CLI main entry point.  This module provides the main CLI dispatcher for, Display package information., Display model and transform inventory., Main CLI entry point. (+12 more)
+### Community 133 - "main"
+Cohesion: 0.07
+Nodes (29): main(), Run Bayesian inference from CLI., main(), Run NLSQ fit from CLI., cli_entry(), create_main_parser(), main(), ArgumentParser (+21 more)
 
-### Community 134 - "Community 134"
+### Community 134 - "Common Patterns"
 Cohesion: 0.05
-Nodes (40): 1. Initialize Store and Signals, 2. Connect Signal Handlers, 3. Load Data, 4. Select Model and Parameters, 5. Store Fit Results, 6. Query State, Advanced Usage, Architecture (+32 more)
+Nodes (41): 1. Initialize Store and Signals, 2. Connect Signal Handlers, 3. Load Data, 4. Select Model and Parameters, 5. Store Fit Results, 6. Query State, Advanced Usage, Architecture (+33 more)
 
-### Community 135 - "Community 135"
+### Community 135 - "Properties"
 Cohesion: 0.05
 Nodes (40): type, description, type, properties, required, type, type, type (+32 more)
 
-### Community 136 - "Community 136"
-Cohesion: 0.07
-Nodes (22): make_ml_ikh_creep_ode_rhs_weighted_sum(), ml_ikh_creep_ode_rhs_weighted_sum(), ml_ikh_flow_curve_steady_state_per_mode(), ml_ikh_flow_curve_steady_state_weighted_sum(), ml_ikh_scan_kernel(), ml_ikh_weighted_sum_kernel(), Multi-mode steady-state flow curve (per-mode yield surfaces).      At steady sta, Multi-mode steady-state flow curve (weighted-sum yield surface).      At steady (+14 more)
+### Community 136 - "._simulate_transient"
+Cohesion: 0.10
+Nodes (13): ml_ikh_scan_kernel(), ml_ikh_weighted_sum_kernel(), Multi-Lambda IKH scan kernel (per-mode yield surfaces).      Each mode has indep, ML-IKH with weighted-sum yield surface.      Single global yield surface: σ_y =, ndarray, Stack per-mode parameters in a single pass.          Reduces repeated dict looku, Predict using parameter dictionary (for NLSQ/Bayesian)., Predict with per-mode yield surfaces. (+5 more)
 
-### Community 137 - "Community 137"
-Cohesion: 0.33
-Nodes (6): parallel_map(), Execute a function over items using process-based parallelism.      Each invocat, Tests for parallel public API., Test parallel_map() generic fan-out., _test_add_one(), TestParallelMap
+### Community 137 - ".model_function"
+Cohesion: 0.10
+Nodes (14): Vectorized multi-network SAOS moduli.      Parameters     ----------     omega_a, vlb_multi_saos_vec(), ndarray, Total modulus: sum G_i + G_e., Zero-shear viscosity: sum G_i/k_d_i + eta_s., Get mode arrays as numpy arrays.          Returns         -------         tuple, Unpack mode parameters from a flat JAX array.          Parameters         ------, Predict response using protocol-aware dispatch.          Parameters         ---- (+6 more)
 
-### Community 138 - "Community 138"
+### Community 138 - "test_fluidity_nlsq_nuts_pipeline.py"
 Cohesion: 0.04
 Nodes (36): flow_curve_data(), oscillation_data(), Validation tests for NLSQ → NUTS pipeline for Fluidity models.  This module vali, Generate synthetic SAOS data (G', G'')., Test NLSQ fitting for FluidityLocal., NLSQ fitting for flow curve should converge., NLSQ fitting for SAOS should converge., Test Bayesian inference for FluidityLocal. (+28 more)
 
-### Community 139 - "Community 139"
+### Community 139 - "ProcessCancellationToken"
 Cohesion: 0.05
-Nodes (24): BaseContext, Exception, ProcessCancellationToken, Event, Store an error that occurred during execution.          Parameters         -----, Get any error that occurred.          Returns         -------         Exception, Wait for cancellation.          Parameters         ----------         timeout :, Cancellation token using multiprocessing.Event for cross-process signaling. (+16 more)
+Nodes (25): BaseContext, Exception, ProcessCancellationToken, Event, Store an error that occurred during execution.          Parameters         -----, Get any error that occurred.          Returns         -------         Exception, Wait for cancellation.          Parameters         ----------         timeout :, Cancellation token using multiprocessing.Event for cross-process signaling. (+17 more)
 
-### Community 141 - "Community 141"
-Cohesion: 0.07
-Nodes (35): DatasetRef, pipeline_context_from_library(), pipeline_inputs_from_library(), Any, Seed a PipelineExecutionService.execute_single_step context from a     Workspace, §11 boundary: feed the legacy pipeline from the new Dataset Library.      Resolv, ExportStep, Path (+27 more)
+### Community 140 - "ResidualsPanel"
+Cohesion: 0.06
+Nodes (23): Figure, ndarray, Connect internal signals., Handle plot type change.          Parameters         ----------         index :, Set data and plot residuals.          Parameters         ----------         y_tr, Set residuals directly.          Parameters         ----------         residuals, Update statistics display., Refresh the current plot. (+15 more)
 
-### Community 142 - "Community 142"
+### Community 141 - "library.py"
+Cohesion: 0.17
+Nodes (12): ExportStep, Path, Write parameters/fitted-curve/provenance (+ posterior, if run) to `directory`., _commit_on_request(), test_save_to_library_stores_fitted_curve_payload(), test_bundle_and_save(), test_save_emits_dataset_commit_requested_with_overwrite_true(), test_save_to_library_reruns_at_same_revision_overwrite() (+4 more)
+
+### Community 142 - "WorkspaceWindow"
 Cohesion: 0.04
-Nodes (65): QMainWindow, DatasetLibraryNotifier, Qt signal carrier for DatasetLibrary mutations.  DatasetLibrary itself stays a p, AppState, Layout helper functions for consistent margins and spacing.  Provides reusable h, InspectorPanel, LibraryRail, StepperCanvas (+57 more)
+Nodes (51): QMainWindow, DatasetLibraryNotifier, Qt signal carrier for DatasetLibrary mutations.  DatasetLibrary itself stays a p, InspectorPanel, LibraryRail, StepperCanvas, AppState, QWidget (+43 more)
 
-### Community 143 - "Community 143"
-Cohesion: 0.07
-Nodes (22): load_anton_paar(), Load RheoCompass CSV export file and return RheoData object(s).      Handles int, Tests for test type auto-detection (US5: T035-T040)., T035: Test auto-detection identifies creep., T036: Test auto-detection identifies relaxation., T037: Test auto-detection identifies oscillation., T038: Test auto-detection identifies rotation., T039: Test explicit test_mode overrides auto-detection. (+14 more)
-
-### Community 144 - "Community 144"
-Cohesion: 0.09
-Nodes (27): compute_credible_band(), generate_diagnostic_suite(), Any, Axes, Figure, ndarray, Path, Render a parameter summary table on a matplotlib axes.          Shows parameter (+19 more)
-
-### Community 145 - "Community 145"
+### Community 143 - ".copy"
 Cohesion: 0.08
-Nodes (16): Physics validation tests for Fluidity-Saramito EVP models.  Tests verify key phy, Test creep bifurcation behavior., Create model for creep tests., Test continuous flow above yield stress., Test arrested flow below yield stress., Test shear banding in nonlocal model., Create nonlocal model., Test nonlocal startup simulation runs. (+8 more)
+Nodes (12): Convert arrays to JAX arrays.          Returns cached result on subsequent calls, Convert arrays to NumPy arrays.          Uses np.asarray() for zero-copy convers, Create a copy of the RheoData.          Returns:             Copy of the RheoDat, Support indexing and slicing., Add two RheoData objects or scalar., Subtract two RheoData objects or scalar., Multiply by scalar or another RheoData., Smooth data using moving average.          Args:             window_size: Size o (+4 more)
 
-### Community 146 - "Community 146"
-Cohesion: 0.05
-Nodes (20): Test limit case: alpha → 0 (purely elastic)., Test limit case: alpha → 1 (classical viscoelastic)., Test that G' and G'' satisfy physical constraints., Test that model works across wide range of time scales., Test that model is sensitive to parameter changes., Test that prediction functions can be JIT compiled., Test suite for FZSL model., Test vectorization with vmap. (+12 more)
-
-### Community 147 - "Community 147"
-Cohesion: 0.07
-Nodes (20): Tests for ITTMCTSchematic (F₁₂) model.  Tests cover: - Parameter initialization, Tests for startup flow predictions., Test stress growth in startup flow., Test stress overshoot in startup (characteristic of MCT)., Tests for creep compliance predictions., Test creep compliance is positive and increasing., Test that glass state creep is bounded., Tests for model fitting. (+12 more)
-
-### Community 148 - "Community 148"
-Cohesion: 0.07
-Nodes (37): main(), RheoJAX GUI Package ==================  Qt-based graphical user interface for Rh, Launch the RheoJAX GUI application.      This is a convenience wrapper that impo, check_dependencies(), _create_workspace_window(), main(), parse_args(), Namespace (+29 more)
-
-### Community 149 - "Community 149"
+### Community 144 - "generate_diagnostic_suite"
 Cohesion: 0.09
-Nodes (44): _compute_complex_modulus(), _compute_compliance(), _compute_relaxation_modulus(), _convert_unit(), _detect_test_type(), _extract_auxiliary_columns(), _extract_geometry_metadata(), _extract_global_metadata() (+36 more)
+Nodes (26): compute_credible_band(), generate_diagnostic_suite(), Any, Axes, Figure, ndarray, Path, Render a parameter summary table on a matplotlib axes.          Shows parameter (+18 more)
 
-### Community 150 - "Community 150"
+### Community 145 - "test_physics.py"
+Cohesion: 0.08
+Nodes (16): Physics validation tests for Fluidity-Saramito EVP models.  Tests verify key phy, Test overshoot increases with waiting time (TC-019).          The simulate_start, Test shear banding in nonlocal model., Create nonlocal model., Test nonlocal startup simulation runs., Test shear banding detection method., Test banding metrics calculation., Compare minimal vs full coupling behavior. (+8 more)
+
+### Community 146 - "TestFractionalZenerSolidLiquid"
+Cohesion: 0.05
+Nodes (21): Test limit case: alpha → 0 (purely elastic)., Test limit case: alpha → 1 (classical viscoelastic)., Test that G' and G'' satisfy physical constraints., Test that model works across wide range of time scales., Test that model is sensitive to parameter changes., Test that prediction functions can be JIT compiled., Test suite for FZSL model., Test vectorization with vmap. (+13 more)
+
+### Community 147 - "test_schematic.py"
+Cohesion: 0.04
+Nodes (32): Tests for ITTMCTSchematic (F₁₂) model.  Tests cover: - Parameter initialization, Tests for SAOS (G', G'') predictions., Test that oscillation returns valid moduli., Test that glass shows plateau modulus., Tests for startup flow predictions., Test stress growth in startup flow., Test stress overshoot in startup (characteristic of MCT)., Tests for creep compliance predictions. (+24 more)
+
+### Community 148 - "main.py"
+Cohesion: 0.05
+Nodes (45): main(), RheoJAX GUI Package ==================  Qt-based graphical user interface for Rh, Launch the RheoJAX GUI application.      This is a convenience wrapper that impo, check_dependencies(), _create_workspace_window(), main(), parse_args(), Namespace (+37 more)
+
+### Community 149 - "load_anton_paar"
 Cohesion: 0.02
-Nodes (147): Unified analysis exporter for Pipeline results.  Bundles data, model parameters,, Custom exceptions and warnings for the RheoJAX package.  This module defines the, Raised for unrecoverable fit failures.      Examples include optimizer divergenc, Raised for unsupported measurement geometry. RheoJAX is shear-only;     tensile/, RheoJaxFitError, UnsupportedDataError, Unified file I/O for rheological data.  This module provides readers and writers, NumpyJSONEncoder (+139 more)
+Nodes (158): _compute_complex_modulus(), _compute_compliance(), _compute_relaxation_modulus(), _convert_unit(), _create_interval_dataframe(), _create_metadata_sheet(), _detect_decimal_separator(), _detect_encoding() (+150 more)
 
-### Community 151 - "Community 151"
+### Community 150 - "UnsupportedDataError"
+Cohesion: 0.03
+Nodes (108): Custom exceptions and warnings for the RheoJAX package.  This module defines the, Raised for unrecoverable fit failures.      Examples include optimizer divergenc, Raised for unsupported measurement geometry. RheoJAX is shear-only;     tensile/, RheoJaxFitError, UnsupportedDataError, Unified file I/O for rheological data.  This module provides readers and writers, load_hdf5(), _normalize_hdf5_geometry_marker() (+100 more)
+
+### Community 151 - "test_trios_chunked_integrity.py"
 Cohesion: 0.06
 Nodes (38): _aggregate_chunks(), create_synthetic_trios_file(), _get_single_segment(), Path, RheoData, TRIOS chunking integrity validation tests.  This module validates that chunked T, If data is a list, return first element; otherwise return as-is., Synthetic TRIOS file (~250 KB, 1000 points). (+30 more)
 
-### Community 152 - "Community 152"
+### Community 152 - "ndarray"
 Cohesion: 0.14
 Nodes (12): ndarray, Predict SAOS moduli (Maxwell, analytical).          In the linear regime, Bell r, Predict steady-state first normal stress difference N1.          For Bell breaka, Simulate startup shear.          Parameters         ----------         t : np.nd, Simulate stress relaxation after cessation of flow.          Parameters, Simulate creep (stress-controlled).          Parameters         ----------, Simulate Large Amplitude Oscillatory Shear (LAOS).          Parameters         -, Predict steady-state extensional stress.          For FENE-P, extensional stress (+4 more)
 
-### Community 153 - "Community 153"
-Cohesion: 0.07
-Nodes (22): ExportPage, Any, Export specific results to file.          Parameters         ----------, Export plot to file.          Parameters         ----------         plot_id : st, Preview export without writing files.          Parameters         ----------, Batch export multiple items.          Parameters         ----------         expo, Handle data format selection change., Handle figure format selection change. (+14 more)
+### Community 153 - "ExportPage"
+Cohesion: 0.06
+Nodes (30): ExportWorker, ExportWorkerSignals, Any, QObject, QRunnable, Export Worker =============  Background worker for export operations (R13-GUI-00, Signals for ExportWorker.      Signals     -------     completed : Signal(list), Worker for performing exports in a background thread.      Parameters     ------ (+22 more)
 
-### Community 154 - "Community 154"
-Cohesion: 0.03
-Nodes (76): inference_data_from_dict(), Utilities for safely importing optional ArviZ dependency., Build inference data across the ArviZ 0.x and 1.x dictionary APIs.      ``groups, Whether the optimizer converged successfully., Diagnostics Page ===============  MCMC diagnostics and posterior analysis with A, Export Page ==========  Result export interface with format selection and batch, BayesianService, Any (+68 more)
+### Community 154 - ".export_data"
+Cohesion: 0.12
+Nodes (14): Any, Figure, Path, RheoData, Export figure to file.          Parameters         ----------         fig : Figu, Convert metadata values to JSON-serializable types., Export posterior samples.          Parameters         ----------         result, Write NUTS posterior samples to NetCDF via ArviZ InferenceData.          `result (+6 more)
 
-### Community 155 - "Community 155"
-Cohesion: 0.07
-Nodes (23): get_config(), LogConfig, Create configuration from environment variables.          Reads the following en, Get the effective log level for a logger.          Args:             logger_name, Get the current logging configuration.      Returns:         Current LogConfig i, RheoJAX logging configuration.      Attributes:         level: Global log level, Validate configuration after initialization., Test from_env with custom log file. (+15 more)
-
-### Community 156 - "Community 156"
+### Community 155 - "LogConfig"
 Cohesion: 0.05
-Nodes (35): extract_frequency_features(), ndarray, Template method defining initialization algorithm.          This method enforces, Common validation logic for extracted features.          Parameters         ----, Estimate all model-specific parameters from frequency features.          Subclas, Extract features from frequency-domain complex modulus data.      Analyzes frequ, Set clipped parameters in the ParameterSet.          Subclasses implement this m, create_mock_param_set() (+27 more)
+Nodes (34): _apply_config(), get_config(), LogConfig, LogFormat, Create configuration from environment variables.          Reads the following en, Get the effective log level for a logger.          Args:             logger_name, Get the current logging configuration.      Returns:         Current LogConfig i, Available log output formats. (+26 more)
 
-### Community 157 - "Community 157"
+### Community 156 - "extract_frequency_features"
+Cohesion: 0.07
+Nodes (20): extract_frequency_features(), ndarray, Template method defining initialization algorithm.          This method enforces, Common validation logic for extracted features.          Parameters         ----, Estimate all model-specific parameters from frequency features.          Subclas, Extract features from frequency-domain complex modulus data.      Analyzes frequ, Set clipped parameters in the ParameterSet.          Subclasses implement this m, Test feature extraction with complex modulus data. (+12 more)
+
+### Community 157 - "ArrayLike"
 Cohesion: 0.09
 Nodes (17): ArrayLike, ndarray, Fit model parameters to data using protocol-aware optimization.          Args:, Fit to steady-state flow curve data., Fit using ODE formulation (for creep/relaxation)., Fit using return mapping formulation (for startup/LAOS)., Fit to oscillatory data (SAOS).          Supports two modes:         1. Frequenc, Fit to frequency-domain SAOS data using Maxwell analytical expressions. (+9 more)
 
-### Community 158 - "Community 158"
+### Community 158 - "ITTMCTIsotropic"
 Cohesion: 0.02
-Nodes (84): ITTMCTIsotropic, Any, ndarray, Predict stress relaxation after flow cessation.          Parameters         ----, Predict LAOS stress response.          Parameters         ----------         t :, Extract Fourier harmonics from LAOS response.          Parameters         ------, Static model function for Bayesian inference.          NOTE: Bayesian inference, Return string representation. (+76 more)
+Nodes (75): ITTMCTIsotropic, Any, ndarray, Predict stress relaxation after flow cessation.          Parameters         ----, Predict LAOS stress response.          Parameters         ----------         t :, Extract Fourier harmonics from LAOS response.          Parameters         ------, Static model function for Bayesian inference.          NOTE: Bayesian inference, Return string representation. (+67 more)
 
-### Community 159 - "Community 159"
-Cohesion: 0.09
-Nodes (12): Test stretch_creation breakage variant adds kappa., Test Bell + FENE combined variant has correct parameters., Tests for model instantiation and parameters., Test model instantiates with default parameters., Test parameters can be set., Test derived properties are computed correctly., Test Weissenberg and Deborah number computations., Test constant breakage model has exactly 3 parameters. (+4 more)
+### Community 159 - "TNTSingleMode"
+Cohesion: 0.07
+Nodes (20): Single-mode Transient Network Theory model.      Implements the Green-Tobolsky /, Get network modulus G (Pa)., Get bond lifetime τ_b (s)., Get solvent viscosity η_s (Pa·s)., Get zero-shear viscosity η₀ = G·τ_b + η_s (Pa·s)., Get slip parameter ξ., Whether this is the basic (constant/linear/UC) variant., TNTSingleMode (+12 more)
 
-### Community 160 - "Community 160"
-Cohesion: 0.09
-Nodes (30): chi_evolution_langer2008(), lambda_evolution(), m_evolution(), plastic_rate(), ndarray, rate_factor_C(), JAX-accelerated physics kernels for STZ model.  This module implements the core, Compute effective temperature evolution d(chi)/dt.      Follows Langer (2008) fo (+22 more)
+### Community 160 - "ExportOptionsDialog"
+Cohesion: 0.11
+Nodes (13): ExportOptionsDialog, Any, QWidget, Load current options into UI., Handle data format radio button change., Handle figure format radio button change., Handle option change., Handle dialog accepted. (+5 more)
 
-### Community 161 - "Community 161"
+### Community 161 - "test_sgr_parity.py"
 Cohesion: 0.07
 Nodes (28): laos_params(), Parity tests: SGRGeneric vs SGRConventional feature comparison.  This module v, Test banded flow prediction matches between models., Parity tests for LAOS analysis., Test I3/I1 harmonic ratio matches within 2% tolerance., Test fundamental amplitude I1 matches between models., Test Chebyshev coefficients match between models., Parity tests for thixotropic stress transients. (+20 more)
 
-### Community 162 - "Community 162"
+### Community 162 - "physics_checks.py"
 Cohesion: 0.07
 Nodes (37): Any, Run physics validation and emit warnings for violations.          Args:, Emitted for post-fit physics violations.      Examples: negative moduli, fractio, RheoJaxPhysicsWarning, _build_param_map(), _check_chebyshev_e1(), check_fit_physics(), _check_fractional_orders() (+29 more)
 
-### Community 163 - "Community 163"
-Cohesion: 0.04
-Nodes (38): Fluidity Models for yield-stress fluids.  This package provides fluidity-based c, FluiditySaramitoBase, Get initial fluidity value based on waiting time.          For aged samples (t_w, Get effective yield stress based on coupling mode.          Parameters         -, Base class for Fluidity-Saramito EVP models.      Implements shared parameter ma, Get characteristic relaxation time λ = 1/(G*f_age).          This is the relaxat, Get Deborah number De = λ * ω (for oscillatory tests).          Returns, Get Weissenberg number Wi = λ * γ̇ (for steady/startup tests).          Returns (+30 more)
+### Community 163 - "FluiditySaramitoNonlocal"
+Cohesion: 0.05
+Nodes (35): Fluidity Models for yield-stress fluids.  This package provides fluidity-based c, FluiditySaramitoBase, Get initial fluidity value based on waiting time.          For aged samples (t_w, Get effective yield stress based on coupling mode.          Parameters         -, Base class for Fluidity-Saramito EVP models.      Implements shared parameter ma, Get characteristic relaxation time λ = 1/(G*f_age).          This is the relaxat, Get Deborah number De = λ * ω (for oscillatory tests).          Returns, Get Weissenberg number Wi = λ * γ̇ (for steady/startup tests).          Returns (+27 more)
 
-### Community 164 - "Community 164"
-Cohesion: 0.12
-Nodes (32): Any, Hébraud–Lequeux (HL) Model implementation.  This module implements the Hébraud–L, Model function for Bayesian inference (NumPyro NUTS).          Args:, Predict response using fitted parameters and stored test_mode., _compute_dt_and_steps_for_rate(), creep_kernel(), flow_curve_kernel(), HLState (+24 more)
-
-### Community 165 - "Community 165"
+### Community 164 - "hebraud_lequeux.py"
 Cohesion: 0.09
-Nodes (16): GeneralizedMaxwell, Initialize Generalized Maxwell Model.          Args:             n_modes: Number, Extract diagnostics from NLSQ OptimizationResult.          Args:             nls, Classify NLSQ convergence quality.          Args:             diagnostics: Dicti, Construct Bayesian priors based on NLSQ convergence classification.          Arg, Get discrete relaxation spectrum (G_i, τ_i).          Returns:             Dicti, Get element minimization diagnostics.          Returns:             Dictionary w, Generalized Maxwell Model with N exponential relaxation modes.      The GMM uses (+8 more)
+Nodes (41): Hébraud–Lequeux (HL) Model implementation.  This module implements the Hébraud–L, Model function for Bayesian inference (NumPyro NUTS).          Args:, _compute_dt_and_steps_for_rate(), creep_kernel(), flow_curve_kernel(), HLGrid, HLState, laos_kernel() (+33 more)
 
-### Community 166 - "Community 166"
-Cohesion: 0.10
-Nodes (13): MastercurvePipeline, Load datasets in parallel using threads (I/O-safe)., Merge multiple datasets with temperature metadata.          Args:             da, Apply horizontal shift to create mastercurve.          This implements a simplif, Get computed shift factors.          Returns:             Dictionary mapping tem, Pipeline for time-temperature superposition analysis.      This pipeline automat, Execute mastercurve workflow.          Args:             file_paths: List of dat, Tests for parallel file loading in MastercurvePipeline. (+5 more)
+### Community 165 - "GeneralizedMaxwell"
+Cohesion: 0.07
+Nodes (20): GeneralizedMaxwell, Extract diagnostics from NLSQ OptimizationResult.          Args:             nls, Classify NLSQ convergence quality.          Args:             diagnostics: Dicti, Construct Bayesian priors based on NLSQ convergence classification.          Arg, Get discrete relaxation spectrum (G_i, τ_i).          Returns:             Dicti, Get element minimization diagnostics.          Returns:             Dictionary w, Generalized Maxwell Model with N exponential relaxation modes.      The GMM uses, Multi-mode rheological models.  Contains models with multiple relaxation modes: (+12 more)
 
-### Community 167 - "Community 167"
-Cohesion: 0.14
-Nodes (14): Fit SPPYieldStress model to extracted yield stresses.          Args:, Get full SPP results for a specific amplitude.          Args:             gamma_, Get nonlinearity metrics (I3/I1, S, T) for each amplitude.          Returns:, Pipeline for SPP analysis of amplitude sweep LAOS data.      This pipeline perfo, SPPAmplitudeSweepPipeline, _make_dataset(), Lightweight integration test for SPP amplitude sweep pipeline., End-to-end pipeline with Bayesian fit (tiny samples for speed). (+6 more)
+### Community 166 - "MastercurvePipeline"
+Cohesion: 0.09
+Nodes (14): MastercurvePipeline, Load datasets sequentially., Load datasets in parallel using threads (I/O-safe)., Merge multiple datasets with temperature metadata.          Args:             da, Apply horizontal shift to create mastercurve.          This implements a simplif, Get computed shift factors.          Returns:             Dictionary mapping tem, Pipeline for time-temperature superposition analysis.      This pipeline automat, Execute mastercurve workflow.          Args:             file_paths: List of dat (+6 more)
 
-### Community 168 - "Community 168"
+### Community 167 - "SPPAmplitudeSweepPipeline"
+Cohesion: 0.08
+Nodes (20): Any, Initialize SPP amplitude sweep pipeline.          Args:             omega: Angul, Fit SPPYieldStress model to extracted yield stresses.          Args:, Get full SPP results for a specific amplitude.          Args:             gamma_, Get fitted SPPYieldStress model.          Returns:             Fitted model or N, Get nonlinearity metrics (I3/I1, S, T) for each amplitude.          Returns:, Initialize model comparison pipeline.          Args:             models: List of, Initialize mastercurve pipeline.          Args:             reference_temp: Refe (+12 more)
+
+### Community 168 - "auto_p0.py"
 Cohesion: 0.10
 Nodes (37): _bounds_midpoint(), _clamp_to_bounds(), _compute_data_features(), _est_eta_0(), _est_modulus(), _est_prony_modulus(), _est_prony_tau(), _est_tau() (+29 more)
 
-### Community 169 - "Community 169"
+### Community 169 - "VLB Model Equation Verification"
 Cohesion: 0.05
 Nodes (40): 10. Creep Compliance, 11. Bell Model Force-Dependent Dissociation, 12. FENE-P Finite Extensibility, 1. Distribution Tensor Evolution Equation, 2. Cauchy Stress, 3. Free Energy, 4. Dissipation, 5. Simple Shear Flow Components (+32 more)
 
-### Community 170 - "Community 170"
+### Community 170 - "test_priors.py"
 Cohesion: 0.08
 Nodes (34): adapt_prior(), map_centered_priors(), Prior format conversion utilities.  Converts between PriorsEditor's ``{"distribu, Convert one PriorsEditor entry to the ``prior_dict_to_dist`` format.      Parame, Build LogNormal priors centered on MAP values plus a HalfNormal sigma prior., Tests for rheojax.gui.foundation.priors., Empty MAP estimate → only sigma key., Passthrough: lognormal params survive unchanged. (+26 more)
 
-### Community 171 - "Community 171"
+### Community 171 - "ITT-MCT Literature Review: Key Equations"
 Cohesion: 0.05
 Nodes (37): 1.1 Density correlator, 1.2 Full MCT equation of motion (underdamped), 1.3 Full MCT memory kernel (microscopic), 1.4 Overdamped (Brownian/colloidal) limit, 1. Equilibrium MCT (No Flow), 2.1 Schematic equation of motion, 2.2 Schematic memory kernel, 2.3 Glass transition criterion (+29 more)
 
-### Community 172 - "Community 172"
-Cohesion: 0.07
-Nodes (30): _apply_config(), LogFormat, Available log output formats., Apply configuration to the Python logging system.      Args:         config: Log, Colors, DetailedFormatter, get_formatter(), JSONFormatter (+22 more)
-
-### Community 173 - "Community 173"
-Cohesion: 0.07
-Nodes (22): _FailingBayesianModel, Regression tests for Round 9 RCA (2026-02-25) prevention.  Guards against the, ISM predict(oscillation, return_components=True) → (N, 2)., Guard: _test_mode must persist after successful fit_bayesian., After successful fit_bayesian, _test_mode must NOT be deleted., After failed fit_bayesian, state must be reverted., Guard: SGR LAOS _predict must build monotonic time grid for interp., SGR LAOS predict should return finite stress (not NaN from bad interp). (+14 more)
-
-### Community 174 - "Community 174"
+### Community 172 - "formatters.py"
 Cohesion: 0.08
-Nodes (29): ndarray, RheoData, Initialize SPP decomposer transform.          Parameters         ----------, SPP decomposition transform for LAOS stress analysis.      Applies the Sequence, Get computed SPP analysis results.          Returns         -------         dict, Get static and dynamic yield stresses.          Returns         -------, Get nonlinearity quantification metrics.          Returns         -------, String representation of transform. (+21 more)
+Nodes (26): Colors, DetailedFormatter, get_formatter(), JSONFormatter, Any, Formatter, LogRecord, RheoJAX Log Formatters.  Custom formatters for human-readable, detailed, JSON, a (+18 more)
 
-### Community 175 - "Community 175"
+### Community 173 - "layout_helpers.py"
+Cohesion: 0.12
+Nodes (16): QLayout, QStackedWidget, QWidget, Layout helper functions for consistent margins and spacing.  Provides reusable h, Set all splitter panes to equal proportional sizes.      Uses the ``[10000, 1000, Apply standard page-level margins (PAGE_MARGIN on all sides).      Use for top-l, Apply compact margins for dense content areas.      Sets XS (4 px) margins on al, Apply toolbar-appropriate margins.      Uses SM (8 px) on the left/right sides a (+8 more)
+
+### Community 174 - "SPPDecomposer"
+Cohesion: 0.11
+Nodes (24): Initialize SPP decomposer transform.          Parameters         ----------, SPP decomposition transform for LAOS stress analysis.      Applies the Sequence, Get static and dynamic yield stresses.          Returns         -------, Get nonlinearity quantification metrics.          Returns         -------, String representation of transform., SPPDecomposer, _make_multi_cycle_data(), _make_rheodata() (+16 more)
+
+### Community 175 - "RheoJAX GUI Smoke Tests"
 Cohesion: 0.06
 Nodes (35): Adding New Tests, All GUI smoke tests, Architecture, CI/CD Integration, Development Workflow, Display-related errors, Example, Expected CI Output (+27 more)
 
-### Community 176 - "Community 176"
+### Community 176 - "_make_fit_result"
 Cohesion: 0.09
 Nodes (14): _make_fit_result(), _make_optimization_result(), FitResult, Tests for FitResult, ModelInfo, and ModelComparison (Phase 1).  Tests cover: - F, Tests for summary and formatting methods., Tests for save/load round-trips., Smoke tests for plotting., Create a realistic OptimizationResult for testing. (+6 more)
 
-### Community 177 - "Community 177"
-Cohesion: 0.06
-Nodes (22): power_law_exponent(), Theoretical power-law exponent for SGR model.      For 1 < x < 2, the SGR model, Power-law exponent equals x - 1 in viscoelastic regime., Tests for SGRConventional model structure.  This test module validates the core, Test amplitude sweep transition from linear to nonlinear., Test suite for SGRConventional prediction methods (Task Group 3)., Test G'(omega) and G''(omega) physical behavior for SGR model.          With the, G(t) must decay as t^(1-x) for 1 < x < 2 (SGR relaxation exponent).          Reg (+14 more)
+### Community 177 - "SGRConventional"
+Cohesion: 0.02
+Nodes (49): Initialize SGR Conventional Model.          Creates ParameterSet with:         -, Determine material phase regime from noise temperature x.          The SGR model, Compute steady-state effective temperature x_ss(gamma_dot).          The steady-, Evolve effective temperature x(t) via ODE integration.          Integrates the e, Extract Fourier harmonics from LAOS stress response.          Performs FFT analy, Compute Chebyshev decomposition of LAOS response.          Decomposes stress int, Enable thixotropy modeling with structural parameter lambda(t).          Adds th, Detect shear banding from constitutive curve.          Computes the steady-state (+41 more)
 
-### Community 178 - "Community 178"
-Cohesion: 0.07
-Nodes (18): _coerce_ndarray(), ArrayLike, ndarray, Ensure data is a proper array., Validate data for common issues., Convert any array-like input to a NumPy array for scalar ops., Number of dimensions of y data., Check if y data is complex. (+10 more)
+### Community 178 - "_coerce_ndarray"
+Cohesion: 0.14
+Nodes (10): _coerce_ndarray(), ArrayLike, Ensure data is a proper array., Validate data for common issues., Convert any array-like input to a NumPy array for scalar ops., Number of dimensions of y data., Check if y data is complex., Interpolate data to new x values.          Args:             new_x: New x values (+2 more)
 
-### Community 179 - "Community 179"
-Cohesion: 0.07
-Nodes (44): TransformController, SlotSpec, transform_slots(), Rebuild slot specs + selector widgets from the current transform_key.          A, SlotsStep, build_transform_controller(), infer_output_protocol(), _is_same_domain() (+36 more)
+### Community 179 - "transform_controller.py"
+Cohesion: 0.08
+Nodes (36): Run one Pipeline-mode transform step against its sole primary slot.          Nam, TransformController, SlotSpec, transform_slots(), build_transform_controller(), infer_output_protocol(), _is_same_domain(), _make_run_fn() (+28 more)
 
-### Community 180 - "Community 180"
-Cohesion: 0.07
-Nodes (18): PlotPanel, Any, Figure, Multi-View Widget ================  Multiple synchronized plot panels for compar, Get matplotlib figure.          Returns         -------         Figure, Get matplotlib canvas.          Returns         -------         FigureCanvasQTAg, Handle layout change.          Parameters         ----------         index : int, Set grid layout.          Parameters         ----------         layout_id : str (+10 more)
+### Community 180 - "MultiView"
+Cohesion: 0.05
+Nodes (27): FigureCanvasQTAgg, Open MultiView dialog overlaying fit curves for the active dataset., MultiView, PlotPanel, Any, Figure, Get matplotlib figure.          Returns         -------         Figure, Get matplotlib canvas.          Returns         -------         FigureCanvasQTAg (+19 more)
 
-### Community 181 - "Community 181"
+### Community 181 - "PriorsEditor"
 Cohesion: 0.08
 Nodes (20): PriorsEditor, Any, ndarray, Connect internal signals., Set model parameters to configure priors for.          Parameters         ------, Rebuild the parameter table., Handle table selection change., Load prior settings to editor panel.          Parameters         ---------- (+12 more)
 
-### Community 182 - "Community 182"
+### Community 182 - "ndarray"
+Cohesion: 0.18
+Nodes (6): ndarray, Initialize parameters from SAOS data.          Uses the crossover frequency an, Initialize parameters from flow curve data.          Parameters         -----, Initialize parameters from stress-relaxation data.          Sets G ≈ G(t=0) an, Generic warm-start for startup/creep/LAOS time-domain protocols.          Sets, Return equilibrium conformation tensor S_eq = I.          In the absence of fl
+
+### Community 183 - "ndarray"
 Cohesion: 0.06
-Nodes (19): ndarray, Compute stretch ratio from conformation tensor.          stretch = sqrt(tr(S)/, Compute Weissenberg number Wi = τ_b·γ̇.          Parameters         ---------, Compute Deborah number De = τ_b·ω.          Parameters         ----------, Get all parameters as a dictionary.          Returns         -------, Set parameters from a dictionary.          Parameters         ----------, Initialize parameters from SAOS data.          Uses the crossover frequency an, Initialize parameters from flow curve data.          Parameters         ----- (+11 more)
+Nodes (21): ndarray, Compute steady-state [f_B, S] via ODE.          Returns array of shape (N, 5) wi, Internal startup simulation for model_function.          Returns total shear str, Internal relaxation simulation for model_function.          Returns relaxing str, Internal creep simulation for model_function.          Returns accumulated strai, Internal LAOS simulation for model_function.          Returns (strain, stress) a, Predict steady shear stress and viscosity.          Parameters         ---------, Predict SAOS storage and loss moduli.          In the linear regime, loop-bridge (+13 more)
 
-### Community 183 - "Community 183"
-Cohesion: 0.07
-Nodes (22): _loop_bridge_creep_ode_rhs(), _loop_bridge_laos_ode_rhs(), _loop_bridge_ode_rhs(), _loop_bridge_relaxation_ode_rhs(), ndarray, ODE right-hand side for loop-bridge dynamics.      State: [f_B, S_xx, S_yy, S_zz, Compute steady-state [f_B, S] via ODE.          Returns array of shape (N, 5) wi, Predict steady shear stress and viscosity.          Parameters         --------- (+14 more)
+### Community 184 - "TNTMultiSpecies"
+Cohesion: 0.10
+Nodes (14): Simulate stress relaxation after cessation of steady shear.          Analytical, Initialize multi-species TNT model.          Parameters         ----------, Get relaxation modulus G(t).          For multi-species TNT: G(t) = Σ G_i·exp(-t, Return string representation., Initialize ParameterSet with 2N+1 parameters.          Parameters are organized, Get number of bond species N., Get G_modes and tau_modes as JAX arrays.          Returns         -------, Get solvent viscosity η_s (Pa·s). (+6 more)
 
-### Community 184 - "Community 184"
-Cohesion: 0.09
-Nodes (14): ndarray, Simulate stress relaxation after cessation of steady shear.          Analytical, Get relaxation modulus G(t).          For multi-species TNT: G(t) = Σ G_i·exp(-t, Extract Fourier harmonics from LAOS stress response.          Parameters, Return string representation., Initialize parameters from creep data for numerical stability.          For mult, Initialize parameters from stress relaxation data.          Parameters         -, Get G_modes and tau_modes as JAX arrays.          Returns         ------- (+6 more)
-
-### Community 185 - "Community 185"
+### Community 185 - "test_notebook_execution_consistency.py"
 Cohesion: 0.12
 Nodes (33): _allowlist_matches(), check_notebook(), _is_fit_cell(), _load_allowlist(), main(), Path, Return the set of repo-relative paths listed in *path* (POSIX style).      Lines, True if *nb_path* matches any entry in *allowed*. (+25 more)
 
-### Community 186 - "Community 186"
+### Community 186 - "TestAdvancedNotebooks"
 Cohesion: 0.06
 Nodes (19): Test advanced workflow notebooks (custom models, batch processing, GPU, etc.), Verify advanced notebooks directory exists and has expected structure., Test advanced workflow notebooks (Phase 4)., Verify multi-technique fitting notebook exists., Execute multi-technique fitting notebook without errors., Validate parameter consistency across test modes., Verify batch processing notebook exists., Execute batch processing notebook without errors. (+11 more)
 
-### Community 187 - "Community 187"
+### Community 187 - "run_fit_isolated"
 Cohesion: 0.08
-Nodes (31): Residual vector from the fit., bfmi(), param_uncertainties(), Result Metrics ==============  Pure numerical functions for post-fit quality met, Reduced chi-squared goodness-of-fit statistic.      Parameters     ----------, Parameter 1-sigma uncertainties from a covariance matrix.      Parameters     --, Energy Bayesian Fraction of Missing Information (E-BFMI).      Computed as ``mea, reduced_chi_squared() (+23 more)
+Nodes (33): Whether the optimizer converged successfully., Residual vector from the fit., bfmi(), param_uncertainties(), Result Metrics ==============  Pure numerical functions for post-fit quality met, Reduced chi-squared goodness-of-fit statistic.      Parameters     ----------, Parameter 1-sigma uncertainties from a covariance matrix.      Parameters     --, Energy Bayesian Fraction of Missing Information (E-BFMI).      Computed as ``mea (+25 more)
 
-### Community 188 - "Community 188"
-Cohesion: 0.08
-Nodes (18): Any, ndarray, Predict stress relaxation after flow cessation.          Parameters         ----, Predict LAOS stress response.          Parameters         ----------         t :, Extract Fourier harmonics from LAOS response.          Parameters         ------, Static model function for Bayesian inference.          NOTE: Bayesian inference, Invalidate Prony cache if physics parameters changed.          Tracks (v1, v2, G, Return string representation. (+10 more)
+### Community 188 - "ndarray"
+Cohesion: 0.07
+Nodes (20): Any, ndarray, Predict stress relaxation after flow cessation.          Parameters         ----, Predict LAOS stress response.          Parameters         ----------         t :, Extract Fourier harmonics from LAOS response.          Parameters         ------, Static model function for Bayesian inference.          NOTE: Bayesian inference, Invalidate Prony cache if physics parameters changed.          Tracks (v1, v2, G, Return string representation. (+12 more)
 
-### Community 189 - "Community 189"
-Cohesion: 0.03
-Nodes (46): Tests for HVM (Hybrid Vitrimer Model).  Test organization: - TestHVMCreation:, Steady-state flow curve behavior., E-network stress → 0 at steady state (vitrimer signature)., D-network viscous stress dominates flow curve., Stress increases monotonically with shear rate., Low shear rate: Newtonian behavior sigma = eta*gamma_dot., Components dict has expected keys., Transient startup shear. (+38 more)
+### Community 189 - "TestHVMStartup"
+Cohesion: 0.14
+Nodes (8): Transient startup shear., Short-time slope = G_tot * gamma_dot., No NaN in startup stress., return_full gives dict with expected keys., Stress is positive for positive gamma_dot., Stress increases initially (elastic loading)., Accumulated strain increases linearly at gamma_dot*t., TestHVMStartup
 
-### Community 190 - "Community 190"
-Cohesion: 0.08
-Nodes (13): Add a shared parameter.          Args:             name: Parameter name, Link a parameter set to a shared parameter.          Args:             param_set, Set shared parameter value.          Args:             name: Parameter name, Validate value against all constraints.          Args:             value: Value, Add a parameter to the set.          Args:             name: Parameter name, Set parameter value.          Args:             name: Parameter name, Set bounds for a parameter.          Args:             name: Parameter name, Get all parameter values as array.          Returns:             Array of parame (+5 more)
+### Community 190 - "BaseArviZWidget"
+Cohesion: 0.12
+Nodes (12): BaseArviZWidget, Any, Figure, Base class for widgets that embed ArviZ figures.      Provides a standardized pr, Initialize base widget.          Parameters         ----------         parent :, Release matplotlib resources before Qt widget deletion.          Prevents segfau, Cancel pending matplotlib draws before the widget is closed., Thread-safe figure replacement with proper cleanup.          This method handles (+4 more)
 
-### Community 191 - "Community 191"
+### Community 191 - "TestDMTRegistry"
 Cohesion: 0.25
 Nodes (5): Test model registry integration., Test DMTLocal is in registry., Test DMTNonlocal is in registry., Test creating models via registry., TestDMTRegistry
 
-### Community 192 - "Community 192"
-Cohesion: 0.11
-Nodes (30): Initialize the Lattice EPM.          See ``EPMBase.__init__`` for the descriptio, compute_plastic_strain_rate(), epm_step(), make_propagator_q(), Array, Kernels for Elasto-Plastic Models (EPM).  This module implements the core physic, Renew yield thresholds for active sites.      Args:         key: PRNG Key., Perform one full EPM time step.      Dynamics:     sigma_dot = mu * gamma_dot - (+22 more)
-
-### Community 193 - "Community 193"
-Cohesion: 0.08
-Nodes (16): FractionalPoyntingThomson, ndarray, Initialize Fractional Poynting-Thomson model., Predict creep compliance J(t).          J(t) = 1/G_e + (1/G_k) * (1 - E_α(-(t/τ), Predict relaxation modulus G(t).          G(t) exhibits stress relaxation from i, Predict complex modulus G*(ω).          Convert from complex compliance:, Predict response for given input.          Parameters         ----------, Model function for Bayesian inference.          This method is required by Bayes (+8 more)
-
-### Community 194 - "Community 194"
-Cohesion: 0.07
-Nodes (19): Manages parameters shared across multiple models., Initialize shared parameter set., Get shared parameter value.          Args:             name: Parameter name, Get models linked to a parameter.          Args:             param_name: Paramet, Create a parameter group.          Args:             group_name: Name for the gr, Get parameters in a group.          Args:             group_name: Group name, Check if shared parameter exists., Get a parameter by name.          Args:             name: Parameter name (+11 more)
-
-### Community 195 - "Community 195"
+### Community 192 - "test_epm_kernels.py"
 Cohesion: 0.09
-Nodes (12): ndarray, Simulate stress relaxation after cessation of steady shear.          Analytical, Simulate creep deformation under constant stress.          Parameters         --, Simulate Large-Amplitude Oscillatory Shear (LAOS).          Parameters         -, Get relaxation modulus G(t).          For Cates model: G(t) = G₀·exp(-t/τ_d), Extract Fourier harmonics from LAOS stress response.          Parameters, Map data-scale estimates to Cates-specific parameter names.          Cates uses, Predict steady shear stress and viscosity.          For Cates model with constan (+4 more)
+Nodes (33): Array, Perform one scalar EPM time step.          Delegates to the `epm_step` kernel fr, Initialize the Lattice EPM.          See ``EPMBase.__init__`` for the descriptio, Initialize scalar stress field.          Args:             key: PRNG key (unused, compute_plastic_strain_rate(), epm_step(), make_propagator_q(), Array (+25 more)
 
-### Community 196 - "Community 196"
-Cohesion: 0.06
-Nodes (41): compute_microscopic_stress(), get_microscopic_stress_prefactor(), prony_decompose_memory(), _prony_leastsq_robust(), _prony_log_spacing(), _prony_multistart(), _prony_residuals(), _prony_smart_init() (+33 more)
+### Community 193 - "FractionalPoyntingThomson"
+Cohesion: 0.13
+Nodes (11): FractionalPoyntingThomson, ndarray, Initialize Fractional Poynting-Thomson model., Predict creep compliance J(t).          J(t) = 1/G_e + (1/G_k) * (1 - E_α(-(t/τ), Predict relaxation modulus G(t).          G(t) exhibits stress relaxation from i, Predict complex modulus G*(ω).          Convert from complex compliance:, Predict response for given input.          Parameters         ----------, Model function for Bayesian inference.          This method is required by Bayes (+3 more)
 
-### Community 197 - "Community 197"
+### Community 194 - "._transform"
+Cohesion: 0.10
+Nodes (18): Array, Compute mask for selected cycles from time series data.          Parameters, Apply SPP decomposition to LAOS stress data.          Parameters         -------, apparent_cage_modulus(), build_spp_exports(), dynamic_yield_stress(), harmonic_reconstruction(), lissajous_metrics() (+10 more)
+
+### Community 195 - "ndarray"
+Cohesion: 0.07
+Nodes (17): ndarray, Simulate stress relaxation after cessation of steady shear.          Analytical, Simulate creep deformation under constant stress.          Parameters         --, Simulate Large-Amplitude Oscillatory Shear (LAOS).          Parameters         -, Get relaxation modulus G(t).          For Cates model: G(t) = G₀·exp(-t/τ_d), Extract Fourier harmonics from LAOS stress response.          Parameters, Map data-scale estimates to Cates-specific parameter names.          Cates uses, Predict response using protocol-aware dispatch.          Parameters         ---- (+9 more)
+
+### Community 196 - "mct_kernels.py"
+Cohesion: 0.04
+Nodes (60): advected_correlator(), advected_memory_decorrelation(), compute_microscopic_stress(), f12_memory_kernel_derivative(), get_microscopic_stress_prefactor(), prony_decompose_memory(), _prony_leastsq_robust(), _prony_log_spacing() (+52 more)
+
+### Community 197 - "Test Data Fixtures for RheoJAX v0.4.0"
 Cohesion: 0.06
 Nodes (32): Adding New Fixtures, Bayesian Mode-Aware Tests, Data Characteristics, Data Formats, Documentation, "File size smaller than target", File Sizes, Files in This Directory (+24 more)
 
-### Community 198 - "Community 198"
+### Community 198 - "RheoJAX Architecture Overview"
 Cohesion: 0.06
 Nodes (32): 1. Float64 Enforcement (MANDATORY), 2. Model Function Bridge, 3. test_mode Kwarg Filtering, 4. Bounds-Constraints Sync, BaseModel (`core/base.py`), BayesianMixin (`core/bayesian.py`), Core Abstractions, Critical Design Invariants (+24 more)
 
-### Community 199 - "Community 199"
+### Community 199 - "BatchPanel"
 Cohesion: 0.08
 Nodes (18): BatchPanel, Open a directory picker and populate the directory field., Scan the directory for files matching the pattern., Emit batch_requested with the current directory, pattern, and file list., Cancel an in-progress batch run., Update the status cell for a single file row.          Parameters         ------, Update the progress bar and status label.          Parameters         ----------, Mark the batch run as complete.          Parameters         ----------         s (+10 more)
 
-### Community 200 - "Community 200"
+### Community 200 - "FractionalMaxwellGel"
 Cohesion: 0.09
-Nodes (18): FractionalMaxwellGel, ndarray, RheoData, Prefer conservative NUTS settings for the stiff Mittag-Leffler kernel., Compute characteristic relaxation time.          Args:             c_alpha: Spri, Predict relaxation modulus G(t) using JAX.          G(t) = c_α t^(-α) E_{1-α,1-α, Predict creep compliance J(t) using JAX.          J(t) = (1/c_α) t^α E_{1+α,1+α}, Predict complex modulus G*(ω) using JAX.          G*(ω) = c_α (iω)^α / (1 + (iωτ (+10 more)
+Nodes (19): FractionalMaxwellGel, ndarray, RheoData, Prefer conservative NUTS settings for the stiff Mittag-Leffler kernel., Compute characteristic relaxation time.          Args:             c_alpha: Spri, Predict relaxation modulus G(t) using JAX.          G(t) = c_α t^(-α) E_{1-α,1-α, Predict creep compliance J(t) using JAX.          J(t) = (1/c_α) t^α E_{1+α,1+α}, Predict complex modulus G*(ω) using JAX.          G*(ω) = c_α (iω)^α / (1 + (iωτ (+11 more)
 
-### Community 201 - "Community 201"
+### Community 201 - "ndarray"
 Cohesion: 0.06
-Nodes (25): ndarray, Fit GMM to creep compliance data.          Args:             t: Time array, Internal creep prediction for optimization.          Args:             t: Time a, Predict based on fitted test mode.          Args:             X: Independent var, JIT-compiled relaxation prediction.          Args:             t: Time array, Predict relaxation modulus E(t).          Args:             t: Time array, JIT-compiled oscillation prediction.          Args:             omega: Angular f, Predict complex modulus in oscillation mode.          Args:             omega: A (+17 more)
+Nodes (27): ndarray, Fit GMM to creep compliance data.          Args:             t: Time array, Internal creep prediction for optimization.          Args:             t: Time a, Predict based on fitted test mode.          Args:             X: Independent var, JIT-compiled relaxation prediction.          Args:             t: Time array, Predict relaxation modulus E(t).          Args:             t: Time array, JIT-compiled oscillation prediction.          Args:             omega: Angular f, Predict complex modulus in oscillation mode.          Args:             omega: A (+19 more)
 
-### Community 202 - "Community 202"
-Cohesion: 0.25
-Nodes (5): Test basic functionality., Test model initialization., Test that a=2 reduces to Carreau model., Test that parameter 'a' affects transition width., TestCarreauYasudaBasics
+### Community 202 - "TestBaseModelEdgeCases"
+Cohesion: 0.10
+Nodes (11): Edge case tests using Maxwell as a concrete model., Predict before fit should use default parameters., Fit with single data point should still work or raise gracefully., Predict with empty array should return empty or raise., Fit with mismatched X and y lengths should raise., Fit with NaN data should raise or handle gracefully., Fit with inf data should raise or handle gracefully., Predict should return same length as input. (+3 more)
 
-### Community 203 - "Community 203"
+### Community 203 - "check_r_hat"
 Cohesion: 0.08
 Nodes (24): check_divergences(), check_ess(), check_posterior_accuracy(), check_r_hat(), Check Gelman-Rubin R-hat convergence diagnostic.      Args:         diagnostics:, Check effective sample size (ESS) diagnostic.      Args:         diagnostics: Di, Check NUTS divergence rate diagnostic.      Args:         diagnostics: Dictionar, Check if posterior mean matches reference within tolerance.      Args:         p (+16 more)
 
-### Community 204 - "Community 204"
+### Community 204 - "TestFrameworkSmoke"
 Cohesion: 0.05
 Nodes (27): ndarray, Smoke tests validating the test framework itself., Verify all framework imports work correctly., Verify examples directory structure exists., Verify tolerance levels are reasonable., Test relative error validation with values that should pass., Test relative error validation with values that should fail., Test array matching with matching arrays. (+19 more)
 
-### Community 205 - "Community 205"
+### Community 205 - "test_migrated_notebooks.py"
 Cohesion: 0.09
 Nodes (26): NotebookNode, convergence_thresholds(), _enable_custom_models_fast_mode(), examples_dir(), expected_parameter_values(), _extract_cell_output(), _extract_fitted_parameters(), _extract_variable_from_output() (+18 more)
 
-### Community 206 - "Community 206"
-Cohesion: 0.07
-Nodes (18): BayesianPipeline, Reset pipeline to initial state.          Clears all data, models, and results i, String representation of Bayesian pipeline., Specialized pipeline for Bayesian rheological analysis workflows.      This clas, Plot posterior distributions.          Generates histogram plots of posterior di, Plot MCMC trace plots.          Generates trace plots showing parameter values a, Initialize Bayesian pipeline.          Args:             data: Optional initial, Integration smoke tests for SPP pipeline workflow. (+10 more)
+### Community 206 - "BayesianPipeline"
+Cohesion: 0.11
+Nodes (10): BayesianPipeline, String representation of Bayesian pipeline., Perform Bayesian inference using NumPyro NUTS sampler.          This method runs, Specialized pipeline for Bayesian rheological analysis workflows.      This clas, Plot posterior distributions.          Generates histogram plots of posterior di, Plot MCMC trace plots.          Generates trace plots showing parameter values a, Test that plot_pair() raises error if no Bayesian fit performed., Test that plot_energy() raises error if no Bayesian fit performed. (+2 more)
 
-### Community 207 - "Community 207"
+### Community 207 - "sgr_population_balance.py"
 Cohesion: 0.12
 Nodes (25): advection_operator(), create_grid(), initialize_equilibrium(), Array, SGR Population Balance Solver (Eulerian Approach).  This module provides an Eule, Initialize P(E, ell) at equilibrium (ell=0, E from prior).      The equilibrium, Advection step: ell -> ell + gamma_dot * dt.      Uses adaptive sub-stepping to, Yielding step: remove mass from traps according to yield rate.      Parameters (+17 more)
 
-### Community 208 - "Community 208"
-Cohesion: 0.02
-Nodes (84): Open MultiView dialog overlaying fit curves for the active dataset., MultiView, Multi-panel plot viewer for comparison and analysis.      Features:         - Co, Handle sync button toggle.          Parameters         ----------         checke, Get number of panels.          Returns         -------         int             N, Get current layout.          Returns         -------         str             Cur, Set layout by preset name.          Parameters         ----------         layout, PlotCanvas (+76 more)
+### Community 208 - "test_visual_regression.py"
+Cohesion: 0.09
+Nodes (38): compare_figures(), figure_to_array(), golden_dir(), Any, ndarray, Path, QApplication, RheoJAX GUI Visual Regression Tests.  Image-based regression tests for GUI plot (+30 more)
 
-### Community 209 - "Community 209"
+### Community 209 - "Hebraud-Lequeux (HL) Model: Equations and Physics"
 Cohesion: 0.06
 Nodes (32): 10. Benchmark Results for Numerical Verification, 10a. Flow curve shape, 10b. Phase transition, 10c. Probability distribution shape, 10d. Macroscopic stress, 10e. Conservation check, 10f. Large shear rate asymptote, 11. Numerical Implementation Notes (+24 more)
 
-### Community 210 - "Community 210"
+### Community 210 - "Background Job System - Implementation Summary"
 Cohesion: 0.07
 Nodes (29): 1. `cancellation.py` (139 lines), 1. Thread Safety, 2. JAX Integration, 2. `worker_pool.py` (284 lines), 3. Error Handling, 3. `fit_worker.py` (294 lines), 4. `bayesian_worker.py` (360 lines), 4. Progress Tracking (+21 more)
 
-### Community 211 - "Community 211"
-Cohesion: 0.12
-Nodes (12): FractionalBurgersModel, ndarray, Initialize Fractional Burgers model., Predict creep compliance J(t).          J(t) = J_g + t^α/(η_1 * Γ(1+α)) + J_k *, Predict relaxation modulus G(t).          Note: Analytical relaxation modulus re, Predict complex modulus G*(ω).          Computed from complex compliance:, Predict response for given input.          Parameters         ----------, Model function for Bayesian inference.          This method is required by Bayes (+4 more)
+### Community 211 - "FractionalBurgersModel"
+Cohesion: 0.08
+Nodes (16): FractionalBurgersModel, ndarray, Initialize Fractional Burgers model., Predict creep compliance J(t).          J(t) = J_g + t^α/(η_1 * Γ(1+α)) + J_k *, Predict relaxation modulus G(t).          Note: Analytical relaxation modulus re, Predict complex modulus G*(ω).          Computed from complex compliance:, Predict response for given input.          Parameters         ----------, Model function for Bayesian inference.          This method is required by Bayes (+8 more)
 
-### Community 212 - "Community 212"
+### Community 212 - "test_protocols.py"
 Cohesion: 0.07
 Nodes (19): Cross-protocol tests for ITT-MCT models.  Tests cover: - Protocol consistency ac, Tests for edge cases and boundary conditions., Test behavior at t=0., Test prediction for single data point., Test numerical stability at extreme shear rates., Tests comparing F₁₂ and ISM models., Tests for consistency across protocols., Test qualitative agreement between F₁₂ and ISM for flow curves. (+11 more)
 
-### Community 213 - "Community 213"
-Cohesion: 0.08
-Nodes (22): format_memory_usage(), get_jax_device_info(), get_jax_info(), JaxUtils, Any, JAX Utilities ============  JAX device detection and configuration helpers for G, Get device memory usage.          Returns         -------         dict, JAX utility functions for GUI.      Features:         - Device detection (+14 more)
+### Community 213 - "test_nlsq_numpyro_workflow.py"
+Cohesion: 0.10
+Nodes (19): Integration tests for complete NLSQ → NUTS workflow.  This module tests the end-, Test that warm-start from NLSQ converges faster than cold start.      Note: This, Test complete NLSQ → NUTS workflow on Maxwell model with convergence checks., Test that 95% credible intervals contain true parameter values., Test that BayesianResult is stored in model for later access., Test that all models automatically gain fit_bayesian() method.      Note: This i, Test NLSQ → NUTS workflow robustness to outliers in data., Test NLSQ → NUTS workflow with ill-conditioned data (limited time range). (+11 more)
 
-### Community 214 - "Community 214"
+### Community 214 - "FIKH (Fractional Isotropic-Kinematic Hardening) Comprehensive Validation Report"
 Cohesion: 0.07
 Nodes (28): 1. Automated Checks, 2.1 Caputo Fractional Structure Evolution — CORRECT, 2.2 L1 Scheme for Caputo Derivative — CORRECT, 2.3 Armstrong-Frederick Backstress — CORRECT, 2.4 Perzyna Plastic Flow Rule — CORRECT, 2.5 Mittag-Leffler Relaxation — CORRECT, 2.6 Cole-Cole Depression Angle — CORRECT, 2.7 Arrhenius Thermal Coupling — CORRECT (+20 more)
 
-### Community 215 - "Community 215"
+### Community 215 - "ndarray"
 Cohesion: 0.07
 Nodes (17): ndarray, Internal LAOS simulation for model_function., Simulate Large-Amplitude Oscillatory Shear (LAOS).          The Giesekus model p, Extract Fourier harmonics from LAOS stress response.          The nonlinear stre, Compute stress overshoot ratio in startup flow.          The overshoot ratio is, Get effective relaxation spectrum G(t).          Note: For single-mode Giesekus,, Predict response using protocol-aware dispatch.          Parameters         ----, NumPyro/BayesianMixin model function.          Routes to appropriate prediction (+9 more)
 
-### Community 216 - "Community 216"
+### Community 216 - "main"
 Cohesion: 0.11
 Nodes (14): create_parser(), main(), ArgumentParser, ndarray, CLI subcommand for loading rheological data files.  Wraps auto_load() to load da, Validate loaded arrays for NaN/Inf. Returns error message or None., Load data from file and print summary or JSON envelope., Create argument parser for load subcommand. (+6 more)
 
-### Community 217 - "Community 217"
-Cohesion: 0.10
-Nodes (17): apply_overrides(), _coerce_value(), config_to_builder(), dry_run_pipeline(), _nested_set(), Any, Apply CLI ``--override key=value`` pairs to a :class:`PipelineConfig`.      Over, Attempt to coerce a string override value to a Python scalar. (+9 more)
+### Community 217 - "apply_overrides"
+Cohesion: 0.13
+Nodes (14): apply_overrides(), _coerce_value(), dry_run_pipeline(), _nested_set(), Any, Apply CLI ``--override key=value`` pairs to a :class:`PipelineConfig`.      Over, Attempt to coerce a string override value to a Python scalar., Set a value in a nested dict via a list of key segments.      When the first key (+6 more)
 
-### Community 218 - "Community 218"
-Cohesion: 0.02
-Nodes (82): PluginInfo, PluginType, Any, Register a plugin in the registry.          Args:             name: Unique name, Validate that a plugin implements the required interface.          Args:, Retrieve a registered plugin class.          Args:             name: Name of the, Get full information about a registered plugin.          Args:             name:, Remove a plugin from the registry.          Args:             name: Name of the (+74 more)
+### Community 218 - "Registry"
+Cohesion: 0.01
+Nodes (133): BayesianMixin, Bayesian convergence diagnostics: R-hat, ESS, divergence counting.  This module, Compute default midpoint for parameter initialization., Mixin class providing Bayesian inference capabilities via NumPyro NUTS.      Thi, BayesianResult, DiagnosticsDict, BayesianResult dataclass and related types for Bayesian inference output.  This, Typed structure for Bayesian convergence diagnostics. (+125 more)
 
-### Community 219 - "Community 219"
+### Community 219 - "EPM (Elasto-Plastic Models) Comprehensive Validation Report"
 Cohesion: 0.07
 Nodes (29): 1. Automated Checks, 2.1 Eshelby Propagator — CORRECT, 2.2 Von Mises Yield Criterion — CORRECT, 2.3 Hill Anisotropic Criterion — CORRECT, 2.4 Prandtl-Reuss Plastic Flow Rule — CORRECT, 2.5 FFT-Based Stress Redistribution — CORRECT, 2.6 Hébraud-Lequeux as Mean-Field Limit — CORRECT, 2.7 Smooth Yielding Approximation — CORRECT (with caveat) (+21 more)
 
-### Community 220 - "Community 220"
-Cohesion: 0.11
-Nodes (15): FractionalKelvinVoigt, ndarray, RheoData, Compute characteristic retardation time.          Args:             Ge: Equilibr, Predict relaxation modulus G(t) using JAX.          G(t) = G_e + c_α t^(-α) / Γ(, Predict creep compliance J(t) using JAX.          J(t) = (1/G_e) (1 - E_α(-(t/τ_, Predict complex modulus G*(ω) using JAX.          G*(ω) = G_e + c_α (iω)^α, Internal predict implementation.          Args:             X: RheoData object o (+7 more)
+### Community 220 - "FractionalKelvinVoigt"
+Cohesion: 0.10
+Nodes (16): FractionalKelvinVoigt, ndarray, RheoData, Compute characteristic retardation time.          Args:             Ge: Equilibr, Predict relaxation modulus G(t) using JAX.          G(t) = G_e + c_α t^(-α) / Γ(, Predict creep compliance J(t) using JAX.          J(t) = (1/G_e) (1 - E_α(-(t/τ_, Predict complex modulus G*(ω) using JAX.          G*(ω) = G_e + c_α (iω)^α, Internal predict implementation.          Args:             X: RheoData object o (+8 more)
 
-### Community 221 - "Community 221"
-Cohesion: 0.05
-Nodes (27): Extract Fourier harmonics from LAOS data.          Parameters         ----------, Compute Weissenberg number Wi = t_R * gamma_dot., Compute Deborah number De = t_R * omega., Network modulus (Pa)., Unstressed dissociation rate (1/s)., Force sensitivity parameter (Bell only)., Maximum extensibility (FENE only)., Equilibrium relaxation time t_R = 1/k_d_0 (s). (+19 more)
+### Community 221 - "VLBVariant"
+Cohesion: 0.06
+Nodes (22): Extract Fourier harmonics from LAOS data.          Parameters         ----------, Compute Weissenberg number Wi = t_R * gamma_dot., Compute Deborah number De = t_R * omega., Network modulus (Pa)., Unstressed dissociation rate (1/s)., Force sensitivity parameter (Bell only)., Maximum extensibility (FENE only)., Equilibrium relaxation time t_R = 1/k_d_0 (s). (+14 more)
 
-### Community 222 - "Community 222"
+### Community 222 - "run_profiling.py"
 Cohesion: 0.11
 Nodes (26): generate_maxwell_oscillation(), generate_maxwell_relaxation(), generate_power_law_flow(), generate_zener_relaxation(), _load_model_class(), main(), print_report(), profile_imports() (+18 more)
 
-### Community 223 - "Community 223"
-Cohesion: 0.07
-Nodes (21): Phase 2 Performance Benchmarking (Task 16.4)  Benchmarks for JAX-powered model f, Benchmark 3: GPU Acceleration (if available)      Test CPU vs GPU performance., Verify fitting performance on the active JAX backend (CPU or GPU)., Benchmark 4: Memory Usage Profiling      Track memory usage for typical workflow, Profile memory usage for typical fitting workflow., Verify no memory leaks in repeated fitting., Benchmark 5: Scalability Tests      Test performance with N=10, 100, 1000, 10000, Test fitting performance scales with data size. (+13 more)
+### Community 223 - "._predict"
+Cohesion: 0.15
+Nodes (11): ndarray, RheoData, Tighten tau bounds based on data scale to avoid pathological samples., Predict relaxation modulus G(t) using JAX.          G(t) = G_m E_{α,1}(-(t/τ)^α), Predict creep compliance J(t) using JAX.          J(t) = (1/G_m) + (t^α)/(G_m τ^, Predict complex modulus G*(ω) using JAX.          G*(ω) = G_m (iωτ_α)^α / (1 + (, Internal predict implementation.          Args:             X: RheoData object o, Model function for Bayesian inference.          This method is required by Bayes (+3 more)
 
-### Community 224 - "Community 224"
+### Community 224 - "RheoJAX v0.4.0 Task Group 1 - Baseline Test Report"
 Cohesion: 0.07
 Nodes (28): 10. Version and Dates, 1. Feature Branch Creation, 2.1 Smoke Tier (105 tests, ~30s-2min), 2.2 Fast Tier (~1069 tests, 5-10 min), 2. Test Infrastructure Verification, 3.1 Available Dependencies, 3.2 Environment Info, 3.3 pytest-benchmark Installation (+20 more)
 
-### Community 225 - "Community 225"
+### Community 225 - "RheoJAX Tech Stack"
 Cohesion: 0.07
 Nodes (27): Build & Quality Commands, CI/CD, Code Quality, Core Dependencies, Development Dependencies, Documentation, Documentation Structure, File I/O (+19 more)
 
-### Community 226 - "Community 226"
-Cohesion: 0.07
-Nodes (22): Process, Event, Queue, Execute the work function in a child process.          Called by QThreadPool.  B, Request cancellation with escalation to SIGTERM/SIGKILL., Poll *result_queue* until a terminal message arrives or the         child dies u, Drain any remaining messages after the process has exited.          If a termina, Check if *proc* is alive, returning False if already closed. (+14 more)
+### Community 226 - "ProcessWorkerAdapter"
+Cohesion: 0.05
+Nodes (44): Process, make_fit_worker(), ProcessWorkerAdapter, Event, Queue, Run a work function inside a ``multiprocessing.Process``.      The adapter start, Execute the work function in a child process.          Called by QThreadPool.  B, Request cancellation with escalation to SIGTERM/SIGKILL. (+36 more)
 
-### Community 227 - "Community 227"
+### Community 227 - "ModelComparison"
 Cohesion: 0.10
 Nodes (12): ModelComparison, Plot the fit result (2-panel: fit + residuals).          Args:             ax: O, Comparison of multiple model fit results.      Ranks models by an information cr, Compute rankings and Akaike weights from results., Return model names sorted by rank (best first)., Human-readable summary table.          Returns:             Formatted string wit, Bar plot of Akaike weights.          Args:             ax: Optional matplotlib a, Tests for FitResult, ModelInfo, and ModelComparison. (+4 more)
 
-### Community 228 - "Community 228"
-Cohesion: 0.08
-Nodes (27): hvm_ber_rate_stress(), hvm_ber_rate_stretch(), hvm_creep_compliance_linear(), hvm_dissociative_stress(), hvm_exchangeable_stress(), hvm_relaxation_modulus(), _hvm_saos_G_double_prime(), _hvm_saos_G_prime() (+19 more)
+### Community 228 - "test_dmta_removal.py"
+Cohesion: 0.12
+Nodes (15): _hits(), Only the central removed-option rejection boundary may name old keys., test_analysis_exporter_does_not_copy_retired_metadata(), test_base_signatures_clean(), test_csv_reader_does_not_create_retired_metadata(), test_excel_reader_does_not_create_retired_metadata(), test_model_registry_create_rejects_removed_option(), test_no_model_imports_deformationmode() (+7 more)
 
-### Community 229 - "Community 229"
-Cohesion: 0.10
-Nodes (15): DMTNonlocal, ndarray, Initialize DMTNonlocal model., Add parameters specific to nonlocal model., Compute cooperativity length scale.          ξ = √(D_λ · t_eq)          Returns, Predict model response., Compute 1D Laplacian with Neumann BCs (∂field/∂y = 0 at walls).          Uses se, Compute shear rate from velocity profile.          γ̇(y) = dv/dy          Parame (+7 more)
+### Community 229 - "DMTNonlocal"
+Cohesion: 0.09
+Nodes (16): de Souza Mendes-Thompson (DMT) thixotropic models.  This module provides DMT mod, DMTNonlocal, ndarray, Initialize DMTNonlocal model., Add parameters specific to nonlocal model., Compute cooperativity length scale.          ξ = √(D_λ · t_eq)          Returns, Predict model response., Compute 1D Laplacian with Neumann BCs (∂field/∂y = 0 at walls).          Uses se (+8 more)
 
-### Community 230 - "Community 230"
+### Community 230 - "ArrayLike"
 Cohesion: 0.12
 Nodes (13): ArrayLike, Predict steady-state flow curve.          Args:             gamma_dot: Array of, Predict startup shear response.          Args:             t: Time array, Predict stress relaxation after step strain.          Args:             t: Time, Predict creep response under constant stress.          Args:             t: Time, Predict large amplitude oscillatory shear response.          Args:             t, Predict response with protocol-aware dispatch.          Args:             X: Inp, Fit model parameters using protocol-aware optimization.          Args: (+5 more)
 
-### Community 231 - "Community 231"
+### Community 231 - "TNTStickyRouse"
 Cohesion: 0.09
 Nodes (15): Predict SAOS storage and loss moduli.          Analytical superposition for mult, Return longest effective relaxation time (terminal mode).          Returns, Predict first normal stress difference N₁(γ̇).          N₁ = Σ 2·G_k·τ_eff_k²·γ̇, Return string representation., Sticky Rouse model for associative polymers.      Multi-mode Maxwell model where, Initialize Sticky Rouse model.          Parameters         ----------         n_, Number of Rouse modes., Sticker lifetime (s). (+7 more)
 
-### Community 232 - "Community 232"
+### Community 232 - "compute_fit_quality"
 Cohesion: 0.12
 Nodes (15): compute_fit_quality(), ArrayLike, r2_complex(), r2_complex_components(), Fit quality metrics for rheological model evaluation.  This module provides func, Compute R² for complex data using separate real and imaginary components.      R, Compute R² and RMSE fit quality metrics.      Parameters     ----------     y_tr, Compute R² for complex-valued data using magnitudes.      Parameters     ------- (+7 more)
 
-### Community 233 - "Community 233"
+### Community 233 - "solve_linear_creep_compliance"
 Cohesion: 0.13
 Nodes (26): creep_compliance_from_prony(), _prony_fit_modulus(), ndarray, Linear-viscoelastic creep compliance via the Volterra history integral.  In line, Non-negative least-squares Prony fit ``G(t) ≈ G_∞ + Σ gᵢ e^{-t/τᵢ}``.      Relax, Creep compliance ``J(t)`` from a sampled relaxation modulus ``G(t)``.      Fits, Creep compliance ``J(t)`` for a Prony-series relaxation modulus.      Solves the, solve_linear_creep_compliance() (+18 more)
 
-### Community 234 - "Community 234"
-Cohesion: 0.11
-Nodes (19): ModuleType, arviz_figure(), _arviz_major_version(), arviz_plot_kwargs(), import_arviz(), Any, Extract the Matplotlib figure from ArviZ 0.x or 1.x plot output., Return ArviZ's major version, defaulting to the legacy API. (+11 more)
-
-### Community 235 - "Community 235"
+### Community 235 - "TestBayesianNotebooks"
 Cohesion: 0.07
 Nodes (16): Test Bayesian inference notebooks with ArviZ diagnostics, Verify Bayesian notebooks directory exists and has expected structure., Test model comparison notebook executes without errors., Validate that three models are fitted (Maxwell, Zener, SpringPot)., Validate that ArviZ compare function is used., Validate that WAIC is computed., Test uncertainty propagation notebook executes without errors., Validate that Zener model is used (4 parameters with correlations). (+8 more)
 
-### Community 236 - "Community 236"
-Cohesion: 0.06
-Nodes (33): get_model_protocol_ids(), get_model_protocol_pairs(), _get_simulation_ids(), _get_simulation_pairs(), ProtocolDataFactory, Any, ndarray, Protocol validation tests for all registered models.  This module validates th (+25 more)
+### Community 236 - ".__init__"
+Cohesion: 0.11
+Nodes (10): QToolBar, QWidget, Initialize main window with pages and services.          Parameters         ----, Hook ``QStyleHints.colorSchemeChanged`` (Qt 6.5+) to re-apply auto theme., Create dock widgets for log panel.          The left DatasetTree dock has been r, Create sidebar + workspace splitter as central widget.          The WorkspaceCon, Place an arbitrary widget inside a non-movable toolbar., Connect store signals to UI updates (theme, pipeline, datasets). (+2 more)
 
-### Community 237 - "Community 237"
+### Community 237 - "handlers.py"
 Cohesion: 0.10
 Nodes (21): Handler, MemoryHandler, create_handlers(), NullHandler, LogRecord, Path, RheoJAX Log Handlers.  Custom handlers for console, file, and memory-based loggi, Check if buffer should be flushed.          Extends stdlib behavior: when no tar (+13 more)
 
-### Community 238 - "Community 238"
-Cohesion: 0.12
-Nodes (15): create_parser(), _fit_single(), main(), _print_summary_table(), ArgumentParser, Path, CLI subcommand for batch processing multiple rheological data files.  Globs file, Load, fit, and return a result dict for a single file.      Returns a dict with (+7 more)
+### Community 238 - "main"
+Cohesion: 0.11
+Nodes (16): create_parser(), main(), _print_summary_table(), ArgumentParser, Path, CLI subcommand for batch processing multiple rheological data files.  Globs file, Print an aligned summary table of batch results., Batch fit a model across multiple files. (+8 more)
 
-### Community 239 - "Community 239"
+### Community 239 - "cmd_transform.py"
 Cohesion: 0.12
 Nodes (16): create_parser(), _load_from_envelope(), _load_from_file(), main(), _parse_params(), ArgumentParser, CLI subcommand for applying rheological transforms.  Wraps TransformRegistry to, Parse a list of 'key=value' strings into a dict with numeric conversion. (+8 more)
 
-### Community 240 - "Community 240"
+### Community 240 - "RheoJAX GUI Stylesheets"
 Cohesion: 0.07
 Nodes (26): Basic Usage, Border Radius, Color Schemes, Container Widgets, Custom Button Variants, Custom Progress Bar Variants, Dark Theme, Dialogs (+18 more)
 
-### Community 241 - "Community 241"
+### Community 241 - "PreferencesDialog"
 Cohesion: 0.08
 Nodes (19): Set parameter value with validation., PreferencesDialog, Any, QWidget, Handle dialog accept., Handle dialog reject., Handle dialog show event., Create general settings tab. (+11 more)
 
-### Community 242 - "Community 242"
-Cohesion: 0.08
-Nodes (15): FittingOptionsDialog, Any, QWidget, Fitting Options Dialog =====================  Configure NLSQ optimization parame, Load current options into UI., Fitting configuration dialog.      Options:         - Optimization algorithm, Handle algorithm combo box change., Handle option change. (+7 more)
+### Community 242 - "test_unit_conversion.py"
+Cohesion: 0.18
+Nodes (16): normalize_temperature(), normalize_units(), Convert a temperature value to Kelvin.      Args:         value: Temperature val, Convert values to SI units.      Handles both multiplicative conversions (kPa ->, Tests for unified unit normalization (Phase 1)., test_celsius_to_kelvin(), test_fahrenheit_to_kelvin(), test_invalid_unit() (+8 more)
 
-### Community 243 - "Community 243"
+### Community 243 - "FractionalJeffreysModel"
 Cohesion: 0.13
 Nodes (12): FractionalJeffreysModel, ndarray, Initialize Fractional Jeffreys model., Predict relaxation modulus G(t).          G(t) = (η_1/τ_1) * t^(-α) * E_{1-α,1-α, Predict creep compliance J(t).          For Jeffreys model, creep shows unbounde, Predict complex modulus G*(ω).          G*(ω) = η_1(iω) * [1 + (iωτ_2)^α] / [1 +, Predict steady shear viscosity η(γ̇).          For Jeffreys model at steady stat, Predict response for given input.          Parameters         ---------- (+4 more)
 
-### Community 244 - "Community 244"
+### Community 244 - "detect_data_range_decades"
 Cohesion: 0.12
 Nodes (17): check_monotonicity(), check_nan_inf(), check_wide_frequency_range(), detect_data_range_decades(), ndarray, Data quality and range detection utilities.  This module provides utilities for, Suggest optimization strategy based on data characteristics.      Analyzes data, Detect the range of data in decades (log10 scale).      Args:         x: Data ar (+9 more)
 
-### Community 245 - "Community 245"
-Cohesion: 0.06
-Nodes (29): Cross, ndarray, RheoData, TestMode, Fit Cross parameters to data.          Args:             X: Shear rate data (γ̇), Predict viscosity for given shear rates.          Args:             X: Shear rat, Model function for Bayesian inference.          This method is required by Bayes, Compute viscosity using Cross model.          Args:             gamma_dot: Shear (+21 more)
+### Community 245 - ".predict_rheo"
+Cohesion: 0.15
+Nodes (10): ndarray, RheoData, TestMode, Fit Cross parameters to data.          Args:             X: Shear rate data (γ̇), Predict viscosity for given shear rates.          Args:             X: Shear rat, Model function for Bayesian inference.          This method is required by Bayes, Compute viscosity using Cross model.          Args:             gamma_dot: Shear, Compute shear stress using Cross model.          Args:             gamma_dot: Sh (+2 more)
 
-### Community 246 - "Community 246"
+### Community 246 - "ProtocolModelStep"
 Cohesion: 0.14
 Nodes (13): _constructor_params(), _make_config_widget(), ProtocolModelStep, Any, Test/programmatic helper: apply a config dict to the widgets, then commit it., Introspect a model class's __init__ for configurable constructor kwargs.      Re, Return (widget, getter) for a supported annotation, or (None, None)., _FakeInfo (+5 more)
 
-### Community 247 - "Community 247"
-Cohesion: 0.21
-Nodes (8): Compute two-time strain decorrelation for full ITT-MCT memory kernel.      The f, two_time_strain_decorrelation(), Tests for the two_time_strain_decorrelation helper function., Test that the helper function can be imported., Test two-time decorrelation with Gaussian form., Test two-time decorrelation with Lorentzian form., Test that two-time decorrelation is bounded in [0, 1]., TestTwoTimeDecorrelationHelper
+### Community 247 - "DMTBase"
+Cohesion: 0.12
+Nodes (10): DMTBase, Initialize ParameterSet with model parameters.          Parameters are added con, Get initial structure parameter value (fully structured).          Returns, Get all parameters as a dictionary.          Returns         -------         dic, Build base args dictionary for ODE integration.          Parameters         ----, Get human-readable description of the closure.          Returns         -------, Base class for DMT (de Souza Mendes-Thompson) thixotropic models.      Implement, Get human-readable description of elasticity setting.          Returns         - (+2 more)
 
-### Community 248 - "Community 248"
-Cohesion: 0.06
-Nodes (30): Tests for GiesekusSingleMode model.  Tests cover: - Instantiation and paramet, Tests for SAOS predictions., Tests for normal stress predictions., Tests for model instantiation and parameters., Tests for startup flow simulation., Tests for stress relaxation simulation., Tests for creep simulation., Tests for LAOS simulation. (+22 more)
+### Community 248 - "test_single_mode.py"
+Cohesion: 0.08
+Nodes (24): Tests for GiesekusSingleMode model.  Tests cover: - Instantiation and paramet, Tests for SAOS predictions., Tests for normal stress predictions., Tests for startup flow simulation., Tests for stress relaxation simulation., Tests for creep simulation., Tests for LAOS simulation., Tests for model registry integration. (+16 more)
 
-### Community 249 - "Community 249"
+### Community 249 - "plot_lissajous"
 Cohesion: 0.10
 Nodes (16): plot_lissajous(), Create Lissajous-Bowditch plots (stress vs strain and stress vs strain rate)., Accepts external axes tuple., Mismatched strain/stress lengths raise ValueError., JAX arrays are accepted (converted internally)., Cross-cutting edge case tests., All-zero signals don't crash any plot function., Single-point signals don't crash. (+8 more)
 
-### Community 250 - "Community 250"
+### Community 250 - "fikh_scan_kernel_thermal"
 Cohesion: 0.08
 Nodes (16): Precompile JIT kernels for faster subsequent predictions.          Triggers JAX, fikh_scan_kernel_isothermal(), fikh_scan_kernel_thermal(), Scan kernel for isothermal FIKH model.      Processes full time series using JAX, Scan kernel for thermal FIKH model.      Args:         times: Array of time poin, Test FIKH model predictions., Create isothermal FIKH model., Create thermal FIKH model. (+8 more)
 
-### Community 251 - "Community 251"
-Cohesion: 0.14
-Nodes (14): HebraudLequeux, ndarray, Return the phase state based on alpha., Get grid parameters based on current or provided sigma_c., Compute adaptive dt and n_steps to cap scan length.          The CFL sub-steppin, Fit HL model parameters to data.          Args:             X: Independent varia, Fit flow curve using derivative-free optimization.          The HL PDE solver ha, Fit creep compliance. (+6 more)
+### Community 251 - "HebraudLequeux"
+Cohesion: 0.12
+Nodes (16): HebraudLequeux, Any, ndarray, Return the phase state based on alpha., Get grid parameters based on current or provided sigma_c., Compute adaptive dt and n_steps to cap scan length.          The CFL sub-steppin, Fit HL model parameters to data.          Args:             X: Independent varia, Fit flow curve using derivative-free optimization.          The HL PDE solver ha (+8 more)
 
-### Community 252 - "Community 252"
+### Community 252 - "Capability Matrix"
 Cohesion: 0.08
 Nodes (24): Capability Matrix, Classical Models (3), DMT — de Souza Mendes-Thompson (2), EPM — Elasto-Plastic Models (2), FIKH — Fractional IKH (2), Flow Models (6), Fluidity (2), Fractional Models (11) (+16 more)
 
-### Community 253 - "Community 253"
+### Community 253 - "Functional Requirements"
 Cohesion: 0.08
 Nodes (24): Critical Invariants, Deliverables, Execution Order, Existing architecture to preserve (non-negotiable):, F10 — Robustness, F1 — Enhanced Model Discovery, F2 — Initial Parameter Estimation Engine, F3 — Extended FitResult Container (+16 more)
 
-### Community 254 - "Community 254"
-Cohesion: 0.02
-Nodes (71): QDialog, BayesianOptionsDialog, Any, QWidget, Bayesian Options Dialog ======================  Configure NUTS sampling paramete, Load current options into UI., Handle sampler combo box change., Handle option change. (+63 more)
+### Community 254 - "BayesianOptionsDialog"
+Cohesion: 0.03
+Nodes (52): QDialog, AboutDialog, QWidget, About Dialog ===========  Application information and credits., Handle dialog show event., Handle link clicks.          Parameters         ----------         url : QUrl, About dialog with version info.      Content:         - RheoJAX version and logo, Initialize about dialog.          Parameters         ----------         parent : (+44 more)
 
-### Community 255 - "Community 255"
-Cohesion: 0.15
-Nodes (17): Run a Pipeline-mode batch (transform/fit/export steps) over one dataset., Run one Pipeline-mode transform step against its sole primary slot.          Nam, Runs `worker` (FitWorker or ProcessWorkerAdapter) synchronously, capturing its, Run one Pipeline-mode export step via ExportService.export_data.          Named, QRunnable driving PipelineExecutionService.execute() once per selected dataset,, DatasetArtifact, FileArtifact, FitArtifact (+9 more)
+### Community 255 - "FitStepResult"
+Cohesion: 0.19
+Nodes (15): Run a Pipeline-mode batch (transform/fit/export steps) over one dataset., Runs `worker` (FitWorker or ProcessWorkerAdapter) synchronously, capturing its, Run one Pipeline-mode export step via ExportService.export_data.          Named, DatasetArtifact, FileArtifact, FitArtifact, FitStepResult, PhaseResult (+7 more)
 
-### Community 256 - "Community 256"
+### Community 256 - "FractionalZenerLiquidLiquid"
 Cohesion: 0.08
-Nodes (18): __getattr__(), Lazy-load top-level subpackages on first access.      This avoids the 270ms star, FractionalZenerLiquidLiquid, ndarray, Predict complex modulus G*(ω).          G*(ω) = c_1 * (iω)^α / (1 + (iωτ)^β) + c, Predict relaxation modulus G(t).          Approximate form (no exact closed-form, Predict creep compliance J(t).          Note: Analytical creep compliance is com, Derive heuristic starting values from relaxation data.          For FZLL, estima (+10 more)
+Nodes (18): FractionalZenerLiquidLiquid, ndarray, Predict complex modulus G*(ω).          G*(ω) = c_1 * (iω)^α / (1 + (iωτ)^β) + c, Predict relaxation modulus G(t).          Approximate form (no exact closed-form, Predict creep compliance J(t).          Note: Analytical creep compliance is com, Derive heuristic starting values from relaxation data.          For FZLL, estima, Fit model to data using NLSQ TRF optimization.          Parameters         -----, Predict response for given input.          Parameters         ---------- (+10 more)
 
-### Community 257 - "Community 257"
-Cohesion: 0.07
-Nodes (19): Parameter, Single parameter with value, bounds, and metadata.      A Parameter represents a, Get parameter bounds., Set parameter bounds and sync any bounds constraint., Return True if the last assignment clamped the value., Make Parameter hashable for use as dict keys.          Returns:             Hash, Check equality with another Parameter.          Matches __hash__: identity-based, Test creating a parameter. (+11 more)
+### Community 257 - "TestParameterClass"
+Cohesion: 0.11
+Nodes (13): Test Parameter class for parameter management., Test creating a parameter., Test parameter value validation., Test parameter without bounds., Test Parameter class for parameter management., Test creating a parameter., Test parameter value validation., Test parameter serialization to dict. (+5 more)
 
-### Community 258 - "Community 258"
+### Community 258 - "._process_file"
 Cohesion: 0.10
 Nodes (16): Any, DataFrame, Exception, Path, RheoData, Process all files in directory matching pattern.          Args:             dire, Pre-load files in parallel using threads (I/O only, thread-safe).          Retur, Process single file with pipeline.          Args:             file_path: Path to (+8 more)
 
-### Community 259 - "Community 259"
-Cohesion: 0.15
-Nodes (22): main(), make_sin_fundamental(), make_sin_noisy(), ndarray, Path, Generate synthetic LAOS datasets for SPP golden-data harness.  Datasets: - sin_f, Generate golden data inputs.      Args:         argv: Command line arguments. If, write_csv() (+14 more)
+### Community 259 - "test_spp_golden_parity.py"
+Cohesion: 0.24
+Nodes (14): load_input(), main(), Path, Run RheoJAX SPP analysis for golden-data harness.  Reads golden_data/input/<data, run_dataset(), _ensure_inputs(), _ensure_rheojax_outputs(), _load_data() (+6 more)
 
-### Community 260 - "Community 260"
+### Community 260 - "validate_model_doc"
 Cohesion: 0.12
 Nodes (22): check_code_blocks(), check_internal_links(), check_math_blocks(), check_quick_reference(), count_references(), find_sections(), main(), print_result() (+14 more)
 
-### Community 261 - "Community 261"
+### Community 261 - "test_gmm_element_search.py"
 Cohesion: 0.09
 Nodes (24): ndarray, Benchmark tests for Generalized Maxwell Model element search optimization.  Test, Generate synthetic creep compliance data.      Returns:         (t, J_t): Time a, Benchmark element search for N=5 in relaxation mode.      Baseline (v0.3.1): ~10, Benchmark element search for N=10 in relaxation mode.      Baseline (v0.3.1): ~2, Benchmark element search for N=20 in relaxation mode.      Baseline (v0.3.1): ~4, Benchmark element search for N=10 in oscillation mode.      Baseline (v0.3.1): ~, Benchmark element search for N=10 in creep mode.      Baseline (v0.3.1): ~30-40s (+16 more)
 
-### Community 262 - "Community 262"
+### Community 262 - ".calculate"
 Cohesion: 0.10
-Nodes (13): Array, RheoData, Perform numerical integration.          Parameters         ----------         x, Extrapolate tail contribution to infinite time.          Parameters         ----, Estimate equilibrium modulus from tail of data.          Parameters         ----, Check if extrapolation should be applied.          Parameters         ----------, Extrapolate the ∫t×G_relax(t)dt integral contribution.          Parameters, Apply tail extrapolation to integrals.          Parameters         ---------- (+5 more)
+Nodes (14): Array, RheoData, Perform numerical integration.          Parameters         ----------         x, Extrapolate tail contribution to infinite time.          Parameters         ----, Validate relaxation data and prepare arrays.          Parameters         -------, Estimate equilibrium modulus from tail of data.          Parameters         ----, Check if extrapolation should be applied.          Parameters         ----------, Extrapolate the ∫t×G_relax(t)dt integral contribution.          Parameters (+6 more)
 
-### Community 263 - "Community 263"
-Cohesion: 0.11
-Nodes (17): ParameterFormBuilder, Any, Read current values from all widgets.          Returns         -------         d, Dynamically build a parameter form from spec dicts.      Parameters     --------, qapp(), Tests for ParameterFormBuilder widget., Form works with actual TransformService specs., Ensure QApplication exists. (+9 more)
+### Community 263 - "._fit"
+Cohesion: 0.12
+Nodes (9): Full Monte Carlo-based LAOS fitting.          Runs MC simulations within optimiz, Determine material phase regime from noise temperature x.          Returns:, Fit SGR GENERIC model to data using NLSQ optimization.          Routes to approp, Fit SGR GENERIC to complex modulus data (oscillation mode).          Uses NLSQ-a, Fit SGR GENERIC to relaxation modulus data (relaxation mode).          Uses NLSQ, Fit SGR GENERIC to creep compliance data (creep mode).          Uses NLSQ-accele, Fit SGR GENERIC to steady shear flow curve data.          Uses NLSQ-accelerated, Fit SGR GENERIC to startup flow data (stress growth coefficient).          Uses (+1 more)
 
-### Community 264 - "Community 264"
+### Community 264 - "compute_plastic_strain_rate"
 Cohesion: 0.09
 Nodes (22): compute_plastic_strain_rate(), r"""Compute component-wise plastic strain rate using Prandtl-Reuss flow rule., Test that plastic strain rate aligns with stress deviator direction., Test that plastic strain rate is zero when not yielding., Test that plastic strain rate magnitude is bounded by physical limits., Test plastic flow rule with extreme relaxation times (numerical stability)., Test that plastic flow is incompressible (ε̇ᵖ_xx + ε̇ᵖ_yy ≈ 0)., Overstress form produces zero plastic rate when sigma_eff <= sigma_c_mean. (+14 more)
 
-### Community 265 - "Community 265"
-Cohesion: 0.06
-Nodes (31): PlotService, Any, Figure, RheoData, Get Wong colorblind-safe palette.          Returns         -------         list[, Get dark-theme-friendly palette., Apply matplotlib style to figure.          Parameters         ----------, Apply publication style (IEEE, Nature, etc.). (+23 more)
+### Community 265 - "PlotService"
+Cohesion: 0.03
+Nodes (66): ModuleType, arviz_figure(), _arviz_major_version(), arviz_plot_kwargs(), import_arviz(), inference_data_from_dict(), Any, Utilities for safely importing optional ArviZ dependency. (+58 more)
 
-### Community 266 - "Community 266"
-Cohesion: 0.08
-Nodes (23): _display_name(), from_yaml(), _get_yaml(), _make_step(), Any, PipelineStepConfig, Pipeline serialization for GUI <-> CLI YAML round-trip.  Provides bidirectional, Import and return the ``yaml`` module, raising a clear error if absent.      Ret (+15 more)
+### Community 266 - "TestFromYaml"
+Cohesion: 0.09
+Nodes (12): from_yaml must parse a minimal pipeline YAML into a step list., from_yaml must preserve step_type for each step in the list., from_yaml must put all non-'type' YAML keys into the config dict., from_yaml must generate sensible display names (e.g., 'Fit: Maxwell')., from_yaml must assign zero-based positions matching list order., All steps from from_yaml must start with PENDING status., from_yaml must raise ValueError when 'version' is missing., from_yaml must raise ValueError when a step is missing 'type'. (+4 more)
 
-### Community 267 - "Community 267"
+### Community 267 - "ndarray"
 Cohesion: 0.15
 Nodes (10): ndarray, Predict flow in shear banding regime with lever rule.          When shear bandin, Fit SGR model to data using NLSQ optimization.          Routes to appropriate fi, Fit SGR to complex modulus data (oscillation mode).          Uses NLSQ-accelerat, Fit SGR to relaxation modulus data (relaxation mode).          Uses NLSQ-acceler, Fit SGR to creep compliance data (creep mode).          Uses NLSQ-accelerated op, Fit SGR to steady shear viscosity data (steady_shear mode).          Uses NLSQ-a, Fit SGR to LAOS data.          Uses Monte Carlo simulation for time-domain stres (+2 more)
 
-### Community 268 - "Community 268"
-Cohesion: 0.08
-Nodes (30): emoji_safe(), get_icon_provider(), get_standard_icon(), is_macos(), is_macos_arm64(), QIcon, Platform-Safe Icon Utilities ============================  Centralized icon hand, Check if running on macOS ARM64 (Apple Silicon).      Returns     -------     bo (+22 more)
+### Community 268 - "._transform"
+Cohesion: 0.16
+Nodes (10): JaxArray, RheoData, Apply moving average smoothing.          Parameters         ----------         y, Compute derivative using Savitzky-Golay filter.          Parameters         ----, Compute derivative using finite differences.          Parameters         -------, Compute derivative using JIT-safe cubic splines via interpax.          Parameter, Compute derivative with total variation regularization.          This minimizes:, Compute smooth derivative of data.          Parameters         ---------- (+2 more)
 
-### Community 269 - "Community 269"
+### Community 269 - "TestInstantiation"
 Cohesion: 0.14
 Nodes (8): Tests for model instantiation and parameters., Test default instantiation creates 2-species model with 5 parameters., Test 3-species model has 7 parameters., Test parameters can be set., Test n_species >= 1 is enforced., Test derived properties (G_total, eta_0)., Test default parameters have logarithmic spacing for tau_b., TestInstantiation
 
-### Community 270 - "Community 270"
+### Community 270 - "TestParameterSet"
 Cohesion: 0.07
-Nodes (19): Test adding parameters to set., Test retrieving parameters., Test setting parameter values., Test getting parameter values as array., Test setting parameter values from array., Test getting parameter bounds., Test serializing parameter set., Test ParameterSet for managing multiple parameters. (+11 more)
+Nodes (21): Test adding parameters to set., Test retrieving parameters., Test setting parameter values., Test getting parameter values as array., Test setting parameter values from array., Test getting parameter bounds., Test serializing parameter set., Test creating parameter set from dict. (+13 more)
 
-### Community 271 - "Community 271"
-Cohesion: 0.19
-Nodes (22): animate_stress_evolution(), plot_lattice_fields(), plot_normal_stress_field(), plot_normal_stress_ratio(), _plot_scalar_lattice(), plot_tensorial_fields(), _plot_tensorial_lattice(), plot_von_mises_field() (+14 more)
+### Community 271 - "epm_plots.py"
+Cohesion: 0.17
+Nodes (25): FuncAnimation, animate_stress_evolution(), animate_tensorial_evolution(), plot_lattice_fields(), plot_normal_stress_field(), plot_normal_stress_ratio(), _plot_scalar_lattice(), plot_tensorial_fields() (+17 more)
 
-### Community 272 - "Community 272"
+### Community 272 - "run_single_notebook_96h.py"
 Cohesion: 0.17
 Nodes (21): categorize_error(), discover_notebooks(), _elapsed(), main(), NotebookResult, Any, Path, Execute a single notebook, capturing all output and warnings. (+13 more)
 
-### Community 273 - "Community 273"
+### Community 273 - "TestDynamicX"
 Cohesion: 0.08
 Nodes (13): Tests for dynamic noise temperature x(t) evolution., Test SGRGeneric(dynamic_x=True) enables 3D state., Test _poisson_bracket_3d() returns antisymmetric L., Test _friction_matrix_3d() returns symmetric M., Test 3D friction matrix is block-diagonal (M_13 = M_23 = 0)., Test 3D friction matrix is positive semi-definite., Test free_energy_gradient() includes dF/dx = -S., Test x evolution: aging at rest (x -> x_eq). (+5 more)
 
-### Community 274 - "Community 274"
+### Community 274 - "TestOptimizationResultStatistics"
 Cohesion: 0.08
 Nodes (13): Test OptimizationResult statistical properties (NLSQ 0.6.0 compatibility)., Create an OptimizationResult with residuals and y_data for testing., Test R² computation from residuals and y_data., Test adjusted R² computation., Test RMSE computation., Test MAE computation., Test AIC computation., Test BIC computation. (+5 more)
 
-### Community 275 - "Community 275"
-Cohesion: 0.14
-Nodes (10): create_parser(), ArgumentParser, Create argument parser for bayesian subcommand., create_global_parser(), ArgumentParser, Shared argparse parent parser and global flag handling for the RheoJAX CLI.  All, Return a parent parser that carries all shared CLI flags.      Intended to be pa, Tests for rheojax.cli._globals — shared parser and global flag handling. (+2 more)
+### Community 275 - "create_global_parser"
+Cohesion: 0.13
+Nodes (12): create_parser(), ArgumentParser, Create argument parser for bayesian subcommand., create_parser(), ArgumentParser, CLI subcommand for NLSQ model fitting.  Usage:     rheojax fit data.csv --mod, Create argument parser for fit subcommand., create_global_parser() (+4 more)
 
-### Community 276 - "Community 276"
-Cohesion: 0.01
-Nodes (120): QPoint, QStatusBar, QTableWidgetItem, QToolBar, QTreeWidget, QTreeWidgetItem, __getattr__(), Application Core Components ===========================  Main window, menu bar, (+112 more)
+### Community 276 - "DatasetTree"
+Cohesion: 0.08
+Nodes (21): QPoint, QTreeWidget, QTreeWidgetItem, DatasetTree, Path, QWidget, Create the root project item., Add dataset to tree.          Parameters         ----------         dataset_stat (+13 more)
 
-### Community 277 - "Community 277"
+### Community 277 - "Background Job System"
 Cohesion: 0.09
 Nodes (20): 1. CancellationToken, 2. WorkerPool, 3. Check Cancellation Regularly, 3. FitWorker, 4. BayesianWorker, 4. Use NLSQ Warm-Start for Bayesian, 5. Handle Errors Gracefully, 6. Shutdown Pool on Application Exit (+12 more)
 
-### Community 278 - "Community 278"
-Cohesion: 0.08
-Nodes (18): ClickableWidget, Path, Create a quick-start action card with title, description, and color accent., A QWidget subclass that emits a signal on click and handles keyboard activation., Create a recent project item., JAXStatusWidget, QLabel, Apply themed badge styling to a QLabel.          Parameters         ---------- (+10 more)
+### Community 278 - "JAXStatusWidget"
+Cohesion: 0.10
+Nodes (15): ClickableWidget, A QWidget subclass that emits a signal on click and handles keyboard activation., JAXStatusWidget, QLabel, Apply themed badge styling to a QLabel.          Parameters         ----------, Apply themed styling to the memory progress bar.          Parameters         ---, Update the list of available devices.          Parameters         ----------, Set the currently active device.          Parameters         ---------- (+7 more)
 
-### Community 279 - "Community 279"
+### Community 279 - "Hybrid Vitrimer Model (HVM) -- Literature Review & Equations"
 Cohesion: 0.08
 Nodes (25): 1. Key References, 2. Physical Model: Three-Subnetwork Architecture, 3.1 Stress Decomposition (General Tensorial Form), 3.2 Simple Shear Stress Components, 3.3 Evolution ODEs (Simple Shear), 3.4 Factor-of-2 in Relaxation, 3. Constitutive Equations, 4.1 Storage and Loss Moduli (SAOS) (+17 more)
 
-### Community 280 - "Community 280"
+### Community 280 - "TestMittagLefflerConvergence"
 Cohesion: 0.11
-Nodes (19): _detect_decimal_separator(), _detect_encoding(), _detect_encoding_cached(), _detect_encoding_impl(), _find_interval_boundaries(), parse_rheocompass_intervals(), Path, Detect file encoding using cascade approach.      RheoCompass exports are typica (+11 more)
+Nodes (10): Test 7: Benchmark Mittag-Leffler performance on arrays., Test 8: Verify alpha != beta case (Pade approximation)., Test suite for Mittag-Leffler convergence optimization., Test 1: Verify convergence criterion produces correct results., Test 2: Verify Kahan summation preserves numerical stability., Test 3: Benchmark performance for typical rheological alpha values., Test 4: Verify convergence for common cases., Test 5: Verify asymptotic approximation logic for large |z|. (+2 more)
 
-### Community 281 - "Community 281"
+### Community 281 - "FractionalKelvinVoigtZener"
 Cohesion: 0.08
 Nodes (17): FractionalKelvinVoigtZener, ndarray, Predict creep compliance J(t).          J(t) = 1/G_e + (1/G_k) * (1 - E_α(-(t/τ), Predict relaxation modulus G(t).          Note: Analytical relaxation modulus re, Predict complex modulus G*(ω).          Convert from complex compliance:, Predict response for given input.          Parameters         ----------, Model function for Bayesian inference.          This method is required by Bayes, Fractional Kelvin-Voigt Zener model.      A fractional viscoelastic model emphas (+9 more)
 
-### Community 282 - "Community 282"
+### Community 282 - "f12_memory_kernel"
 Cohesion: 0.23
 Nodes (7): f12_memory_kernel(), Compute F₁₂ schematic model memory kernel.      The memory kernel for the F₁₂ mo, Tests for the F12 schematic model memory kernel., m(0) = 0 for any v1, v2., m(Phi) = v1*Phi + v2*Phi^2., At v2=4, phi=1: m(1) = v2 = 4., TestF12MemoryKernel
 
-### Community 283 - "Community 283"
+### Community 283 - "initialize_equilibrium"
 Cohesion: 0.16
 Nodes (17): initialize_equilibrium(), Array, SGR Monte Carlo Simulator (Lagrangian Approach).  This module provides a vectori, Advance Monte Carlo simulation by one time step.      Implements robust Poisson-, Simulate steady shear at constant rate.      Parameters     ----------     key :, Simulate stress relaxation after step strain.      Parameters     ----------, Simulate oscillatory shear (LAOS or SAOS).      Parameters     ----------     ke, State container for SGR Monte Carlo simulation.      Attributes:         E: Trap (+9 more)
 
-### Community 284 - "Community 284"
-Cohesion: 0.07
-Nodes (22): dmt_exponential(), dmt_herschel_bulkley(), dmt_nonlocal(), dmt_viscous(), Unit tests for DMT (de Souza Mendes-Thompson) models.  Tests cover: - Model crea, Tests for LAOS predict dispatch., model._predict(t, test_mode='laos') should not raise., Test fit() -> predict() through the public BaseModel API. (+14 more)
+### Community 284 - "test_dmt.py"
+Cohesion: 0.04
+Nodes (33): dmt_exponential(), dmt_herschel_bulkley(), dmt_nonlocal(), dmt_viscous(), Unit tests for DMT (de Souza Mendes-Thompson) models.  Tests cover: - Model crea, Viscous variant LAOS fit works., Tests for LAOS predict dispatch., model._predict(t, test_mode='laos') should not raise. (+25 more)
 
-### Community 285 - "Community 285"
-Cohesion: 0.12
-Nodes (17): detect_delimiter(), detect_encoding(), detect_header_row(), extract_units_from_header(), _is_numeric(), parse_metadata_header(), parse_trios_csv(), Any (+9 more)
+### Community 285 - "ndarray"
+Cohesion: 0.18
+Nodes (9): ndarray, Predict relaxation modulus G(t) using JAX.          G(t) = G_e + G_m * E_α(-(t/τ, Predict relaxation modulus G(t).          Wrapper for JIT-compiled implementatio, Predict creep compliance J(t) using JAX.          For FZSS, creep compliance is:, Predict creep compliance J(t).          Wrapper for JIT-compiled implementation., Predict complex modulus G*(ω) using JAX.          G*(ω) = G_e + G_m / (1 + (iωτ_, Predict complex modulus G*(ω).          Wrapper for JIT-compiled implementation., Predict response for given input.          Parameters         ---------- (+1 more)
 
-### Community 286 - "Community 286"
+### Community 286 - "MenuBar"
 Cohesion: 0.14
 Nodes (10): QMenuBar, MenuBar, QWidget, Create Transforms menu., Create Analysis menu., Create Pipeline menu for visual pipeline management., Populate recent files menu (placeholder)., Application menu bar for RheoJAX GUI.      Menu Structure:         - File: New, (+2 more)
 
-### Community 287 - "Community 287"
+### Community 287 - "._predict"
 Cohesion: 0.11
 Nodes (14): Array, RheoData, Initialize tensorial stress field.          Args:             key: PRNG key (unu, Extract parameters as dictionary for kernel calls.          Extends base class m, Perform one tensorial EPM time step.          Delegates to tensorial_epm_step ke, Extract shear stress component from stress tensor.          Args:             st, Compute normal stress differences from stress tensor.          For plane strain:, Convenience method to predict normal stress differences.          Runs the simul (+6 more)
 
-### Community 288 - "Community 288"
+### Community 288 - "ColumnMapperDialog"
 Cohesion: 0.11
 Nodes (12): ColumnMapperDialog, QWidget, Handle dialog accept., Handle dialog reject., Handle dialog show event., Populate combo boxes with column names., Apply current mapping to combo boxes., Auto-detect column mapping based on common patterns. (+4 more)
 
-### Community 289 - "Community 289"
-Cohesion: 0.07
-Nodes (62): File, invalidate_downstream(), _is_allowed_member(), load_project_v2(), Any, Path, Versioned .rheojax v2 project persistence.  write_result_arrays()/read_result_ar, Rejects a ref id that could escape tmp_root when interpolated into a path     (s (+54 more)
+### Community 289 - "AppState"
+Cohesion: 0.05
+Nodes (89): File, invalidate_downstream(), _is_allowed_member(), load_project_v2(), Any, Path, Versioned .rheojax v2 project persistence.  write_result_arrays()/read_result_ar, Rejects a ref id that could escape tmp_root when interpolated into a path     (s (+81 more)
 
-### Community 290 - "Community 290"
-Cohesion: 0.04
-Nodes (53): Get default prior distributions for model.          Parameters         ---------, infer_model_kwargs(), _is_placeholder_model(), ModelService, normalize_model_name(), Any, FitResult, ndarray (+45 more)
+### Community 290 - "ModelService"
+Cohesion: 0.03
+Nodes (72): Any, BayesianResult, RheoData, Run NUTS sampling for Bayesian inference.          Parameters         ----------, Calculate MCMC diagnostics using ArviZ.          If the core BayesianResult alre, Get default prior distributions for model.          Parameters         ---------, Get credible intervals from posterior.          Parameters         ----------, Get posterior mean for each parameter.          Parameters         ---------- (+64 more)
 
-### Community 291 - "Community 291"
-Cohesion: 0.12
-Nodes (10): ndarray, RheoData, Execute SPP analysis on amplitude sweep data.          Args:             stress_, Get extracted yield stresses from amplitude sweep.          Returns:, Load datasets sequentially., Execute conversion workflow.          Args:             creep_data: RheoData wit, Apply approximate conversion G(t) ≈ 1/J(t).          This is valid for small str, Apply exact conversion using Laplace transform inversion.          This is more (+2 more)
-
-### Community 292 - "Community 292"
+### Community 291 - "RheoData"
 Cohesion: 0.11
-Nodes (10): Test suite for SGRConventional NLSQ fitting (Task Group 3)., Test basic oscillation mode fitting with synthetic data., Test basic relaxation mode fitting with synthetic data., Test basic creep mode fitting with synthetic data., Test basic steady shear mode fitting with synthetic data., Test oscillation fitting with complex array input., Test that fitting stores test_mode for mode-aware Bayesian inference., Test fitting robustness with noisy data. (+2 more)
+Nodes (11): ndarray, RheoData, Execute SPP analysis on amplitude sweep data.          Args:             stress_, Get extracted yield stresses from amplitude sweep.          Returns:, Fit multiple models and compare.          Args:             data: RheoData to fi, Run model fits in parallel subprocesses., Execute conversion workflow.          Args:             creep_data: RheoData wit, Apply approximate conversion G(t) ≈ 1/J(t).          This is valid for small str (+3 more)
 
-### Community 293 - "Community 293"
+### Community 292 - "test_base_initializer.py"
+Cohesion: 0.16
+Nodes (13): create_mock_param_set(), MockInitializer, Unit tests for BaseInitializer template method pattern.  Tests verify: - Templat, Mock initializer for testing template method., Mock parameter estimation., Mock parameter setting., Create mock ParameterSet for testing., Test that template method calls all methods in correct order. (+5 more)
+
+### Community 293 - "TestHebraudLequeux"
 Cohesion: 0.09
 Nodes (11): Test that grid adapts to large sigma_c., Create a standard HL model instance., Test model_function for Bayesian inference compatibility., Test model initialization and parameter defaults., Test phase classification., Test steady shear flow curve prediction., Test creep compliance prediction., Test stress relaxation prediction. (+3 more)
 
-### Community 294 - "Community 294"
+### Community 294 - "TestVLBMultiNetworkAnalytical"
 Cohesion: 0.09
 Nodes (12): Test multi-network analytical predictions., G' and G'' should be sum of Maxwell contributions., G(t) should be a multi-exponential Prony series., Startup stress is sum of individual mode transients., Flow curve should be Newtonian: sigma = eta_0 * gdot., 1 mode + permanent should give SLS creep (bounded)., G(inf) should equal G_e for network with permanent component., Creep compliance for mode + permanent network reaches bounded plateau. (+4 more)
 
-### Community 295 - "Community 295"
+### Community 295 - "_VizTestTransform"
 Cohesion: 0.09
-Nodes (15): fitted_pipeline(), Pipeline that has been fitted with a model., Tests for Pipeline.plot_transform()., plot_transform() after transform() creates a figure., Transform results are cached for later plotting., plot_transform() without prior transform() raises ValueError., plot_transform() can reference a specific transform by name., plot_transform() with show_intermediate=False skips input panel. (+7 more)
+Nodes (12): fitted_pipeline(), Pipeline that has been fitted with a model., plot_transform() after transform() creates a figure., Transform results are cached for later plotting., plot_transform() can reference a specific transform by name., plot_transform() with show_intermediate=False skips input panel., reset() clears cached transform results., Complete workflow: transform → plot_transform → fit → plot_fit. (+4 more)
 
-### Community 296 - "Community 296"
+### Community 296 - "_SpyModel"
 Cohesion: 0.20
 Nodes (13): Behavioral guards for removed DMTA kwargs at pipeline boundaries., Permissive duck-typed model that records every received kwarg., shear_data(), _SpyModel, test_batch_fit_replay_rejects_removed_kwargs_before_model(), test_batch_replay_preserves_fit_bayesian_and_export_fields(), test_model_comparison_preserves_supported_kwargs(), test_model_comparison_rejects_removed_kwargs_before_model() (+5 more)
 
-### Community 297 - "Community 297"
-Cohesion: 0.14
-Nodes (11): FuncAnimation, Apply a batch of name→value updates with optional failure tolerance.          Re, animate_tensorial_evolution(), Create animation of tensorial stress field evolution.      Args:         history, Test animation of tensorial stress evolution., Test animation with all components., Test animation with single component (e.g., 'xx')., Test animation of von Mises effective stress. (+3 more)
+### Community 297 - "TestTensorialAnimation"
+Cohesion: 0.17
+Nodes (7): Test animation of tensorial stress evolution., Test animation with all components., Test animation with single component (e.g., 'xx')., Test animation of von Mises effective stress., Test animate_stress_evolution with scalar stress history., Test that an unrecognised component name raises ValueError., TestTensorialAnimation
 
-### Community 298 - "Community 298"
+### Community 298 - "main"
 Cohesion: 0.15
 Nodes (11): _build_pipeline_from_envelope(), create_parser(), main(), ArgumentParser, CLI subcommand for exporting pipeline analysis results.  Wraps AnalysisExporter, Construct a minimal Pipeline populated with envelope data for export., Export pipeline results to the chosen format., Create argument parser for export subcommand. (+3 more)
 
-### Community 299 - "Community 299"
+### Community 299 - "test_performance_f9.py"
 Cohesion: 0.15
 Nodes (10): _maxwell_data(), _maxwell_osc_data(), Performance benchmarks for F9 compliance.  Tests that NLSQ fits complete within, JIT compilation overhead must not exceed 10s., First fit (includes JIT compilation) must finish within 10s., Generate Maxwell relaxation data., Generate Maxwell oscillation data., NLSQ fits must complete in < 2s for N ≤ 1000. (+2 more)
 
-### Community 300 - "Community 300"
+### Community 300 - "._handle_transform_result"
 Cohesion: 0.12
-Nodes (13): ParameterConstraint, Validate parameter after initialization., Constraint on a parameter value., Check if value satisfies the constraint.          Args:             value: Value, Test applying multiple constraints., Test parameter constraint system., Test bounds constraints on parameters., Test positive value constraint. (+5 more)
+Nodes (8): FitResult, Render fit plot and residuals on fit page using PlotService., Handle transform application via background worker (T-009)., Synchronous fallback when WorkerPool is unavailable., Process transform output into state store (shared by async and sync paths)., Handle transform requests originating from TransformPage.          Uses Transfor, Auto-save project if a path is set and auto-save is enabled.          Defers the, Connect Transforms menu actions.
 
-### Community 301 - "Community 301"
-Cohesion: 0.14
-Nodes (8): PoolFuture, Any, Future-like object for pool task results., Block until result is available, then return it., Submit a task to the pool.          The function must be module-level (picklable, Submit multiple tasks and yield results in order., Shutdown all workers gracefully., Background thread that routes results to futures.          SYS-03: Poll interval
+### Community 301 - ".result"
+Cohesion: 0.08
+Nodes (16): _atexit_kill_pools(), PoolFuture, Any, Queue, Future-like object for pool task results., Block until result is available, then return it., Check if any worker processes are still running., Submit a task to the pool.          The function must be module-level (picklable (+8 more)
 
-### Community 302 - "Community 302"
-Cohesion: 0.03
-Nodes (40): GiesekusMultiMode, ndarray, Get solvent viscosity η_s (Pa·s)., Get zero-shear viscosity η₀ = η_s + Σ η_p,i (Pa·s)., Get parameters for a specific mode.          Parameters         ----------, Set parameters for a specific mode.          Parameters         ----------, Get all mode parameters as JAX arrays.          Uses vectorized extraction via g, Predict response.          Parameters         ----------         x : array-like (+32 more)
+### Community 302 - "GiesekusMultiMode"
+Cohesion: 0.06
+Nodes (25): GiesekusMultiMode, ndarray, Initialize multi-mode Giesekus model.          Parameters         ----------, Initialize ParameterSet with multi-mode parameters.          Creates parameters:, Get solvent viscosity η_s (Pa·s)., Get zero-shear viscosity η₀ = η_s + Σ η_p,i (Pa·s)., Get parameters for a specific mode.          Parameters         ----------, Set parameters for a specific mode.          Parameters         ---------- (+17 more)
 
-### Community 303 - "Community 303"
-Cohesion: 0.07
-Nodes (37): evolution_lambda(), ikh_creep_ode_rhs(), ikh_flow_curve_steady_state(), ikh_maxwell_ode_rhs(), ikh_scan_kernel(), macaulay(), make_ml_ikh_creep_ode_rhs_per_mode(), make_ml_ikh_maxwell_ode_rhs_per_mode() (+29 more)
+### Community 303 - "ml_ikh.py"
+Cohesion: 0.06
+Nodes (47): evolution_lambda(), ikh_creep_ode_rhs(), ikh_flow_curve_steady_state(), ikh_maxwell_ode_rhs(), ikh_scan_kernel(), macaulay(), make_ml_ikh_creep_ode_rhs_per_mode(), make_ml_ikh_creep_ode_rhs_weighted_sum() (+39 more)
 
-### Community 304 - "Community 304"
+### Community 304 - "ndarray"
 Cohesion: 0.15
 Nodes (11): ndarray, Get stored ODE trajectory from last prediction.          Returns         -------, Initialize parameters from SAOS data.          Uses crossover frequency to estim, Compute model prediction for given parameters.          Parameters         -----, Predict complex modulus G*(ω) for SAOS (vectorized).          Parameters, Predict stress relaxation σ(t) (vectorized).          Parameters         -------, Predict steady shear stress σ(γ̇) (vectorized).          For UCM conformation te, Predict response for given input.          Parameters         ---------- (+3 more)
 
-### Community 305 - "Community 305"
+### Community 305 - "TestBasicNotebooks"
 Cohesion: 0.09
 Nodes (12): Test basic model fitting notebooks (Maxwell, Zener, SpringPot, etc.), Verify basic notebooks directory exists and has expected structure., Test Zener model fitting notebook executes without errors., Validate Zener model fitted parameters match expected values., Validate Bayesian inference convergence for Zener model., Test SpringPot model fitting notebook executes without errors., Validate SpringPot alpha parameter is in valid range [0, 1]., Test Bingham model fitting notebook executes without errors. (+4 more)
 
-### Community 306 - "Community 306"
+### Community 306 - "1. Dullaert-Mewis Model (2006) -- Literature Equations"
 Cohesion: 0.10
 Nodes (19): 1.1 Primary References, 1.2 Stress Decomposition, 1.3 Elastic Stress Component, 1.4 Structure Kinetics (dλ/dt), 1.5 Distribution of Time Constants, 1.6 Material Function Dependencies on lambda, 1.7 Oscillatory/Viscoelastic Variant, 1. Dullaert-Mewis Model (2006) -- Literature Equations (+11 more)
 
-### Community 307 - "Community 307"
-Cohesion: 0.05
-Nodes (31): _PreviewWorker, Any, Lazily create the preview canvas on first use.          Deferred from ``_setup_u, Add newly-imported datasets to the multi-dataset checklist.          Called on `, Tear down and rebuild the scrollable detail content., Return current parameter values for the selected transform., Return list of available transforms with metadata., Take every Nth element if array exceeds preview limit. (+23 more)
+### Community 307 - "test_transform_page_redesign.py"
+Cohesion: 0.11
+Nodes (16): mock_store(), page(), Tests for the redesigned TransformPage., Selecting Mastercurve shows dataset checklist., Selecting FFT does NOT show dataset checklist., Empty state widget is visible before any transform is selected., Mock StateStore for testing., Clicking a sidebar item populates the parameter form. (+8 more)
 
-### Community 308 - "Community 308"
+### Community 308 - "create_parser"
 Cohesion: 0.16
 Nodes (10): create_parser(), main(), ArgumentParser, CLI subcommand for executing YAML pipeline configurations.  Delegates to rheojax, Create argument parser for run subcommand., Execute a YAML pipeline config., Tests for rheojax.cli.cmd_run — run subcommand., TestCreateParser (+2 more)
 
-### Community 309 - "Community 309"
-Cohesion: 0.15
-Nodes (11): Provide subprocess runner for crash detection tests.      Returns     -------, subprocess_runner(), Subprocess-based tests that detect potential crashes., Verify GUI can be imported and initialized without crash., Verify ParameterTable creation doesn't crash., Verify StatusBar updates don't crash., Verify IconProvider icon retrieval doesn't crash., Regression tests for specific crash bugs that were fixed. (+3 more)
+### Community 309 - "TestPhysicalConstraints"
+Cohesion: 0.12
+Nodes (9): Property-based tests for physical constraints on SGR model predictions., G' and G'' predictions are positive for all valid parameters., Relaxation modulus G(t) > 0 for all times., Relaxation modulus G(t) decays monotonically with time., Creep compliance J(t) > 0 for all times., Creep compliance J(t) increases monotonically with time., Viscosity eta(gamma_dot) > 0 for all shear rates., Loss tangent tan(delta) = G''/G' > 0. (+1 more)
 
-### Community 310 - "Community 310"
+### Community 310 - "Module Breakdown"
 Cohesion: 0.10
 Nodes (19): Architecture Compliance, Background Workers (5 files), Code Quality Checklist, Core Application (5 files), Custom Widgets (12 files), File Size Distribution, Import Validation Results, JAX Integration Verification (+11 more)
 
-### Community 311 - "Community 311"
-Cohesion: 0.09
-Nodes (28): QRunnable, FitController, Editing a completed step bumps revision and re-locks everything downstream., Step, WorkflowController, _CallableWorker, _CallableWorkerSignals, _r2_sort_key() (+20 more)
+### Community 311 - "fit_controller.py"
+Cohesion: 0.07
+Nodes (33): QRunnable, FitController, Editing a completed step bumps revision and re-locks everything downstream., Step, WorkflowController, _CallableWorker, _CallableWorkerSignals, _r2_sort_key() (+25 more)
 
-### Community 312 - "Community 312"
-Cohesion: 0.09
-Nodes (22): _create_interval_dataframe(), _create_metadata_sheet(), _format_aux_column_name(), _get_x_column_name(), _get_y_column_name(), RheoData, Export multi-interval RheoData to Excel with one sheet per interval.      Create, Create metadata DataFrame summarizing all intervals.      Args:         rheo_dat (+14 more)
+### Community 312 - "TestFluidityLocalModelFunction"
+Cohesion: 0.12
+Nodes (9): Tests for Bayesian model_function interface., Test model_function works for flow curve mode., Test model_function works for oscillation mode., TC-001: Test model_function for startup protocol., TC-001: Test model_function for relaxation protocol., TC-001: Test model_function for creep protocol., TC-001: Test model_function for LAOS protocol., TC-004: LAOS without gamma_0/omega should raise. (+1 more)
 
-### Community 313 - "Community 313"
+### Community 313 - "TestHVNMLimitingCases"
 Cohesion: 0.11
 Nodes (8): Create filled elastomer (no exchange networks).          Parameters         ----, Create model with frozen interphase (k_BER^int=0).          The interphase acts, Test limiting case recovery — highest priority tests., PRIMARY VALIDATION: phi=0 must match HVM exactly., phi=0 relaxation must match HVM., phi=0 startup must match HVM., G_E=0, G_D=0, phi>0 → only amplified permanent network., TestHVNMLimitingCases
 
-### Community 314 - "Community 314"
-Cohesion: 0.07
-Nodes (16): Return string representation., Get plateau modulus G₀ (Pa)., Get solvent viscosity η_s (Pa·s)., Cates living polymer (wormlike micelle) model.      Implements the Cates theory, TNTCates, Test flow curve prediction via predict()., Test flow curve with viscosity and N₁., Cates with constant breakage gives Newtonian viscosity. (+8 more)
+### Community 314 - "TNTCates"
+Cohesion: 0.11
+Nodes (11): Return string representation., Initialize Cates living polymer model., Initialize ParameterSet with Cates parameters.          Parameters:         - G_, Get plateau modulus G₀ (Pa)., Get reptation time τ_rep (s)., Get breaking time τ_break (s)., Get solvent viscosity η_s (Pa·s)., Get effective relaxation time τ_d = √(τ_rep · τ_break) (s). (+3 more)
 
-### Community 315 - "Community 315"
+### Community 315 - "lve_envelope"
 Cohesion: 0.12
-Nodes (14): lve_envelope(), _lve_envelope_jax(), Any, ndarray, RheoData, JIT-compiled LVE envelope computation., Compute LVE startup stress envelope.      σ_LVE⁺(t) = γ̇₀ [G_e * t + Σ Gᵢτᵢ (1 −, Compute LVE envelope.          Args:             data: Optional RheoData. If G_i (+6 more)
+Nodes (12): lve_envelope(), _lve_envelope_jax(), Any, ndarray, RheoData, JIT-compiled LVE envelope computation., Compute LVE startup stress envelope.      σ_LVE⁺(t) = γ̇₀ [G_e * t + Σ Gᵢτᵢ (1 −, Compute LVE envelope.          Args:             data: Optional RheoData. If G_i (+4 more)
 
-### Community 316 - "Community 316"
+### Community 316 - "plot_harmonic_spectrum"
 Cohesion: 0.14
 Nodes (12): plot_harmonic_spectrum(), Plot harmonic spectrum bar chart (I_n/I_1 vs harmonic number).      Parameters, Tests for plot_harmonic_spectrum., Bar chart creates figure with odd-harmonic labels., Normalized amplitudes: I_n/I_1 ylabel., Unnormalized: I_n ylabel., n_harmonics limits displayed bars., Empty amplitudes returns figure with 'empty' title. (+4 more)
 
-### Community 317 - "Community 317"
+### Community 317 - "TestFluidityNonlocalModelFunction"
 Cohesion: 0.12
-Nodes (9): Test that BayesianMixin is properly integrated., Test that model_function has correct signature for NumPyro., Test that _test_mode is stored for mode-aware inference., Test suite for SGRConventional model structure., Test model instantiation with default parameters., Test ParameterSet has correct parameters with bounds., Test that x parameter is validated to be in valid range., Test that SGRConventional inherits from BaseModel. (+1 more)
+Nodes (9): Tests for Bayesian model_function interface., Test model_function works for flow curve mode., Test model_function works for oscillation mode., TC-002: Test model_function for startup protocol., TC-002: Test model_function for relaxation protocol., TC-002: Test model_function for creep protocol., TC-002: Test model_function for LAOS protocol., TC-004: LAOS without gamma_0/omega should raise. (+1 more)
 
-### Community 318 - "Community 318"
-Cohesion: 0.11
-Nodes (12): Tests for RheoCompass CSV parser (Anton Paar).  This module tests the full RheoC, Tests for European locale decimal separator handling (T074)., Test parsing with comma as decimal separator (European format)., Test parsing relaxation data with European comma decimal format., Performance regression tests for CI.      Run with: pytest tests/io/test_anton_p, Tests for encoding detection (T011)., SC-004: Load time <2s for 10,000 points., Test UTF-8 encoded file is parsed correctly. (+4 more)
+### Community 318 - "test_sgr_generic_extended.py"
+Cohesion: 0.12
+Nodes (14): dynamic_x_model(), fluid_model(), glass_model(), model(), Extended tests for SGRGeneric model with advanced features.  This module conta, Create a basic SGRGeneric model with default parameters., Create SGRGeneric model in glass regime (x < 1)., Create SGRGeneric model in power-law fluid regime (x > 1). (+6 more)
 
-### Community 319 - "Community 319"
+### Community 319 - "test_trios_memory_profiling.py"
 Cohesion: 0.19
 Nodes (19): cleanup_temp_files(), measure_peak_memory(), Memory profiling tests for TRIOS auto-chunking feature.  This test module valida, Cleanup temporary files after each test., Measure peak memory usage of a function.      Args:         func: Function to me, Test memory reduction for 5 MB file (at threshold)., Test memory reduction for 10 MB file., Test memory reduction for 50 MB file (large file). (+11 more)
 
-### Community 320 - "Community 320"
-Cohesion: 0.25
-Nodes (7): creep_multi_decade_data(), multi_decade_relaxation_data(), oscillation_multi_decade_data(), GMM element search warm-start correctness validation tests.  This module validat, Multi-decade creep compliance data.      Time-dependent creep response over 6 de, Multi-decade relaxation data (10⁻³ to 10⁵ s).      Typical for polymer melt visc, Multi-decade oscillatory shear data.      Frequency sweep from 0.01 to 1000 rad/
-
-### Community 321 - "Community 321"
+### Community 320 - "test_generalized_maxwell_warm_start.py"
 Cohesion: 0.10
-Nodes (18): _cleanup_jit_caches(), Tests for TNTLoopBridge model.  Tests cover: - Instantiation and parameter ma, Free JIT caches after each test to prevent xdist worker OOM.      TNT loop_bri, Tests for creep simulation., Tests for model instantiation and parameters., Tests for BayesianMixin compatibility., Tests for model registry integration., Test model creation via registry. (+10 more)
+Nodes (15): creep_multi_decade_data(), multi_decade_relaxation_data(), oscillation_multi_decade_data(), GMM element search warm-start correctness validation tests.  This module validat, Multi-decade creep compliance data.      Time-dependent creep response over 6 de, Test that early termination doesn't skip viable N candidates., Verify that early termination criterion is applied correctly.          Early ter, Test that optimization_factor controls element minimization aggressiveness. (+7 more)
 
-### Community 322 - "Community 322"
+### Community 321 - "test_loop_bridge.py"
+Cohesion: 0.12
+Nodes (12): _cleanup_jit_caches(), Tests for TNTLoopBridge model.  Tests cover: - Instantiation and parameter ma, Free JIT caches after each test to prevent xdist worker OOM.      TNT loop_bri, Tests for model registry integration., Test model creation via registry., Tests for model fitting., Test fitting to flow curve data via scipy (NLSQ AD incompatible with diffrax)., Tests for analysis helper methods. (+4 more)
+
+### Community 322 - "TestHessianCI"
 Cohesion: 0.11
 Nodes (10): The optimal parameter value must lie within its CI., Tighter alpha should produce wider intervals (more conservative)., hessian_ci works on models fitted to complex G* data., All CI bounds must be finite floats., When _nlsq_result.pcov exists, hessian_ci must reuse it (no Hessian)., Explicit test_mode kwarg is accepted without error., Tests for hessian_ci()., hessian_ci returns a dict keyed by parameter names. (+2 more)
 
-### Community 323 - "Community 323"
+### Community 323 - "TestSTZFlowTransient"
 Cohesion: 0.12
-Nodes (9): Test model_function() for LatticeEPM., Create a small LatticeEPM for fast testing., model_function for flow_curve should return array with correct shape., model_function for flow_curve should return positive stresses., model_function for startup should return array with correct shape., model_function for relaxation should return array with correct shape., model_function for creep should return array with correct shape., model_function for oscillation should return array with correct shape. (+1 more)
+Nodes (9): Test stress relaxation (gamma_dot = 0 after initial loading)., Test creep response (constant stress, measure strain)., Test that different variants produce different dynamics., Test suite for STZ Flow and Transient protocols., Test that Diffrax ODE integration converges properly., Test steady-state flow curve prediction., Test that stress saturates near sigma_y at high shear rates., Test stress overshoot in startup flow (strain-controlled). (+1 more)
 
-### Community 324 - "Community 324"
+### Community 324 - "spp.py"
 Cohesion: 0.16
 Nodes (18): _add_analyze_args(), _add_batch_args(), create_parser(), main(), ArgumentParser, Namespace, Path, SPP (Sequence of Physical Processes) CLI commands.  This module provides command (+10 more)
 
-### Community 325 - "Community 325"
-Cohesion: 0.05
-Nodes (48): BayesianMixin, compute_diagnostics(), compute_per_param_diagnostic(), _import_numpyro_diagnostics(), MCMC, ndarray, Bayesian convergence diagnostics: R-hat, ESS, divergence counting.  This module, Compute convergence diagnostics from MCMC samples.      Args:         mcmc: NumP (+40 more)
-
-### Community 326 - "Community 326"
+### Community 325 - ".fit_bayesian"
 Cohesion: 0.11
-Nodes (14): Slice data between x values.          Args:             start: Start x value, Test G(t) shows power-law decay t^(1-x) at long times., Test eta(gamma_dot) viscosity shows shear-thinning behavior., Test constant viscosity for x >= 2 (Newtonian phase)., Test 4th-order derivative of sin(t) matches cos(t)., Test 4th-order second derivative of sin(t) matches -sin(t)., Test Fourier SPP analysis recovers linear moduli., For linear material, moduli should be constant so rates ~0. (+6 more)
+Nodes (16): Any, ndarray, RheoData, TestMode, Perform Bayesian inference using NumPyro NUTS sampler.          Runs NUTS (No-U-, Validate that required attributes exist for Bayesian inference.          R12-B-0, Build the NumPyro probabilistic model function.          Delegates to numpyro_mo, Validate that all parameter bounds are valid.          Parameters with near-equa (+8 more)
 
-### Community 327 - "Community 327"
-Cohesion: 0.18
-Nodes (9): Bingham, Bingham model for linear viscoplastic flow (ROTATION only).      The Bingham mod, Test that this is Herschel-Bulkley with n=1., Test basic stress prediction: σ = σ_y + η_p γ̇., Test that stress is zero below yield threshold., Test that σ_y = 0 reduces to Newtonian., Test apparent viscosity prediction., Test that stress grows linearly above yield. (+1 more)
+### Community 326 - "test_spp_kernels.py"
+Cohesion: 0.03
+Nodes (62): Slice data between x values.          Args:             start: Start x value, Test G(t) shows power-law decay t^(1-x) at long times., Test eta(gamma_dot) viscosity shows shear-thinning behavior., Test constant viscosity for x >= 2 (Newtonian phase)., Unit tests for SPP JAX kernels.  These tests exercise the lightweight analytical, Test second derivative of sin(t) should be -sin(t)., Test periodic differentiation on a complete period., Test SPP numerical analysis on a linear viscoelastic material. (+54 more)
 
-### Community 328 - "Community 328"
+### Community 327 - "TestBinghamPredictions"
+Cohesion: 0.15
+Nodes (7): Test that this is Herschel-Bulkley with n=1., Test basic stress prediction: σ = σ_y + η_p γ̇., Test that stress is zero below yield threshold., Test that σ_y = 0 reduces to Newtonian., Test apparent viscosity prediction., Test that stress grows linearly above yield., TestBinghamPredictions
+
+### Community 328 - "HerschelBulkley"
 Cohesion: 0.13
 Nodes (12): HerschelBulkley, Herschel-Bulkley model for viscoplastic flow (ROTATION only).      The Herschel-, String representation., Test apparent viscosity prediction., Test shear-thinning behavior (n < 1)., Test shear-thickening behavior (n > 1)., Test predictions for Herschel-Bulkley model., Test basic stress prediction: σ = σ_y + K γ̇^n. (+4 more)
 
-### Community 329 - "Community 329"
-Cohesion: 0.15
-Nodes (12): PipelineConfigureRunStep, PipelineStepConfig, A step's config must actually satisfy what execute() requires for that step_type, _step_config_is_complete(), _ref(), test_add_step_appends_to_state(), test_add_step_from_ui_collects_export_config(), test_add_step_from_ui_collects_fit_config() (+4 more)
+### Community 329 - "PipelineConfigureRunStep"
+Cohesion: 0.14
+Nodes (13): PipelineConfigureRunStep, PipelineStepConfig, Pipeline mode's single step body: assemble a step sequence, select datasets, Run, A step's config must actually satisfy what execute() requires for that step_type, _step_config_is_complete(), _ref(), test_add_step_appends_to_state(), test_add_step_from_ui_collects_export_config() (+5 more)
 
-### Community 330 - "Community 330"
+### Community 330 - "TestPlotModuliEvolution"
 Cohesion: 0.20
 Nodes (6): Tests for plot_moduli_evolution., Minimal call creates 2 subplots (G', G'')., Adding delta_t creates 3 subplots., Adding delta_t + G_speed creates 4 subplots., JAX arrays are accepted., TestPlotModuliEvolution
 
-### Community 331 - "Community 331"
+### Community 331 - "RheoJAX Architecture Review — 2026-04-06"
 Cohesion: 0.07
 Nodes (29): Additional Observations, ADR-001: BaseModel God Class (1,610 lines, 44cc fit()), ADR-002: _fit() Boilerplate Duplication Across 41 Model Files, ADR-003: BayesianMixin at 2,163 Lines — Mixed Abstraction Levels, ADR-004: predict() Defensive kwargs Stripping (Lines 984-1021), ADR-005: GUI Complexity Hotspots, Consequences, Consequences (+21 more)
 
-### Community 332 - "Community 332"
+### Community 332 - "PipelineTemplateDialog"
 Cohesion: 0.16
 Nodes (10): PipelineTemplateDialog, QListWidgetItem, QWidget, Populate the list widget from the CLI template registry., Update the YAML preview and description when selection changes., Store selected template name and close with Accepted result., Close with Rejected result; selected_template remains None., Show the dialog and return the selected template name.          Parameters (+2 more)
 
-### Community 333 - "Community 333"
+### Community 333 - "FitOrchestrator"
 Cohesion: 0.23
 Nodes (10): FitOrchestrator, Any, ArrayLike, Extract arrays and test_mode from RheoData., Ensure model.X_data / y_data are raw arrays, not RheoData., Remove optimization-only kwargs so they don't leak to model_function., Compute R-squared (DEBUG only) and log fit completion., Construct a FitResult, attaching uncertainty if available. (+2 more)
 
-### Community 334 - "Community 334"
+### Community 334 - "RheoJAX GUI Package"
 Cohesion: 0.11
-Nodes (17): Architecture, Background Workers, Contributing, Development Status, Float64 Critical, Important Notes, JAX Import Pattern, Launch GUI (+9 more)
+Nodes (18): Architecture, Architecture Overview, Background Workers, Contributing, Development Status, Float64 Critical, Important Notes, JAX Import Pattern (+10 more)
 
-### Community 335 - "Community 335"
+### Community 335 - "ThemeDemo"
 Cohesion: 0.15
 Nodes (12): main(), QWidget, Example usage of RheoJAX GUI stylesheets.  This demonstrates how to apply themes, Create inputs demonstration tab., Create progress and feedback tab., Apply the current theme to the application., Toggle between light and dark themes., Run the theme demo application. (+4 more)
 
-### Community 336 - "Community 336"
-Cohesion: 0.17
-Nodes (7): Test FENE-P finite extensibility physics., FENE-P prevents divergence in extensional stress., FENE-P gives strain hardening relative to linear at moderate rates., Large L_max makes FENE-P approach linear stress., FENE factor f(tr(mu)=3) = L^2/L^2 = 1., FENE N1 values are all finite (no divergence to inf)., TestVLBFenePhysics
+### Community 336 - "vlb_fene_factor"
+Cohesion: 0.12
+Nodes (11): FENE-P Peterlin spring factor.      f = L²/(L² - tr(mu) + 3)      Note: We use (, FENE-P first normal stress difference: N1 = G0·f·(mu_xx - mu_yy).      Parameter, vlb_fene_factor(), vlb_stress_fene_n1(), Test FENE-P finite extensibility physics., FENE-P prevents divergence in extensional stress., FENE-P gives strain hardening relative to linear at moderate rates., Large L_max makes FENE-P approach linear stress. (+3 more)
 
-### Community 337 - "Community 337"
-Cohesion: 0.18
-Nodes (6): Any, Get pipeline execution history.          Returns:             List of (operation, Construct a FitResult from the last fitted model.          Returns:, Save the most recent plot to file.          Convenience method for exporting plo, Plot NLSQ fit with uncertainty band and residuals.          Requires a prior cal, Plot Bayesian posterior predictive with credible interval.          Requires a p
+### Community 337 - ".get_fit_result"
+Cohesion: 0.22
+Nodes (5): Any, Get pipeline execution history.          Returns:             List of (operation, Construct a FitResult from the last fitted model.          Returns:, Plot NLSQ fit with uncertainty band and residuals.          Requires a prior cal, Plot Bayesian posterior predictive with credible interval.          Requires a p
 
-### Community 338 - "Community 338"
-Cohesion: 0.25
-Nodes (12): detect_excel_header_row(), extract_units_from_excel(), _is_numeric(), parse_excel_metadata(), parse_excel_sheet(), Any, Extract metadata from early rows of Excel sheet.      TRIOS Excel exports have m, Find data table header row in Excel sheet.      Args:         sheet: openpyxl wo (+4 more)
+### Community 338 - "TestSTZOscillatory"
+Cohesion: 0.12
+Nodes (9): Test SAOS at high frequency approaches G0., Test LAOS simulation runs without errors., Test FFT harmonic extraction on synthetic signal., Test that chi_inf affects the relaxation behavior., Test suite for STZ SAOS and LAOS protocols., Test SAOS prediction returns correct shape [G', G'']., Test SAOS shows Maxwell-like viscoelastic behavior., Test SAOS at low frequency produces low modulus. (+1 more)
 
-### Community 339 - "Community 339"
+### Community 339 - "test_optimization_validation.py"
 Cohesion: 0.11
 Nodes (12): Test optimization failure detection and validation for fractional models.  This, Test that optimization with bad data either raises or accepts partial results., Test that optimization with bad data either raises or completes with warning., Test that fitted_ is consistent with optimization outcome., Test that error messages are helpful when optimization does fail., Test that error messages include actionable guidance when raised., Test that all fixed models have valid default parameter values., Test that no parameters have None as default value. (+4 more)
 
-### Community 340 - "Community 340"
+### Community 340 - "test_ikh_fitting.py"
 Cohesion: 0.11
 Nodes (14): creep_data(), flow_curve_data(), Validation tests for NLSQ → NUTS pipeline for IKH models.  This module validates, Generate synthetic stress relaxation data., Generate synthetic creep data., Tests for ML-IKH fitting., ML-IKH per_mode should fit startup data., ML-IKH weighted_sum should fit startup data. (+6 more)
 
-### Community 341 - "Community 341"
+### Community 341 - "ndarray"
+Cohesion: 0.13
+Nodes (8): ndarray, Get modulus of complex data., Get phase of complex data., Get real component of y data.          For complex modulus data (G* = G' + i·G'', Get imaginary component of y data.          For complex modulus data (G* = G' +, Get storage modulus (G') from complex modulus data.          Alias for y_real th, Get loss modulus (G'') from complex modulus data.          Alias for y_imag that, Get loss tangent (tan δ = G''/G') from complex modulus data.          The loss t
+
+### Community 342 - "test_cates.py"
+Cohesion: 0.12
+Nodes (11): Tests for TNTCates model (Cates living polymer / wormlike micelle).  Tests cov, Tests for analysis helper methods., Test relaxation spectrum G(t)., Tests for model registry integration., Test model creation via registry., Regression tests for F-TNT-001: LAOS branch must use kwargs, not self._., Test that model_function LAOS branch respects kwargs over self._., Test that kwargs-passed gamma_0/omega actually override self._. (+3 more)
+
+### Community 343 - "test_multi_species.py"
 Cohesion: 0.11
-Nodes (10): Tests for stress_form parameter., Test that schematic is the default stress form., Test that phi_volume is required for microscopic stress., Test initialization with microscopic stress form., Test that invalid stress_form raises ValueError., Test that microscopic stress form produces valid results., Test that microscopic form gives different stress magnitudes., Test microscopic stress with custom thermal energy. (+2 more)
+Nodes (12): Tests for TNTMultiSpecies model.  Tests cover: - Instantiation and parameter, Tests for LAOS simulation., Test LAOS simulation runs and returns dict with expected keys., Test LAOS response is periodic after transient., Test LAOS harmonic extraction., Tests for model fitting., Test fitting to flow curve data., Tests for string representation. (+4 more)
 
-### Community 342 - "Community 342"
-Cohesion: 0.08
-Nodes (24): Tests for TNTCates model (Cates living polymer / wormlike micelle).  Tests cov, Tests for flow curve (steady shear) predictions., Tests for SAOS predictions., Tests for model instantiation and parameters., Tests for startup flow simulation., Tests for stress relaxation simulation., Tests for creep simulation., Tests for BayesianMixin compatibility. (+16 more)
-
-### Community 343 - "Community 343"
-Cohesion: 0.08
-Nodes (23): Tests for TNTMultiSpecies model.  Tests cover: - Instantiation and parameter, Verify TNTMultiSpecies recovers multi-mode Maxwell (generalized UCM).      For, Tests for flow curve (steady shear) predictions., Tests for SAOS predictions., Tests for startup flow simulation., Tests for stress relaxation simulation., Tests for LAOS simulation., Tests for physical correctness and consistency. (+15 more)
-
-### Community 344 - "Community 344"
+### Community 344 - "TestInstantiation"
 Cohesion: 0.11
 Nodes (10): Test default modulus is equally split across modes., Tests for model instantiation and parameters., Test model instantiates with default 3 modes and 8 parameters., Test n_modes property returns the correct number of modes., Test parameters can be set., Test n_modes >= 1 is enforced., Test single-mode instantiation (N=1, 4 params)., Test five-mode instantiation (N=5, 12 params). (+2 more)
 
-### Community 345 - "Community 345"
+### Community 345 - "TestPhysicalConsistency"
 Cohesion: 0.11
 Nodes (10): Tests for physical correctness and consistency., Test stress is positive for positive shear rate., Test plateau modulus is positive when sticker floor is active., Test zero-shear viscosity is positive., Test terminal time is positive., Test first normal stress difference is positive., Test plateau modulus equals sum of modes where tau_R < tau_s.          Plateau, Test η₀ = Σ G_k·τ_eff_k + η_s. (+2 more)
 
-### Community 346 - "Community 346"
+### Community 346 - "TestVLBVariantCreation"
 Cohesion: 0.11
 Nodes (10): Default variant has 3 params: G0, k_d_0, eta_s., Bell variant adds nu parameter., FENE variant adds L_max parameter., Bell + FENE has 5 params., Temperature adds E_a and T_ref., VLBVariant registered as 'vlb_variant'., Test relaxation_time and viscosity properties., Repr includes active flags. (+2 more)
 
-### Community 347 - "Community 347"
+### Community 347 - "TestVLBBellPhysics"
 Cohesion: 0.11
 Nodes (10): Test Bell breakage physics: force-dependent k_d., Bell gives shear-thinning: eta(gamma_dot) decreasing., Bell with nu=0 recovers constant k_d (Newtonian)., Bell startup shows stress overshoot at high Wi., Bell N1 deviates from quadratic at high shear rates., Bell LAOS produces nonzero higher harmonics (I3/I1 > 0)., Bell relaxation from pre-sheared state decays to zero., At Wi → 0, viscosity approaches eta_0 = G0/k_d_0. (+2 more)
 
-### Community 348 - "Community 348"
-Cohesion: 0.11
-Nodes (10): Tests for bootstrap_ci().  Marked slow for full suite runs., bootstrap_ci returns a dict keyed by parameter names., Each CI must have lower < upper for non-degenerate data., All bootstrap CI bounds must be finite., Same seed must produce identical CIs., Different seeds should typically produce different CIs., bootstrap_ci works on models fitted to complex G* data., Wider bootstrap distribution (small n) should have wider CIs than large n. (+2 more)
+### Community 348 - "test_jobs.py"
+Cohesion: 0.14
+Nodes (13): Test script for background job system.  This demonstrates the functionality with, Test FitResult dataclass., Test CancellationToken functionality., Test BayesianResult dataclass., Test cancellation in a simulated workflow., Test error storage and retrieval., Test wait with timeout., test_bayesian_result_structure() (+5 more)
 
-### Community 349 - "Community 349"
+### Community 349 - ".predict"
 Cohesion: 0.14
 Nodes (8): ndarray, RheoData, Plot the result of a previously applied transform.          Uses TransformPlotte, Get current data state.          Returns:             Current RheoData, Attach explicit test mode information to loaded data., Generate predictions from fitted model.          Args:             model: Model, Plot current data state.          Args:             show: Whether to call plt.sh, Initialize pipeline.          Args:             data: Optional initial RheoData.
 
-### Community 350 - "Community 350"
-Cohesion: 0.33
-Nodes (6): apply_globals(), Namespace, Configure logging from parsed global flags.      Should be called once per comma, Namespace, Patch configure_logging and silence the module logger for clean testing., TestApplyGlobals
+### Community 350 - "apply_globals"
+Cohesion: 0.24
+Nodes (8): apply_globals(), Namespace, Shared argparse parent parser and global flag handling for the RheoJAX CLI.  All, Configure logging from parsed global flags.      Should be called once per comma, Namespace, Tests for rheojax.cli._globals — shared parser and global flag handling., Patch configure_logging and silence the module logger for clean testing., TestApplyGlobals
 
-### Community 351 - "Community 351"
-Cohesion: 0.12
-Nodes (10): Provenance, Any, Provenance Tracking ==================  Track analysis provenance and metadata., Clear operation history., Return number of recorded operations., Provenance tracking for reproducibility.      Features:         - Operation hist, Initialize provenance tracker., Record operation with metadata.          Parameters         ----------         o (+2 more)
+### Community 351 - "._transform"
+Cohesion: 0.18
+Nodes (8): JaxArray, RheoData, Get window function of length n.          Parameters         ----------, Remove linear trend from data.          Parameters         ----------         y, Apply FFT transform to time-domain data.          Parameters         ----------, Apply inverse FFT to return to time domain.          Parameters         --------, Find characteristic frequency peaks in FFT spectrum.          Parameters, Extract characteristic time from FFT peak frequency.          Parameters
 
-### Community 352 - "Community 352"
+### Community 352 - "FractionalZenerSolidLiquid"
+Cohesion: 0.07
+Nodes (21): __getattr__(), Lazy-load top-level subpackages on first access.      This avoids the 270ms star, FractionalZenerSolidLiquid, ndarray, Initialize Fractional Zener Solid-Liquid model., Predict relaxation modulus G(t).          G(t) = G_e + c_α * t^(-α) * E_{1-α,1}(, Predict creep compliance J(t).          Note: Analytical creep compliance for FZ, Predict complex modulus G*(ω).          G*(ω) = G_e + c_α * (iω)^α / (1 + (iωτ)^ (+13 more)
+
+### Community 353 - "get_worker_isolation_mode"
 Cohesion: 0.09
-Nodes (16): FractionalZenerSolidLiquid, ndarray, Initialize Fractional Zener Solid-Liquid model., Predict relaxation modulus G(t).          G(t) = G_e + c_α * t^(-α) * E_{1-α,1}(, Predict creep compliance J(t).          Note: Analytical creep compliance for FZ, Predict complex modulus G*(ω).          G*(ω) = G_e + c_α * (iω)^α / (1 + (iωτ)^, Predict response for given input.          Parameters         ----------, Model function for Bayesian inference.          This method is required by Bayes (+8 more)
+Nodes (19): get_worker_isolation_mode(), Return the configured worker isolation mode.      Reads the ``RHEOJAX_WORKER_ISO, Run one Pipeline-mode fit step: synchronous NLSQ, then optional NUTS.          N, _assert_process_dead(), get_worker_isolation_mode reads RHEOJAX_WORKER_ISOLATION env var., Work function that completes immediately with a dict result., Assert a multiprocessing.Process is dead or already closed.      After ``_ensure, Work function that loops until cancel event is set. (+11 more)
 
-### Community 353 - "Community 353"
+### Community 354 - "test_trios_chunked.py"
 Cohesion: 0.14
-Nodes (11): _assert_process_dead(), Work function that completes immediately with a dict result., Assert a multiprocessing.Process is dead or already closed.      After ``_ensure, Work function that loops until cancel event is set., Start worker -> let it complete -> verify no child process remains., Start long worker -> cancel -> verify child process is terminated., Start unresponsive worker -> cancel -> verify SIGKILL after timeout., Work function that ignores SIGTERM (tests SIGKILL escalation). (+3 more)
+Nodes (9): Tests for TRIOS chunked reading functionality.  This module tests memory-efficie, Test backward compatibility with existing load_trios., Test that load_trios accepts chunk_size parameter., Test that generator properly cleans up file handles., Memory profiling and performance tests., Simulate memory-efficient reading of large file.          This test verifies the, Test chunked reading with model fitting workflow., TestTriosChunkedBackwardCompatibility (+1 more)
 
-### Community 354 - "Community 354"
-Cohesion: 0.10
-Nodes (11): Test ParameterSet.unpack() method for multi-value extraction.      This test cla, Create a ParameterSet with test parameters., T003: unpack() returns values in the same order as requested names., T004: unpack() works with a single parameter name., T005: unpack() with no arguments returns empty tuple., T006: unpack() raises KeyError for non-existent parameter names., T007: KeyError message lists available parameter names., T007a: unpack() with duplicate names returns the same value multiple times. (+3 more)
+### Community 355 - "VLBNonlocal"
+Cohesion: 0.09
+Nodes (11): Cooperativity length xi = sqrt(D_mu / k_d_0).          This sets the shear band, Build PDE RHS function for diffrax integration.          State: [Sigma, mu_xx[0:, Simulate approach to steady state under imposed average shear rate.          Par, Simulate startup from rest with banding evolution.          Parameters         -, Simulate stress-controlled creep with spatial resolution.          In creep, the, Detect shear banding from steady-state profiles.          Parameters         ---, Nonlocal VLB with tensor diffusion for shear banding.      Solves a 1D PDE acros, Plot spatial profiles (shear rate and mu_xy).          Parameters         ------ (+3 more)
 
-### Community 355 - "Community 355"
-Cohesion: 0.12
-Nodes (8): Cooperativity length xi = sqrt(D_mu / k_d_0).          This sets the shear band, Simulate stress-controlled creep with spatial resolution.          In creep, the, Detect shear banding from steady-state profiles.          Parameters         ---, Nonlocal VLB with tensor diffusion for shear banding.      Solves a 1D PDE acros, Plot spatial profiles (shear rate and mu_xy).          Parameters         ------, Fit is not supported for nonlocal models (use simulate methods)., Predict is not directly supported for nonlocal models., VLBNonlocal
-
-### Community 356 - "Community 356"
+### Community 356 - "._optimized_wavelet_transform"
 Cohesion: 0.13
 Nodes (10): Array, ndarray, RheoData, Generate chirp wavelet at given frequency.          The chirp wavelet is a Morle, Compute wavelet transform of signal.          Uses vectorized JAX operations (vm, Optimized wavelet transform using FFT convolution.          This is much faster, Apply OWChirp transform to LAOS data.          Parameters         ----------, Get full time-frequency map (spectrogram).          Parameters         --------- (+2 more)
 
-### Community 357 - "Community 357"
-Cohesion: 0.15
-Nodes (10): _fast_perf_mode(), Test fractional model speedup from Mittag-Leffler optimization.          Target:, Test Mastercurve transform on multiple datasets.          Target: 2-5x speedup f, Test batch pipeline processing multiple datasets.          Target: 3-4x speedup, Test that data remains on device throughout pipeline.          Checks that JAX a, Test backward compatibility of all modified APIs.          Verifies that:, Integration tests for v0.3.2 performance optimizations., Validate cumulative performance improvement vs v0.3.1 baseline.          This is (+2 more)
+### Community 357 - "TestCarreauPredictions"
+Cohesion: 0.14
+Nodes (8): Test stress prediction: σ = η(γ̇) * γ̇., Test Newtonian limit when λ → 0., Test Newtonian limit when n = 1., Test predictions for Carreau model., Test Newtonian plateau at low shear rates., Test power-law behavior at high shear rates., Test smooth transition in middle shear rates., TestCarreauPredictions
 
-### Community 358 - "Community 358"
-Cohesion: 0.25
-Nodes (7): ndarray, Integrate FluidityNonlocal creep and return strain(t).      Uses a small grid (N, Numerical proof that G, f_inf, a, n_rejuv, xi are inert for the     nonlocal cre, Perturbing an inert parameter must leave creep strain(t) unchanged         to ~1, Sanity check: tau_y and theta (both in the identifiable set)         MUST shift, _simulate_nonlocal_creep(), TestNonlocalCreepInertParams
+### Community 358 - "test_identifiability.py"
+Cohesion: 0.09
+Nodes (17): ndarray, Tests for Fluidity identifiability reporting and the structural degeneracies it, Integrate the relaxation ODE at gamma_dot=0 and return sigma(t).      Uses the s, Numerical proof of the (G, f_eq, f_inf) scale degeneracy at gamma_dot=0., sigma(t) must be invariant (to 1e-6 relative) under the transform         (G, f_, Changing theta (at fixed G, f_eq, f_inf) must change sigma(t) —         theta is, FluidityNonlocal overrides _IDENTIFIABILITY because its PDE kernels     use HB-a, a, n_rejuv, f_inf never enter the nonlocal PDE RHS — assert         they appear (+9 more)
 
-### Community 359 - "Community 359"
+### Community 359 - "TestVLBVariantRegression"
 Cohesion: 0.21
 Nodes (9): VLBVariant(constant, linear) must match VLBLocal for all 6 protocols., Return (local_params, variant_params)., Flow curve matches VLBLocal to rtol < 1e-4., SAOS matches VLBLocal exactly (both analytical)., Startup matches VLBLocal to rtol < 1e-6., Relaxation matches VLBLocal exactly (both analytical for constant)., Creep matches VLBLocal to rtol < 1e-6., LAOS matches VLBLocal exactly (same ODE approach). (+1 more)
 
-### Community 360 - "Community 360"
-Cohesion: 0.04
-Nodes (49): Mastercurve, ndarray, Initialize Mastercurve transform.          Parameters         ----------, Detect and remove outliers (first point) if it improves fit.          Following, Compute shift factor between two adjacent curves via intersection.          Uses, Compute automatic shift factors via sequential pairwise power-law intersection., Time-Temperature Superposition (TTS) mastercurve generation.      This transform, Get automatic shift factors as arrays for plotting.          Returns         --- (+41 more)
+### Community 360 - "Mastercurve"
+Cohesion: 0.02
+Nodes (73): Mastercurve, ndarray, Detect and remove outliers (first point) if it improves fit.          Following, Compute shift factor between two adjacent curves via intersection.          Uses, Compute automatic shift factors via sequential pairwise power-law intersection., Time-Temperature Superposition (TTS) mastercurve generation.      This transform, Get automatic shift factors as arrays for plotting.          Returns         ---, Set manual shift factors for each temperature.          Parameters         ----- (+65 more)
 
-### Community 361 - "Community 361"
-Cohesion: 0.13
-Nodes (12): ascii_checker(), is_ascii_safe(), Check if text contains only ASCII characters.      Parameters     ----------, Provide ASCII safety checker function.      Returns     -------     Callable, Verify status bar uses ASCII status indicators., Tests verifying emoji crash prevention mechanisms., Verify IconProvider returns ASCII-only icons on macOS., Verify all category icons contain only ASCII characters. (+4 more)
-
-### Community 362 - "Community 362"
-Cohesion: 0.06
-Nodes (27): _coerce_array(), ParameterOptimizer, ArrayLike, ndarray, Optimizer for parameter fitting., Initialize parameter optimizer.          Args:             parameters: Parameter, Number of parameters., Get current parameter values. (+19 more)
-
-### Community 363 - "Community 363"
-Cohesion: 0.04
-Nodes (44): _load_schema(), parse_trios_json(), Any, Path, Low-level JSON parser returning TRIOSExperiment and metadata.      Args:, Load the bundled TRIOS JSON schema.      Returns:         Schema dictionary or N, Validate JSON data against bundled TRIOS schema.      Args:         data: Parsed, validate_schema() (+36 more)
-
-### Community 364 - "Community 364"
+### Community 361 - "TestMLIKH"
 Cohesion: 0.14
-Nodes (8): Test suite for dynamic effective temperature x(t) evolution (Task Group 4)., Test aging: x decreases at rest when gamma_dot = 0., Test rejuvenation: x increases under shear when gamma_dot > 0., Test x converges to steady-state x_ss(gamma_dot) under constant shear., Test static x mode: x is constant fitted parameter, no dynamics., Test ODE integration remains stable over long simulation times., Test that x(t) dynamics couple to constitutive predictions., TestSGRConventionalDynamicX
+Nodes (8): Tests for the ML-IKH model., Test ML-IKH initialization with per_mode yield., Test ML-IKH initialization with weighted_sum yield., Verify ML-IKH sums contributions correctly in per_mode., Test that different tau_thix produce different dynamics., Ensure model runs under JIT compilation without errors., Single-mode weighted_sum should be similar to MIKH., TestMLIKH
 
-### Community 365 - "Community 365"
-Cohesion: 0.12
-Nodes (11): Config, Any, Path, Configuration Management =======================  Application configuration and, Application configuration manager.      Features:         - Persistent settings, Initialize configuration manager.          Parameters         ----------, Get configuration value.          Parameters         ----------         key : st, Set configuration value.          Parameters         ----------         key : st (+3 more)
+### Community 362 - ".step"
+Cohesion: 0.14
+Nodes (12): _coerce_array(), ArrayLike, ndarray, Get current parameter values., Evaluate objective at given values.          Args:             values: Parameter, Compute gradient of objective.          Args:             values: Parameter valu, Check if constraints are satisfied.          Args:             values: Parameter, Perform one optimization step.          Args:             values: Current parame (+4 more)
 
-### Community 366 - "Community 366"
+### Community 363 - "TRIOSDataSet"
+Cohesion: 0.15
+Nodes (9): TRIOS JSON DataSet dataclass.  This module provides the TRIOSDataSet dataclass f, Extract units mapping from column definitions.          Returns:             Dic, Get list of column names., Get number of data rows., Get number of columns., Dataset containing column definitions and values.      Represents a single datas, TRIOSDataSet, TRIOS JSON Experiment and Result dataclasses.  This module provides dataclasses (+1 more)
+
+### Community 364 - "TestThermodynamicConsistency"
+Cohesion: 0.14
+Nodes (8): Test eig(M) >= 0 for 2D state., Test W >= 0 for 2D state., Test full thermodynamic verification for 2D state., Test thermodynamic consistency across parameter space., Tests for GENERIC thermodynamic consistency requirements., Test L + L^T = 0 for 2D state (standard mode)., Test M = M^T for 2D state., TestThermodynamicConsistency
+
+### Community 365 - "TestMaterialTypeDetection"
+Cohesion: 0.14
+Nodes (8): Test detection of gel-like material from relaxation., Test detection of solid from oscillation data., Test detection of liquid from oscillation data., Test that no data returns UNKNOWN., Tests for material type detection., Test detection of solid-like material from relaxation., Test detection of liquid-like material from relaxation., TestMaterialTypeDetection
+
+### Community 366 - ".predict_rheo"
 Cohesion: 0.15
 Nodes (10): ndarray, RheoData, TestMode, Fit Carreau-Yasuda parameters to data.          Args:             X: Shear rate, Predict viscosity for given shear rates.          Args:             X: Shear rat, Model function for Bayesian inference.          This method is required by Bayes, Compute viscosity using Carreau-Yasuda model.          Args:             gamma_d, Compute shear stress using Carreau-Yasuda model.          Args:             gamm (+2 more)
 
-### Community 367 - "Community 367"
+### Community 367 - "TestThixotropy"
 Cohesion: 0.14
 Nodes (8): Tests for thixotropic stress transients., Test enable_thixotropy() activates parameters correctly., Test evolve_lambda() with build/break kinetics., Test lambda recovery at rest (zero shear)., Test predict_thixotropic_stress() returns reasonable values., Test stress overshoot behavior for step-up shear., Test W >= 0 during thixotropic evolution (1000 random states)., TestThixotropy
 
-### Community 368 - "Community 368"
+### Community 368 - ".predict_rheo"
 Cohesion: 0.14
 Nodes (10): ndarray, RheoData, TestMode, Predict stress for given shear rates.          Args:             X: Shear rate d, Model function for Bayesian inference.          This method is required by Bayes, Compute shear stress using Herschel-Bulkley model.          Args:             ga, Compute apparent viscosity using Herschel-Bulkley model.          Args:, Predict apparent viscosity for given shear rates.          Args:             gam (+2 more)
 
-### Community 369 - "Community 369"
+### Community 369 - "G0"
+Cohesion: 0.11
+Nodes (14): G0(), Equilibrium modulus for SGR model.      Computes the dimensionless equilibrium m, Property-based tests for JAX transformation correctness., JIT compilation preserves G0 values., JIT compilation preserves Gp values., TestJAXInvariance, Test G0(x) asymptotic limits., Test that G0(x) >= 0 for all x > 0. (+6 more)
+
+### Community 370 - "vlb_arrhenius_shift"
 Cohesion: 0.14
-Nodes (8): Test G0(x) asymptotic limits., Test that G0(x) >= 0 for all x > 0., Test scalar input returns scalar output., Test array input returns array output., Test G0(x) equilibrium modulus., Test G0(x) values via numerical integration., Test G0(x) in glass-Newtonian transition range., TestEquilibriumModulus
+Nodes (9): Arrhenius temperature shift for dissociation rate.      k_d(T) = k_d_0 · exp(-E_, vlb_arrhenius_shift(), Test Arrhenius temperature dependence., Higher T increases k_d (more thermal energy)., G0 scales linearly with T (rubber elasticity)., At T=T_ref, temperature model matches non-temp model., Time-temperature superposition: a_T = k_d(T)/k_d(T_ref)., model_function is JAX-traceable with temperature kwarg. (+1 more)
 
-### Community 370 - "Community 370"
-Cohesion: 0.15
-Nodes (7): Test Arrhenius temperature dependence., Higher T increases k_d (more thermal energy)., G0 scales linearly with T (rubber elasticity)., At T=T_ref, temperature model matches non-temp model., Time-temperature superposition: a_T = k_d(T)/k_d(T_ref)., model_function is JAX-traceable with temperature kwarg., TestVLBTemperature
-
-### Community 371 - "Community 371"
+### Community 371 - "TestBaseTransform"
 Cohesion: 0.08
 Nodes (17): Test BaseTransform abstract class., Test that BaseTransform defines required interface., Test transform with numpy arrays., Test transform with JAX arrays., Test fit_transform method., Test transform with parameters., Test transform input validation., Test chaining multiple transforms. (+9 more)
 
-### Community 372 - "Community 372"
+### Community 372 - "Giesekus Model Mathematical Verification Report"
 Cohesion: 0.17
 Nodes (11): 1. Constitutive Equation: CORRECT, 2. Upper-Convected Derivative in Simple Shear: CORRECT, 3. Stress Tensor Product tau.tau: CORRECT, 4. Component ODE System: CORRECT, 5. SAOS (Small Amplitude Oscillatory Shear): CORRECT, 6. Normal Stress Ratio N2/N1: CORRECT (with clarification), 7. Psi_1 Formula: CORRECT (with caveat from item 6), 8. Creep Formulation: CORRECT (+3 more)
 
-### Community 373 - "Community 373"
-Cohesion: 0.20
-Nodes (7): ndarray, TestMode, Fit SPP yield stress model to data.          The fitting strategy depends on the, Fit to amplitude sweep data (oscillation mode).          Uses power-law scaling:, Fit to steady shear flow curve (rotation mode).          Uses Herschel-Bulkley-l, Predict full amplitude sweep response.          Computes both static and dynamic, Predict steady shear flow curve.          Parameters         ----------
+### Community 373 - "TestModelCompatibility"
+Cohesion: 0.14
+Nodes (8): Tests for model-data compatibility checking., Test that FZSS is detected as incompatible with exponential decay., Test that Maxwell is compatible with exponential decay., Test that Maxwell is incompatible with power-law decay., Test that FractionalMaxwellGel is compatible with power-law., Test that FractionalMaxwellLiquid is incompatible with solid data., Test compatibility check with unknown model., TestModelCompatibility
 
-### Community 374 - "Community 374"
+### Community 374 - "TestFMLIKHPredictions"
 Cohesion: 0.12
 Nodes (9): Test FMLIKH model predictions., Create 2-mode isothermal FMLIKH., Test startup prediction with multiple modes., Test flow curve prediction with multiple modes., FMLIKH startup fit must reach R^2 > 0.9 when warm-started.          Regression f, FMLIKH flow-curve fit must reach R^2 > 0.9 when warm-started.          Regressio, Test that more modes changes the response., Test single-mode FMLIKH is similar to FIKH. (+1 more)
 
-### Community 375 - "Community 375"
+### Community 375 - "TestComposedVariants"
 Cohesion: 0.12
 Nodes (9): Tests for combining multiple variant flags., Bell+FENE should have both nu and L_max parameters., Bell+FENE composition should run all 6 protocols., Bell+NonAffine should run without errors., Full composition: Bell+FENE+NonAffine should run all protocols., model_function should work for fully composed variant., Power-law breakage variant should run all protocols., Stretch-creation variant should run all protocols. (+1 more)
 
-### Community 376 - "Community 376"
+### Community 376 - "TRIOSExperiment"
 Cohesion: 0.15
-Nodes (9): Zero viscosity values should not produce NaN/inf in log interpolation., Tests for the Cox-Merz rule validation transform., Create oscillation + flow data that satisfy Cox-Merz exactly., Cox-Merz should pass for data that satisfies the rule., Cox-Merz should fail when data diverges significantly., Should raise ValueError for wrong number of inputs., Should raise ValueError when frequency ranges don't overlap., When flow data is stress, it should be auto-converted to viscosity. (+1 more)
+Nodes (7): Root container for TRIOS JSON experiment data.      Represents the complete expe, Get experiment name from properties., Get experiment date from properties., Get operator from properties., Get instrument name from properties., Get number of results., TRIOSExperiment
 
-### Community 377 - "Community 377"
+### Community 377 - "Fractional Viscoelastic Models: Equation Verification Report"
 Cohesion: 0.08
 Nodes (24): 1. Springpot (Scott Blair Element), 2. Fractional Maxwell Model (FMM) -- Two Springpots in Series, 3. Fractional Kelvin-Voigt (FKV) -- Two Springpots in Parallel, 4. Fractional Zener (Standard Linear Solid), 5. Relaxation Modulus for FMM, 6. Mittag-Leffler Function, 7. Creep Compliance for FMM, Fractional Viscoelastic Models: Equation Verification Report (+16 more)
 
-### Community 378 - "Community 378"
+### Community 378 - "TestShearBandingDetection"
 Cohesion: 0.17
 Nodes (7): Tests for shear banding detection in glass regime., Test detect_shear_banding() returns correct types., Test shear banding detection in glass regime (x < 1)., Test no shear banding in fluid regime (x > 1)., Test predict_banded_flow() returns correct types., Test lever rule conservation in banded flow., TestShearBandingDetection
 
-### Community 379 - "Community 379"
-Cohesion: 0.17
-Nodes (7): Test VLBMultiNetwork creation., Test creation with 2 modes., Test creation with permanent network., Test parameter count for various configurations., Single mode VLBMultiNetwork should match VLBLocal., Test error on invalid n_modes., TestVLBMultiNetworkCreation
+### Community 379 - ".apply_transform"
+Cohesion: 0.21
+Nodes (7): Any, RheoData, Validate data for transform.          Parameters         ----------         name, Get configurable parameters for transform.          Parameters         ---------, Return display metadata for all transforms.          Returns         -------, Apply transform and return new data.          Parameters         ----------, Compute transform and return plot data for preview.          Parameters
 
-### Community 380 - "Community 380"
+### Community 380 - "style_helpers.py"
 Cohesion: 0.23
 Nodes (14): _mark_buttons(), mark_primary_buttons(), mark_secondary_buttons(), QWidget, Style helper functions for property-based widget styling., Set density mode on a widget and all its children.      Triggers QSS [density="c, Mark buttons as primary variant by their objectName.      Convenience function f, Set a button's visual variant via QSS property.      Triggers QSS [variant="..." (+6 more)
 
-### Community 381 - "Community 381"
-Cohesion: 0.03
-Nodes (61): ndarray, Fit Zener model to data.          Args:             X: RheoData object or indepe, Predict response based on input data.          Args:             X: RheoData obj, Model function for Bayesian inference.          This method is required by Bayes, Predict relaxation modulus G(t).          Theory: G(t) = G_e + G_m * exp(-t/tau), Predict creep compliance J(t).          Theory: J(t) = 1/(G_e+G_m) + (G_m/(G_e*(, Predict complex modulus G*(omega).          Theory:             G'(omega) = G_e, Predict steady shear stress sigma(gamma_dot).          Theory: sigma = eta * gam (+53 more)
+### Community 381 - "Zener"
+Cohesion: 0.02
+Nodes (68): ndarray, Fit Zener model to data.          Args:             X: RheoData object or indepe, Predict response based on input data.          Args:             X: RheoData obj, Model function for Bayesian inference.          This method is required by Bayes, Predict relaxation modulus G(t).          Theory: G(t) = G_e + G_m * exp(-t/tau), Predict creep compliance J(t).          Theory: J(t) = 1/(G_e+G_m) + (G_m/(G_e*(, Predict complex modulus G*(omega).          Theory:             G'(omega) = G_e, Predict steady shear stress sigma(gamma_dot).          Theory: sigma = eta * gam (+60 more)
 
-### Community 382 - "Community 382"
-Cohesion: 0.15
-Nodes (9): FluidityBase, ndarray, Seed HB parameters (tau_y, K, n_flow) from flow-curve data.          Estimates a, Base class for Fluidity models for yield-stress fluids.      Implements shared p, Get initial fluidity value (equilibrium).          Returns:             Initial, Get all parameters as a dictionary.          Returns:             Dictionary of, Build base args dictionary for ODE integration.          Args:             param, Initialize Fluidity Base Model. (+1 more)
+### Community 382 - "FluidityBase"
+Cohesion: 0.20
+Nodes (7): FluidityBase, Base class for Fluidity models for yield-stress fluids.      Implements shared p, Get initial fluidity value (equilibrium).          Returns:             Initial, Get all parameters as a dictionary.          Returns:             Dictionary of, Build base args dictionary for ODE integration.          Args:             param, Initialize Fluidity Base Model., Initialize ParameterSet with shared parameters.
 
-### Community 383 - "Community 383"
-Cohesion: 0.18
-Nodes (10): ndarray, RheoData, Predict relaxation modulus G(t) using JAX.          Derived from the inverse Lap, Predict creep compliance J(t) using JAX.          Derived from J̃(s) = 1/(s·G*(s, Predict complex modulus G*(ω) using JAX.          G*(ω) = c_1 (iω)^α / (1 + (iωτ, Internal predict implementation.          Args:             X: RheoData object o, Model function for Bayesian inference.          This method is required by Bayes, Predict response for RheoData.          Args:             rheo_data: Input RheoD (+2 more)
+### Community 383 - "._predict"
+Cohesion: 0.21
+Nodes (9): ndarray, RheoData, Predict relaxation modulus G(t) using JAX.          Derived from the inverse Lap, Predict creep compliance J(t) using JAX.          Derived from J̃(s) = 1/(s·G*(s, Predict complex modulus G*(ω) using JAX.          G*(ω) = c_1 (iω)^α / (1 + (iωτ, Internal predict implementation.          Args:             X: RheoData object o, Model function for Bayesian inference.          This method is required by Bayes, Predict response for RheoData.          Args:             rheo_data: Input RheoD (+1 more)
 
-### Community 384 - "Community 384"
+### Community 384 - "._transform"
 Cohesion: 0.19
 Nodes (14): _assemble_target(), _build_kernel(), _max_entropy_inversion(), Any, ndarray, RheoData, Build the kernel matrix A for the linear inverse problem A @ H ≈ b.      The tar, Assemble the target vector b from measurement data. (+6 more)
 
-### Community 385 - "Community 385"
+### Community 385 - "TestPlotPipkinDiagram"
 Cohesion: 0.25
 Nodes (5): Tests for plot_pipkin_diagram., Pipkin diagram creates figure with colorbar., Custom metric name appears on colorbar., Pipkin diagram axes are log scale., TestPlotPipkinDiagram
 
-### Community 386 - "Community 386"
+### Community 386 - "create_spp_report"
 Cohesion: 0.17
 Nodes (10): create_spp_report(), Create comprehensive SPP analysis report figure.      Generates a multi-panel fi, Tests for create_spp_report., Report creates 6-panel figure., Report with spp_results lacking delta_t hides 6th panel., omega=0 raises ValueError., gamma_0=0 raises ValueError., JAX arrays in strain/stress are accepted. (+2 more)
 
-### Community 387 - "Community 387"
+### Community 387 - "TestBaseModel"
 Cohesion: 0.08
 Nodes (17): Test BaseModel abstract class., Test that BaseModel defines required interface., Test model fitting with numpy arrays., Test model fitting with JAX arrays., Test model prediction., Test model parameter management., Test model serialization., Test scikit-learn style interface. (+9 more)
 
-### Community 388 - "Community 388"
-Cohesion: 0.09
-Nodes (13): Any, Convert to dictionary representation., Create from dictionary representation.          Uses Parameter.from_dict() to pr, Link a model to a shared parameter.          Args:             model: Model to l, Get optimization history.          Returns:             List of history dictiona, Convert to dictionary representation., Create from dictionary representation., Serialize constraint to a dictionary. (+5 more)
+### Community 388 - ".from_json"
+Cohesion: 0.18
+Nodes (8): Any, Create TRIOSDataSet from dictionary.          Args:             data: Dictionary, Any, Create TRIOSExperiment from parsed JSON dict.          Args:             data: P, Get consolidated metadata from experiment.          Returns:             Diction, Convert CamelCase to snake_case., Create TRIOSResult from dictionary.          Args:             data: Dictionary, _snake_case()
 
-### Community 389 - "Community 389"
+### Community 389 - "TestDMTBayesian"
 Cohesion: 0.12
 Nodes (9): Test model_function and Bayesian inference for DMT models., Test model_function returns correct flow curve (exponential)., Test model_function returns correct flow curve (HB)., Test model_function returns correct startup stress., Test model_function returns correct relaxation stress., Test model_function returns complex modulus for SAOS., Test model_function returns LAOS stress waveform., Smoke test: fit_bayesian works end-to-end for flow curve. (+1 more)
 
-### Community 390 - "Community 390"
+### Community 390 - "Notebook Validation Tests - Tiered Testing Strategy"
 Cohesion: 0.13
 Nodes (14): Adding New Tests, CI Configuration Examples, Future Optimizations, GitHub Actions `.github/workflows/test.yml`, Local Development, Markers Reference, Notebook Validation Tests - Tiered Testing Strategy, Overview (+6 more)
 
-### Community 391 - "Community 391"
-Cohesion: 0.25
-Nodes (5): Tests for get_icon_provider singleton function., Test get_icon_provider returns an IconProvider., Test get_icon_provider default does not use emoji., Test a global replacement cannot change another caller's return value., TestGetIconProvider
+### Community 391 - "._model_function_scalar"
+Cohesion: 0.17
+Nodes (7): _jit_creep_kernel(), Check if this is a scalar (not tensorial) EPM.          Returns True for Lattice, Compute EPM predictions for BayesianMixin integration.          This method prov, Model function using JIT-compiled scalar kernels (for LatticeEPM)., JIT-friendly creep simulation with controller substep.          The creep P-cont, Dispatch to JIT-compiled creep kernel (substepped controller)., JIT-compiled creep simulation with a substepped P-controller.      The controlle
 
-### Community 392 - "Community 392"
+### Community 392 - "build_numpyro_model"
 Cohesion: 0.20
 Nodes (9): Convert a prior specification dict to a NumPyro distribution.          Delegates, build_numpyro_model(), _import_numpyro(), prior_dict_to_dist(), Any, TestMode, Lazy-import NumPyro and its submodules., Convert a prior specification dict to a NumPyro distribution.      Supports prio (+1 more)
 
-### Community 393 - "Community 393"
-Cohesion: 0.12
-Nodes (9): Tests for ML-IKH protocol-specific fitting., Generate synthetic flow curve data., Test fitting flow curve data., Test startup fitting uses return mapping (not ODE)., Test fitting relaxation data., Test fitting creep data., Test Bayesian inference on flow curve data., Verify _fit dispatches to correct sub-method based on test_mode. (+1 more)
+### Community 393 - "._model_function_general"
+Cohesion: 0.20
+Nodes (6): Model function using general (non-JIT) methods (for TensorialEPM)., JAX-pure flow curve simulation (no RheoData, no numpy)., Extract the mean shear stress from a stress field.          For scalar EPM (shap, JAX-pure startup simulation., JAX-pure relaxation simulation., JAX-pure oscillation simulation.
 
-### Community 394 - "Community 394"
-Cohesion: 0.19
-Nodes (10): ExportWorker, ExportWorkerSignals, Any, QObject, QRunnable, Export Worker =============  Background worker for export operations (R13-GUI-00, Signals for ExportWorker.      Signals     -------     completed : Signal(list), Worker for performing exports in a background thread.      Parameters     ------ (+2 more)
+### Community 394 - "Carreau"
+Cohesion: 0.17
+Nodes (7): Carreau, Carreau model for non-Newtonian flow (ROTATION only).      The Carreau model des, String representation., Initialize Carreau model., Test fitting with synthetic data., Test against Carreau formula directly., Test that model_function output matches predict.
 
-### Community 395 - "Community 395"
+### Community 395 - "giesekus_saos_moduli"
 Cohesion: 0.16
 Nodes (10): giesekus_complex_viscosity(), giesekus_saos_moduli(), Compute storage and loss moduli G'(ω) and G''(ω).      Uses the Cole-Cole gene, Compute complex viscosity magnitude and phase.      The complex viscosity is::, Tests for small-amplitude oscillatory shear predictions., Test G' → 0 and G'' → η₀ω as ω → 0., Test G' → G and G'' → 0 as ω → ∞., Test crossover occurs at ω = 1/λ. (+2 more)
 
-### Community 396 - "Community 396"
-Cohesion: 0.14
-Nodes (7): Internal startup simulation for model_function.          Returns total shear str, Internal relaxation simulation for model_function.          Returns relaxing str, Internal creep simulation for model_function.          Returns accumulated strai, Internal LAOS simulation for model_function.          Returns (strain, stress) a, Simulate Large-Amplitude Oscillatory Shear (LAOS).          Parameters         -, Predict response using protocol-aware dispatch.          Parameters         ----, NumPyro/BayesianMixin model function.          Routes to appropriate prediction
+### Community 396 - "rho_trap"
+Cohesion: 0.18
+Nodes (12): _G0_compute(), _G0_integrand(), _Gp_integrand_imag(), _Gp_integrand_real(), _Gp_quadrature(), Integrand for G0(x) equilibrium modulus integral.      G0(x) = integral_0^inf rh, Compute G0(x) using numerical quadrature (internal).      Parameters     -------, Real part of Gp integrand for storage modulus G'(omega).      Parameters     --- (+4 more)
 
-### Community 397 - "Community 397"
-Cohesion: 0.21
-Nodes (8): ndarray, Predict response based on input data.          Args:             X: RheoData obj, Model function for Bayesian inference.          This method is required by Bayes, Predict relaxation modulus G(t).          Theory: G(t) = G0 * exp(-t/tau) where, Predict creep compliance J(t).          Theory: J(t) = 1/G0 + t/eta          Arg, Predict complex modulus G*(omega).          Theory:             G'(omega) = G0 *, Predict steady shear stress sigma(gamma_dot).          Theory: sigma = eta * gam, Test that prediction methods are JIT-compilable.
+### Community 397 - "TestFluidityLocalOscillation"
+Cohesion: 0.17
+Nodes (7): Tests for FluidityLocal oscillation protocols., Test SAOS prediction returns [G', G''] shape., Test SAOS shows Maxwell-like behavior., Test LAOS simulation returns valid output., TC-014: At small amplitude, I_3/I_1 should be very small., Test harmonic extraction from LAOS., TestFluidityLocalOscillation
 
-### Community 398 - "Community 398"
+### Community 398 - "plot_cole_cole"
 Cohesion: 0.17
 Nodes (10): plot_cole_cole(), Create Cole-Cole diagram (G'' vs G') with optional time coloring.      Parameter, Tests for plot_cole_cole., Cole-Cole diagram creates single-axis figure., Trajectory mode with time coloring., Scatter mode (show_trajectory=False)., Mismatched G'/G'' lengths raise ValueError., Empty arrays produce a 'No data' text instead of crash. (+2 more)
 
-### Community 400 - "Community 400"
-Cohesion: 0.05
-Nodes (55): Tests for Bayesian inference infrastructure.  This module tests the BayesianMixi, Test that BayesianResult dataclass has required fields., Test basic fit_bayesian() workflow on simple problem., Simple model for testing BayesianMixin functionality., Test that NUTS sampling maintains float64 precision., Test that warm-starting from NLSQ initial values works., Initialize simple model., Test that warm-starting with initial values works correctly for multi-chain MCMC (+47 more)
+### Community 400 - "SimpleBayesianModel"
+Cohesion: 0.04
+Nodes (44): Test basic fit_bayesian() workflow on simple problem., Simple model for testing BayesianMixin functionality., Test that NUTS sampling maintains float64 precision., Test that warm-starting from NLSQ initial values works., Initialize simple model., Test that warm-starting with initial values works correctly for multi-chain MCMC, Simple linear model: y = a * X + b., Test that R-hat convergence diagnostic is computed correctly for multi-chain sam (+36 more)
 
-### Community 401 - "Community 401"
+### Community 401 - "TestLogOperation"
 Cohesion: 0.14
 Nodes (8): Tests for log_operation context manager., Test that start and end are logged., Test that elapsed time is logged., Test that exceptions are logged., Test that context dict can be updated., Test that custom log level is used., Test that additional context is included., TestLogOperation
 
-### Community 402 - "Community 402"
+### Community 402 - "TestLoggerMethods"
 Cohesion: 0.14
 Nodes (8): Tests for logger method calls., Create a logger with mocked underlying logger., Test debug method calls log with DEBUG level., Test info method calls log with INFO level., Test warning method calls log with WARNING level., Test error method calls log with ERROR level., Test critical method calls log with CRITICAL level., TestLoggerMethods
 
-### Community 403 - "Community 403"
-Cohesion: 0.07
-Nodes (25): log_capture(), LogCapture, LogRecord, Integration tests for RheoJAX logging with actual model fitting.  Tests the logg, Test logging with RheoJAX pipeline workflows., Test JAX-specific logging utilities with real JAX operations., Test logging with RheoJAX data transforms., Test logging configuration with actual usage. (+17 more)
+### Community 403 - "test_logging_integration.py"
+Cohesion: 0.05
+Nodes (35): configure_logging(), is_configured(), Configure the RheoJAX logging system.      This function should be called once a, Check if logging has been explicitly configured.      Returns:         True if c, Tests for configuration functions., Test basic configure_logging call., Test configure_logging with file output., Test is_configured returns False initially. (+27 more)
 
-### Community 404 - "Community 404"
+### Community 404 - "TestDMTLocalCreation"
 Cohesion: 0.14
 Nodes (8): Test parameter bounds are physically reasonable., Test string representation., Test closure info string., Test DMTLocal model instantiation and parameters., Test creation with exponential closure., Test creation with Herschel-Bulkley closure., Test creation without elasticity., TestDMTLocalCreation
 
-### Community 405 - "Community 405"
+### Community 405 - "TestDMTLocalCreep"
 Cohesion: 0.14
 Nodes (8): Test creep simulations., Test creep simulation runs., Strain should accumulate during creep., Creep below yield stress should be very slow., Maxwell creep should have initial elastic strain γ_e(0) = σ₀/G., As structure breaks down (λ decreases), elastic modulus decreases,         so el, Compare viscous and Maxwell creep initial behavior., TestDMTLocalCreep
 
-### Community 406 - "Community 406"
-Cohesion: 0.33
-Nodes (4): _extract(), Return [(name, bounds), ...] in registration order., Lock the current parameter schema for every fluidity model.      Changes to thes, TestParameterSchema
+### Community 406 - "test_parameter_schema.py"
+Cohesion: 0.20
+Nodes (7): _extract(), Parameter-schema regression tests for the Fluidity family.  Freezes the exact pa, Explicitly assert that the old pre-April-2026 names no longer exist.      If any, Return [(name, bounds), ...] in registration order., Lock the current parameter schema for every fluidity model.      Changes to thes, TestLegacyNamesRejected, TestParameterSchema
 
-### Community 407 - "Community 407"
+### Community 407 - "TestHVNMSAOS"
 Cohesion: 0.13
 Nodes (7): Test SAOS (Small Amplitude Oscillatory Shear) predictions., G'(omega->0) ≈ G_P * X(phi) (amplified plateau, plus residual I-network)., G'(omega->inf) approaches sum of all moduli., tau_I > tau_E when E_a^int > E_a^mat., Filling with NPs should increase G'., tau_E = 1/(2*k_BER^mat) and tau_I = 1/(2*k_BER^int)., TestHVNMSAOS
 
-### Community 408 - "Community 408"
+### Community 408 - "When Analytical SAOS Breaks Down for Transient Network Models and Vitrimers"
 Cohesion: 0.14
 Nodes (13): 1. VLB Multi-Network SAOS: Exact or Approximate?, 2. Vitrimer TST Stress-Coupled Bond Exchange: SAOS Validity, 3. MAOS Corrections at O(γ²) for Transient Networks, 4. The Factor-of-2 in τ_eff = 1/(2k_BER): Exact or Linear-Limit Only?, 5. Literature on SAOS Breakdown for Vitrimers, 6. Implications for RheoJAX Implementation, Critical strain amplitude γ_c, Is the analytical SAOS exact below γ_c? (+5 more)
 
-### Community 409 - "Community 409"
-Cohesion: 0.14
-Nodes (8): Test GMM oscillation mode prediction and fitting., Oscillation prediction should match analytical Fourier transform., GMM with N=1 should match single Maxwell element in oscillation., Fitting oscillation data should minimize combined G' + G'' residual., Tan delta (G''/G') should be physically reasonable., Element minimization should work for oscillation data., Oscillation output should be a 1D complex array (N,) for G* = G' + iG''., TestGMMOscillationMode
+### Community 409 - "TestFluidityLocalFitting"
+Cohesion: 0.17
+Nodes (7): Tests for FluidityLocal fitting capability., Test fitting synthetic flow curve data., Test fitting sets test_mode correctly., TC-010: Test that 'rotation' alias is handled correctly., TC-011: Test predict() call after oscillation fit()., TC-023: Test that 'saos' alias is handled correctly., TestFluidityLocalFitting
 
-### Community 410 - "Community 410"
+### Community 410 - ".get_instance"
 Cohesion: 0.20
 Nodes (5): Get the singleton registry instance.          Returns:             The global Re, Save and clear registry before each test., Save and clear registry before each test., Restore registry state after each test., ValueError not matching 'already registered' must propagate.
 
-### Community 411 - "Community 411"
+### Community 411 - "TestSTZCoverage"
 Cohesion: 0.14
 Nodes (7): Test predict raising ValueError when test_mode is missing., Test extract_harmonics with zero fundamental (edge case)., Test _fit raising ValueError for invalid test_mode., Test _fit_transient raising ValueError when missing required kwargs., Test _fit_oscillation handling laos vs saos logic branches., Test LAOS mode raising ValueError when missing gamma_0 or omega.          This c, TestSTZCoverage
 
-### Community 412 - "Community 412"
+### Community 412 - "TestPhysicalConsistency"
 Cohesion: 0.14
 Nodes (8): Tests for physical correctness and consistency., Test stress is positive for positive shear rate., Test bridge fraction stays in [0, 1] during startup., Test bridge fraction starts at f_B_eq., Test N₁ > 0 for loop-bridge model., Test relaxation stress stays positive., Test bridge fraction decreases with shear rate., TestPhysicalConsistency
 
-### Community 413 - "Community 413"
+### Community 413 - "test_sticky_rouse.py"
 Cohesion: 0.13
 Nodes (11): Tests for TNTStickyRouse model.  Tests cover: - Instantiation and parameter m, Tests for model registry integration., Test model creation via registry., Test model creation via registry., Tests for model fitting., Test fitting to flow curve data., Tests for __repr__ method., Test __repr__ contains n_modes, tau_s, and G_plateau. (+3 more)
 
-### Community 414 - "Community 414"
+### Community 414 - "TestModelFunctionCompleteness"
 Cohesion: 0.14
 Nodes (8): Regression tests for F-TNT-002: model_function must handle all protocols., Test model_function handles startup protocol., Test model_function handles creep protocol., Test model_function handles LAOS protocol., Test that kwargs gamma_0/omega override self._ attributes., Test startup raises ValueError without gamma_dot., Test that _fit() caches protocol kwargs for model_function fallback., TestModelFunctionCompleteness
 
-### Community 415 - "Community 415"
-Cohesion: 0.24
-Nodes (5): Simulate with given parameters (for fitting).          This method directly call, Simulate startup of steady shear from rest.          Parameters         --------, Simulate startup for DMT-Viscous (no elasticity)., Simulate startup for DMT-Maxwell (with elasticity).          Uses semi-implicit, Predict startup stress.
+### Community 415 - "TestInstantiation"
+Cohesion: 0.17
+Nodes (7): Tests for model instantiation and parameters., Test model instantiates with default parameters., Test parameters can be set., Test derived properties are computed correctly., Test Weissenberg and Deborah number computations., Test theoretical N₂/N₁ ratio., TestInstantiation
 
-### Community 416 - "Community 416"
-Cohesion: 0.20
-Nodes (6): Tests for oscillatory test loading (US3: T028-T030)., T028: Test oscillatory loading returns complex G*., Test complex modulus G* = G' + i*G'' is computed., T030: Test G'/G'' accessible via properties., T029: Test Hz to rad/s conversion., TestOscillatoryLoading
+### Community 416 - "TestKwargsCaching"
+Cohesion: 0.17
+Nodes (7): Tests for protocol kwargs caching in _fit().      Verifies that _fit() correct, Test that _fit() stores test_mode., Test that _fit() caches gamma_dot for startup/relaxation., Test that _fit() caches sigma_applied for creep., Test that _fit() caches gamma_0 and omega for LAOS., Test model_function falls back to cached kwargs when called without explicit kwa, TestKwargsCaching
 
-### Community 417 - "Community 417"
+### Community 417 - ".confidence_intervals"
 Cohesion: 0.18
 Nodes (6): ndarray, Parameter covariance matrix from the Jacobian., Parameter confidence intervals (95%) as {name: (lower, upper)}., Parameter confidence intervals from the covariance matrix.          Args:, Prediction intervals for new x values.          Args:             x_new: New inp, Human-readable summary of the fit result.          Returns:             Multi-li
 
-### Community 418 - "Community 418"
-Cohesion: 0.20
-Nodes (6): Tests for multi-interval handling (T061-T064)., T061: Single-interval file returns RheoData (not list)., T062: Multi-interval file returns list when return_all=True., T063: Test interval parameter selects specific interval., T064: Test progress_callback invoked., TestMultiInterval
-
-### Community 419 - "Community 419"
+### Community 418 - "TestHVMFlowCurve"
 Cohesion: 0.17
-Nodes (8): Any, Random seed manager for reproducibility.      Features:         - JAX PRNG key m, Initialize seed manager.          Parameters         ----------         seed : i, Get current PRNG key.          Returns         -------         PRNGKey, Split PRNG key.          Parameters         ----------         num : int, defaul, Set new random seed.          Parameters         ----------         seed : int, Get current seed.          Returns         -------         int | None, SeedManager
+Nodes (7): Steady-state flow curve behavior., E-network stress → 0 at steady state (vitrimer signature)., D-network viscous stress dominates flow curve., Stress increases monotonically with shear rate., Low shear rate: Newtonian behavior sigma = eta*gamma_dot., Components dict has expected keys., TestHVMFlowCurve
 
-### Community 420 - "Community 420"
+### Community 419 - "TestHVMRelaxation"
+Cohesion: 0.17
+Nodes (7): Stress relaxation after step strain., G(0+) ≈ G_P + G_E + G_D., G(t → inf) → G_P (permanent network plateau)., G(t) decreases monotonically., No NaN in relaxation modulus., return_full dict has expected keys., TestHVMRelaxation
+
+### Community 420 - "TestPlotRheoData"
 Cohesion: 0.20
 Nodes (6): Test plot_rheo_data automatic plot type selection., Test plotting time-domain data., Test plotting frequency-domain data., Test plotting with custom matplotlib kwargs., Test plotting rotation (flow curve) data., TestPlotRheoData
 
-### Community 421 - "Community 421"
-Cohesion: 0.17
-Nodes (8): Any, ArrayLike, ndarray, Get current parameters as dictionary., Compute the static substep count for return-mapping stabilization.          The, Densify (times, strains) onto a stable-dt grid for the scan kernel.          Use, Extract time and strain arrays from input.          Args:             X: Input d, Get initial state vector for ODE integration.          Always returns 5-componen
+### Community 421 - "FIKHBase"
+Cohesion: 0.10
+Nodes (17): FIKHBase, Any, ArrayLike, ndarray, TestMode, Setup base FIKH parameters (mechanical + fractional)., Setup thermal coupling parameters., Setup isotropic hardening parameters. (+9 more)
 
-### Community 422 - "Community 422"
+### Community 422 - "TestPlot3DTrajectory"
 Cohesion: 0.20
 Nodes (6): Tests for plot_3d_trajectory., 3D trajectory creates figure with 3D axes., omega=0 raises ValueError., Empty strain array raises ValueError., JAX arrays are accepted., TestPlot3DTrajectory
 
-### Community 423 - "Community 423"
+### Community 423 - "micro_benchmarks.py"
 Cohesion: 0.24
 Nodes (11): bench_instantiation_overhead(), bench_jit_caching(), bench_transfer_overhead(), BenchResult, main(), Measure the cost of passing native Numpy arrays to JAX endpoints., Measure the fixed cost of creating ParameterSets and Model objects., Single benchmark result. (+3 more)
 
-### Community 425 - "Community 425"
-Cohesion: 0.25
-Nodes (9): CubicSpline, Interpolator1D, create_sk_interpolator(), create_sk_interpolator_jax(), interpolate_sk(), ndarray, Interpolate user-provided S(k) data to target k-grid.      Parameters     ------, Create a cubic spline interpolator for S(k).      Parameters     ---------- (+1 more)
+### Community 425 - "percus_yevick_sk"
+Cohesion: 0.10
+Nodes (18): CubicSpline, Interpolator1D, Compute MCT vertex function V(k,q)., create_sk_interpolator(), create_sk_interpolator_jax(), interpolate_sk(), percus_yevick_sk(), ndarray (+10 more)
 
-### Community 426 - "Community 426"
+### Community 426 - "TestFluidityNonlocalShearBanding"
 Cohesion: 0.14
 Nodes (8): Tests for shear banding analysis functionality., Test fluidity profile retrieval., Test fluidity profile retrieval at specific time index., Test CV is low for uniform fluidity., Test CV increases with heterogeneity., Test banding ratio is computed correctly., Test banding detection based on CV threshold., TestFluidityNonlocalShearBanding
 
-### Community 427 - "Community 427"
+### Community 427 - "TestGMMBayesianInference"
 Cohesion: 0.14
 Nodes (8): Test that Bayesian inference produces reasonable convergence diagnostics., Test credible interval computation from posterior samples., Test GMM Bayesian inference capabilities., Test model_function works in relaxation mode., Test model_function works in oscillation mode., Test model_function works in creep mode., Test complete NLSQ → NUTS workflow with warm-start., TestGMMBayesianInference
 
-### Community 428 - "Community 428"
+### Community 428 - "TestIdentifiabilityAPI"
 Cohesion: 0.15
 Nodes (7): Locked-in behaviour for identifiability_check()., Relaxation: theta identifiable, (G, f_eq, f_inf) degenerate,         the rest in, Flow curve: only HB params are identifiable; dynamic params inert., saos' is an alias for 'oscillation'., Startup: all 6 dynamic params identifiable (gamma_dot != 0).         Creep: G is, verbose=True runs the warning code path without raising., TestIdentifiabilityAPI
 
-### Community 429 - "Community 429"
+### Community 429 - "TestFluidityPredictWithoutFit"
 Cohesion: 0.24
 Nodes (5): ndarray, Small (101-point) log-linear time grid covering early + late transient., Direct regression tests for the four fluidity models.      Each test constructs, _t_grid(), TestFluidityPredictWithoutFit
 
-### Community 430 - "Community 430"
+### Community 430 - "._predict_stress"
 Cohesion: 0.25
 Nodes (5): ndarray, Predict stress for given shear rates.          Args:             X: Shear rate d, Model function for Bayesian inference.          This method is required by Bayes, Compute shear stress using Bingham model.          Args:             gamma_dot:, Fit Bingham parameters to data.          Args:             X: Shear rate data (g
 
-### Community 431 - "Community 431"
+### Community 431 - "TestHVNMStartup"
 Cohesion: 0.15
 Nodes (6): Test startup shear predictions., Stress should increase monotonically at short times., Higher phi → amplified modulus → higher peak stress., Short-time slope ≈ G_tot * gamma_dot., Startup stress at long time → flow curve stress., TestHVNMStartup
 
-### Community 432 - "Community 432"
+### Community 432 - "TestVLBNonlocalCreation"
 Cohesion: 0.15
 Nodes (7): Cooperativity length xi = sqrt(D_mu / k_d_0)., Repr includes grid info., Default nonlocal has core params + D_mu., Bell nonlocal has nu parameter., Constant: G0, k_d_0, eta_s, D_mu = 4 params., Spatial grid is correctly set up., TestVLBNonlocalCreation
 
-### Community 433 - "Community 433"
+### Community 433 - "TestHVMCreep"
 Cohesion: 0.17
-Nodes (10): GuiLogHandler, install_gui_log_handler(), _LogEmitter, Formatter, LogRecord, Route log records into the GUI log panel safely., Attach GUI handler to root logger and return it., Logging utilities tests for RheoJAX GUI. (+2 more)
+Nodes (7): Creep compliance under constant stress., No NaN in creep strain., Strain is positive for positive stress., Strain increases with time under load., return_full dict has expected keys., Higher applied stress → more strain., TestHVMCreep
 
-### Community 434 - "Community 434"
-Cohesion: 0.25
-Nodes (5): Test monotonicity checking utilities., Test detection of monotonic increasing., Test detection of monotonic decreasing., Test monotonicity with small noise (tolerance)., TestMonotonicityChecks
-
-### Community 435 - "Community 435"
-Cohesion: 0.11
-Nodes (10): Simulate startup flow at constant shear rate.          Parameters         ------, Simulate creep deformation under constant stress.          Parameters         --, Simulate Large-Amplitude Oscillatory Shear (LAOS).          Parameters         -, Return equilibrium conformation for all N modes.          Returns         ------, Predict response using protocol-aware dispatch.          Parameters         ----, NumPyro/BayesianMixin model function.          Routes to appropriate prediction, Internal startup simulation for model_function.          Returns total shear str, Internal relaxation simulation for model_function.          Analytical multi-mod (+2 more)
-
-### Community 436 - "Community 436"
-Cohesion: 0.20
-Nodes (6): Uniform initial conditions should give uniform profiles., Constant k_d with uniform IC gives uniform mu_xy profile., Startup with uniform IC stays uniform., D_mu > 0 damps spatial perturbations over time., Neumann BC: gradient at boundaries is approximately zero., TestVLBNonlocalHomogeneous
-
-### Community 437 - "Community 437"
+### Community 434 - "is_monotonic_decreasing"
 Cohesion: 0.18
-Nodes (11): HLGrid, make_grid(), _physics_step(), Single explicit Euler step for HL model physics., Advance HL model by one time step with adaptive sub-stepping.      Implements th, Grid specification for HL solver.      Attributes:         sigma: Stress grid po, Create discretization grid for stress P(sigma).      Args:         sigma_max: Ma, step_hl() (+3 more)
+Nodes (10): is_monotonic_decreasing(), is_monotonic_increasing(), ndarray, Check if data is mostly monotonically increasing.      Args:         data: Array, Check if data is mostly monotonically decreasing.      Args:         data: Array, Test monotonicity checking utilities., Test detection of monotonic increasing., Test detection of monotonic decreasing. (+2 more)
 
-### Community 438 - "Community 438"
-Cohesion: 0.11
-Nodes (13): Public API for parallel execution.  High-level convenience functions that hide p, get_parallel_config(), is_sequential_mode(), Any, Adaptive parallelism configuration.  Auto-detects optimal worker count based on, Get full parallel configuration as dict.      Takes a snapshot of _overrides und, Check if all parallelism is disabled.      Automatically enabled when running un, __getattr__() (+5 more)
+### Community 435 - "ndarray"
+Cohesion: 0.09
+Nodes (16): ndarray, Simulate startup flow at constant shear rate.          Parameters         ------, Simulate creep deformation under constant stress.          Parameters         --, Simulate Large-Amplitude Oscillatory Shear (LAOS).          Parameters         -, Extract Fourier harmonics from LAOS stress response.          Parameters, Initialize parameters from creep data for numerical stability.          For mult, Initialize parameters from stress relaxation data.          Parameters         -, Return equilibrium conformation for all N modes.          Returns         ------ (+8 more)
 
-### Community 439 - "Community 439"
-Cohesion: 0.18
-Nodes (8): parallel_load(), Any, Path, Load multiple data files in parallel using threads.      Uses ThreadPoolExecutor, Test parallel_load() for multi-file I/O., TestParallelLoad, Load multiple CSV files in parallel threads., Parallel and sequential loading produce identical data.
+### Community 436 - "laplacian_1d_neumann_vlb"
+Cohesion: 0.17
+Nodes (8): laplacian_1d_neumann_vlb(), 1D Laplacian with Neumann (zero-flux) boundary conditions.      ∂²f/∂y² using se, Uniform initial conditions should give uniform profiles., Constant k_d with uniform IC gives uniform mu_xy profile., Startup with uniform IC stays uniform., D_mu > 0 damps spatial perturbations over time., Neumann BC: gradient at boundaries is approximately zero., TestVLBNonlocalHomogeneous
 
-### Community 440 - "Community 440"
+### Community 437 - "TestHVMLAOS"
+Cohesion: 0.17
+Nodes (7): Large Amplitude Oscillatory Shear., No NaN in LAOS stress., LAOS returns dict with expected keys., Strain follows sin(omega*t)., Harmonic extraction returns expected structure., Small amplitude → nearly sinusoidal stress (linear regime)., TestHVMLAOS
+
+### Community 438 - "TestInstantiation"
+Cohesion: 0.17
+Nodes (7): Tests for model instantiation and parameters., Test model instantiates with default parameters., Test parameters can be set., Test model has exactly 6 parameters., Test derived properties are computed correctly., Test equilibrium state vector is correct., TestInstantiation
+
+### Community 439 - "parallel_load"
+Cohesion: 0.10
+Nodes (15): parallel_load(), parallel_map(), Any, Path, Load multiple data files in parallel using threads.      Uses ThreadPoolExecutor, Execute a function over items using process-based parallelism.      Each invocat, Tests for parallel public API., Test parallel_load() for multi-file I/O. (+7 more)
+
+### Community 440 - "plot_moduli_evolution"
 Cohesion: 0.27
 Nodes (12): _ensure_matplotlib(), plot_3d_trajectory(), plot_moduli_evolution(), plot_pipkin_diagram(), Axes, Figure, ndarray, SPP (Sequence of Physical Processes) visualization module.  This module provides (+4 more)
 
-### Community 441 - "Community 441"
+### Community 441 - "_modulus_labels"
 Cohesion: 0.25
 Nodes (7): _modulus_labels(), RheoData, Return shear storage, loss, and generic modulus labels., Gap-6: _modulus_labels returns shear modulus labels., No deformation mode → G'/G'' labels., y_units kwarg reflected in label., TestModulusLabels
 
-### Community 442 - "Community 442"
+### Community 442 - "TestHVNMInterphase"
 Cohesion: 0.15
 Nodes (5): Test interphase physics and NP geometry., Verify Guth-Gold formula at known values., Matrix and interphase BER rates should differ (different E_a)., T_v^int > T_v^mat when E_a^int > E_a^mat., TestHVNMInterphase
 
-### Community 443 - "Community 443"
+### Community 443 - "TestDMTLocalStartup"
 Cohesion: 0.17
 Nodes (7): Test startup of steady shear simulations., Test that startup simulation runs without error., Maxwell variant should show stress overshoot., Structure should decay from λ=1 toward λ_eq during startup., Startup stress should approach steady-state value., Viscous variant may not show true stress overshoot., TestDMTLocalStartup
 
-### Community 444 - "Community 444"
+### Community 444 - "TestF002KwargsCache"
 Cohesion: 0.17
 Nodes (7): Regression tests for F-002: model_function must use cached protocol kwargs., After _fit_transient(gamma_dot=10), model_function must use 10, not 1., After _fit_relaxation(sigma_init=200), model_function must use 200., After _fit_creep(sigma_0=50), model_function must use 50., After _fit_oscillation(lam_0=0.8), model_function must use 0.8., After _fit_laos, model_function must use cached gamma_0/omega., TestF002KwargsCache
 
-### Community 445 - "Community 445"
+### Community 445 - "TestRheoDataSerialization"
 Cohesion: 0.25
 Nodes (5): Test serialization/deserialization., Test conversion to dictionary., Test creation from dictionary., Test that serialization round-trip preserves data., TestRheoDataSerialization
 
-### Community 446 - "Community 446"
-Cohesion: 0.04
-Nodes (39): Unit tests for FluiditySaramitoLocal model.  Tests cover: - Model instantiation, Tests for startup transient protocol., Test startup simulation runs., Test trajectory is stored for plotting., Tests for model creation and setup., Tests for creep protocol., Test creep simulation runs., Test bounded strain below yield stress. (+31 more)
+### Community 446 - "test_local.py"
+Cohesion: 0.03
+Nodes (43): Unit tests for FluiditySaramitoLocal model.  Tests cover: - Model instantiation, Tests for startup transient protocol., Test startup simulation runs., Test trajectory is stored for plotting., Tests for model creation and setup., Tests for creep protocol., Test creep simulation runs., Test bounded strain below yield stress. (+35 more)
 
-### Community 447 - "Community 447"
+### Community 447 - "TestDataIntegrity"
 Cohesion: 0.25
 Nodes (5): Test data integrity through I/O operations., Test numeric precision in CSV round-trip., Test that data shapes are preserved in workflows., Test that dtypes are handled correctly., TestDataIntegrity
 
-### Community 448 - "Community 448"
+### Community 448 - "TestRheoDataDomainConsistency"
 Cohesion: 0.25
 Nodes (5): F-IO-R3-004: rheodata_from_dataset_state must derive domain from test_mode., Oscillation dataset with no domain in metadata must get domain='frequency'., Relaxation dataset must get domain='time'., If metadata has domain set, it should be respected., TestRheoDataDomainConsistency
 
-### Community 449 - "Community 449"
+### Community 449 - "TestFluidityNonlocalSmoke"
 Cohesion: 0.17
 Nodes (7): Smoke tests for basic FluidityNonlocal functionality., Test FluidityNonlocal can be instantiated., Test FluidityNonlocal with custom grid parameters., Test FluidityNonlocal is registered correctly., Test expected parameters are present including xi., Test cooperativity length parameter has valid bounds., TestFluidityNonlocalSmoke
 
-### Community 450 - "Community 450"
+### Community 450 - "TestNormalStresses"
 Cohesion: 0.17
 Nodes (7): Tests for normal stress differences., Test N₂/N₁ → -α/2 at low Wi (zero-shear limit)., Test that exact N₂/N₁ deviates from -α/2 at high Wi., Test N₁ > 0 (first normal stress is always positive)., Test N₂ < 0 (second normal stress is always negative)., Test N₂ → 0 as α → 0 (UCM limit)., TestNormalStresses
 
-### Community 451 - "Community 451"
+### Community 451 - "CancelWorkerRunnable"
 Cohesion: 0.26
 Nodes (6): CancelWorkerRunnable, Any, Dispatches a worker's .cancel() off the GUI thread.  ProcessWorkerAdapter.cancel, _FakeWorker, test_cancel_worker_runnable_calls_cancel(), test_cancel_worker_runnable_runs_via_threadpool()
 
-### Community 452 - "Community 452"
+### Community 452 - "TestBinghamStability"
 Cohesion: 0.25
 Nodes (5): Test numerical stability., Test with extreme shear rates., Test at zero shear rate., Test with negative shear rates., TestBinghamStability
 
-### Community 453 - "Community 453"
+### Community 453 - "TestGMMRelaxationMode"
 Cohesion: 0.17
 Nodes (7): Element minimization should reduce N from initial to optimal., Fit quality (R²) should be high for multi-mode relaxation data., Test GMM relaxation mode prediction and fitting., GMM with N=1 should recover total modulus and relaxation time.          Individu, Internal-variable update should produce exponential decay., Two-step NLSQ fitting should converge and produce positive moduli., TestGMMRelaxationMode
 
-### Community 454 - "Community 454"
+### Community 454 - "TestGMMCreepMode"
 Cohesion: 0.17
 Nodes (7): Test GMM creep mode prediction and fitting., Creep optimizer results must remain valid ParameterSet values., Creep simulation using backward-Euler should be unconditionally stable., Creep compliance J(t) = ε(t)/σ₀ should be correctly calculated., GMM with N=1 should match single Maxwell creep behavior., Element minimization should work for creep data., TestGMMCreepMode
 
-### Community 455 - "Community 455"
+### Community 455 - "TestGMMElementMinimization"
 Cohesion: 0.17
 Nodes (7): Test GMM element minimization correctness and accuracy., Test that optimal N is selected correctly in relaxation mode.          Verifies, Test that R² degradation from N=10 to optimal N is < 0.1%.          Ensures warm, Test that Prony series parameters match cold-start accuracy.          Validates, Test element minimization in oscillation mode.          Ensures element search w, Test element minimization in creep mode.          Validates element search for c, TestGMMElementMinimization
 
-### Community 456 - "Community 456"
-Cohesion: 0.20
-Nodes (6): Compute total shear stress from distribution tensor components., Return standard diffrax solver and controller., Internal startup simulation. Returns total shear stress sigma_xy(t)., Internal relaxation simulation.          Computes steady-state pre-shear conform, Internal creep simulation. Returns accumulated strain gamma(t)., Internal LAOS simulation. Returns (strain, stress) arrays.
+### Community 456 - ".model_function"
+Cohesion: 0.17
+Nodes (8): Compute total shear stress from distribution tensor components., Return standard diffrax solver and controller., Predict response from fitted model., NumPyro/BayesianMixin model function.          Routes to appropriate prediction, Internal startup simulation. Returns total shear stress sigma_xy(t)., Internal relaxation simulation.          Computes steady-state pre-shear conform, Internal creep simulation. Returns accumulated strain gamma(t)., Internal LAOS simulation. Returns (strain, stress) arrays.
 
-### Community 458 - "Community 458"
-Cohesion: 0.05
-Nodes (23): Multi-species Transient Network Theory model.      Implements a network with N i, TNTMultiSpecies, Single species (N=1) should behave identically to single Maxwell mode., Verify σ = Σ(G_i·τ_b_i)·γ̇ + η_s·γ̇ for 2 species., 2-species should show broader relaxation spectrum than 1-species., Test flow curve prediction returns correct shape, positive, finite., Multi-mode with constant breakage should be Newtonian (constant viscosity)., Test SAOS prediction returns correct shapes, positive. (+15 more)
+### Community 457 - "TestInstantiation"
+Cohesion: 0.17
+Nodes (7): Tests for model instantiation and parameters., Test model instantiates with default parameters., Test derived τ_d = √(τ_rep · τ_break)., Test parameters can be set., Test derived η₀ = G₀·τ_d + η_s., Test Cates model has exactly 4 parameters., TestInstantiation
 
-### Community 459 - "Community 459"
-Cohesion: 0.07
-Nodes (26): Tests for TNTSingleMode model.  Tests cover: - Instantiation and parameter ma, Tests for non-affine chain slip via Gordon-Schowalter derivative., Tests for flow curve (steady shear) predictions., Tests for SAOS predictions., Tests for startup flow simulation., Tests for stress relaxation simulation., Tests for creep simulation., Tests for LAOS simulation. (+18 more)
+### Community 458 - "TestPhysicalConsistency"
+Cohesion: 0.17
+Nodes (7): Tests for physical correctness and consistency., Test equilibrium conformation for 2 modes is [1,1,1,0, 1,1,1,0]., Test stress is positive for positive shear rate., Test N₁ >= 0 for multi-mode UCM., Test relaxation stress stays positive., Test conformation tensor stays positive definite during startup., TestPhysicalConsistency
 
-### Community 463 - "Community 463"
+### Community 459 - "test_single_mode.py"
+Cohesion: 0.10
+Nodes (13): Tests for TNTSingleMode model.  Tests cover: - Instantiation and parameter ma, Tests for stress relaxation simulation., Test relaxation simulation runs., Verify single-exponential relaxation for constant breakage., Test stress decays during relaxation., Tests for model registry integration., Test model creation via registry., Test alias creation via registry. (+5 more)
+
+### Community 460 - "TestStartupSimulation"
+Cohesion: 0.17
+Nodes (7): Tests for startup flow simulation., Test startup simulation runs., Constant breakage (UCM) should have monotonic startup (no overshoot)., Startup should approach steady-state stress for constant breakage., Test full conformation tensor return., Test startup via predict() method., TestStartupSimulation
+
+### Community 461 - "TestPhysicalConsistency"
+Cohesion: 0.17
+Nodes (7): Tests for physical correctness and consistency., Test equilibrium conformation tensor is identity., Test stress is positive for positive shear rate., Test conformation tensor stays positive definite during startup., Test N₁ > 0 and N₂ = 0 for upper-convected (ξ=0)., Test relaxation stress stays positive., TestPhysicalConsistency
+
+### Community 462 - "TestBellVariant"
+Cohesion: 0.17
+Nodes (7): Tests for Bell force-dependent breakage: β = (1/τ_b)·exp(ν·(stretch-1))., Bell variant should have nu parameter., Bell breakage should produce enhanced shear thinning vs constant.          At, Bell breakage should produce stress overshoot in startup flow.          At hig, Test model_function works for Bell variant flow curve., Verify Bell variant can execute all 6 protocols without error., TestBellVariant
+
+### Community 463 - "TestFENEVariant"
 Cohesion: 0.17
 Nodes (7): Tests for FENE-P finite extensibility: σ = G·f(trS)·(S-I)., FENE variant should have L_max parameter., FENE stress should saturate at high stretch (bounded by L_max).          Unlik, FENE should show strain stiffening in startup (higher transient stress)., Test model_function for FENE variant., Verify FENE variant can execute all 6 protocols., TestFENEVariant
 
-### Community 464 - "Community 464"
+### Community 464 - "TestCreepSimulation"
 Cohesion: 0.17
 Nodes (7): Tests for creep simulation., Test creep simulation runs without error., Test creep returns correct shape., Test creep strain is finite., Test strain increases during creep., Test creep with eta_s > 0 works properly., TestCreepSimulation
 
-### Community 465 - "Community 465"
+### Community 465 - "TestStressOvershoot"
 Cohesion: 0.25
 Nodes (5): Tests for stress overshoot in startup flow., Test stress overshoot occurs in startup., Test overshoot ratio increases with Weissenberg number., Test overshoot occurs at strain ~ O(1).          The characteristic strain for, TestStressOvershoot
 
-### Community 466 - "Community 466"
-Cohesion: 0.25
-Nodes (5): Tests for combining memory_form and stress_form., Test combining full memory with microscopic stress., Test combining all new options with existing options., Test that __repr__ shows all form options., TestCombinedFeatures
+### Community 466 - "TestVLBVariantProtocols"
+Cohesion: 0.17
+Nodes (7): Test NLSQ fitting for various protocols., NLSQ fits shear-thinning flow curve., SAOS fitting (analytical Maxwell)., predict() works after fit., Startup fitting recovers Bell parameters., Relaxation fitting for constant k_d., TestVLBVariantProtocols
 
-### Community 467 - "Community 467"
-Cohesion: 0.25
-Nodes (7): Unit tests for VLB (Vernerey-Long-Brighenti) transient network models.  Tests co, VLBLocal with known parameters: G0=1000 Pa, k_d=1 1/s., VLBMultiNetwork with 2 modes, no permanent, no solvent., VLBMultiNetwork with 1 mode + permanent., vlb_local(), vlb_multi_2(), vlb_multi_perm()
+### Community 467 - "TestDecayTypeDetection"
+Cohesion: 0.17
+Nodes (7): Tests for decay type detection from relaxation data., Test detection of exponential decay (Maxwell-like)., Test detection of power-law decay (gel-like)., Test that insufficient data returns UNKNOWN., Test handling of invalid data (NaN, inf)., Test detection of multi-mode decay., TestDecayTypeDetection
 
-### Community 468 - "Community 468"
-Cohesion: 0.20
-Nodes (7): fitted_maxwell(), _maxwell_data(), hessian_ci raises RuntimeError on an unfitted model., bootstrap_ci raises RuntimeError on an unfitted model., Bootstrap 95% CI should cover the true parameter values for noisy data., Generate synthetic Maxwell relaxation data: G(t) = G0 * exp(-t/tau)., Return a Maxwell model fitted to synthetic relaxation data.
+### Community 468 - "TestEdgeCases"
+Cohesion: 0.17
+Nodes (7): Tests for edge cases in compatibility checking., Test handling of empty arrays., Test handling of single data point., Test handling of negative times., Test handling of zero modulus values., Test handling of negative modulus values., TestEdgeCases
 
-### Community 469 - "Community 469"
+### Community 469 - "Material Classification"
 Cohesion: 0.18
 Nodes (11): **Critical Gels**, **Fractional Order α (0 < α < 1)**, Material Classification, Model Selection Flowchart, Parameter Interpretation, 🔬 Rheological Fundamentals, **Shear-Thinning/Thickening**, Test Mode Guide (+3 more)
 
-### Community 470 - "Community 470"
+### Community 470 - "NamedTuple"
 Cohesion: 0.24
 Nodes (10): NamedTuple, DefaultParameters, FeatureExtractionConfig, InitializationConstants, ParameterBounds, Constants for fractional model initialization.  This module centralizes all magi, Configuration constants for parameter initialization., Configuration for frequency-domain feature extraction. (+2 more)
 
-### Community 471 - "Community 471"
-Cohesion: 0.25
-Nodes (5): Test ArviZ integration with complete workflows., Test that plot methods return self for chaining., Test that ArviZ plots can be saved to files., Test that optional parameters are validated correctly., TestArviZIntegration
+### Community 471 - "TestMittagLefflerEdgeCases"
+Cohesion: 0.17
+Nodes (7): Test edge cases and error handling., Test that negative alpha raises error., Test that alpha=0 raises error., Test that alpha > 2 raises error., Test behavior for very small |z|., Test array with both small and moderate |z| values., TestMittagLefflerEdgeCases
 
-### Community 472 - "Community 472"
+### Community 472 - ".from_registry"
 Cohesion: 0.22
 Nodes (6): Construct ModelInfo by inspecting a registered model.          Temporarily insta, Test ModelInfo.from_registry., TestModelInfo, Tests for ModelInfo construction., Test ModelInfo construction from a known registered model., TestModelInfo
 
-### Community 473 - "Community 473"
+### Community 473 - "TestConfiguration"
 Cohesion: 0.25
 Nodes (5): Test suite for project configuration files., Test that pyproject.toml exists and is valid., Test that pytest configuration exists (in pyproject.toml)., Test that pre-commit configuration exists., TestConfiguration
 
-### Community 474 - "Community 474"
+### Community 474 - "TestShearBandingMetrics"
 Cohesion: 0.17
 Nodes (7): Tests for shear banding detection., Test CV is low for uniform profile., Test CV is high for step profile., Test banding ratio for heterogeneous profile., Test detection correctly identifies uniform flow., Test detection correctly identifies shear bands., TestShearBandingMetrics
 
-### Community 475 - "Community 475"
+### Community 475 - ".create_mastercurve"
 Cohesion: 0.14
 Nodes (10): RheoData, Optimize WLF parameters to minimize overlap error.          Parameters         -, Calculate WLF shift factor.          Parameters         ----------         T : f, Calculate Arrhenius shift factor.          Parameters         ----------, Get shift factor for a given temperature.          Parameters         ----------, Apply horizontal shift to single-temperature data.          Parameters         -, Apply horizontal shift to single-temperature data or create mastercurve., Create mastercurve from multiple temperature datasets.          Parameters (+2 more)
 
-### Community 476 - "Community 476"
+### Community 476 - "TestTensorialFieldPlots"
 Cohesion: 0.25
 Nodes (5): Test that tensorial fields use coolwarm diverging colormap., Test specialized tensorial field plotting functions., Test that plot_tensorial_fields creates 3-panel layout., Test that tensorial field panels have correct LaTeX titles., TestTensorialFieldPlots
 
-### Community 477 - "Community 477"
+### Community 477 - "TestNormalStressPlots"
 Cohesion: 0.25
 Nodes (5): Test normal stress difference visualization., Test that plot_normal_stress_field computes N₁ correctly., Test that normal stress field has LaTeX label., Test log-log plot of N₁/σ_xy vs shear rate., TestNormalStressPlots
 
-### Community 478 - "Community 478"
+### Community 478 - "TestTensorialAutoDetection"
 Cohesion: 0.25
 Nodes (5): Test auto-detection of scalar vs tensorial stress fields., Test that plot_lattice_fields auto-detects scalar (L, L) stress., Test that plot_lattice_fields auto-detects tensorial (3, L, L) stress., Test that invalid stress shape raises ValueError., TestTensorialAutoDetection
 
-### Community 479 - "Community 479"
+### Community 479 - "TestGetLogger"
 Cohesion: 0.17
 Nodes (7): Test get_logger creates different loggers for different context., Tests for get_logger function., Test basic get_logger call., Test get_logger with initial context., Test get_logger returns cached instance., Test get_logger creates different loggers for different names., TestGetLogger
 
-### Community 480 - "Community 480"
-Cohesion: 0.18
-Nodes (5): Test that pipeline stages are properly logged., Test log_operation with JAX computation., Test log_transform context manager., Test that log_fit properly logs exceptions., Test logging with FractionalMaxwellModel.
+### Community 480 - ".has_message"
+Cohesion: 0.15
+Nodes (6): Test that pipeline stages are properly logged., Test log_operation with JAX computation., Test log_transform context manager., Test that log_fit properly logs exceptions., Test log_fit context manager with actual Maxwell model., Test logging with FractionalMaxwellModel.
 
-### Community 481 - "Community 481"
+### Community 481 - "TestParameterManagement"
 Cohesion: 0.17
 Nodes (7): Test getting all mode parameters as arrays., Test total zero-shear viscosity., Tests for per-mode parameter management., Test getting mode parameters., Test setting mode parameters., Test error for out-of-bounds mode index., TestParameterManagement
 
-### Community 482 - "Community 482"
+### Community 482 - "TestHVNMFlowCurve"
 Cohesion: 0.18
 Nodes (5): Test steady-state flow curve predictions., E and I networks relax to zero at steady state., D-network viscous stress dominates at steady state., Steady-state flow curve is independent of phi (only D-network)., TestHVNMFlowCurve
 
-### Community 483 - "Community 483"
+### Community 483 - "TestHVNMRelaxation"
 Cohesion: 0.18
 Nodes (5): Test stress relaxation predictions., G(t) has 4 modes: permanent plateau + E + D + I decay., G(inf) → G_P * X(phi) (amplified permanent modulus)., G(0+) ≈ sum of all network moduli., TestHVNMRelaxation
 
-### Community 484 - "Community 484"
+### Community 484 - "TestVLBUtilities"
 Cohesion: 0.17
 Nodes (7): Test utility methods., Test relaxation spectrum for single mode., Test relaxation spectrum for multi-mode., Test dimensionless number calculations., Test equilibrium distribution tensor., Test parameter dict round-trip., TestVLBUtilities
 
-### Community 485 - "Community 485"
-Cohesion: 0.20
-Nodes (6): fitted_pipeline(), MockBayesianModel, Simple exponential decay model for testing., Test complete workflow: load → fit_nlsq → fit_bayesian → plot_*., Test that all plotting methods require Bayesian fit., Create a fitted BayesianPipeline with NLSQ + Bayesian results.
+### Community 485 - "MockBayesianModel"
+Cohesion: 0.11
+Nodes (11): fitted_pipeline(), MockBayesianModel, Simple exponential decay model for testing., Test ArviZ integration with complete workflows., Test complete workflow: load → fit_nlsq → fit_bayesian → plot_*., Test that all plotting methods require Bayesian fit., Test that plot methods return self for chaining., Test that ArviZ plots can be saved to files. (+3 more)
 
-### Community 486 - "Community 486"
+### Community 486 - "TestExportFormats"
 Cohesion: 0.25
 Nodes (5): Test export to different file formats., Test export to PNG format., Test export to PDF format., Test export to SVG format., TestExportFormats
 
-### Community 487 - "Community 487"
-Cohesion: 0.33
-Nodes (4): Validate Maxwell model against ANSYS MELAS reference., Test Maxwell fits ANSYS relaxation data correctly.          Expected behavior: P, Test that Maxwell predictions match ANSYS relaxation behavior.          Uses fit, TestMaxwellANSYSRelaxation
+### Community 487 - "compute_diagnostics"
+Cohesion: 0.20
+Nodes (9): compute_diagnostics(), compute_per_param_diagnostic(), _import_numpyro_diagnostics(), MCMC, ndarray, Compute convergence diagnostics from MCMC samples.      Args:         mcmc: NumP, Lazy-import NumPyro diagnostics functions., Compute a per-parameter diagnostic (R-hat or ESS).      Reshapes flat posterior (+1 more)
 
-### Community 488 - "Community 488"
+### Community 488 - "Migration Guide"
 Cohesion: 0.20
 Nodes (9): For Scripts and Automation, For Users with Bookmarks, Get Started, Migration Guide, New Location, Notebook Mapping, Questions?, Tutorial Notebooks Have Moved! (+1 more)
 
-### Community 489 - "Community 489"
+### Community 489 - "Classical Linear Viscoelastic Model Equations -- Verification Reference"
 Cohesion: 0.20
 Nodes (9): 1. Maxwell Model (Spring + Dashpot in Series), 2. Kelvin-Voigt Model (Spring + Dashpot in Parallel), 3. Jeffreys Model (Maxwell Element + Solvent Viscosity), 4. Zener / Standard Linear Solid (SLS) Model, 5. Generalized Maxwell Model (GMM / Prony Series), 6. SpringPot / Scott-Blair Fractional Element, Classical Linear Viscoelastic Model Equations -- Verification Reference, References (+1 more)
 
-### Community 490 - "Community 490"
+### Community 490 - "RheoJAX Documentation Structure"
 Cohesion: 0.20
 Nodes (9): Archive Files, Building Documentation, Documentation Tiers, Key Features, Production Documentation, RheoJAX Documentation Structure, Tier 1: User Guide (Conceptual Learning), Tier 2: Model Handbook (Technical Reference) (+1 more)
 
-### Community 491 - "Community 491"
-Cohesion: 0.17
-Nodes (7): Tests for model initialization., Test default initialization creates fluid state., Test initialization with separation parameter., Test initialization with direct v2 value., Test that specifying both epsilon and v2 raises error., Test epsilon property getter and setter., TestITTMCTSchematicInitialization
+### Community 491 - "_process_remaining_rows"
+Cohesion: 0.18
+Nodes (11): _create_rheodata_chunk(), _parse_row_values(), _process_real_row(), _process_remaining_rows(), RheoData, Process remaining data rows after sample rows.      Args:         Various state, Convert tab-separated values to floats, skipping first column.      Args:, Process a single row for real-valued data.      Args:         row: Parsed row va (+3 more)
 
-### Community 492 - "Community 492"
+### Community 492 - "TestTransformPlotterDispatch"
 Cohesion: 0.25
 Nodes (5): Tests for auto-dispatch based on transform name., Unknown transform falls back to generic plot., Known transform name dispatches to correct method., Transform names are normalized (case, hyphens, spaces)., TestTransformPlotterDispatch
 
-### Community 493 - "Community 493"
-Cohesion: 0.33
-Nodes (6): _check_excel_dependencies(), parse_trios_excel(), Path, Low-level Excel parser returning raw TRIOSFile structure.      For advanced user, Check that required Excel libraries are available.      Args:         filepath:, read_only=True workbook should be closed after parsing.
+### Community 493 - "load_trios"
+Cohesion: 0.24
+Nodes (11): _detect_txt_encoding(), _extract_metadata(), _find_data_segments(), load_trios(), Path, Extract metadata from file header.      Args:         lines: File lines      Ret, Find all [step] data segments in file.      Args:         lines: File lines, Load TA Instruments TRIOS .txt file.      Reads rheological data from TRIOS expo (+3 more)
 
-### Community 494 - "Community 494"
+### Community 494 - "run_all_notebooks.py"
 Cohesion: 0.29
 Nodes (9): discover_notebooks(), _is_setup_cell(), main(), _print_result(), Check if a cell is an injected matplotlib setup cell., Execute a single notebook. Returns (success, error_message, duration)., Print a single notebook result., Find all runnable notebooks, excluding archive/checkpoint/hidden files. (+1 more)
 
-### Community 495 - "Community 495"
+### Community 495 - "Array"
 Cohesion: 0.22
-Nodes (11): advected_correlator(), advected_memory_decorrelation(), f12_memory_kernel_derivative(), Array, Public wrapper for _solve_equilibrium_correlator_f12_jit with empty-array guard., Compute strain decorrelation function h(γ).      Under shear, the correlator dec, Compute advected correlator Φ(t,t') under shear.      The advected correlator is, Compute derivative of F₁₂ memory kernel with respect to Φ.      dm/dΦ = v₁ + 2v₂ (+3 more)
+Nodes (8): _jit_flow_curve_single(), _jit_oscillation_kernel(), Array, JIT-friendly oscillation simulation., Dispatch to JIT-compiled oscillation kernel., JIT-compiled flow curve for a single shear rate.      Args:         gdot: Shear, JIT-compiled oscillatory shear simulation.      ``fluidity_form`` selects the pl, Perform one EPM time step (subclass-specific kernel).          Args:
 
-### Community 496 - "Community 496"
+### Community 496 - ".predict_rheo"
 Cohesion: 0.29
 Nodes (5): RheoData, TestMode, Compute apparent viscosity using Bingham model.          Args:             gamma, Predict apparent viscosity for given shear rates.          Args:             gam, Predict rheological response for RheoData.          Args:             rheo_data:
 
-### Community 497 - "Community 497"
-Cohesion: 0.33
-Nodes (3): Automatically detect or retrieve test mode.          The test mode is detected b, Execute MCMC in background thread.          This method runs in a separate threa, Execute file import in background thread.
+### Community 497 - ".test_mode"
+Cohesion: 0.06
+Nodes (24): Automatically detect or retrieve test mode.          The test mode is detected b, Auto-populate a newly-added pipeline step's config from current UI state., Execute all pipeline steps in sequence on a background thread.          Pipeline, Execute a single pipeline step with accumulated context.          Builds context, Execute MCMC in background thread.          This method runs in a separate threa, ImportWorker, ImportWorkerSignals, Any (+16 more)
 
-### Community 498 - "Community 498"
-Cohesion: 0.33
-Nodes (3): Initialize SPP amplitude sweep pipeline.          Args:             omega: Angul, Initialize model comparison pipeline.          Args:             models: List of, Initialize mastercurve pipeline.          Args:             reference_temp: Refe
-
-### Community 499 - "Community 499"
+### Community 498 - "create_prony_parameter_set"
 Cohesion: 0.20
-Nodes (6): Test stress relaxation simulations., Relaxation should raise error without elasticity., Test relaxation simulation runs., Stress should decay during relaxation., Structure should recover toward λ=1 during relaxation., TestDMTLocalRelaxation
+Nodes (8): Initialize Generalized Maxwell Model.          Args:             n_modes: Number, create_prony_parameter_set(), Create ParameterSet for N-mode Prony series.      Dynamically generates paramete, test_no_tensile_modulus_type(), Test create_prony_parameter_set() for N modes., Create shear modulus parameters (G_inf, G_i, tau_i)., n_modes < 1 should raise ValueError., TestParameterSetCreation
 
-### Community 500 - "Community 500"
+### Community 499 - "TestCrossPredictions"
+Cohesion: 0.18
+Nodes (6): Test Newtonian limit when λ → 0., Test Newtonian plateau at low shear rates., Test Cross formula: η = η∞ + (η0-η∞)/[1+(λγ̇)^m]., Test shear-thinning behavior., Test stress prediction., TestCrossPredictions
+
+### Community 500 - "TestDMTLocalLAOS"
 Cohesion: 0.20
 Nodes (6): Test large amplitude oscillatory shear simulations., Test LAOS simulation runs., Input strain should be sinusoidal., Test Fourier harmonic extraction., Higher harmonics should increase with strain amplitude., TestDMTLocalLAOS
 
-### Community 501 - "Community 501"
+### Community 501 - "TestDMTNonlocal"
 Cohesion: 0.20
 Nodes (6): Test nonlocal (1D) DMT model., Test nonlocal model instantiation., Test cooperativity length calculation., Test steady shear simulation runs., Test shear banding detection., TestDMTNonlocal
 
-### Community 502 - "Community 502"
-Cohesion: 0.07
-Nodes (19): Unit tests for FIKH model.  Tests cover: - Model initialization with various con, Test FIKH limiting behavior as α → 1., Test that α → 1 gives exponential-like relaxation., Test that small α gives slower structure recovery., Test FIKH relaxation protocol predictions., Create isothermal FIKH model for relaxation tests., Test relaxation prediction produces valid output., Test that relaxation shows stress decay (Mittag-Leffler behavior). (+11 more)
+### Community 502 - "test_fikh.py"
+Cohesion: 0.04
+Nodes (30): fikh_flow_curve_steady_state(), Compute steady-state flow curve for FIKH model.      At steady state:     - λ_ss, Unit tests for FIKH model.  Tests cover: - Model initialization with various con, Test FIKH limiting behavior as α → 1., Test that α → 1 gives exponential-like relaxation., Test that small α gives slower structure recovery., Test FIKH relaxation protocol predictions., Create isothermal FIKH model for relaxation tests. (+22 more)
 
-### Community 503 - "Community 503"
+### Community 503 - "TestHerschelBulkleyNumericalStability"
 Cohesion: 0.20
 Nodes (6): Test numerical stability of Herschel-Bulkley model., Test with extreme shear rates., Test behavior at exactly zero shear rate., Test with negative shear rates., Test with edge parameter values., TestHerschelBulkleyNumericalStability
 
-### Community 504 - "Community 504"
-Cohesion: 0.33
-Nodes (4): Test JSON serialization of parameters., Test JSON serialization for data and parameters., Test converting RheoData to JSON., TestJSONSerialization
+### Community 504 - "._sync_fit_step_config"
+Cohesion: 0.11
+Nodes (6): Update the selected pipeline step's config when model selection changes., Update pipeline chips when state changes., Test main window can be created with QApplication., Test main window has valid geometry., Test switching between Fitting and Transform workflows.      The main window now, test_workflow_switching()
 
-### Community 505 - "Community 505"
+### Community 505 - "TestNormalStressScaling"
 Cohesion: 0.20
 Nodes (6): Test normal stress difference scaling., Create model for normal stress tests., Test N₁ > 0 (Weissenberg effect)., Test N₁ increases with shear rate., Test N₂ = 0 for upper-convected Maxwell., TestNormalStressScaling
 
-### Community 506 - "Community 506"
-Cohesion: 0.18
-Nodes (6): Small Amplitude Oscillatory Shear., G'(omega → inf) → G_P + G_E + G_D., G'' has two peaks from E and D networks., tau_E_eff = 1/(2*k_BER_0), not 1/k_BER_0., return_components=False returns |G*|., TestHVMSAOS
-
-### Community 507 - "Community 507"
+### Community 506 - "Cross"
 Cohesion: 0.20
-Nodes (6): Tests for FluidityLocal transient protocols., TC-025: Higher f_inf (initial fluidity for relaxation) -> faster decay., Test startup shows stress increase from zero., Test relaxation shows stress decay., Test creep shows strain accumulation., TestFluidityLocalTransient
+Nodes (6): Cross, Cross model for non-Newtonian flow (ROTATION only).      The Cross model describ, String representation., Initialize Cross model., Test fitting with synthetic data., Test that model_function output matches predict.
 
-### Community 508 - "Community 508"
+### Community 507 - "format_compatibility_message"
+Cohesion: 0.24
+Nodes (7): format_compatibility_message(), Format compatibility check results as a user-friendly message.      Parameters, Tests for compatibility message formatting., Test formatting of compatible message., Test formatting of incompatible message., Test formatting when decay/material types are unknown., TestCompatibilityMessageFormatting
+
+### Community 508 - "test_window_file_menu.py"
+Cohesion: 0.38
+Nodes (9): test_maybe_confirm_unsaved_clean_state_proceeds_without_dialog(), test_maybe_confirm_unsaved_discard_still_proceeds(), test_maybe_confirm_unsaved_save_blocked_by_active_jobs_warns_and_aborts(), test_maybe_confirm_unsaved_save_cancelled_does_not_proceed(), test_maybe_confirm_unsaved_save_success_proceeds(), test_on_open_shows_critical_dialog_on_value_error(), test_on_save_as_shows_critical_dialog_on_os_error(), test_on_save_shows_critical_dialog_on_value_error() (+1 more)
+
+### Community 509 - "TestCascadeProvenance"
 Cohesion: 0.20
-Nodes (5): Predict response using protocol-aware dispatch.          Parameters         ----, NumPyro/BayesianMixin model function.          Routes to appropriate prediction, Internal startup simulation for model_function.          Returns total shear str, Internal relaxation simulation for model_function.          Analytical: σ(t) = G, Internal creep simulation for model_function.          Returns accumulated strai
+Nodes (6): F-IO-002, F-IO-011: auto_load must track format_detected in metadata., auto_load on a CSV file should set format_detected='csv'., Direct CSV load via auto_load sets format_detected., A .txt file that's actually CSV should track all attempted readers., CSV reader should set encoding_fallback when fallback encoding used., TestCascadeProvenance
 
-### Community 509 - "Community 509"
+### Community 510 - "TestTriosChunkedBasic"
 Cohesion: 0.20
-Nodes (5): Internal relaxation simulation for model_function.          For constant breakag, Internal creep simulation for model_function.          Returns accumulated strai, Unpack variant parameters from a JAX params array.          Used by model_functi, Predict response using protocol-aware dispatch.          Parameters         ----, NumPyro/BayesianMixin model function.          Routes to appropriate prediction
+Nodes (6): Test that metadata is preserved across all chunks., Test that units are preserved across chunks., Basic chunked reading tests., Test chunked reading with data smaller than chunk size., Test chunked reading with data split across chunks., TestTriosChunkedBasic
 
-### Community 510 - "Community 510"
-Cohesion: 0.33
-Nodes (4): Test CSV read/write cycle., Test writing and reading CSV files., Test that metadata is preserved in CSV workflow., TestCSVRoundTrip
-
-### Community 511 - "Community 511"
+### Community 511 - "TestSteadyShearAnalytical"
 Cohesion: 0.20
 Nodes (6): Tests for steady-state analytical solutions., Test viscosity approaches η₀ at low Wi.          Note: The quartic solver has, Test viscosity decreases with shear rate., Test α=0 gives constant viscosity (UCM limit)., Test vectorized stress prediction., TestSteadyShearAnalytical
 
-### Community 512 - "Community 512"
-Cohesion: 0.22
-Nodes (6): NaNProducingModel, Verify NaN predictions are penalized, not silently zeroed., Model that can produce NaN should complete Bayesian inference., num_nonfinite deterministic should be tracked in posterior., Model that produces NaN for certain parameter regions., TestNaNGuard
-
-### Community 513 - "Community 513"
+### Community 512 - "TestFluidityLocalFlowCurve"
 Cohesion: 0.20
-Nodes (6): Test time values are correctly extracted., Test compliance values are correctly extracted., T019: Test compliance calculated when J(t) column missing., Tests for creep test loading (US1: T018-T019)., T018: Test creep loading returns correct structure., TestCreepLoading
+Nodes (6): Tests for FluidityLocal flow curve (steady-state) protocol., Test flow curve prediction returns correct shape., Test flow curve stress increases with shear rate., Test flow curve shows yield stress at low rates., Test flow curve at high rates approaches power-law., TestFluidityLocalFlowCurve
 
-### Community 514 - "Community 514"
+### Community 513 - "TestFluidityNonlocalTransient"
+Cohesion: 0.20
+Nodes (6): Tests for FluidityNonlocal transient protocols., Test startup shows stress increase from zero., Test fluidity field trajectory is stored after simulation., Test relaxation shows stress decay., TC-012: Test creep strain increases under applied stress., TestFluidityNonlocalTransient
+
+### Community 514 - "TestBinghamBasics"
 Cohesion: 0.33
 Nodes (4): Test basic functionality., Test model initialization., Test parameter bounds., TestBinghamBasics
 
-### Community 515 - "Community 515"
+### Community 515 - "TestBinghamFitting"
 Cohesion: 0.33
 Nodes (4): Test parameter fitting., Test fitting with synthetic data., Test fitting with noisy data., TestBinghamFitting
 
-### Community 516 - "Community 516"
+### Community 516 - "TestDiffraxCompilation"
 Cohesion: 0.20
 Nodes (6): Tests for diffrax JIT compilation performance., Create ITTMCTSchematic model for testing., Test that JIT compilation happens on first call., Test that precompile() method triggers compilation., Test that precompile() reduces the effective first-call time., TestDiffraxCompilation
 
-### Community 517 - "Community 517"
+### Community 517 - "TestTieredPriorConstruction"
 Cohesion: 0.20
 Nodes (6): Test tiered prior construction based on convergence classification., Test that good convergence uses NLSQ estimates and covariance for priors., Test that suspicious convergence uses safer priors decoupled from Hessian., Test that hard failure in strict mode raises informative error., Test that hard failure with allow_fallback_priors=True provides generic priors., TestTieredPriorConstruction
 
-### Community 518 - "Community 518"
+### Community 518 - "TestFIKHParameters"
 Cohesion: 0.20
 Nodes (6): Test _get_params_dict returns correct dictionary., Test FIKH parameter handling., Test all base parameters exist., Test thermal parameters exist when enabled., Test all parameters have valid bounds., TestFIKHParameters
 
-### Community 519 - "Community 519"
+### Community 519 - "TestCatesMaxwellLimit"
 Cohesion: 0.20
 Nodes (6): Verify Cates model reduces to Maxwell behavior with effective τ_d.      The Ca, Test τ_d = √(τ_rep · τ_break)., Verify σ = (G₀·τ_d + η_s)·γ̇ for Cates model., Verify G'(ω) and G''(ω) match Maxwell with τ_d., Test G' = G'' crossover at ω_c = 1/τ_d., TestCatesMaxwellLimit
 
-### Community 520 - "Community 520"
+### Community 520 - "TestBinghamPhysicalBehavior"
 Cohesion: 0.33
 Nodes (4): Test physical behavior., Test yield stress consistency., Test that plastic viscosity is constant above yield., TestBinghamPhysicalBehavior
 
-### Community 523 - "Community 523"
+### Community 521 - "TestStartupSimulation"
+Cohesion: 0.20
+Nodes (6): Tests for startup flow simulation., Test startup simulation runs., Cates model should have monotonic startup (no overshoot)., Startup should approach steady-state stress σ_ss = η₀·γ̇., Test full conformation tensor return., TestStartupSimulation
+
+### Community 522 - "TestCreepSimulation"
+Cohesion: 0.20
+Nodes (6): Tests for creep simulation., Test creep simulation runs., Test strain increases during creep., Test creep with rate return., Test creep reaches steady shear rate γ̇ → σ/η₀., TestCreepSimulation
+
+### Community 523 - "TestLAOSSimulation"
 Cohesion: 0.20
 Nodes (6): Tests for LAOS simulation., Test LAOS simulation runs., Test LAOS response is periodic after transient., Small-amplitude LAOS should match SAOS (linear limit)., Test LAOS harmonic extraction., TestLAOSSimulation
 
-### Community 525 - "Community 525"
+### Community 524 - "TestPhysicalConsistency"
+Cohesion: 0.20
+Nodes (6): Tests for physical correctness and consistency., Test stress is positive for positive shear rate., Test first normal stress difference N₁ >= 0., Test conformation tensor stays positive definite during startup., Test relaxation stress stays positive., TestPhysicalConsistency
+
+### Community 525 - "TestFlowCurve"
 Cohesion: 0.20
 Nodes (6): Tests for flow curve (steady shear) predictions., Test flow curve prediction via predict()., Test direct predict_flow_curve method., Test flow curve with viscosity and N1., Test flow curve shows shear thinning for Bell force sensitivity., TestFlowCurve
 
-### Community 526 - "Community 526"
+### Community 526 - "TestStartupSimulation"
 Cohesion: 0.20
 Nodes (6): Tests for startup flow simulation., Test startup simulation runs., Test startup approaches steady-state stress., Test startup with bridge fraction return., Test bridge fraction decreases during startup flow., TestStartupSimulation
 
-### Community 527 - "Community 527"
-Cohesion: 0.33
-Nodes (4): Tests for stress relaxation predictions., Test stress decay in relaxation., Test residual stress in glass relaxation., TestRelaxationProtocol
+### Community 527 - "TestFluidityNonlocalGrid"
+Cohesion: 0.20
+Nodes (6): Tests for spatial grid functionality., Test initial fluidity field has correct shape., Test initial fluidity field is uniform., Test initial state vector has correct shape., Test grid arguments are correctly assembled., TestFluidityNonlocalGrid
 
-### Community 528 - "Community 528"
+### Community 528 - "TestPlasticityAlpha"
 Cohesion: 0.20
 Nodes (6): Test α is bounded [0, 1]., Tests for Saramito plasticity function., Test α = 0 below yield stress., Test α > 0 above yield stress., Test α → 1 far above yield., TestPlasticityAlpha
 
-### Community 531 - "Community 531"
+### Community 529 - "TestMaxwellLimit"
+Cohesion: 0.20
+Nodes (6): Verify TNTMultiSpecies recovers multi-mode Maxwell (generalized UCM).      For, Single species (N=1) should behave identically to single Maxwell mode., Verify σ = Σ(G_i·τ_b_i)·γ̇ + η_s·γ̇ for 2 species., Verify G'(ω) and G''(ω) match multi-mode Maxwell formulas., 2-species should show broader relaxation spectrum than 1-species., TestMaxwellLimit
+
+### Community 530 - "TestFlowCurve"
+Cohesion: 0.20
+Nodes (6): Tests for flow curve (steady shear) predictions., Test flow curve prediction returns correct shape, positive, finite., Test direct predict_flow_curve method., Test flow curve with viscosity and N1., Multi-mode with constant breakage should be Newtonian (constant viscosity)., TestFlowCurve
+
+### Community 531 - "TestCreepSimulation"
 Cohesion: 0.20
 Nodes (6): Tests for creep simulation., Test creep simulation runs and returns correct shape, finite., Test strain increases during creep., Test creep with rate return., Creep simulation needs eta_s > 0 to be well-posed., TestCreepSimulation
 
-### Community 532 - "Community 532"
+### Community 532 - "TestBayesianInterface"
 Cohesion: 0.20
 Nodes (6): Tests for BayesianMixin compatibility., Test model_function for flow curve with 2 species (5 params)., Test model_function for SAOS., Test model_function params match ParameterSet.keys() order., Test model_function for 3 species (7 params)., TestBayesianInterface
 
-### Community 534 - "Community 534"
+### Community 533 - "TestNonAffineVariant"
+Cohesion: 0.20
+Nodes (6): Tests for non-affine chain slip via Gordon-Schowalter derivative., Non-affine model should store xi > 0., Non-affine deformation produces N₂ ≠ 0.          The Gordon-Schowalter derivat, At xi=0, non-affine should give same result as basic model., Verify non-affine variant can execute all 6 protocols., TestNonAffineVariant
+
+### Community 534 - "TestMaxwellLimits"
 Cohesion: 0.20
 Nodes (6): Verify TNT basic model recovers exact Maxwell behavior.      The constant-brea, Verify σ = (G·τ_b + η_s)·γ̇ for constant breakage., Verify G'(ω) and G''(ω) match Maxwell formulas exactly., Test G' = G'' at crossover frequency ω_c = 1/τ_b., Verify N₁ = 2G·(τ_b·γ̇)² for constant breakage., TestMaxwellLimits
 
-### Community 535 - "Community 535"
-Cohesion: 0.03
-Nodes (29): Single-mode Transient Network Theory model.      Implements the Green-Tobolsky /, Get network modulus G (Pa)., Get solvent viscosity η_s (Pa·s)., Whether this is the basic (constant/linear/UC) variant., TNTSingleMode, Non-affine model should store xi > 0., At xi=0, non-affine should give same result as basic model., Verify non-affine variant can execute all 6 protocols. (+21 more)
-
-### Community 536 - "Community 536"
+### Community 535 - "TestFlowCurve"
 Cohesion: 0.20
-Nodes (5): Test creep predictions., Strain should increase monotonically under constant stress., NP filling should reduce creep compliance., Creep strain increases with time as networks relax., TestHVNMCreep
+Nodes (6): Tests for flow curve (steady shear) predictions., Test flow curve prediction via predict()., Test direct predict_flow_curve method., Test flow curve with viscosity and N1., Constant breakage gives Newtonian viscosity (no shear thinning)., TestFlowCurve
 
-### Community 538 - "Community 538"
+### Community 536 - "TestInstantiation"
+Cohesion: 0.20
+Nodes (6): Tests for multi-mode instantiation., Test model instantiates with default 3 modes., Test instantiation with custom number of modes., Test error for invalid n_modes., Test parameters are created for each mode., TestInstantiation
+
+### Community 537 - "TestLAOSSimulation"
+Cohesion: 0.20
+Nodes (6): Tests for LAOS simulation., Test LAOS simulation runs., Test LAOS response is periodic after transient., Small-amplitude LAOS should match SAOS (linear limit)., Test LAOS harmonic extraction., TestLAOSSimulation
+
+### Community 538 - "TestFlowCurve"
 Cohesion: 0.20
 Nodes (6): Tests for flow curve (steady shear) predictions., Test flow curve prediction returns correct shape., Test flow curve stress is positive., Test flow curve stress is finite., Test flow curve approaches Newtonian behavior at low shear rates.          At, TestFlowCurve
 
-### Community 539 - "Community 539"
+### Community 539 - "TestStartupSimulation"
 Cohesion: 0.20
 Nodes (6): Tests for startup flow simulation., Test startup simulation runs without error., Test startup returns correct shape., Test startup stress is finite., Test startup approaches steady-state stress.          At long times, σ(t) → σ_, TestStartupSimulation
 
-### Community 540 - "Community 540"
+### Community 540 - "TestRelaxationSimulation"
 Cohesion: 0.20
 Nodes (6): Tests for stress relaxation simulation., Test relaxation simulation runs without error., Test relaxation returns correct shape., Test relaxation stress is finite., Test stress decays during relaxation., TestRelaxationSimulation
 
-### Community 541 - "Community 541"
+### Community 541 - "TestBayesianInterface"
 Cohesion: 0.20
 Nodes (6): Tests for BayesianMixin compatibility., Test model_function for flow curve., Test model_function for SAOS., Test model_function params match ParameterSet order.          Parameter order:, Test model_function with default 3 modes (8 params)., TestBayesianInterface
 
-### Community 542 - "Community 542"
+### Community 542 - "TestDerivedProperties"
 Cohesion: 0.20
 Nodes (6): Tests for derived property methods., When tau_s very small, plateau modulus should be near zero.          With no s, When tau_s very large, all modes contribute to plateau., Test η₀ from method matches low-rate flow curve., Test N1 prediction works for both scalar and array input., TestDerivedProperties
 
-### Community 543 - "Community 543"
+### Community 543 - "TestVLBNonlocalProtocols"
 Cohesion: 0.20
 Nodes (6): Test simulation protocols., simulate_steady_shear returns correct keys., simulate_startup returns correct structure., simulate_creep returns correct structure., Nonlocal model cannot be fitted directly., TestVLBNonlocalProtocols
 
-### Community 544 - "Community 544"
+### Community 544 - "TestVLBLocalFlowCurve"
 Cohesion: 0.20
 Nodes (6): Test VLBLocal steady shear predictions., Sigma should be proportional to gamma_dot (Newtonian)., Viscosity should equal G0/k_d., N1 should be proportional to gamma_dot^2., Test predict_flow_curve with return_components., TestVLBLocalFlowCurve
 
-### Community 545 - "Community 545"
+### Community 545 - "TestVLBLocalStartup"
 Cohesion: 0.20
 Nodes (6): Test VLBLocal startup shear predictions., Compare analytical formula against known values., Stress at t=0 should be zero., Stress at long time should equal steady-state., Test N1 during startup., TestVLBLocalStartup
 
-### Community 546 - "Community 546"
+### Community 546 - "TestVLBLocalSAOS"
 Cohesion: 0.20
 Nodes (6): Test VLBLocal small-amplitude oscillatory shear., G'(omega) = G0*omega^2*t_R^2 / (1 + omega^2*t_R^2)., G''(omega) = G0*omega*t_R / (1 + omega^2*t_R^2)., G' = G'' at omega = k_d., Test |G*| via predict with test_mode=oscillation., TestVLBLocalSAOS
 
-### Community 547 - "Community 547"
+### Community 547 - "TestVLBCrossProtocol"
 Cohesion: 0.20
 Nodes (6): Test cross-protocol consistency of VLB models., Steady-state startup stress should match flow curve., Crossover frequency should match relaxation rate., Zero-shear viscosity from flow curve, creep, and SAOS should agree., G(0) from relaxation should match G0 from SAOS high-freq limit., TestVLBCrossProtocol
 
-### Community 548 - "Community 548"
+### Community 548 - "TestStartupSimulation"
 Cohesion: 0.20
-Nodes (6): Test LVEEnvelope as a BaseTransform., Basic transform with explicit Prony parameters., Read Prony params from data metadata., Should raise ValueError when no Prony params available., G_i and tau_i must have same length., TestLVEEnvelopeTransform
+Nodes (6): Tests for multi-mode startup simulation., Test startup simulation runs.          Note: Multi-mode ODE has JIT compatibil, Test startup approaches steady state., Test startup with per-mode stress return., Test startup via predict() with protocol kwargs., TestStartupSimulation
 
-### Community 549 - "Community 549"
+### Community 549 - "TestMittagLefflerJAXCompatibility"
 Cohesion: 0.20
 Nodes (6): Test JAX-specific features., Test mittag_leffler_e is already JIT compiled., Test mittag_leffler_e2 is already JIT compiled., Test that mittag_leffler_e works with vmap., Test that gradient can be computed through mittag_leffler_e., TestMittagLefflerJAXCompatibility
 
-### Community 550 - "Community 550"
+### Community 550 - "TestCompareModels"
 Cohesion: 0.20
 Nodes (6): Tests for compare_models function., Compare 2 classical models on relaxation data., Akaike weights should sum to 1., Invalid criterion should raise ValueError., Nonexistent models should be skipped, not crash., TestCompareModels
 
-### Community 551 - "Community 551"
+### Community 551 - "TestFlowCurve"
 Cohesion: 0.20
-Nodes (5): Test model_function JAX-traceability and Bayesian interface., model_function must accept JAX arrays without error., NLSQ then NUTS for SAOS data., NLSQ then NUTS for relaxation data., TestHVNMBayesian
+Nodes (6): Test direct predict_flow_curve method., Test flow curve with viscosity and N1., Test viscosity decreases with shear rate., Tests for flow curve (steady shear) predictions., Test flow curve prediction via predict()., TestFlowCurve
 
-### Community 552 - "Community 552"
+### Community 552 - "test_spp_plots.py"
 Cohesion: 0.12
 Nodes (12): laos_signals(), Tests for SPP (Sequence of Physical Processes) visualization module.  Covers a, Generate synthetic LAOS signals (1 cycle)., Generate synthetic SPP analysis results dict., Gap-5: create_spp_report uses strain_rate_normalized when present., When strain_rate_normalized is provided, it overrides computed rate., Gap-7: plot_moduli_evolution raises ValueError for single Axes with multi-panel., Single Axes with n_plots > 1 raises ValueError. (+4 more)
 
-### Community 553 - "Community 553"
+### Community 553 - "RheoJAX Documentation"
 Cohesion: 0.22
 Nodes (8): 🙏 Acknowledgments, 📝 Contributing to Documentation, Documentation Standards, 📄 License, RheoJAX Documentation, 📮 Support, 🔗 Useful Links, 📚 What is RheoJAX?
 
-### Community 554 - "Community 554"
+### Community 554 - "📖 Documentation Structure"
 Cohesion: 0.22
 Nodes (9): **1. Models Handbook** (53 Models Documented), **2. Transforms** (7 Transforms Documented), **3. User Guides**, **4. API Reference**, **5. Examples** (100+ Jupyter Notebooks), **Classical Models** (3 models), 📖 Documentation Structure, **Flow & Viscoplastic Models** (6 models) (+1 more)
 
-### Community 555 - "Community 555"
+### Community 555 - "TestPlotPair"
 Cohesion: 0.33
 Nodes (4): Test plot_pair() method for parameter correlations., Test that plot_pair() returns matplotlib Figure., Test plot_pair() with optional parameters., TestPlotPair
 
-### Community 556 - "Community 556"
+### Community 556 - "TestPlotForest"
 Cohesion: 0.33
 Nodes (4): Test plot_forest() method for credible intervals., Test that plot_forest() returns matplotlib Axes., Test plot_forest() displays multiple parameters., TestPlotForest
 
-### Community 557 - "Community 557"
-Cohesion: 0.17
-Nodes (17): ColumnSpec, input_contract(), InputContract, import_dataset(), Path, RheoData, CLI/non-interactive dataset import, backing `rheojax-gui --import FILE --protoco, test_flow_curve_default_has_y_column() (+9 more)
+### Community 557 - "DatasetRef"
+Cohesion: 0.06
+Nodes (48): ColumnSpec, input_contract(), InputContract, import_dataset(), Path, RheoData, CLI/non-interactive dataset import, backing `rheojax-gui --import FILE --protoco, DatasetRef (+40 more)
 
-### Community 558 - "Community 558"
+### Community 558 - "TestPlotAutocorr"
 Cohesion: 0.33
 Nodes (4): Test plot_autocorr() method for mixing quality., Test that plot_autocorr() returns matplotlib Axes., Test plot_autocorr() with custom max_lag parameter., TestPlotAutocorr
 
-### Community 559 - "Community 559"
+### Community 559 - "TestSAOS"
 Cohesion: 0.20
 Nodes (6): Tests for SAOS predictions., Test SAOS prediction., Test |G*| prediction via test_mode='oscillation'., Test terminal regime scaling: G' ~ ω², G'' ~ ω., Test SAOS matches effective Maxwell model with G_eff = f_B_eq·G., TestSAOS
 
-### Community 560 - "Community 560"
+### Community 560 - "TestPlotRank"
 Cohesion: 0.33
 Nodes (4): Test plot_rank() method for convergence assessment., Test that plot_rank() returns matplotlib Axes., Test plot_rank() for convergence assessment., TestPlotRank
 
-### Community 561 - "Community 561"
+### Community 561 - "._predict_viscosity"
 Cohesion: 0.25
 Nodes (5): ndarray, Predict viscosity for given shear rates.          Args:             X: Shear rat, Model function for Bayesian inference.          This method is required by Bayes, Compute viscosity: η(γ̇) = K |γ̇|^(n-1).          Args:             gamma_dot: S, Fit Power Law parameters to data.          Args:             X: Shear rate data
 
-### Community 562 - "Community 562"
+### Community 562 - ".predict_normal_stresses"
 Cohesion: 0.22
 Nodes (5): ndarray, Get all parameters as a dictionary.          Returns         -------         dic, Build args dictionary for ODE integration.          Parameters         ---------, Initialize parameters from flow curve data.          Smart initialization strate, Predict first and second normal stress differences.          The Saramito model
 
-### Community 563 - "Community 563"
+### Community 563 - "TestPlotESS"
 Cohesion: 0.33
 Nodes (4): Test plot_ess() method for effective sample size., Test that plot_ess() returns matplotlib Axes., Test plot_ess() shows threshold reference lines., TestPlotESS
 
-### Community 564 - "Community 564"
-Cohesion: 0.33
-Nodes (4): Cross-method consistency checks., Both methods should produce intervals containing the optimal value., On noisy synthetic data, Hessian and bootstrap CIs should overlap.          NOTE, TestHessianVsBootstrap
+### Community 564 - "TestCreepSimulation"
+Cohesion: 0.20
+Nodes (6): Tests for creep simulation., Test creep simulation runs., Test strain increases during creep., Test creep with rate return., Test creep requires eta_s > 0 for stability., TestCreepSimulation
 
-### Community 565 - "Community 565"
+### Community 565 - "TestVonMisesPlots"
 Cohesion: 0.33
 Nodes (4): Test von Mises stress visualization., Test that plot_von_mises_field creates 2-panel layout., Test that von Mises panels use correct colormaps., TestVonMisesPlots
 
-### Community 566 - "Community 566"
+### Community 566 - "TestPlotTimeDomain"
 Cohesion: 0.33
 Nodes (4): Test time-domain plotting functions., Test plotting relaxation data., Test plotting with logarithmic scale., TestPlotTimeDomain
 
-### Community 567 - "Community 567"
+### Community 567 - "TestPlotFrequencyDomain"
 Cohesion: 0.33
 Nodes (4): Test frequency-domain plotting functions., Test plotting complex modulus (G' and G'')., Test plotting real modulus only., TestPlotFrequencyDomain
 
-### Community 568 - "Community 568"
+### Community 568 - "TestLogFit"
 Cohesion: 0.33
 Nodes (4): Tests for log_fit context manager., Test that fit-specific context is logged., Test that completion context is included., TestLogFit
 
-### Community 569 - "Community 569"
+### Community 569 - "TestPowerLawPredictions"
 Cohesion: 0.20
 Nodes (6): Test stress prediction: σ = K * γ̇^n., Test Newtonian limit (n = 1)., Test predictions for Power Law model., Test viscosity prediction for shear-thinning (n < 1)., Test viscosity prediction for shear-thickening (n > 1)., TestPowerLawPredictions
 
-### Community 570 - "Community 570"
-Cohesion: 0.04
-Nodes (26): GiesekusBase, ndarray, Initialize ParameterSet with Giesekus parameters.          The Giesekus model ha, Get polymer viscosity η_p (Pa·s)., Get relaxation time λ (s)., Get solvent viscosity η_s (Pa·s)., Get zero-shear viscosity η₀ = η_p + η_s (Pa·s)., Get elastic modulus G = η_p/λ (Pa). (+18 more)
+### Community 570 - "GiesekusBase"
+Cohesion: 0.05
+Nodes (21): GiesekusBase, Initialize ParameterSet with Giesekus parameters.          The Giesekus model ha, Get polymer viscosity η_p (Pa·s)., Get relaxation time λ (s)., Get solvent viscosity η_s (Pa·s)., Get zero-shear viscosity η₀ = η_p + η_s (Pa·s)., Get elastic modulus G = η_p/λ (Pa)., Get relaxation time λ (s). Alias for lambda_1. (+13 more)
 
-### Community 571 - "Community 571"
+### Community 571 - "TestHVNMLAOS"
 Cohesion: 0.22
 Nodes (4): Test LAOS (Large Amplitude Oscillatory Shear)., LAOS with dual TST should produce odd harmonics., Stress-strain Lissajous should be approximately closed., TestHVNMLAOS
 
-### Community 572 - "Community 572"
+### Community 572 - "TestBatchVectorization"
 Cohesion: 0.08
 Nodes (14): Test handling of variable-length datasets with padding/masking., Benchmark multi-dataset processing with 3-4x speedup target., Test that parallel I/O produces correct results (structural check)., Test that error handling preserves file-level granularity., Test backward compatibility with batch_vectorize=False (default)., Test _stack_datasets helper with padding for variable lengths., Test that model fitting can be vmapped over datasets., Simple model that supports vectorization. (+6 more)
 
-### Community 573 - "Community 573"
+### Community 573 - "TestPlotFlowCurve"
 Cohesion: 0.33
 Nodes (4): Test flow curve plotting functions., Test plotting viscosity vs shear rate., Test plotting shear stress vs shear rate., TestPlotFlowCurve
 
-### Community 574 - "Community 574"
+### Community 574 - "SPP Parity Reference (MATLAB SPPplus v2.1, R oreo, RheoJAX)"
 Cohesion: 0.25
 Nodes (7): Gap Matrix (parity notes), Golden-Data Harness (actionable plan), How to generate goldens, Immediate use, MATLAB SPPplus v2.1 (key points), Scope, SPP Parity Reference (MATLAB SPPplus v2.1, R oreo, RheoJAX)
 
-### Community 575 - "Community 575"
+### Community 575 - "TestPlotResiduals"
 Cohesion: 0.33
 Nodes (4): Test residual plotting functions., Test plotting residuals., Test plotting data with predictions and residuals., TestPlotResiduals
 
-### Community 576 - "Community 576"
-Cohesion: 0.29
-Nodes (6): _import_numpyro(), Lazy-import NumPyro and its submodules.      Returns all NumPyro symbols needed, Verify that _import_numpyro() provides all necessary symbols., _import_numpyro() should return numpyro, dist, transforms, MCMC, NUTS, init_to_*, Calling _import_numpyro() twice returns same objects., TestLazyNumPyroImports
+### Community 576 - "TestBayesianInterface"
+Cohesion: 0.20
+Nodes (6): Tests for BayesianMixin compatibility., Test model_function for flow curve., Test model_function for SAOS., Test model_function params match ParameterSet order., Verify parameter order for Bayesian inference., TestBayesianInterface
 
-### Community 577 - "Community 577"
+### Community 577 - "TestPublicationQuality"
 Cohesion: 0.33
 Nodes (4): Test publication-quality output., Test that publication-quality settings are applied., Test default style settings., TestPublicationQuality
 
-### Community 578 - "Community 578"
+### Community 578 - "PowerLaw"
 Cohesion: 0.25
 Nodes (6): PowerLaw, String representation., Power Law model for non-Newtonian flow (ROTATION only).      The Power Law (Ostw, Initialize Power Law model., Test float64 precision for a flow model.      Flow models have different physics, test_flow_model_float64_precision()
 
-### Community 579 - "Community 579"
+### Community 579 - "IKHBase"
 Cohesion: 0.29
 Nodes (5): IKHBase, ArrayLike, Helper to extract time and strain from inputs.          Args:             X:, Fit model parameters to data.          Args:             X: Time/Strain input, Base class for Isotropic-Kinematic Hardening models.      These models describ
 
-### Community 580 - "Community 580"
-Cohesion: 0.25
-Nodes (4): Build PDE RHS function for diffrax integration.          State: [Sigma, mu_xx[0:, Build initial state with small perturbation for symmetry breaking.          Para, Simulate approach to steady state under imposed average shear rate.          Par, Simulate startup from rest with banding evolution.          Parameters         -
+### Community 580 - "TestCreepSimulation"
+Cohesion: 0.20
+Nodes (6): Tests for creep simulation., Test creep simulation runs., Test strain increases during creep., Test creep with rate return., Test creep reaches steady shear rate.          At long times: γ̇ → σ/(G·τ_b +, TestCreepSimulation
 
-### Community 581 - "Community 581"
+### Community 581 - "TestModulusFrequencyTemplate"
 Cohesion: 0.33
 Nodes (4): Test modulus-frequency plotting template., Test G' and G'' vs frequency plot., Test plotting on single axis., TestModulusFrequencyTemplate
 
-### Community 582 - "Community 582"
-Cohesion: 0.40
-Nodes (4): PostFitValidator, ArrayLike, Runs post-fit physics checks and uncertainty quantification., Compute post-fit uncertainty estimates.          Args:             model: Fitted
+### Community 582 - "TestMittagLefflerAccuracy"
+Cohesion: 0.20
+Nodes (6): Test accuracy for moderate |z| in rheological range., Test E_α(-z) for negative arguments (relaxation modulus case)., Test E_{α,β}(z) accuracy for various parameter combinations., Test numerical accuracy for rheological range |z| < 10., Test accuracy for small |z| using hybrid Taylor/asymptotic., TestMittagLefflerAccuracy
 
-### Community 583 - "Community 583"
-Cohesion: 0.25
-Nodes (5): Property-based tests for GENERIC model thermodynamic consistency., Entropy production rate >= 0 (second law of thermodynamics)., Entropy production is small at near-equilibrium states., Free energy is finite for valid state., TestGENERICThermodynamics
+### Community 583 - "TestPartitionFunction"
+Cohesion: 0.20
+Nodes (6): Test Z(x, omega) partition function., Test Z(x) matches analytical formula: Z = x / (x + 1)., Test that Z is independent of frequency for equilibrium SGR., Test Z(x) asymptotic limits., Test that 0 <= Z(x) <= 1 for all x > 0., TestPartitionFunction
 
-### Community 584 - "Community 584"
-Cohesion: 0.25
-Nodes (4): Compute thermal interfacial BER rate at zero stress.          k_BER^int_0 = nu, Compute modulus fractions for all four subnetworks.          Returns, Classify interphase state based on temperature.          Returns         ----, Identify which limiting case is currently active.          Returns         --
+### Community 584 - "TestTrapDistribution"
+Cohesion: 0.20
+Nodes (6): Test exponential trap distribution rho(E)., Test that rho(E) = exp(-E) is properly normalized., Test rho(E) values match exp(-E)., Test that rho(E) = 0 for E < 0 (unphysical)., Test scalar input returns scalar output., TestTrapDistribution
 
-### Community 585 - "Community 585"
-Cohesion: 0.25
-Nodes (5): Smoke benchmarks for v0.3.2 optimizations (run in smoke tier)., Smoke test: Maxwell model fit completes without error., Smoke test: Fractional model fit completes without error., Smoke test: Mastercurve transform completes without error., TestV032SmokeBenchmarks
+### Community 585 - "TestJAXCompatibility"
+Cohesion: 0.20
+Nodes (6): Test JAX transformations (jit, vmap, grad)., Test that G0 JIT compiles successfully., Test that Gp JIT compiles successfully., Test G0 vectorization with vmap., Test Gp vectorization over frequency array., TestJAXCompatibility
 
-### Community 586 - "Community 586"
-Cohesion: 0.40
-Nodes (3): Array, Perform one scalar EPM time step.          Delegates to the `epm_step` kernel fr, Initialize scalar stress field.          Args:             key: PRNG key (unused
+### Community 586 - "TestPhysicalBehavior"
+Cohesion: 0.20
+Nodes (6): Test physical phase regimes from SGR theory., Test theoretical power-law exponent = x - 1., Test solid-like behavior for x < 1 (glass phase)., Test power-law viscoelastic behavior for 1 < x < 2., Test Newtonian behavior for x >= 2., TestPhysicalBehavior
 
-### Community 587 - "Community 587"
-Cohesion: 0.25
-Nodes (5): Tests for relaxation test loading (US2: T020-T021)., T020: Test relaxation loading returns correct structure., Test relaxation modulus values are correctly extracted., T021: Test G(t) calculated when column missing., TestRelaxationLoading
+### Community 587 - "._run_nuts_sampling"
+Cohesion: 0.22
+Nodes (6): Array, BayesianResult, MCMC, Compute convergence diagnostics from MCMC samples.          Delegates to bayesia, Run NUTS sampling with fallback to uniform initialization.          Args:, Process MCMC results into BayesianResult.
 
-### Community 588 - "Community 588"
-Cohesion: 0.25
-Nodes (5): Tests for rotational/flow test loading (US4: T055-T057)., T055: Test rotational loading returns correct structure., T056: Test shear rate ordering preserved., T057: Test y_col allows selecting alternative column., TestRotationalLoading
+### Community 588 - ".update_metadata"
+Cohesion: 0.22
+Nodes (5): Any, Invalidate JAX cache when x or y data is reassigned., Update metadata dictionary.          Args:             metadata: Dictionary of m, Convert to dictionary representation.          Returns:             Dictionary w, Create from dictionary representation.          Args:             data_dict: Dic
 
-### Community 589 - "Community 589"
-Cohesion: 0.25
-Nodes (5): Tests for error handling (T075-T078)., T075: Test FileNotFoundError for missing file., T076: Test ValueError for no interval blocks., T078: Test error for interval index out of range., TestErrorHandling
+### Community 589 - ".get_dataframe"
+Cohesion: 0.28
+Nodes (5): DataFrame, Extract DataFrame from specified result set.          Args:             result_i, Split result DataFrame by step column.          Args:             result_index:, Get DataFrames from all results.          Returns:             List of DataFrame, Get DataFrame from specified dataset.          Args:             dataset_index:
 
-### Community 590 - "Community 590"
-Cohesion: 0.40
-Nodes (3): Any, Get fitted SPPYieldStress model.          Returns:             Fitted model or N, Get detailed results for a specific model.          Args:             model_name
+### Community 590 - "._get_initial_stress_state"
+Cohesion: 0.22
+Nodes (5): ndarray, Initialize parameters from SAOS data.          Uses the crossover frequency and, Initialize parameters from viscosity vs shear rate data.          Uses the zero-, Get initial stress state for ODE integration.          Parameters         ------, Clip estimated parameters to their defined bounds.          Common logic to ensu
 
-### Community 591 - "Community 591"
+### Community 591 - "TestEquilibriumStructure"
 Cohesion: 0.25
 Nodes (5): Test equilibrium structure calculations., λ_eq should approach 0 at high shear rates., λ_eq should approach 1 at low shear rates., λ_eq should decrease monotonically with γ̇., TestEquilibriumStructure
 
-### Community 592 - "Community 592"
+### Community 592 - "TestDMTLocalFlowCurve"
 Cohesion: 0.25
 Nodes (5): Test steady-state flow curve predictions., Flow curve should show shear-thinning behavior., HB flow curve should show yield stress plateau., Test viscosity limits at extreme shear rates., TestDMTLocalFlowCurve
 
-### Community 593 - "Community 593"
+### Community 593 - "TestDMTLocalSAOS"
 Cohesion: 0.25
 Nodes (5): Test small amplitude oscillatory shear predictions., SAOS should raise error without elasticity., SAOS should return G' and G''., SAOS should show Maxwell-like frequency dependence., TestDMTLocalSAOS
 
-### Community 594 - "Community 594"
+### Community 594 - "main"
+Cohesion: 0.36
+Nodes (8): main(), make_sin_fundamental(), make_sin_noisy(), ndarray, Path, Generate synthetic LAOS datasets for SPP golden-data harness.  Datasets: - sin_f, Generate golden data inputs.      Args:         argv: Command line arguments. If, write_csv()
+
+### Community 595 - "TRIOSResult"
 Cohesion: 0.25
-Nodes (5): Tests for _fit_oscillation implementation., _fit_oscillation returns self for fluent API., _fit_oscillation accepts (N,2) input [G', G'']., Fitted model should reproduce SAOS moduli., TestFitOscillation
+Nodes (5): Get step number from properties if present., Single result set within a TRIOS experiment.      Represents one test result con, Get units mapping from specified result.          Args:             result_index, Get units mapping from specified dataset.          Args:             dataset_ind, TRIOSResult
 
-### Community 595 - "Community 595"
+### Community 596 - "TestDialogIntegration"
 Cohesion: 0.25
-Nodes (5): Test sign_safe fix (F-001)., Test sign_safe returns +1 for positive values., Test sign_safe returns -1 for negative values., Test sign_safe returns 0 for zero., TestFIKHSignSafe
+Nodes (5): Test that dialogs are properly integrated with menu actions., Verify PreferencesDialog can be imported and instantiated., Verify AboutDialog can be imported and instantiated., Verify ImportWizard can be imported and instantiated., TestDialogIntegration
 
-### Community 596 - "Community 596"
-Cohesion: 0.16
-Nodes (9): _atexit_kill_pools(), Queue, Persistent process pool for JAX-safe parallel execution.  Long-lived subprocesse, Check if any worker processes are still running., Kill all remaining pool worker processes at interpreter exit., Safety net: kill worker processes if pool is garbage-collected without shutdown., Force-kill all worker processes without waiting., Worker main loop — runs in a subprocess.      Receives (task_id, fn, args, kwarg (+1 more)
-
-### Community 597 - "Community 597"
+### Community 597 - "TestHerschelBulkleyRheoData"
 Cohesion: 0.25
 Nodes (5): Test Herschel-Bulkley with RheoData., Test prediction with RheoData (stress output)., Test prediction with RheoData (viscosity output)., Test that wrong test mode raises error., TestHerschelBulkleyRheoData
 
-### Community 598 - "Community 598"
+### Community 598 - "TestPowerLawRheoData"
 Cohesion: 0.25
 Nodes (5): Test Power Law with RheoData., Test prediction with RheoData (viscosity output)., Test prediction with RheoData (stress output)., Test that wrong test mode raises error., TestPowerLawRheoData
 
-### Community 599 - "Community 599"
+### Community 599 - "TestPowerLawBasics"
 Cohesion: 0.25
 Nodes (5): Test basic functionality of Power Law model., Test model initialization., Test parameter bounds., Test setting parameters., TestPowerLawBasics
 
-### Community 600 - "Community 600"
+### Community 600 - "TestPowerLawNumericalStability"
 Cohesion: 0.25
 Nodes (5): Test numerical stability of Power Law model., Test with extreme shear rates., Test behavior at zero shear rate., Test with negative shear rates (should use absolute value)., TestPowerLawNumericalStability
 
-### Community 601 - "Community 601"
+### Community 601 - "TestSteadyStateFlowCurve"
 Cohesion: 0.25
 Nodes (5): Tests for steady-state flow curve prediction., Test yield stress appears at low rates.          Note: FS-015 removed the dead G, Test stress increases monotonically with rate., Test full coupling increases low-rate stress., TestSteadyStateFlowCurve
 
-### Community 602 - "Community 602"
+### Community 602 - "TestPhaseRegimes"
 Cohesion: 0.25
-Nodes (5): Test parameter sensitivity analysis., Test local sensitivity analysis., Test global sensitivity analysis (variance-based)., Test parameter identifiability analysis., TestParameterSensitivity
+Nodes (5): Property-based tests for correct behavior in different phase regimes., Model correctly identifies glass phase for x < 1., Model correctly identifies power-law fluid phase for 1 < x < 2., Model correctly identifies Newtonian phase for x >= 2., TestPhaseRegimes
 
-### Community 603 - "Community 603"
+### Community 603 - "TestNonlocalCreep"
 Cohesion: 0.25
 Nodes (5): Tests for nonlocal creep simulation., Test creep with stress above yield produces increasing strain., Test creep with stress below yield returns elastic jump γ = σ/G., Test creep returns spatial fluidity field., TestNonlocalCreep
 
-### Community 604 - "Community 604"
-Cohesion: 0.10
-Nodes (18): Tests for GiesekusMultiMode model.  Tests cover: - Instantiation with differe, Tests for multi-mode SAOS predictions., Tests for multi-mode flow curve predictions., Tests for multi-mode instantiation., Tests for multi-mode startup simulation., Tests for relaxation spectrum analysis., Tests for model registry integration., Test model creation via registry. (+10 more)
+### Community 604 - "test_multi_mode.py"
+Cohesion: 0.20
+Nodes (8): Tests for GiesekusMultiMode model.  Tests cover: - Instantiation with differe, Tests for relaxation spectrum analysis., Tests for model registry integration., Test model creation via registry., Tests for ParameterSet→model_function roundtrip (the actual NUTS path).      D, TestParameterSetRoundtrip, TestRegistryIntegration, TestRelaxationSpectrum
 
-### Community 605 - "Community 605"
-Cohesion: 0.07
-Nodes (18): GUI Crash Prevention Tests ==========================  Comprehensive tests for G, Tests verifying widgets render safely without crashes., Verify QLabel can render ASCII text without issues., Verify QTableWidget can render ASCII text without issues., Tests for widget creation/destruction safety., Test rapid creation and destruction of widgets., Tests for Unicode edge cases and safety., Test that high Unicode codepoints are detected. (+10 more)
-
-### Community 606 - "Community 606"
+### Community 605 - "TestNumericalStability"
 Cohesion: 0.25
-Nodes (5): Tests for edge cases (T070-T074)., T071: Test bracket [unit] notation., T071: Test parentheses (unit) notation., T072: Test Unicode characters in headers., TestEdgeCases
+Nodes (5): Property-based tests for numerical stability near edge cases., G0 and Gp are numerically stable near x = 1., Gp is numerically stable at extreme frequencies., All predictions are finite for valid parameter combinations., TestNumericalStability
 
-### Community 607 - "Community 607"
+### Community 606 - "TestCarreauNumericalStability"
 Cohesion: 0.25
-Nodes (5): Test model_function for Bayesian inference., Test model_function accepts parameter dictionary., Test model_function accepts parameter array., Test model_function for flow curve mode., TestFIKHModelFunction
+Nodes (5): Test numerical stability of Carreau model., Test with extreme shear rates., Test behavior at zero shear rate., Test with negative shear rates., TestCarreauNumericalStability
 
-### Community 608 - "Community 608"
-Cohesion: 0.60
-Nodes (4): Unit tests for SPPYieldStress model., _synthetic_amplitude_sweep(), test_bayesian_warm_start_uses_nlsq_init_static(), test_nlsq_converges_and_sets_exponent_static()
+### Community 607 - "TestCreepBifurcation"
+Cohesion: 0.25
+Nodes (5): Test creep bifurcation behavior., Create model for creep tests., Test continuous flow above yield stress., Test arrested flow below yield stress., TestCreepBifurcation
 
-### Community 609 - "Community 609"
+### Community 608 - "TestFractionalMaxwellLiquidOscillation"
+Cohesion: 0.25
+Nodes (4): Test complex modulus predictions., Test power-law scaling at low frequency., Test that G* approaches Gm at high frequency., TestFractionalMaxwellLiquidOscillation
+
+### Community 609 - "TestGMMBayesianPipelineBugs"
 Cohesion: 0.25
 Nodes (5): Regression tests for F-GMM-001/002/003 GUI Bayesian pipeline bugs., F-GMM-001: infer_model_kwargs detects n_modes from G_i names., F-GMM-002: model_function uses _laos_omega/_laos_gamma_0 from self attrs., F-GMM-001: fit_bayesian works after element minimization reduces n_modes., TestGMMBayesianPipelineBugs
 
-### Community 610 - "Community 610"
+### Community 610 - "TestConvergenceClassification"
 Cohesion: 0.25
 Nodes (5): Test that a failed fit is classified as 'hard_failure'., Test NLSQ convergence classification into hard failure, suspicious, or good., Test that a well-converged fit is classified as 'good'., Test that a questionable fit with high uncertainty is classified appropriately., TestConvergenceClassification
 
-### Community 613 - "Community 613"
-Cohesion: 0.40
-Nodes (5): Generate a simple LAOS waveform with optional 3rd harmonic., _synthetic_laos(), test_apparent_cage_modulus_matches_modulus_in_linear_regime(), test_lissajous_metrics_positive_area(), test_static_and_dynamic_yield_stress_linear_material()
+### Community 611 - "TestSAOS"
+Cohesion: 0.25
+Nodes (5): Tests for SAOS predictions., Test SAOS prediction., Test |G*| prediction via test_mode='oscillation'., Test terminal regime scaling: G' ~ ω², G'' ~ ω., TestSAOS
 
-### Community 615 - "Community 615"
+### Community 612 - "TestBayesianInterface"
+Cohesion: 0.25
+Nodes (5): Tests for BayesianMixin compatibility., Test model_function for flow curve., Test model_function for SAOS., Test model_function params match ParameterSet order., TestBayesianInterface
+
+### Community 613 - "TestStressTensorProduct"
+Cohesion: 0.25
+Nodes (5): Tests for τ·τ computation., Test τ·τ for pure shear stress., Test τ·τ with normal stresses., Test τ·τ = 0 when τ = 0., TestStressTensorProduct
+
+### Community 614 - "TestStartupSimulation"
+Cohesion: 0.25
+Nodes (5): Tests for startup flow simulation., Test startup simulation runs and returns correct shape, finite., Startup should approach steady-state stress at long times., Test full conformation tensor return for all modes., TestStartupSimulation
+
+### Community 615 - "TestFluidityEvolution"
 Cohesion: 0.25
 Nodes (5): Tests for fluidity evolution kernel., Test fluidity decreases (ages) at rest., Test fluidity increases under flow., Test df/dt ≈ 0 at f = f_age with no flow.          Note: With FS-008 (driving fl, TestFluidityEvolution
 
-### Community 619 - "Community 619"
+### Community 616 - "TestSAOS"
+Cohesion: 0.25
+Nodes (5): Tests for SAOS predictions., Test SAOS prediction., Test |G*| prediction via test_mode='oscillation'., Test terminal regime scaling: G' ~ ω², G'' ~ ω., TestSAOS
+
+### Community 617 - "TestSAOSPredictions"
+Cohesion: 0.25
+Nodes (5): Tests for multi-mode SAOS predictions., Test SAOS prediction., Test SAOS is sum of Maxwell modes., Test multi-mode captures broad frequency range., TestSAOSPredictions
+
+### Community 618 - "TestBayesianInterface"
+Cohesion: 0.25
+Nodes (5): Tests for BayesianMixin compatibility., Test model_function for flow curve., Test model_function for SAOS., Test model_function params match ParameterSet order., TestBayesianInterface
+
+### Community 619 - "TestStickerFloorPhysics"
 Cohesion: 0.25
 Nodes (5): Tests for sticker floor constraint: tau_eff_k = max(tau_R_k, tau_s)., Test effective times are τ_R_k + τ_s (Leibler-Rubinstein-Colby 1991)., When tau_s > tau_R_k, sticker contribution dominates., When tau_s ≪ all tau_R_k, model reduces to multi-mode Maxwell., TestStickerFloorPhysics
 
-### Community 620 - "Community 620"
+### Community 620 - "TestSAOS"
 Cohesion: 0.25
 Nodes (5): Tests for SAOS predictions., Test SAOS prediction returns correct shapes., Test G' and G'' are positive., Multi-mode should give broader plateau than single mode.          The multi-mo, TestSAOS
 
-### Community 621 - "Community 621"
+### Community 621 - "TestLAOSSimulation"
 Cohesion: 0.25
 Nodes (5): Tests for LAOS simulation., Test LAOS simulation runs without error., Test LAOS simulation returns expected output., Test LAOS stores trajectory data., TestLAOSSimulation
 
-### Community 622 - "Community 622"
+### Community 622 - "TestVonMisesStress"
 Cohesion: 0.25
 Nodes (5): Tests for Von Mises equivalent stress calculation., Test Von Mises stress for pure shear., Test that traceless stress gives consistent result., Test zero stress gives zero magnitude., TestVonMisesStress
 
-### Community 623 - "Community 623"
+### Community 623 - "test_vlb_nonlocal.py"
 Cohesion: 0.25
 Nodes (7): Unit tests for VLBNonlocal (nonlocal VLB with spatial PDE).  Tests cover: - Mode, VLBNonlocal with constant breakage, few grid points for speed., VLBNonlocal with Bell breakage, few grid points., VLBNonlocal with FENE stress, few grid points., vlb_nl_bell(), vlb_nl_constant(), vlb_nl_fene()
 
-### Community 624 - "Community 624"
+### Community 624 - "TestVLBNonlocalBanding"
 Cohesion: 0.25
 Nodes (5): Shear banding with Bell breakage + nonlocal diffusion., Bell + nonlocal produces banding for suitable parameters., Integral of gamma_dot across gap gives V_wall., Transient simulation converges to steady state., TestVLBNonlocalBanding
 
-### Community 625 - "Community 625"
+### Community 625 - "TestVLBLocalLAOS"
 Cohesion: 0.25
 Nodes (5): Test VLBLocal large-amplitude oscillatory shear., At small gamma_0, LAOS should match SAOS., Test LAOS via model_function interface., N1 should be nonzero during LAOS (second harmonic)., TestVLBLocalLAOS
 
-### Community 626 - "Community 626"
+### Community 626 - "TestFlowCurvePredictions"
 Cohesion: 0.25
-Nodes (5): Test VLBLocal uniaxial extension., Trouton ratio should approach 3 at low extension rate., High extension rate near k_d/2 should give large stress., Test transient extensional stress., TestVLBLocalExtension
+Nodes (5): Tests for multi-mode flow curve predictions., Test flow curve prediction., Test flow curve via predict() method., Test flow curve with viscosity return., TestFlowCurvePredictions
 
-### Community 627 - "Community 627"
+### Community 627 - "TestModelFunction"
 Cohesion: 0.25
-Nodes (5): Test overshoot increases with waiting time (TC-019).          The simulate_start, Test thixotropic stress overshoot behavior., Create thixotropic model with parameters that show overshoot.          Key insig, Test stress overshoot is present in startup., TestThixotropicOvershoot
+Nodes (5): Tests for model_function (Bayesian interface)., Test model_function for SAOS., Test model_function output matches predict_saos for oscillation.          Dive, Test model_function output matches predict for flow_curve., TestModelFunction
 
-### Community 628 - "Community 628"
+### Community 628 - "TestYieldStressEmergence"
 Cohesion: 0.25
 Nodes (5): Test yield stress behavior in flow curves., Create model with known yield stress., Test stress approaches τ_y at low shear rates., Test HB power-law scaling at high rates., TestYieldStressEmergence
 
-### Community 629 - "Community 629"
+### Community 629 - "TestInferenceDataConversion"
 Cohesion: 0.25
 Nodes (5): Test conversion from BayesianResult to ArviZ InferenceData., Test that to_inference_data() returns valid InferenceData object., Test that InferenceData contains required groups., Test that NUTS-specific diagnostics are preserved in InferenceData., TestInferenceDataConversion
 
-### Community 630 - "Community 630"
+### Community 630 - "TestNonexponentialRelaxation"
 Cohesion: 0.25
 Nodes (5): Test non-exponential stress relaxation., Create model for relaxation tests., Test stress decreases during relaxation., Test residual stress can remain above zero (yield stress effect)., TestNonexponentialRelaxation
 
-### Community 631 - "Community 631"
+### Community 631 - "TestVLBBellFeneCombined"
 Cohesion: 0.25
-Nodes (5): Integration tests with actual model classes., Test FractionalZenerSolidSolid with smart initialization., Test FractionalKelvinVoigt with smart initialization., Test that smart initialization improves fit quality vs defaults., TestModelIntegration
+Nodes (5): Test combined Bell + FENE-P behavior., Bell+FENE: shear thinning (viscosity) but stress hardening., Bell+FENE: extensional stress is bounded., Bell+FENE LAOS produces higher harmonics., TestVLBBellFeneCombined
 
-### Community 632 - "Community 632"
+### Community 632 - "TestModelFunction"
 Cohesion: 0.25
 Nodes (5): Tests for model_function interface used by BayesianMixin., Test model_function for flow_curve mode., Test model_function for oscillation mode., Test model_function is differentiable via JAX., TestModelFunction
 
-### Community 633 - "Community 633"
+### Community 633 - "TestShearThinning"
 Cohesion: 0.25
 Nodes (5): Tests for shear-thinning behavior., Test η(γ̇) is monotonically decreasing for α > 0., Test η approaches η₀ = η_p + η_s at low shear rates.          Note: Numerical, Test power-law thinning at high Wi.          At high Wi, η ~ γ̇^(n-1) where n, TestShearThinning
 
-### Community 635 - "Community 635"
+### Community 634 - "TestMittagLefflerComplexArguments"
+Cohesion: 0.25
+Nodes (5): Test complex argument support., Test E_α(z) with complex z., Test E_{α,β}(z) with complex z., Test E_α(iω) for frequency-domain applications., TestMittagLefflerComplexArguments
+
+### Community 635 - "🚀 Key Features"
 Cohesion: 0.29
 Nodes (7): **Bayesian Inference** (NEW in v0.2.0), **Data I/O**, 🚀 Key Features, **Model-Data Compatibility** (NEW in v0.2.0), **Performance**, **Smart Initialization** (NEW in v0.2.0), **Visualization**
 
-### Community 636 - "Community 636"
+### Community 636 - ".plot_data"
 Cohesion: 0.38
 Nodes (5): PlotDataItem, floating, NDArray, Plot data points.          Parameters         ----------         x : NDArray, Plot a line (typically for fits/predictions).          Parameters         ------
 
-### Community 638 - "Community 638"
-Cohesion: 0.22
-Nodes (5): Any, Serialize model to dictionary.          Returns:             Dictionary represen, Create model from dictionary.          Args:             data: Dictionary repres, String representation of model., Get model parameters.          Args:             deep: If True, return parameter
+### Community 637 - "Bingham"
+Cohesion: 0.15
+Nodes (9): Bingham, String representation., Bingham model for linear viscoplastic flow (ROTATION only).      The Bingham mod, Initialize Bingham model., Test prediction with RheoData (stress output)., Test prediction with RheoData (viscosity output)., Test error for wrong test mode., Test that model_function output matches predict. (+1 more)
 
-### Community 639 - "Community 639"
+### Community 638 - "._fit"
+Cohesion: 0.17
+Nodes (7): Any, Serialize model to dictionary.          Returns:             Dictionary represen, String representation of model., Fit the model to data using NLSQ optimization.          This method uses NLSQ (G, Precompile NLSQ residual functions to eliminate JIT cold-start.          Trigger, Internal fit implementation to be overridden by subclasses.          Args:, Get model parameters.          Args:             deep: If True, return parameter
+
+### Community 639 - "TestFlowCurveProtocol"
 Cohesion: 0.25
 Nodes (5): Tests for flow curve (steady shear) predictions., Test flow curve in fluid state., Test flow curve in glass state (yield stress)., Test shear thinning behavior., TestFlowCurveProtocol
 
-### Community 640 - "Community 640"
-Cohesion: 0.50
-Nodes (3): Test behavior when ArviZ is not available., Test that plotting methods handle missing ArviZ gracefully., TestArviZAvailability
+### Community 640 - "TestMittagLefflerRheologicalApplications"
+Cohesion: 0.25
+Nodes (5): Test Mittag-Leffler in typical rheological scenarios., Test E_α(-t^α) for fractional relaxation modulus., Test E_{α,2}(z) for fractional Kelvin-Voigt model., Test E_α((iω)^α) for frequency-domain applications., TestMittagLefflerRheologicalApplications
 
-### Community 641 - "Community 641"
-Cohesion: 0.50
-Nodes (3): Tests for multi-chain parallelization in BayesianPipeline., Test that default num_chains in BayesianPipeline is 4., TestBayesianPipelineMultiChain
+### Community 641 - "TestRSquaredComputation"
+Cohesion: 0.25
+Nodes (5): Test compute_r_squared() metric for element minimization., R² = 1.0 for perfect predictions., R² = 0.0 when predictions equal mean., R² close to 1.0 for good predictions., TestRSquaredComputation
 
-### Community 642 - "Community 642"
+### Community 642 - "Any"
 Cohesion: 0.29
 Nodes (4): Any, Emit a signal by name with logging.          Parameters         ----------, Connect a handler to a signal by name with logging.          Parameters, Disconnect a handler from a signal by name with logging.          Parameters
 
-### Community 644 - "Community 644"
+### Community 644 - ".predict_rheo"
 Cohesion: 0.29
 Nodes (5): RheoData, TestMode, Compute shear stress: σ(γ̇) = K |γ̇|^n.          Args:             gamma_dot: Sh, Predict shear stress for given shear rates.          Args:             gamma_dot, Predict rheological response for RheoData.          Args:             rheo_data:
 
-### Community 645 - "Community 645"
-Cohesion: 0.29
-Nodes (4): ndarray, Unpack state vector into named fields., Compute local shear rate profile from state., Compute velocity profile from final shear rate profile.          v(y) = integral
+### Community 645 - "vlb_stress_fene_xy"
+Cohesion: 0.18
+Nodes (7): FENE-P shear stress: sigma_xy = G0 · f(tr(mu)) · mu_xy.      Parameters     ----, vlb_stress_fene_xy(), ndarray, Build initial state with small perturbation for symmetry breaking.          Para, Unpack state vector into named fields., Compute local shear rate profile from state., Compute velocity profile from final shear rate profile.          v(y) = integral
 
-### Community 646 - "Community 646"
+### Community 646 - "TestNumericalStability"
 Cohesion: 0.25
-Nodes (5): Tests for glass transition behavior., Test properties in fluid state (ε < 0)., Test properties in glass state (ε > 0)., Test behavior at critical point (ε ≈ 0)., TestGlassTransition
+Nodes (5): Test numerical stability near glass transition and edge cases., Test G0(x) stability near x=1 (glass transition)., Test Gp(x, z) stability near x=1., Test Gp at very low and very high frequencies., TestNumericalStability
 
-### Community 647 - "Community 647"
+### Community 647 - "generate_synthetic_trios_file"
 Cohesion: 0.33
 Nodes (7): generate_synthetic_trios_file(), generate_trios_files_batch(), get_fixture_path(), Path, Generate batch of TRIOS files for testing at multiple sizes.      Args:, Get or create path to fixture file.      Args:         filename: Name of fixture, Generate synthetic TRIOS file of specified size.      Creates a valid TRIOS form
 
-### Community 648 - "Community 648"
+### Community 648 - ".closeEvent"
 Cohesion: 0.29
-Nodes (4): ndarray, Generate sample Maxwell relaxation data., Establish NLSQ fitting baseline for Maxwell model.          Reference: ~50-200ms, Establish Bayesian fitting baseline for Maxwell model.          Reference: ~5-30
+Nodes (4): QCloseEvent, Handle new file action., Handle save file action.          Returns         -------         bool, Handle window close event with cleanup.          Parameters         ----------
 
-### Community 650 - "Community 650"
+### Community 650 - "TestNonlocalModelFunction"
 Cohesion: 0.25
 Nodes (5): Tests for nonlocal model_function interface., Test model_function routes correctly for flow_curve., Test model_function routes correctly for startup., Test model_function routes correctly for creep., TestNonlocalModelFunction
 
-### Community 651 - "Community 651"
+### Community 651 - "._on_state_changed"
 Cohesion: 0.29
-Nodes (3): FluidityNonlocal overrides _IDENTIFIABILITY because its PDE kernels     use HB-a, a, n_rejuv, f_inf never enter the nonlocal PDE RHS — assert         they appear, TestNonlocalIdentifiabilityAPI
+Nodes (4): AppState, Sync chip statuses from the current pipeline state., Update visible page on mode change.          In the new splitter layout the side, Handle state changes from store.          Parameters         ----------
 
-### Community 652 - "Community 652"
+### Community 652 - "percus_yevick_sk_jax"
 Cohesion: 0.67
 Nodes (3): percus_yevick_sk_jax(), Array, JAX-compatible Percus-Yevick S(k) computation.      Parameters     ----------
 
-### Community 653 - "Community 653"
+### Community 653 - "TestVLBLocalRelaxation"
 Cohesion: 0.29
 Nodes (4): Test VLBLocal stress relaxation., G(t) should be a single exponential., G(t) -> 0 at long times., TestVLBLocalRelaxation
 
-### Community 654 - "Community 654"
+### Community 654 - "TestVLBLocalCreep"
 Cohesion: 0.29
 Nodes (4): Test VLBLocal creep compliance., J(t) = (1 + k_d*t) / G0 for Maxwell., dJ/dt = k_d/G0 = 1/eta., TestVLBLocalCreep
 
-### Community 657 - "Community 657"
-Cohesion: 0.33
-Nodes (3): Effective relaxation time of the interphase network.          tau_I_eff = 1 /, Return discrete relaxation spectrum [(G_i, tau_i)].          Returns, Compute Weissenberg numbers for both matrix and interphase.          Wi^mat =
+### Community 655 - "TestFractionalMaxwellLiquidRelaxation"
+Cohesion: 0.29
+Nodes (3): Test relaxation modulus predictions., G(t) ~ Gm * t^(-α) at short times (t >> tau_alpha)., TestFractionalMaxwellLiquidRelaxation
 
-### Community 658 - "Community 658"
+### Community 656 - "TestFractionalMaxwellModelNumericalStability"
+Cohesion: 0.29
+Nodes (4): Test numerical stability., Test stability with extreme parameter values., Test that small parameter changes give small result changes., TestFractionalMaxwellModelNumericalStability
+
+### Community 657 - "RheoJAX Workspace Shell"
+Cohesion: 0.33
+Nodes (5): File Menu / Project Model, Package Structure, Relationship to `foundation/`, RheoJAX Workspace Shell, The Three Modes
+
+### Community 658 - "SPP Parity Status (MATLAB SPPplus v2.1 / R oreo / RheoJAX)"
 Cohesion: 0.33
 Nodes (5): Current status, Open risks / follow-ups, Remaining actions (require MATLAB/R availability), SPP Parity Status (MATLAB SPPplus v2.1 / R oreo / RheoJAX), What's done
 
-### Community 660 - "Community 660"
+### Community 660 - ".__init__"
 Cohesion: 0.33
 Nodes (4): Any, Logger, Initialize the logger adapter.          Args:             logger: Underlying Pyt, Process the log message and kwargs.          Merges extra kwargs into the log re
 
-### Community 662 - "Community 662"
+### Community 661 - "_read_segment_chunked"
+Cohesion: 0.33
+Nodes (6): _extract_step_temperature(), _parse_segment_header(), Extract temperature from step name line.      Args:         line: Line containin, Read a single segment in chunks (internal generator).      Args:         filepat, Parse segment header to find data section start.      Args:         file_handle:, _read_segment_chunked()
+
+### Community 662 - ".__init__"
 Cohesion: 0.33
 Nodes (4): BreakageType, StressType, Initialize VLBVariant model., Initialize ParameterSet with variant-dependent parameters.          Core paramet
 
-### Community 663 - "Community 663"
+### Community 663 - ".__init__"
 Cohesion: 0.33
 Nodes (4): BreakageType, StressType, Initialize single-mode TNT model.          Parameters         ----------, Initialize ParameterSet with TNT parameters.          Core parameters (always pr
 
-### Community 664 - "Community 664"
+### Community 664 - ".__init__"
 Cohesion: 0.33
 Nodes (4): BreakageType, StressType, Initialize VLBNonlocal model., Initialize ParameterSet for nonlocal model.
 
-### Community 665 - "Community 665"
+### Community 665 - "TestModeEnum"
 Cohesion: 0.33
 Nodes (4): Test TestMode enumeration., Test TestMode enum values., Test converting string to TestMode., TestModeEnum
 
-### Community 667 - "Community 667"
+### Community 666 - "._model_relaxation_jit"
+Cohesion: 0.33
+Nodes (4): _jit_relaxation_kernel(), JIT-friendly relaxation simulation.          Threads ``self.fluidity_form`` thro, Dispatch to JIT-compiled relaxation kernel., JIT-compiled stress relaxation simulation.      ``fluidity_form`` selects the pl
+
+### Community 667 - "TestYAMLInjection"
 Cohesion: 0.33
 Nodes (4): Verify yaml.safe_load rejects Python object tags.      These are regression test, !!python/object tags must not instantiate arbitrary objects., !!python/name tags must be rejected by safe_load., TestYAMLInjection
 
-### Community 668 - "Community 668"
+### Community 668 - "conftest.py"
 Cohesion: 0.33
 Nodes (5): _io_test_gc(), Shared fixtures for tests/io/., Skip tests if rheocompass fixtures are not available., Free memory after each io test to prevent xdist worker OOM.      Several io te, rheocompass_fixtures()
 
-### Community 670 - "Community 670"
+### Community 670 - "TestLogBayesian"
 Cohesion: 0.33
 Nodes (4): Tests for log_bayesian context manager., Test that Bayesian-specific context is logged., Test that MCMC diagnostics can be added., TestLogBayesian
 
-### Community 671 - "Community 671"
+### Community 671 - "._model_startup_jit"
 Cohesion: 0.33
-Nodes (4): Viscous variant LAOS fit works., Tests for _fit_laos implementation., _fit_laos returns self for fluent API., TestFitLAOS
+Nodes (4): _jit_startup_kernel(), JIT-friendly startup simulation., Dispatch to JIT-compiled startup kernel., JIT-compiled startup shear simulation.      ``fluidity_form`` selects the plasti
 
-### Community 673 - "Community 673"
+### Community 673 - "TestUpperConvected"
 Cohesion: 0.33
 Nodes (4): Tests for upper-convected derivative., Test convective terms in simple shear., Test zero convective terms at zero rate., TestUpperConvected
 
-### Community 674 - "Community 674"
+### Community 674 - "TestYieldStressCoupling"
 Cohesion: 0.33
 Nodes (4): Tests for dynamic yield stress coupling., Test constant yield stress with zero coupling., Test increased yield stress at low fluidity., TestYieldStressCoupling
 
-### Community 675 - "Community 675"
+### Community 675 - "TestHerschelBulkleyViscosity"
 Cohesion: 0.33
 Nodes (4): Tests for HB viscosity calculation., Test shear-thinning behavior (n < 1)., Test solvent viscosity adds correctly., TestHerschelBulkleyViscosity
 
-### Community 676 - "Community 676"
+### Community 676 - "TestNormalStresses"
 Cohesion: 0.33
 Nodes (4): Tests for normal stress predictions., Test N₁ is positive (Weissenberg effect)., Test N₁ ~ γ̇² (approximately at high rates)., TestNormalStresses
 
-### Community 677 - "Community 677"
+### Community 677 - "test_herschel_bulkley.py"
 Cohesion: 0.33
 Nodes (4): Tests for Herschel-Bulkley model.  This module tests the Herschel-Bulkley model, Test model_function for Bayesian inference compatibility., Test that model_function output matches predict., TestHerschelBulkleyModelFunction
 
-### Community 678 - "Community 678"
+### Community 678 - "TestHerschelBulkleyBasics"
 Cohesion: 0.33
 Nodes (4): Test basic functionality of Herschel-Bulkley model., Test model initialization., Test parameter bounds., TestHerschelBulkleyBasics
 
-### Community 679 - "Community 679"
+### Community 679 - "TestHerschelBulkleyFitting"
 Cohesion: 0.33
 Nodes (4): Test parameter fitting for Herschel-Bulkley model., Test fitting with synthetic data., Test fitting with noisy data., TestHerschelBulkleyFitting
 
-### Community 680 - "Community 680"
+### Community 680 - "TestHerschelBulkleyPhysicalBehavior"
 Cohesion: 0.33
 Nodes (4): Test physical behavior of Herschel-Bulkley model., Test that yield stress is consistent across predictions., Test that stress is continuous across yield threshold., TestHerschelBulkleyPhysicalBehavior
 
-### Community 681 - "Community 681"
+### Community 681 - "TestPowerLawFitting"
 Cohesion: 0.33
 Nodes (4): Test parameter fitting for Power Law model., Test fitting with synthetic data., Test fit_predict method., TestPowerLawFitting
 
-### Community 682 - "Community 682"
+### Community 682 - "TestPowerLawPerformance"
 Cohesion: 0.33
 Nodes (4): Test JAX performance optimizations., Test that JIT compilation works., Test that vectorization works correctly., TestPowerLawPerformance
 
-### Community 683 - "Community 683"
+### Community 683 - "TestPowerLawModelFunction"
 Cohesion: 0.33
 Nodes (4): Test model_function for Bayesian inference compatibility., Test that model_function output matches predict., Test that model_function works with JAX arrays., TestPowerLawModelFunction
 
-### Community 684 - "Community 684"
+### Community 684 - "TestLaplacian"
 Cohesion: 0.33
 Nodes (4): Tests for 1D Laplacian with Neumann BCs., Test Laplacian of constant is zero., Test Laplacian of parabola is constant., TestLaplacian
 
-### Community 685 - "Community 685"
+### Community 685 - "TestCredibleIntervals"
 Cohesion: 0.33
 Nodes (4): Tests for credible interval extraction., Test 95% credible interval extraction., Test that 95% CI contains true value (statistical test)., TestCredibleIntervals
 
-### Community 686 - "Community 686"
+### Community 686 - "TestNonlocalFlowCurve"
 Cohesion: 0.33
 Nodes (4): Tests for nonlocal flow curve prediction., Test flow curve output shape and finiteness., Test flow curve is monotonically increasing., TestNonlocalFlowCurve
 
-### Community 687 - "Community 687"
+### Community 687 - "spp_analyze"
 Cohesion: 0.33
-Nodes (4): Tests for SAOS (G', G'') predictions., Test that oscillation returns valid moduli., Test that glass shows plateau modulus., TestOscillationProtocol
+Nodes (5): ndarray, RheoData, Get computed SPP analysis results.          Returns         -------         dict, Convenience function for single-shot SPP analysis.      A standalone function fo, spp_analyze()
 
-### Community 688 - "Community 688"
+### Community 688 - "capture_golden_screens.py"
+Cohesion: 0.53
+Nodes (5): _capture(), _ensure_offscreen(), main(), Path, Helper script to capture GUI golden screenshots locally.  Usage (run locally wit
+
+### Community 689 - "TestPowerLawScaling"
 Cohesion: 0.33
-Nodes (4): Fast smoke tests for Bayesian pipeline (FAST_MODE compatible)., Verify Bayesian pipeline completes with minimal samples.          Uses 10 warm, Verify Bayesian SAOS pipeline completes with minimal samples., TestBayesianSmoke
+Nodes (4): Property-based tests for power-law scaling behavior., G' exhibits positive slope (increasing with frequency) in power-law regime., G(t) exhibits negative slope (decaying with time) at long times., TestPowerLawScaling
 
-### Community 694 - "Community 694"
+### Community 690 - "TestFitCreep"
+Cohesion: 0.33
+Nodes (4): Tests for _fit_creep implementation., _fit_creep returns self for fluent API., Viscous variant creep fit works., TestFitCreep
+
+### Community 691 - "TestCarreauBasics"
+Cohesion: 0.33
+Nodes (4): Test basic functionality of Carreau model., Test model initialization., Test parameter bounds., TestCarreauBasics
+
+### Community 692 - "TestCarreauRheoData"
+Cohesion: 0.33
+Nodes (4): Test Carreau with RheoData., Test prediction with RheoData (viscosity output)., Test that wrong test mode raises error., TestCarreauRheoData
+
+### Community 693 - "TestCrossBasics"
+Cohesion: 0.33
+Nodes (4): Test basic functionality., Test model initialization., Test parameter bounds., TestCrossBasics
+
+### Community 694 - "TestVLBNonlocalFene"
 Cohesion: 0.33
 Nodes (4): Test FENE-P with nonlocal model., FENE + nonlocal simulation completes., FENE nonlocal with uniform IC stays uniform., TestVLBNonlocalFene
 
-### Community 696 - "Community 696"
+### Community 695 - "TestCrossStability"
+Cohesion: 0.33
+Nodes (4): Test numerical stability., Test with extreme shear rates., Test at zero shear rate., TestCrossStability
+
+### Community 696 - "TestPublicAPI"
 Cohesion: 0.33
 Nodes (4): Verify the functions are importable from the package top-level., hessian_ci and bootstrap_ci must be importable from rheojax.utils., Direct import from rheojax.utils.uncertainty must work., TestPublicAPI
 
-### Community 697 - "Community 697"
+### Community 697 - "TestFractionalZenerANSYS"
 Cohesion: 0.33
 Nodes (4): Validate fractional models against ANSYS UD material reference., Test FZSS fits ANSYS fractional relaxation data., Test FZSS predictions match ANSYS behavior., TestFractionalZenerANSYS
 
-### Community 698 - "Community 698"
+### Community 698 - "TestPronySeries"
 Cohesion: 0.33
 Nodes (4): Test Prony series accuracy for multi-mode representation., Test single-mode Prony series (Maxwell).          ANSYS single-mode: G(t) = G_0, Test two-mode Prony series matching ANSYS reference.          ANSYS two-mode: G(, TestPronySeries
 
-### Community 700 - "Community 700"
+### Community 699 - "TestFractionalMaxwellLiquidCreep"
 Cohesion: 0.33
-Nodes (4): Tests for Upper-Convected Maxwell (α = 0) limit., Test α=0 gives N₂ = 0.          UCM predicts N₁ > 0 but N₂ = 0., Test α=0 SAOS matches Maxwell model exactly.          SAOS is independent of α, TestUCMLimit
+Nodes (3): Test creep compliance predictions., Test that J(t) starts at 1/Gm., TestFractionalMaxwellLiquidCreep
 
-### Community 701 - "Community 701"
+### Community 700 - "TestRelaxation"
 Cohesion: 0.33
-Nodes (4): Tests for LAOS predictions., Test LAOS gives oscillatory stress response., Test extraction of LAOS harmonics., TestLAOSProtocol
+Nodes (4): Tests for stress relaxation physics., Test stress decays to zero during relaxation., Test Giesekus relaxes faster than pure exponential.          The quadratic τ·τ, TestRelaxation
 
-### Community 702 - "Community 702"
+### Community 701 - "TestLAOSKwargsRegression"
 Cohesion: 0.33
-Nodes (4): Test that early termination doesn't skip viable N candidates., Verify that early termination criterion is applied correctly.          Early ter, Test that optimization_factor controls element minimization aggressiveness., TestEarlyTermination
+Nodes (4): Regression tests for F-TNT-001: LAOS branch must use kwargs, not self._., Test that model_function LAOS branch respects kwargs over self._., Test that kwargs-passed gamma_0/omega actually override self._., TestLAOSKwargsRegression
 
-### Community 703 - "Community 703"
+### Community 702 - "TestAnalysisMethods"
 Cohesion: 0.33
-Nodes (4): Test accuracy of multi-mode Prony series representations., Test that increasing n_modes improves R² (with diminishing returns).          Va, Test that fitted model can extrapolate beyond training data range.          Gene, TestMultiModeRepresentation
+Nodes (4): Tests for analysis helper methods., Test relaxation modulus G(t) for multi-species., Test relaxation spectrum for 3 species., TestAnalysisMethods
 
-### Community 706 - "Community 706"
+### Community 703 - "TestRegistryIntegration"
+Cohesion: 0.33
+Nodes (4): Tests for model registry integration., Test model creation via registry., Test registry creation with n_species argument., TestRegistryIntegration
+
+### Community 704 - "TestBatchVectorizationSmoke"
+Cohesion: 0.33
+Nodes (4): Smoke tests for batch vectorization (quick validation)., Test that batch processing handles empty file list., Test that n_workers parameter is accepted., TestBatchVectorizationSmoke
+
+### Community 705 - "TestSoftmaxPenalty"
+Cohesion: 0.33
+Nodes (4): Test softmax_penalty() for constrained optimization., Negative Eᵢ should increase penalty significantly., Penalty should be differentiable with JAX., TestSoftmaxPenalty
+
+### Community 706 - "TestUncertaintyBand"
 Cohesion: 0.33
 Nodes (4): Tests for compute_uncertainty_band and plot_fit_with_uncertainty., Test uncertainty band for a simple linear model., Test that complex model output returns None for bands., TestUncertaintyBand
 
-### Community 707 - "Community 707"
+### Community 707 - "🎓 Learning Paths"
 Cohesion: 0.40
 Nodes (5): **Advanced Path** (Bayesian Inference & Fractional Models), **Beginner Path** (New to Rheology), **Industrial Path** (Practical Applications), **Intermediate Path** (Experienced with Rheology), 🎓 Learning Paths
 
-### Community 708 - "Community 708"
+### Community 708 - "🎯 Quick Navigation"
 Cohesion: 0.40
 Nodes (5): Advanced Topics, By Analysis Type, By Material Type, For New Users, 🎯 Quick Navigation
 
-### Community 709 - "Community 709"
+### Community 709 - "💡 Quick Examples"
 Cohesion: 0.40
 Nodes (5): Basic Model Fitting, Bayesian Inference Workflow, Fluent Pipeline API, 💡 Quick Examples, Time-Temperature Superposition
 
-### Community 710 - "Community 710"
+### Community 710 - "📚 Key References"
 Cohesion: 0.40
 Nodes (5): **Foundational Textbooks**, **Fractional Calculus**, 📚 Key References, **Modern Techniques**, **Recent Reviews (2020-2024)**
 
-### Community 711 - "Community 711"
+### Community 711 - "._inverse_transform"
 Cohesion: 0.40
-Nodes (5): fitted_maxwell_oscillation(), _maxwell_oscillation_data(), ndarray, Generate synthetic Maxwell oscillation data: G* = G0*(i*omega*tau)/(1+i*omega*ta, Return a Maxwell model fitted to synthetic oscillation data.
+Nodes (3): Internal inverse transform implementation.          Args:             data: Tran, Apply inverse transformation.          Args:             data: Transformed data, Apply inverse transforms in reverse order.          Args:             data: Tran
 
-### Community 713 - "Community 713"
-Cohesion: 0.03
-Nodes (46): ArrayLike, BayesianResult, Internal transform implementation to be overridden by subclasses.          Args:, Internal inverse transform implementation.          Args:             data: Tran, Transform the data.          Args:             data: Input data (RheoData or lis, Apply inverse transformation.          Args:             data: Transformed data, Fit the transform to data (learn parameters if needed).          Args:, Fit to data and transform it.          Args:             data: Input data (RheoD (+38 more)
+### Community 712 - "._transform"
+Cohesion: 0.40
+Nodes (3): Internal transform implementation to be overridden by subclasses.          Args:, Transform the data.          Args:             data: Input data (RheoData or lis, Apply all transforms in sequence.          Args:             data: Input data (R
 
-### Community 716 - "Community 716"
+### Community 713 - ".shape"
+Cohesion: 0.13
+Nodes (11): ArrayLike, RuntimeError, Fit the transform to data (learn parameters if needed).          Args:, Fit to data and transform it.          Args:             data: Input data (RheoD, Fit all transforms in the pipeline.          Args:             data: Training da, Check model-data compatibility and return result.          Args:             X:, Enhance optimization error with compatibility information.          Args:, Make predictions.          Args:             X: Input features             test_ (+3 more)
+
+### Community 714 - "._on_batch_requested"
+Cohesion: 0.40
+Nodes (3): Any, Handle batch fit action — opens the BatchPanel dialog., Execute the current pipeline for each file in the batch.          For each file,
+
+### Community 715 - ".plot"
+Cohesion: 0.40
+Nodes (3): Any, Clear all plot content., Plot data and optional fit result.          Dispatches to the appropriate backen
+
+### Community 716 - "evolve_thixotropy_lambda"
 Cohesion: 0.22
 Nodes (8): compute_thixotropic_stress(), evolve_thixotropy_lambda(), ndarray, Compute stress response with thixotropic modulus.      The effective modulus is, Get shift factors as arrays for plotting.          Parameters         ----------, Single step of thixotropy evolution for jax.lax.scan.      This is JIT-compiled, Evolve structural parameter lambda(t) for given shear history.      Integrates t, _thixotropy_scan_step()
 
-### Community 719 - "Community 719"
+### Community 717 - ".get_initial_state"
+Cohesion: 0.40
+Nodes (3): ndarray, Get initial state vector based on variant.          Args:             stress_ini, ODE vector field wrapper for Diffrax.          Delegates to the JAX-compiled ker
+
+### Community 718 - "test_spp_integration.py"
+Cohesion: 0.60
+Nodes (4): Integration smoke tests for SPP pipeline workflow., _spp_dataset(), test_pipeline_bayesian_warm_start(), test_pipeline_nlsq_only()
+
+### Community 719 - "🛠️ Building the Documentation Locally"
 Cohesion: 0.50
 Nodes (4): Build HTML, Build PDF (Optional), 🛠️ Building the Documentation Locally, Prerequisites
 
-### Community 720 - "Community 720"
+### Community 720 - "📊 Documentation Statistics"
 Cohesion: 0.50
 Nodes (4): **Coverage**, 📊 Documentation Statistics, **Quality Metrics**, **Research Foundation**
 
-### Community 725 - "Community 725"
+### Community 722 - "TestFractionalMaxwellLiquidNumericalStability"
+Cohesion: 0.40
+Nodes (3): Test numerical stability., Test small parameter changes give small result changes., TestFractionalMaxwellLiquidNumericalStability
+
+### Community 724 - "TestCrossValidation"
+Cohesion: 0.50
+Nodes (3): Property-based tests for consistency between different test modes., Both oscillation and relaxation predictions are positive., TestCrossValidation
+
+### Community 725 - ".precompile"
 Cohesion: 0.50
 Nodes (3): precompile_flow_curve_solver(), Pre-compile the diffrax ODE solver for fast subsequent calls.          Triggers, Stub when diffrax not available.
 
-### Community 728 - "Community 728"
+### Community 726 - ".test_conventional_generic_oscillation_match"
 Cohesion: 0.50
-Nodes (3): Create unfilled vitrimer (phi=0, recovers HVM exactly).          Parameters, HVNM with phi=0 (should recover HVM)., unfilled_model()
+Nodes (3): Property-based tests for consistency between SGRConventional and SGRGeneric., SGRConventional and SGRGeneric should give identical oscillation predictions., TestModelComparison
 
-### Community 729 - "Community 729"
+### Community 727 - "conftest.py"
+Cohesion: 0.50
+Nodes (3): _clean_parallel_config(), Shared fixtures for parallel module tests., Reset parallel config state before and after each test.      Ensures no test pol
+
+### Community 729 - "clean_notebook"
 Cohesion: 0.67
 Nodes (3): clean_notebook(), main(), Reads a notebook, clears all outputs and execution counts, and saves it back.
 
-### Community 731 - "Community 731"
+### Community 731 - "test_visual_regression_spec_scaffold.py"
 Cohesion: 0.50
 Nodes (3): Visual regression scaffold aligned to GUI SPEC.md golden images., Smoke check golden files exist (replace with real renders when available)., test_home_page_visual_golden()
 
-### Community 738 - "Community 738"
+### Community 738 - "TestGMMBayesianPriorSafetyIntegration"
 Cohesion: 0.50
 Nodes (3): Test integration of prior safety with Bayesian inference., Test that fit_bayesian uses NLSQ estimates when convergence is good., TestGMMBayesianPriorSafetyIntegration
 
-### Community 739 - "Community 739"
+### Community 739 - "TestBayesianIntegration"
 Cohesion: 0.50
 Nodes (3): Test integration of prior safety with fit_bayesian() workflow., Test that fit_bayesian() runs end-to-end with prior safety., TestBayesianIntegration
 
-### Community 740 - "Community 740"
+### Community 740 - "TestNLSQDiagnostics"
 Cohesion: 0.50
 Nodes (3): Test NLSQ diagnostics extraction from OptimizationResult., Test that NLSQ diagnostics are correctly extracted after a successful fit., TestNLSQDiagnostics
 
-### Community 741 - "Community 741"
+### Community 741 - "TestPlotEnergy"
 Cohesion: 0.33
 Nodes (4): Test plot_energy() method for NUTS diagnostics., Test that plot_energy() returns matplotlib Axes., Test plot_energy() can highlight divergences., TestPlotEnergy
 
-### Community 744 - "Community 744"
-Cohesion: 0.50
-Nodes (3): Test credible interval computation and validity., Test that credible intervals contain true parameter values.          For synthet, TestBayesianCredibleIntervals
+### Community 768 - "._on_finished"
+Cohesion: 0.05
+Nodes (24): _is_qobject_alive(), Check whether a QObject's C++ counterpart is still alive.      Works across PySi, Any, BayesianResult, ndarray, Handle Bayesian inference completion.          Parameters         ----------, Handle error during inference.          Parameters         ----------         er, Update convergence diagnostics display.          Parameters         ---------- (+16 more)
 
-### Community 745 - "Community 745"
-Cohesion: 0.50
-Nodes (3): Comprehensive tests for all 11 fractional models in relaxation mode., Test that all fractional models can be sampled in relaxation mode.          This, TestFractionalModelsRelaxation
+### Community 776 - "TestFlowCurve"
+Cohesion: 0.20
+Nodes (6): Tests for flow curve (steady shear) predictions., Test flow curve prediction via predict()., Test direct predict_flow_curve method., Test flow curve with viscosity and N₁., Cates with constant breakage gives Newtonian viscosity., TestFlowCurve
 
-### Community 768 - "Community 768"
-Cohesion: 0.12
-Nodes (11): _is_qobject_alive(), Check whether a QObject's C++ counterpart is still alive.      Works across PySi, BayesianResult, Handle Bayesian inference completion.          Parameters         ----------, Handle error during inference.          Parameters         ----------         er, Update convergence diagnostics display.          Parameters         ----------, Disconnect this page's slots from the current worker's signals.          Disconn, Prepare this page for parent window close.          Called by MainWindow.closeEv (+3 more)
+### Community 781 - "TestRelaxationSimulation"
+Cohesion: 0.25
+Nodes (5): Tests for stress relaxation simulation., Test relaxation simulation runs., Test stress decays during relaxation., Verify single-exponential relaxation: σ(t) = G₀·τ_d·γ̇·exp(-t/τ_d)., TestRelaxationSimulation
 
-### Community 785 - "Community 785"
+### Community 785 - "TestJAXSupport"
 Cohesion: 0.17
 Nodes (9): Test JAX-specific functionality in base classes., Test that methods can be JIT compiled., Test that methods support automatic differentiation., Test that methods support vectorization., Test JAX-specific functionality in base classes., Test that methods can be JIT compiled., Test that methods support automatic differentiation., Test that methods support vectorization. (+1 more)
 
-### Community 822 - "Community 822"
+### Community 813 - "TestRelaxationSimulation"
+Cohesion: 0.25
+Nodes (5): Tests for stress relaxation simulation., Test relaxation simulation runs and returns correct shape, finite., Test stress decays during relaxation (σ[0] > σ[-1])., Verify multi-exponential relaxation for 2 species., TestRelaxationSimulation
+
+### Community 822 - "TestPipelineExport"
 Cohesion: 0.12
 Nodes (9): Tests for Pipeline.export() method., Pipeline.export() creates directory export., Pipeline.export() with .xlsx creates Excel., Auto format detection for directory path., Auto format detection for .xlsx path., Export records operation in pipeline history., Export supports fluent chaining., Invalid format raises ValueError. (+1 more)
 
-### Community 849 - "Community 849"
+### Community 824 - "TestAnalysisMethods"
+Cohesion: 0.33
+Nodes (4): Tests for analysis helper methods., For UCM (constant breakage), overshoot ratio should be ~1., Test relaxation spectrum G(t)., TestAnalysisMethods
+
+### Community 849 - "TestRelaxationSimulation"
 Cohesion: 0.20
 Nodes (6): Tests for stress relaxation simulation., Test relaxation simulation runs., Test stress decays during relaxation., Test relaxation with bridge fraction return., Test bridge fraction stays bounded during relaxation., TestRelaxationSimulation
 
-### Community 850 - "Community 850"
+### Community 850 - "TestLAOSSimulation"
 Cohesion: 0.20
 Nodes (6): Tests for LAOS simulation., Test LAOS simulation runs., Test LAOS response becomes periodic after transient., Test LAOS harmonic extraction., Test bridge fraction oscillates during LAOS., TestLAOSSimulation
 
-### Community 861 - "Community 861"
-Cohesion: 0.17
-Nodes (7): Tests for Pipeline.plot_fit()., plot_fit() creates a figure and records history., plot_fit() with residuals creates multi-panel figure., plot_fit() before fit() raises ValueError., plot_fit() works with all style presets., plot_fit() supports fluent chaining., TestPipelinePlotFit
+### Community 851 - "TestSAOS"
+Cohesion: 0.25
+Nodes (5): Tests for SAOS predictions., Test SAOS prediction returns correct shapes, positive., Test |G*| prediction via test_mode='oscillation'., Test terminal regime scaling: G' ~ ω², G'' ~ ω., TestSAOS
 
-### Community 1001 - "Community 1001"
-Cohesion: 0.06
-Nodes (26): QStackedWidget, DiagnosticsPage, Any, BayesianResult, FitResult, Populate the per-parameter R-hat/ESS table from a BayesianResult., Refresh model comparison table with all bayesian results., Handle Bayesian inference completion from state.          Parameters         --- (+18 more)
+### Community 856 - "TestLAOSKwargsRegression"
+Cohesion: 0.33
+Nodes (4): Regression tests for F-TNT-001: LAOS branch must use kwargs, not self._., Test that model_function LAOS branch respects kwargs over self._., Test that kwargs-passed gamma_0/omega actually override self._., TestLAOSKwargsRegression
 
-### Community 1038 - "Community 1038"
-Cohesion: 0.20
-Nodes (7): BayesianResult, FitResult, Results Panel Widget ====================  Displays summary metrics for the late, Compact panel to show fit/Bayesian summary metrics., Render a fit result summary., Render a Bayesian result summary., ResultsPanel
+### Community 1001 - "QTableWidgetItem"
+Cohesion: 0.04
+Nodes (28): QTableWidgetItem, Any, Display dataset in plot canvas.          Parameters         ----------         d, Validate dataset quality.          Parameters         ----------         dataset, Apply preprocessing operations.          Parameters         ----------         d, Load and display data preview asynchronously.          Offloads file I/O to a ba, Handle successful preview load (called on main thread via signal)., Handle failed preview load (called on main thread via signal). (+20 more)
 
 ## Knowledge Gaps
-- **624 isolated node(s):** `$schema`, `title`, `description`, `type`, `type` (+619 more)
+- **630 isolated node(s):** `$schema`, `title`, `description`, `type`, `type` (+625 more)
   These have ≤1 connection - possible missing edges or undocumented components.
-- **221 thin communities (<3 nodes) omitted from report** — run `graphify query` to explore isolated nodes.
+- **125 thin communities (<3 nodes) omitted from report** — run `graphify query` to explore isolated nodes.
 
 ## Suggested Questions
 _Questions this graph is uniquely positioned to answer:_
 
-- **Why does `ModelRegistry` connect `Core NLSQ & Bayesian Base` to `RheoData & Data Layer`, `BaseModel API & Methods`, `VLB Viscoelastic Models`, `Community 519`, `CLI SPP Analysis`, `GUI Import Worker & Drop Zone`, `Saramito Fluidity Models`, `ArviZ Utils & Bayesian Results`, `Community 523`, `Initialization Base`, `Community 525`, `Community 526`, `Giesekus Single-Mode Model`, `Transform Page & Worker`, `Qt Widgets`, `Community 532`, `Community 531`, `Community 534`, `Community 535`, `Community 24`, `Community 25`, `Community 26`, `Community 536`, `Community 28`, `Community 541`, `Community 542`, `Community 538`, `Community 32`, `Community 33`, `Community 34`, `Community 540`, `Community 539`, `Community 547`, `Community 544`, `Community 551`, `Community 40`, `Community 41`, `Community 42`, `Community 546`, `Community 44`, `Community 557`, `Community 46`, `Community 559`, `Community 51`, `Community 52`, `Community 55`, `Community 59`, `Community 571`, `Community 63`, `Community 578`, `Community 68`, `Community 70`, `Community 74`, `Community 75`, `Community 591`, `Community 80`, `Community 592`, `Community 593`, `Community 83`, `Community 594`, `Community 86`, `Community 91`, `Community 92`, `Community 604`, `Community 101`, `Community 103`, `Community 619`, `Community 620`, `Community 109`, `Community 621`, `Community 111`, `Community 625`, `Community 626`, `Community 116`, `Community 119`, `Community 121`, `Community 128`, `Community 131`, `Community 653`, `Community 654`, `Community 158`, `Community 671`, `Community 159`, `Community 163`, `Community 164`, `Community 165`, `Community 166`, `Community 167`, `Community 177`, `Community 545`, `Community 189`, `Community 191`, `Community 193`, `Community 200`, `Community 206`, `Community 718`, `Community 211`, `Community 218`, `Community 220`, `Community 221`, `Community 227`, `Community 229`, `Community 231`, `Community 236`, `Community 238`, `Community 243`, `Community 245`, `Community 246`, `Community 248`, `Community 251`, `Community 254`, `Community 256`, `Community 269`, `Community 276`, `Community 281`, `Community 284`, `Community 290`, `Community 292`, `Community 294`, `Community 295`, `Community 302`, `Community 303`, `Community 822`, `Community 313`, `Community 314`, `Community 317`, `Community 321`, `Community 327`, `Community 328`, `Community 329`, `Community 336`, `Community 849`, `Community 850`, `Community 342`, `Community 343`, `Community 344`, `Community 345`, `Community 346`, `Community 347`, `Community 861`, `Community 352`, `Community 355`, `Community 359`, `Community 364`, `Community 370`, `Community 375`, `Community 379`, `Community 381`, `Community 389`, `Community 404`, `Community 405`, `Community 407`, `Community 412`, `Community 413`, `Community 414`, `Community 426`, `Community 429`, `Community 431`, `Community 442`, `Community 443`, `Community 444`, `Community 446`, `Community 449`, `Community 458`, `Community 459`, `Community 463`, `Community 464`, `Community 467`, `Community 481`, `Community 482`, `Community 483`, `Community 484`, `Community 499`, `Community 500`, `Community 501`, `Community 506`, `Community 507`?**
+- **Why does `ModelRegistry` connect `ModelRegistry` to `TestFluidityLocalFlowCurve`, `TestFluidityNonlocalTransient`, `StateStore`, `RheoData`, `TestCatesMaxwellLimit`, `Pipeline`, `TestStartupSimulation`, `.create`, `GiesekusSingleMode`, `TestCreepSimulation`, `TestLAOSSimulation`, `TestPhysicalConsistency`, `TestFluidityNonlocalGrid`, `TestFlowCurve`, `SGRGeneric`, `TestStartupSimulation`, `STZConventional`, `TestBayesianInterface`, `TestCreepSimulation`, `TestFlowCurve`, `TestMaxwellLimit`, `TensorialEPM`, `Maxwell`, `PipelineBuilder`, `TestInstantiation`, `SpringPot`, `TestFlowCurve`, `TestLAOSSimulation`, `TestMaxwellLimits`, `FIKH`, `HVNMLocal`, `FractionalMaxwellModel`, `TestBayesianInterface`, `DataService`, `TestStartupSimulation`, `_kernels_diffrax.py`, `TestFlowCurve`, `FluiditySaramitoLocal`, `TestVLBCrossProtocol`, `FMLIKH`, `TestVLBLocalSAOS`, `FitPage`, `DatasetRef`, `FractionalMaxwellLiquid`, `TestSAOS`, `CreepToRelaxationPipeline`, `TestCreepSimulation`, `FluidityNonlocal`, `FitResult`, `TestHVNMLAOS`, `TestBayesianInterface`, `PowerLaw`, `local.py`, `TestCreepSimulation`, `conftest.py`, `ModelComparisonPipeline`, `MLIKH`, `TestEquilibriumStructure`, `TestDMTLocalFlowCurve`, `TestDMTLocalSAOS`, `ITTMCTSchematic`, `MIKH`, `DMTLocal`, `FluidityLocal`, `test_multi_mode.py`, `TestFractionalMaxwellLiquidOscillation`, `BatchPipeline`, `TestSAOS`, `TestBayesianInterface`, `TNTLoopBridge`, `TestStartupSimulation`, `BayesianWorker`, `TestSAOS`, `TestSAOSPredictions`, `TestBayesianInterface`, `TestSTZIntegration`, `TestSAOS`, `schematic.py`, `TestLAOSSimulation`, `test_hvm.py`, `TestStickerFloorPhysics`, `TestVLBLocalLAOS`, `TestFlowCurvePredictions`, `TestModelFunction`, `HVMLocal`, `TestVLBBellFeneCombined`, `FitResult`, `TestNonAffineVariant`, `Bingham`, `FitState`, `SPPYieldStress`, `VLBLocal`, `TestVLBLocalRelaxation`, `TestVLBLocalCreep`, `TestFractionalMaxwellLiquidRelaxation`, `TestFractionalMaxwellModelNumericalStability`, `TestFlowCurve`, `TestStartupSimulation`, `TestRelaxationSimulation`, `ITTMCTIsotropic`, `TNTSingleMode`, `FluiditySaramitoNonlocal`, `hebraud_lequeux.py`, `GeneralizedMaxwell`, `MastercurvePipeline`, `SPPAmplitudeSweepPipeline`, `TestDerivedProperties`, `SGRConventional`, `TestFitCreep`, `TestVLBLocalFlowCurve`, `TestVLBLocalStartup`, `TNTMultiSpecies`, `TestFractionalMaxwellLiquidCreep`, `TestHVMStartup`, `TestLAOSKwargsRegression`, `TestDMTRegistry`, `TestAnalysisMethods`, `FractionalPoyntingThomson`, `TestRegistryIntegration`, `FractionalMaxwellGel`, `BayesianPipeline`, `TestFractionalMaxwellLiquidLimitCases`, `TestFractionalMaxwellLiquidNumericalStability`, `FractionalBurgersModel`, `Registry`, `FractionalKelvinVoigt`, `VLBVariant`, `ModelComparison`, `test_dmta_removal.py`, `DMTNonlocal`, `TNTStickyRouse`, `main`, `FractionalJeffreysModel`, `ProtocolModelStep`, `test_single_mode.py`, `HebraudLequeux`, `FractionalZenerLiquidLiquid`, `TestFlowCurve`, `TestRelaxationSimulation`, `TestInstantiation`, `create_global_parser`, `FractionalKelvinVoigtZener`, `test_dmt.py`, `ModelService`, `TestVLBMultiNetworkAnalytical`, `_VizTestTransform`, `TestRelaxationSimulation`, `GiesekusMultiMode`, `ml_ikh.py`, `TestPipelineExport`, `TestFluidityLocalModelFunction`, `TestHVNMLimitingCases`, `TNTCates`, `TestAnalysisMethods`, `TestFluidityNonlocalModelFunction`, `test_loop_bridge.py`, `HerschelBulkley`, `PipelineConfigureRunStep`, `vlb_fene_factor`, `TestRelaxationSimulation`, `TestLAOSSimulation`, `TestSAOS`, `test_cates.py`, `test_multi_species.py`, `TestLAOSKwargsRegression`, `TestInstantiation`, `TestPhysicalConsistency`, `TestVLBBellPhysics`, `TestVLBVariantCreation`, `FractionalZenerSolidLiquid`, `VLBNonlocal`, `TestVLBVariantRegression`, `vlb_arrhenius_shift`, `TestComposedVariants`, `Zener`, `TestDMTBayesian`, `Carreau`, `TestFluidityLocalOscillation`, `TestDMTLocalCreation`, `TestDMTLocalCreep`, `TestHVNMSAOS`, `TestFluidityLocalFitting`, `TestPhysicalConsistency`, `test_sticky_rouse.py`, `TestModelFunctionCompleteness`, `TestInstantiation`, `TestKwargsCaching`, `TestHVMFlowCurve`, `TestHVMRelaxation`, `TestFluidityNonlocalShearBanding`, `TestFluidityPredictWithoutFit`, `TestHVNMStartup`, `TestHVMCreep`, `TestHVMLAOS`, `TestInstantiation`, `TestHVNMInterphase`, `TestDMTLocalStartup`, `TestF002KwargsCache`, `test_local.py`, `TestFluidityNonlocalSmoke`, `TestInstantiation`, `TestPhysicalConsistency`, `test_single_mode.py`, `TestStartupSimulation`, `TestPhysicalConsistency`, `TestBellVariant`, `TestFENEVariant`, `TestCreepSimulation`, `TestVLBVariantProtocols`, `TestParameterManagement`, `TestHVNMFlowCurve`, `TestHVNMRelaxation`, `TestVLBUtilities`, `TestDMTLocalLAOS`, `TestDMTNonlocal`, `Cross`?**
   _High betweenness centrality (0.185) - this node is a cross-community bridge._
-- **Why does `RheoData` connect `VLB Viscoelastic Models` to `Core NLSQ & Bayesian Base`, `RheoData & Data Layer`, `Community 513`, `Community 514`, `Community 515`, `Anton Paar IO Reader`, `CLI SPP Analysis`, `Community 520`, `GUI Import Worker & Drop Zone`, `ArviZ Utils & Bayesian Results`, `Initialization Base`, `Transform Page & Worker`, `Community 21`, `Community 23`, `Community 24`, `Community 25`, `Community 26`, `Community 28`, `Community 31`, `Community 34`, `Community 548`, `Community 41`, `Community 555`, `Community 44`, `Community 557`, `Community 46`, `Community 558`, `Community 556`, `Community 49`, `Community 560`, `Community 563`, `Community 52`, `Community 54`, `Community 567`, `Community 566`, `Community 569`, `Community 573`, `Community 62`, `Community 575`, `Community 64`, `Community 577`, `Community 578`, `Community 67`, `Community 66`, `Community 581`, `Community 70`, `Community 71`, `Community 72`, `Community 585`, `Community 74`, `Community 587`, `Community 588`, `Community 589`, `Community 78`, `Community 84`, `Community 597`, `Community 598`, `Community 599`, `Community 600`, `Community 86`, `Community 85`, `Community 93`, `Community 94`, `Community 95`, `Community 606`, `Community 98`, `Community 103`, `Community 104`, `Community 116`, `Community 117`, `Community 629`, `Community 121`, `Community 127`, `Community 128`, `Community 640`, `Community 130`, `Community 641`, `Community 142`, `Community 143`, `Community 149`, `Community 150`, `Community 151`, `Community 153`, `Community 154`, `Community 665`, `Community 677`, `Community 166`, `Community 167`, `Community 678`, `Community 679`, `Community 680`, `Community 681`, `Community 683`, `Community 682`, `Community 174`, `Community 178`, `Community 697`, `Community 698`, `Community 187`, `Community 706`, `Community 200`, `Community 713`, `Community 202`, `Community 203`, `Community 206`, `Community 718`, `Community 218`, `Community 220`, `Community 222`, `Community 223`, `Community 227`, `Community 741`, `Community 744`, `Community 745`, `Community 236`, `Community 239`, `Community 245`, `Community 259`, `Community 265`, `Community 276`, `Community 280`, `Community 287`, `Community 289`, `Community 290`, `Community 295`, `Community 296`, `Community 298`, `Community 822`, `Community 312`, `Community 315`, `Community 318`, `Community 325`, `Community 326`, `Community 327`, `Community 328`, `Community 333`, `Community 340`, `Community 861`, `Community 357`, `Community 360`, `Community 373`, `Community 376`, `Community 381`, `Community 383`, `Community 393`, `Community 397`, `Community 416`, `Community 418`, `Community 420`, `Community 434`, `Community 441`, `Community 445`, `Community 447`, `Community 448`, `Community 452`, `Community 471`, `Community 485`, `Community 486`, `Community 487`, `Community 492`, `Community 497`, `Community 503`, `Community 504`, `Community 510`?**
-  _High betweenness centrality (0.164) - this node is a cross-community bridge._
-- **Why does `get_logger()` connect `Core NLSQ & Bayesian Base` to `RheoData & Data Layer`, `BaseModel API & Methods`, `Community 130`, `GUI App & Main Window`, `Community 133`, `Community 394`, `Community 266`, `ArviZ Utils & Bayesian Results`, `Community 268`, `Community 1038`, `Transform Page & Worker`, `GUI Icons & Utils`, `Community 271`, `CSV Reader & IO`, `Community 275`, `Community 276`, `Community 148`, `Community 150`, `Community 149`, `Community 21`, `Community 23`, `Community 154`, `Community 283`, `Community 403`, `Community 290`, `Community 162`, `Community 36`, `Community 164`, `Community 35`, `Community 168`, `Community 298`, `Community 47`, `Community 48`, `Community 49`, `Community 308`, `Community 53`, `Community 180`, `Community 54`, `Community 440`, `Community 59`, `Community 60`, `Community 64`, `Community 324`, `Community 325`, `Community 68`, `Community 196`, `Community 713`, `Community 73`, `Community 79`, `Community 207`, `Community 82`, `Community 213`, `Community 216`, `Community 93`, `Community 351`, `Community 479`, `Community 97`, `Community 480`, `Community 103`, `Community 1001`, `Community 106`, `Community 363`, `Community 108`, `Community 365`, `Community 238`, `Community 239`, `Community 109`, `Community 112`, `Community 242`, `Community 115`, `Community 244`, `Community 123`, `Community 124`, `Community 254`?**
-  _High betweenness centrality (0.105) - this node is a cross-community bridge._
+- **Why does `RheoData` connect `RheoData` to `ModelRegistry`, `ParameterSet`, `StateStore`, `TestBinghamBasics`, `TestBinghamFitting`, `test_io_fixes.py`, `Pipeline`, `TestBinghamPhysicalBehavior`, `.create`, `ValueError`, `load_csv`, `json.py`, `txt.py`, `TensorialEPM`, `Maxwell`, `PipelineBuilder`, `SpringPot`, `FractionalMaxwellModel`, `DataService`, `_translate_y2_col`, `TestPlotPair`, `FitPage`, `DatasetRef`, `FractionalMaxwellLiquid`, `TestPlotAutocorr`, `TestPlotForest`, `TestPlotRank`, `TestPlotESS`, `CreepToRelaxationPipeline`, `test_multi_file.py`, `TestPlotFrequencyDomain`, `TestPlotTimeDomain`, `TestPowerLawPredictions`, `TestPlotFlowCurve`, `TransformService`, `TestPlotResiduals`, `RheoJAXMainWindow`, `TestPublicationQuality`, `PowerLaw`, `SmoothDerivative`, `test_transform_plotter.py`, `TestModulusFrequencyTemplate`, `conftest.py`, `ModelComparisonPipeline`, `DatasetLibrary`, `MLIKH`, `.update_metadata`, `._transform`, `TestHerschelBulkleyRheoData`, `TestPowerLawRheoData`, `TestPowerLawBasics`, `TestPowerLawNumericalStability`, `MIKH`, `plot_model_fit`, `__init__.py`, `TransformPlotter`, `FFTAnalysis`, `TestCarreauNumericalStability`, `TestFractionalMaxwellLiquidOscillation`, `BatchPipeline`, `BayesianWorker`, `MockBayesianModel`, `load_trios_chunked`, `AnalysisExporter`, `TestInferenceDataConversion`, `FitResult`, `Bingham`, `PronyConversion`, `SPPYieldStress`, `RheoJaxValidationWarning`, `main`, `WorkspaceWindow`, `.copy`, `TestFractionalMaxwellLiquidRelaxation`, `TestFractionalMaxwellModelNumericalStability`, `load_anton_paar`, `UnsupportedDataError`, `test_trios_chunked_integrity.py`, `ExportPage`, `TestModeEnum`, `test_herschel_bulkley.py`, `MastercurvePipeline`, `SPPAmplitudeSweepPipeline`, `TestHerschelBulkleyBasics`, `TestHerschelBulkleyFitting`, `TestHerschelBulkleyPhysicalBehavior`, `TestPowerLawFitting`, `TestPowerLawModelFunction`, `TestPowerLawPerformance`, `SPPDecomposer`, `spp_analyze`, `_coerce_ndarray`, `TestCarreauBasics`, `TestCarreauRheoData`, `TestCrossBasics`, `TestCrossStability`, `TestFractionalZenerANSYS`, `TestPronySeries`, `run_fit_isolated`, `TestFractionalMaxwellLiquidCreep`, `TestUncertaintyBand`, `FractionalMaxwellGel`, `.shape`, `check_r_hat`, `test_spp_integration.py`, `TestFractionalMaxwellLiquidLimitCases`, `TestFractionalMaxwellLiquidNumericalStability`, `Registry`, `FractionalKelvinVoigt`, `run_profiling.py`, `._predict`, `ModelComparison`, `test_dmta_removal.py`, `TestPlotEnergy`, `cmd_transform.py`, `test_spp_golden_parity.py`, `PlotService`, `._predict`, `AppState`, `ModelService`, `_VizTestTransform`, `_SpyModel`, `main`, `TestPipelineExport`, `.fit_bayesian`, `test_spp_kernels.py`, `TestBinghamPredictions`, `HerschelBulkley`, `FitOrchestrator`, `test_ikh_fitting.py`, `ndarray`, `test_trios_chunked.py`, `TestCarreauPredictions`, `Mastercurve`, `Zener`, `._predict`, `Carreau`, `TestPlotRheoData`, `is_monotonic_decreasing`, `_modulus_labels`, `TestRheoDataSerialization`, `TestDataIntegrity`, `TestRheoDataDomainConsistency`, `TestBinghamStability`, `MockBayesianModel`, `TestExportFormats`, `compute_diagnostics`, `_process_remaining_rows`, `TestTransformPlotterDispatch`, `load_trios`, `.test_mode`, `TestCrossPredictions`, `TestHerschelBulkleyNumericalStability`, `Cross`, `TestCascadeProvenance`, `TestTriosChunkedBasic`?**
+  _High betweenness centrality (0.157) - this node is a cross-community bridge._
+- **Why does `get_logger()` connect `ModelRegistry` to `ParameterSet`, `StateStore`, `RheoJaxValidationWarning`, `main`, `RheoData`, `test_io_fixes.py`, `PlotService`, `IconProvider`, `ValueError`, `device.py`, `load_csv`, `epm_plots.py`, `test_fractional_initializers.py`, `create_global_parser`, `main.py`, `load_anton_paar`, `json.py`, `txt.py`, `UnsupportedDataError`, `ExportPage`, `test_logging_integration.py`, `initialize_equilibrium`, `ModelService`, `physics_checks.py`, `DataService`, `hebraud_lequeux.py`, `auto_p0.py`, `main`, `from_yaml`, `layout_helpers.py`, `TransformState`, `_make_mock_spp_results`, `ml_ikh.py`, `create_parser`, `__init__.py`, `test_multi_file.py`, `plot_moduli_evolution`, `FitResult`, `__init__.py`, `TransformService`, `spp.py`, `local.py`, `mct_kernels.py`, `check_model_compatibility`, `WorkerPool`, `sgr_population_balance.py`, `PipelineConfig`, `main`, `Registry`, `__init__.py`, `apply_globals`, `TestGetLogger`, `.has_message`, `PreviewWorker`, `BayesianWorker`, `PreprocessingResult`, `TRIOSDataSet`, `test_column_mapping.py`, `schematic.py`, `main`, `cmd_transform.py`, `spp_kernels.py`, `.test_mode`, `get_template`, `detect_data_range_decades`, `_yaml_runner.py`, `Envelope`, `BayesianOptionsDialog`?**
+  _High betweenness centrality (0.112) - this node is a cross-community bridge._
 - **Are the 490 inferred relationships involving `RheoData` (e.g. with `BaseModel` and `._detect_optimization_strategy()`) actually correct?**
   _`RheoData` has 490 INFERRED edges - model-reasoned connections that need verification._
 - **Are the 425 inferred relationships involving `ModelRegistry` (e.g. with `FitResult` and `ModelComparison`) actually correct?**

--- a/graphify-out/manifest.json
+++ b/graphify-out/manifest.json
@@ -1,5177 +1,5192 @@
 {
   "docs/source/conf.py": {
-    "mtime": 1782840585.9944196,
+    "mtime": 1783141475.652429,
     "ast_hash": "bbd3583e22059e63518bfc2972fa31cd",
     "semantic_hash": "bbd3583e22059e63518bfc2972fa31cd"
   },
   "rheojax/__init__.py": {
-    "mtime": 1782840586.0454202,
+    "mtime": 1783141477.1654243,
     "ast_hash": "699932f5ff80c06d418513bc5ab6af41",
     "semantic_hash": "699932f5ff80c06d418513bc5ab6af41"
   },
   "rheojax/cli/__init__.py": {
-    "mtime": 1773332567.6569538,
+    "mtime": 1783141477.1654243,
     "ast_hash": "dc9de96a737355314e1c3c19d63849f7",
     "semantic_hash": "dc9de96a737355314e1c3c19d63849f7"
   },
   "rheojax/cli/_envelope.py": {
-    "mtime": 1773332567.6569538,
+    "mtime": 1783141477.1654243,
     "ast_hash": "192bbdb9bd8fc60b6f30dd2df0611ac5",
     "semantic_hash": "192bbdb9bd8fc60b6f30dd2df0611ac5"
   },
   "rheojax/cli/_globals.py": {
-    "mtime": 1773332567.6569538,
+    "mtime": 1783141477.1654243,
     "ast_hash": "fe199e9b358cf6bd2c7ff6d16ef9a784",
     "semantic_hash": "fe199e9b358cf6bd2c7ff6d16ef9a784"
   },
   "rheojax/cli/_output.py": {
-    "mtime": 1773332567.6569538,
+    "mtime": 1783141477.1654243,
     "ast_hash": "f86bfbf4343f29347be071cb3e372de4",
     "semantic_hash": "f86bfbf4343f29347be071cb3e372de4"
   },
   "rheojax/cli/_templates.py": {
-    "mtime": 1773332567.6569538,
+    "mtime": 1783141477.1654243,
     "ast_hash": "c5ba94cb19886f18b396c46410b2ba58",
     "semantic_hash": "c5ba94cb19886f18b396c46410b2ba58"
   },
   "rheojax/cli/_yaml_runner.py": {
-    "mtime": 1782840586.0454202,
+    "mtime": 1783141477.1654243,
     "ast_hash": "6bb5c616a0170f7ec5f637b551fc065a",
     "semantic_hash": "6bb5c616a0170f7ec5f637b551fc065a"
   },
   "rheojax/cli/_yaml_schema.py": {
-    "mtime": 1782840586.0454202,
+    "mtime": 1783141477.1654243,
     "ast_hash": "b6446ce13b832f239c5f1da244289824",
     "semantic_hash": "b6446ce13b832f239c5f1da244289824"
   },
   "rheojax/cli/bayesian.py": {
-    "mtime": 1782840586.04642,
+    "mtime": 1783141477.1654243,
     "ast_hash": "e50baccaeb5b3f1a58e1e67739719cd5",
     "semantic_hash": "e50baccaeb5b3f1a58e1e67739719cd5"
   },
   "rheojax/cli/cmd_batch.py": {
-    "mtime": 1782840586.04642,
+    "mtime": 1783141477.1654243,
     "ast_hash": "5238ada2039822aee3e2880d67a3c2f6",
     "semantic_hash": "5238ada2039822aee3e2880d67a3c2f6"
   },
   "rheojax/cli/cmd_export.py": {
-    "mtime": 1777045619.9323702,
+    "mtime": 1783141477.1654243,
     "ast_hash": "fe7442f9beff8a1d8f58b77a3da6433a",
     "semantic_hash": "fe7442f9beff8a1d8f58b77a3da6433a"
   },
   "rheojax/cli/cmd_load.py": {
-    "mtime": 1777045619.9323702,
+    "mtime": 1783141477.1654243,
     "ast_hash": "b697f5b50d6d0581b36f122b3b09c912",
     "semantic_hash": "b697f5b50d6d0581b36f122b3b09c912"
   },
   "rheojax/cli/cmd_pipeline.py": {
-    "mtime": 1773332567.6569538,
+    "mtime": 1783141477.1654243,
     "ast_hash": "faca1b8f340c03647dc82c5b714e2e86",
     "semantic_hash": "faca1b8f340c03647dc82c5b714e2e86"
   },
   "rheojax/cli/cmd_run.py": {
-    "mtime": 1773332567.6569538,
+    "mtime": 1783141477.1654243,
     "ast_hash": "bdbe7c3d05ef5d4eb02329572aceb1e3",
     "semantic_hash": "bdbe7c3d05ef5d4eb02329572aceb1e3"
   },
   "rheojax/cli/cmd_transform.py": {
-    "mtime": 1777045619.9323702,
+    "mtime": 1783141477.1654243,
     "ast_hash": "821e3f05ea4c70c851d7c4485d868d6c",
     "semantic_hash": "821e3f05ea4c70c851d7c4485d868d6c"
   },
   "rheojax/cli/fit.py": {
-    "mtime": 1782840586.04642,
+    "mtime": 1783141477.1664243,
     "ast_hash": "36f61a25a3ff3f50ce4e6fa13784895b",
     "semantic_hash": "36f61a25a3ff3f50ce4e6fa13784895b"
   },
   "rheojax/cli/main.py": {
-    "mtime": 1782779014.4702597,
+    "mtime": 1783141477.1664243,
     "ast_hash": "500765f917a9550f12b913a8657d2016",
     "semantic_hash": "500765f917a9550f12b913a8657d2016"
   },
   "rheojax/cli/spp.py": {
-    "mtime": 1782500709.976391,
+    "mtime": 1783141477.1664243,
     "ast_hash": "3060ff534f4f5988341a707ad1e12dc0",
     "semantic_hash": "3060ff534f4f5988341a707ad1e12dc0"
   },
   "rheojax/core/__init__.py": {
-    "mtime": 1782840586.04642,
+    "mtime": 1783141477.1664243,
     "ast_hash": "c13aae6efbe38c9022ae2a8b89330389",
     "semantic_hash": "c13aae6efbe38c9022ae2a8b89330389"
   },
   "rheojax/core/arviz_utils.py": {
-    "mtime": 1782840586.04642,
+    "mtime": 1783141477.1664243,
     "ast_hash": "88e49e7cfbfb48263c66d43c33c39a30",
     "semantic_hash": "88e49e7cfbfb48263c66d43c33c39a30"
   },
   "rheojax/core/base.py": {
-    "mtime": 1782840586.04642,
+    "mtime": 1783141477.1664243,
     "ast_hash": "bfb798fe4646a9cb8f31b668f02b3981",
     "semantic_hash": "bfb798fe4646a9cb8f31b668f02b3981"
   },
   "rheojax/core/bayesian.py": {
-    "mtime": 1782840586.04642,
+    "mtime": 1783141477.1664243,
     "ast_hash": "54fcbf2939f453aa0e8600206dca4dcb",
     "semantic_hash": "54fcbf2939f453aa0e8600206dca4dcb"
   },
   "rheojax/core/bayesian_diagnostics.py": {
-    "mtime": 1777045619.9333704,
+    "mtime": 1783141477.1664243,
     "ast_hash": "c65dd512e5fded1698f9866718c01cfd",
     "semantic_hash": "c65dd512e5fded1698f9866718c01cfd"
   },
   "rheojax/core/bayesian_result.py": {
-    "mtime": 1782840586.04642,
+    "mtime": 1783141477.1664243,
     "ast_hash": "62f50f1163d12311e3f5c30eb388f1aa",
     "semantic_hash": "62f50f1163d12311e3f5c30eb388f1aa"
   },
   "rheojax/core/data.py": {
-    "mtime": 1782840586.0474203,
+    "mtime": 1783141477.1664243,
     "ast_hash": "c14a7ffa8711db2627a3225976dec2ab",
     "semantic_hash": "c14a7ffa8711db2627a3225976dec2ab"
   },
   "rheojax/core/fit_orchestrator.py": {
-    "mtime": 1782840586.0474203,
+    "mtime": 1783141477.1664243,
     "ast_hash": "35dcd9f8222321052d95275403896763",
     "semantic_hash": "35dcd9f8222321052d95275403896763"
   },
   "rheojax/core/fit_result.py": {
-    "mtime": 1782840586.0474203,
+    "mtime": 1783141477.1674244,
     "ast_hash": "49c4dc2ad3bde72710f323ca4840e81f",
     "semantic_hash": "49c4dc2ad3bde72710f323ca4840e81f"
   },
   "rheojax/core/inventory.py": {
-    "mtime": 1771374330.2828257,
+    "mtime": 1783141477.1674244,
     "ast_hash": "ebf43a166ca57ad02b7c161b5a4df345",
     "semantic_hash": "ebf43a166ca57ad02b7c161b5a4df345"
   },
   "rheojax/core/jax_config.py": {
-    "mtime": 1777045619.9333704,
+    "mtime": 1783141477.1674244,
     "ast_hash": "d901b24e2bfb8a9498c67537427efbee",
     "semantic_hash": "d901b24e2bfb8a9498c67537427efbee"
   },
   "rheojax/core/numpyro_model_builder.py": {
-    "mtime": 1780618617.2383204,
+    "mtime": 1783141477.1674244,
     "ast_hash": "e0cbf8c54d53635a40c4216be1d3d4e9",
     "semantic_hash": "e0cbf8c54d53635a40c4216be1d3d4e9"
   },
   "rheojax/core/parameters.py": {
-    "mtime": 1782779014.4712596,
+    "mtime": 1783141477.1674244,
     "ast_hash": "49a893e915c7c86aba9f35ccd7d9af34",
     "semantic_hash": "49a893e915c7c86aba9f35ccd7d9af34"
   },
   "rheojax/core/post_fit_validator.py": {
-    "mtime": 1777045619.9333704,
+    "mtime": 1783141477.1674244,
     "ast_hash": "840feafc57d006cb45ce9c72d7e6c7a7",
     "semantic_hash": "840feafc57d006cb45ce9c72d7e6c7a7"
   },
   "rheojax/core/registry.py": {
-    "mtime": 1782840586.0474203,
+    "mtime": 1783141477.1674244,
     "ast_hash": "4997d6461f2d8ec52f687f32ced75003",
     "semantic_hash": "4997d6461f2d8ec52f687f32ced75003"
   },
   "rheojax/core/test_modes.py": {
-    "mtime": 1782840586.0474203,
+    "mtime": 1783141477.1674244,
     "ast_hash": "f107afcba420ca25e34db590785a846f",
     "semantic_hash": "f107afcba420ca25e34db590785a846f"
   },
   "rheojax/gui/__init__.py": {
-    "mtime": 1777045619.9333704,
+    "mtime": 1783141477.1674244,
     "ast_hash": "c07706e4175ff212b9c23508f5b2b45b",
     "semantic_hash": "c07706e4175ff212b9c23508f5b2b45b"
   },
   "rheojax/gui/app/__init__.py": {
-    "mtime": 1765522476.682319,
+    "mtime": 1783141477.1674244,
     "ast_hash": "ddbfc63655308551d2305fdae23309af",
     "semantic_hash": "ddbfc63655308551d2305fdae23309af"
   },
   "rheojax/gui/app/main_window.py": {
-    "mtime": 1783016198.9733684,
+    "mtime": 1783141477.1684244,
     "ast_hash": "b80125fff196755bfbc6a29461b3781b",
     "semantic_hash": "b80125fff196755bfbc6a29461b3781b"
   },
   "rheojax/gui/app/menu_bar.py": {
-    "mtime": 1777045619.9343703,
+    "mtime": 1783141477.1684244,
     "ast_hash": "1552dc0dc65f51382e1c0b5759f73e75",
     "semantic_hash": "1552dc0dc65f51382e1c0b5759f73e75"
   },
   "rheojax/gui/app/status_bar.py": {
-    "mtime": 1768708239.0772598,
+    "mtime": 1783141477.1684244,
     "ast_hash": "acc58af0cc0d67748cc32880b3447190",
     "semantic_hash": "acc58af0cc0d67748cc32880b3447190"
   },
   "rheojax/gui/app/toolbar.py": {
-    "mtime": 1770953435.567701,
+    "mtime": 1783141477.1684244,
     "ast_hash": "dabc68b8ede2fcf3bf535559d8053e8c",
     "semantic_hash": "dabc68b8ede2fcf3bf535559d8053e8c"
   },
   "rheojax/gui/compat.py": {
-    "mtime": 1782480148.6423051,
+    "mtime": 1783141477.1684244,
     "ast_hash": "90db359b4219703394a041122c6a6549",
     "semantic_hash": "90db359b4219703394a041122c6a6549"
   },
   "rheojax/gui/dialogs/__init__.py": {
-    "mtime": 1773332567.6679537,
+    "mtime": 1783141477.1684244,
     "ast_hash": "a46ba53723c659edf105ae24bf04ac17",
     "semantic_hash": "a46ba53723c659edf105ae24bf04ac17"
   },
   "rheojax/gui/dialogs/about.py": {
-    "mtime": 1768708239.0772598,
+    "mtime": 1783141477.1684244,
     "ast_hash": "8dbf72aae7acebf594dcff32c22ac25e",
     "semantic_hash": "8dbf72aae7acebf594dcff32c22ac25e"
   },
   "rheojax/gui/dialogs/bayesian_options.py": {
-    "mtime": 1783023586.5730257,
+    "mtime": 1783141477.1684244,
     "ast_hash": "6cee658b35aacdf566c7be4906df9463",
     "semantic_hash": ""
   },
   "rheojax/gui/dialogs/column_mapper.py": {
-    "mtime": 1782840586.0484202,
+    "mtime": 1783141477.1684244,
     "ast_hash": "84a4a298e2fe628e28b312629cc51ba8",
     "semantic_hash": "84a4a298e2fe628e28b312629cc51ba8"
   },
   "rheojax/gui/dialogs/export_options.py": {
-    "mtime": 1768708239.0772598,
+    "mtime": 1783141477.1684244,
     "ast_hash": "86b2d888323e2988d43ebe201d892b58",
     "semantic_hash": "86b2d888323e2988d43ebe201d892b58"
   },
   "rheojax/gui/dialogs/fitting_options.py": {
-    "mtime": 1777045619.9343703,
+    "mtime": 1783141477.1684244,
     "ast_hash": "86ac9c463f19ca9da5427552795566bc",
     "semantic_hash": "86ac9c463f19ca9da5427552795566bc"
   },
   "rheojax/gui/dialogs/import_wizard.py": {
-    "mtime": 1777045619.9343703,
+    "mtime": 1783141477.1684244,
     "ast_hash": "890b90a3b728d29a92c0be02f3af6a86",
     "semantic_hash": "890b90a3b728d29a92c0be02f3af6a86"
   },
   "rheojax/gui/dialogs/pipeline_templates.py": {
-    "mtime": 1783023586.5730257,
+    "mtime": 1783141477.1684244,
     "ast_hash": "973bbea75e206256562bd418275b5dd4",
     "semantic_hash": ""
   },
   "rheojax/gui/dialogs/preferences.py": {
-    "mtime": 1777045619.9343703,
+    "mtime": 1783141477.1684244,
     "ast_hash": "84f6b48dcf3453ba7a89963f2c288945",
     "semantic_hash": "84f6b48dcf3453ba7a89963f2c288945"
   },
   "rheojax/gui/jobs/__init__.py": {
-    "mtime": 1773332567.6679537,
+    "mtime": 1783141477.1694243,
     "ast_hash": "f8bc9bbdcbc4f64483f54714f1baa8c1",
     "semantic_hash": "f8bc9bbdcbc4f64483f54714f1baa8c1"
   },
   "rheojax/gui/jobs/_cleanup.py": {
-    "mtime": 1773332567.6679537,
+    "mtime": 1783141477.1694243,
     "ast_hash": "73e6005c893ca9f7046f726d3ab48067",
     "semantic_hash": "73e6005c893ca9f7046f726d3ab48067"
   },
   "rheojax/gui/jobs/bayesian_worker.py": {
-    "mtime": 1782868060.7243557,
+    "mtime": 1783141477.1694243,
     "ast_hash": "111371cee6ef348f498f9812e4de8293",
     "semantic_hash": "111371cee6ef348f498f9812e4de8293"
   },
   "rheojax/gui/jobs/cancellation.py": {
-    "mtime": 1782840586.0484202,
+    "mtime": 1783141477.1694243,
     "ast_hash": "f5382a0e5162564f212932d74c1001ea",
     "semantic_hash": "f5382a0e5162564f212932d74c1001ea"
   },
   "rheojax/gui/jobs/export_worker.py": {
-    "mtime": 1773332567.6689537,
+    "mtime": 1783141477.1694243,
     "ast_hash": "a0ee1c0227845ecb329468added416c0",
     "semantic_hash": "a0ee1c0227845ecb329468added416c0"
   },
   "rheojax/gui/jobs/fit_worker.py": {
-    "mtime": 1782779014.4722598,
+    "mtime": 1783141477.1694243,
     "ast_hash": "cdf7fd28be0f1a18829ff60d193a5f5b",
     "semantic_hash": "cdf7fd28be0f1a18829ff60d193a5f5b"
   },
   "rheojax/gui/jobs/import_worker.py": {
-    "mtime": 1773332567.6689537,
+    "mtime": 1783141477.1694243,
     "ast_hash": "8fc1044d12f230ff40d9b3fb59d99d28",
     "semantic_hash": "8fc1044d12f230ff40d9b3fb59d99d28"
   },
   "rheojax/gui/jobs/preview_worker.py": {
-    "mtime": 1773332567.6689537,
+    "mtime": 1783141477.1694243,
     "ast_hash": "68deab3263af4cceeda63a1075f530ae",
     "semantic_hash": "68deab3263af4cceeda63a1075f530ae"
   },
   "rheojax/gui/jobs/process_adapter.py": {
-    "mtime": 1782870323.5679414,
+    "mtime": 1783141477.1694243,
     "ast_hash": "f9f80b1a89a1aae650e0287e03b9beff",
     "semantic_hash": "f9f80b1a89a1aae650e0287e03b9beff"
   },
   "rheojax/gui/jobs/subprocess_bayesian.py": {
-    "mtime": 1783016198.9743683,
+    "mtime": 1783141477.1694243,
     "ast_hash": "824812057f6be3afc9fba6d6af94634a",
     "semantic_hash": "824812057f6be3afc9fba6d6af94634a"
   },
   "rheojax/gui/jobs/subprocess_fit.py": {
-    "mtime": 1782868060.7243557,
+    "mtime": 1783141477.1694243,
     "ast_hash": "c01d1cd034723e28db09c223e1ea9621",
     "semantic_hash": "c01d1cd034723e28db09c223e1ea9621"
   },
   "rheojax/gui/jobs/test_jobs.py": {
-    "mtime": 1771754195.3499806,
+    "mtime": 1783141477.1704242,
     "ast_hash": "2420b58d5be4a3263af3e804b7e8ab36",
     "semantic_hash": "2420b58d5be4a3263af3e804b7e8ab36"
   },
   "rheojax/gui/jobs/transform_worker.py": {
-    "mtime": 1777045619.9353702,
+    "mtime": 1783141477.1704242,
     "ast_hash": "ff1a2bb2177caef903cbf1bf4e4c4921",
     "semantic_hash": "ff1a2bb2177caef903cbf1bf4e4c4921"
   },
   "rheojax/gui/jobs/worker_pool.py": {
-    "mtime": 1782779014.4722598,
+    "mtime": 1783141477.1704242,
     "ast_hash": "073fa4f48bd10adf9a7c747aaf235b53",
     "semantic_hash": "073fa4f48bd10adf9a7c747aaf235b53"
   },
   "rheojax/gui/main.py": {
-    "mtime": 1783096292.3402772,
-    "ast_hash": "08460d1c9f4e82c36ce1285acd7babc8",
+    "mtime": 1783141477.1704242,
+    "ast_hash": "fb8d8795250a53d92d4a2c0840b450c7",
     "semantic_hash": ""
   },
   "rheojax/gui/pages/__init__.py": {
-    "mtime": 1767875584.3445628,
+    "mtime": 1783141477.1704242,
     "ast_hash": "f535312b256a670450de4c0a7197fe8f",
     "semantic_hash": "f535312b256a670450de4c0a7197fe8f"
   },
   "rheojax/gui/pages/bayesian_page.py": {
-    "mtime": 1783016198.9743683,
+    "mtime": 1783141477.1704242,
     "ast_hash": "464c2c36e02627c462f19a09c7bcf853",
     "semantic_hash": "464c2c36e02627c462f19a09c7bcf853"
   },
   "rheojax/gui/pages/data_page.py": {
-    "mtime": 1782840586.04942,
+    "mtime": 1783141477.1704242,
     "ast_hash": "1654a376927820e14abbb5dfed12684d",
     "semantic_hash": "1654a376927820e14abbb5dfed12684d"
   },
   "rheojax/gui/pages/diagnostics_page.py": {
-    "mtime": 1783016198.9753685,
+    "mtime": 1783141477.1704242,
     "ast_hash": "25c14d427c818fc7126e69d1a6099de9",
     "semantic_hash": "25c14d427c818fc7126e69d1a6099de9"
   },
   "rheojax/gui/pages/export_page.py": {
-    "mtime": 1782840586.04942,
+    "mtime": 1783141477.1714244,
     "ast_hash": "b0e4578a21d4b91da5038d3c900f15ea",
     "semantic_hash": "b0e4578a21d4b91da5038d3c900f15ea"
   },
   "rheojax/gui/pages/fit_page.py": {
-    "mtime": 1783016198.9753685,
+    "mtime": 1783141477.1714244,
     "ast_hash": "3a5e92baca8392fe7e2dceffd4d28bc4",
     "semantic_hash": "3a5e92baca8392fe7e2dceffd4d28bc4"
   },
   "rheojax/gui/pages/home_page.py": {
-    "mtime": 1782779014.4742596,
+    "mtime": 1783141477.1714244,
     "ast_hash": "711570b31721e06008e7bf5d830ad392",
     "semantic_hash": "711570b31721e06008e7bf5d830ad392"
   },
   "rheojax/gui/pages/transform_page.py": {
-    "mtime": 1783016198.9753685,
+    "mtime": 1783141477.1714244,
     "ast_hash": "a023fd51586b02ae2fb420e824eb9e45",
     "semantic_hash": "a023fd51586b02ae2fb420e824eb9e45"
   },
   "rheojax/gui/resources/__init__.py": {
-    "mtime": 1765012492.0,
+    "mtime": 1783141477.1714244,
     "ast_hash": "24d93c770d1e6af3e6701bd26541d9f0",
     "semantic_hash": "24d93c770d1e6af3e6701bd26541d9f0"
   },
   "rheojax/gui/resources/styles/__init__.py": {
-    "mtime": 1777045619.9363701,
+    "mtime": 1783141477.1714244,
     "ast_hash": "b39bbf0a5def09f6d8fbf4c22e1729d6",
     "semantic_hash": "b39bbf0a5def09f6d8fbf4c22e1729d6"
   },
   "rheojax/gui/resources/styles/example_usage.py": {
-    "mtime": 1764941454.0,
+    "mtime": 1783141477.1714244,
     "ast_hash": "fe3d4bcc3f5d37c26a2a66d4599f90b8",
     "semantic_hash": "fe3d4bcc3f5d37c26a2a66d4599f90b8"
   },
   "rheojax/gui/resources/styles/plot_styles/__init__.py": {
-    "mtime": 1764923740.0,
+    "mtime": 1783141477.1714244,
     "ast_hash": "6a71df35cea44e0745f4390e1e7ff029",
     "semantic_hash": "6a71df35cea44e0745f4390e1e7ff029"
   },
   "rheojax/gui/services/__init__.py": {
-    "mtime": 1767875584.467562,
+    "mtime": 1783141477.1714244,
     "ast_hash": "64163379daddfeda7d6c4306319be659",
     "semantic_hash": "64163379daddfeda7d6c4306319be659"
   },
   "rheojax/gui/services/bayesian_service.py": {
-    "mtime": 1783002867.869239,
+    "mtime": 1783141477.1724243,
     "ast_hash": "948a544a5126c9d2a340aace4e982cc9",
     "semantic_hash": "948a544a5126c9d2a340aace4e982cc9"
   },
   "rheojax/gui/services/data_service.py": {
-    "mtime": 1782840586.0504203,
+    "mtime": 1783141477.1724243,
     "ast_hash": "9d4192990d6e87b960a5639518e80b32",
     "semantic_hash": "9d4192990d6e87b960a5639518e80b32"
   },
   "rheojax/gui/services/export_service.py": {
-    "mtime": 1782980449.8462136,
+    "mtime": 1783141477.1724243,
     "ast_hash": "29845a0dda1034167884c0e1cd631280",
     "semantic_hash": "29845a0dda1034167884c0e1cd631280"
   },
   "rheojax/gui/services/model_service.py": {
-    "mtime": 1782868060.7253556,
+    "mtime": 1783141477.1724243,
     "ast_hash": "437040b8cbd912eb3aed50bb3eeb3574",
     "semantic_hash": "437040b8cbd912eb3aed50bb3eeb3574"
   },
   "rheojax/gui/services/pipeline_execution_service.py": {
-    "mtime": 1783096292.3412771,
-    "ast_hash": "0c0f185dd271e4ab1e5561e17096fc64",
+    "mtime": 1783141477.1724243,
+    "ast_hash": "b86ff3316146ef0d635c4dde533a4f70",
     "semantic_hash": ""
   },
   "rheojax/gui/services/plot_service.py": {
-    "mtime": 1782840586.0514202,
+    "mtime": 1783141477.1724243,
     "ast_hash": "ec48bbc0d935d27880ed43d5b18c9117",
     "semantic_hash": "ec48bbc0d935d27880ed43d5b18c9117"
   },
   "rheojax/gui/services/transform_service.py": {
-    "mtime": 1782870323.5679414,
+    "mtime": 1783141477.1724243,
     "ast_hash": "ceeaccff134f11fd2ee3f89546927502",
     "semantic_hash": "ceeaccff134f11fd2ee3f89546927502"
   },
   "rheojax/gui/state/__init__.py": {
-    "mtime": 1764941454.0,
+    "mtime": 1783141477.1724243,
     "ast_hash": "5e84c3e3a2082ccd0365f9dd4c35c2ae",
     "semantic_hash": "5e84c3e3a2082ccd0365f9dd4c35c2ae"
   },
   "rheojax/gui/state/actions.py": {
-    "mtime": 1783016198.9763684,
+    "mtime": 1783141477.1734242,
     "ast_hash": "398b8e3ab249320297cf12d0e66ed007",
     "semantic_hash": "398b8e3ab249320297cf12d0e66ed007"
   },
   "rheojax/gui/state/reducers/__init__.py": {
-    "mtime": 1782840586.0514202,
+    "mtime": 1783141477.1734242,
     "ast_hash": "b6d8852e31dbecdadcb4b73e9721fd11",
     "semantic_hash": "b6d8852e31dbecdadcb4b73e9721fd11"
   },
   "rheojax/gui/state/reducers/bayesian_reducers.py": {
-    "mtime": 1783016198.9763684,
+    "mtime": 1783141477.1734242,
     "ast_hash": "a91a2e9d8217d9b21e9276c81ab82589",
     "semantic_hash": "a91a2e9d8217d9b21e9276c81ab82589"
   },
   "rheojax/gui/state/reducers/data_reducers.py": {
-    "mtime": 1783016198.9763684,
+    "mtime": 1783141477.1734242,
     "ast_hash": "51ca27a9e2f0f265aae1b688c6143239",
     "semantic_hash": "51ca27a9e2f0f265aae1b688c6143239"
   },
   "rheojax/gui/state/reducers/fitting_reducers.py": {
-    "mtime": 1783016198.9763684,
+    "mtime": 1783141477.1734242,
     "ast_hash": "61f95c0eb4346f024ed26c8e90fc1e91",
     "semantic_hash": "61f95c0eb4346f024ed26c8e90fc1e91"
   },
   "rheojax/gui/state/reducers/model_reducers.py": {
-    "mtime": 1783016198.9763684,
+    "mtime": 1783141477.1734242,
     "ast_hash": "f995d7d0344af10f530aa6a7c4a1b057",
     "semantic_hash": "f995d7d0344af10f530aa6a7c4a1b057"
   },
   "rheojax/gui/state/reducers/pipeline_reducers.py": {
-    "mtime": 1783016198.9773684,
+    "mtime": 1783141477.1734242,
     "ast_hash": "5268743a239a1e87ddae6dfe238d74ae",
     "semantic_hash": "5268743a239a1e87ddae6dfe238d74ae"
   },
   "rheojax/gui/state/reducers/project_reducers.py": {
-    "mtime": 1777045619.9373703,
+    "mtime": 1783141477.1734242,
     "ast_hash": "dca1570d29f8378840287c7ac1d4f223",
     "semantic_hash": "dca1570d29f8378840287c7ac1d4f223"
   },
   "rheojax/gui/state/reducers/ui_reducers.py": {
-    "mtime": 1782840586.0514202,
+    "mtime": 1783141477.1734242,
     "ast_hash": "43069123fd902f49da0fa4aa8cacd265",
     "semantic_hash": "43069123fd902f49da0fa4aa8cacd265"
   },
   "rheojax/gui/state/selectors.py": {
-    "mtime": 1773332567.6719537,
+    "mtime": 1783141477.1734242,
     "ast_hash": "5adcd6d253fa729981a46a09985e979c",
     "semantic_hash": "5adcd6d253fa729981a46a09985e979c"
   },
   "rheojax/gui/state/signals.py": {
-    "mtime": 1777045619.9373703,
+    "mtime": 1783141477.1734242,
     "ast_hash": "3cb1f9172b5f7493b247e788bdcdecf1",
     "semantic_hash": "3cb1f9172b5f7493b247e788bdcdecf1"
   },
   "rheojax/gui/state/store.py": {
-    "mtime": 1783016198.9773684,
+    "mtime": 1783141477.1734242,
     "ast_hash": "d5f252711b4cf9fada5bcb4a6177f4a2",
     "semantic_hash": "d5f252711b4cf9fada5bcb4a6177f4a2"
   },
   "rheojax/gui/utils/__init__.py": {
-    "mtime": 1773332567.6729536,
+    "mtime": 1783141477.1734242,
     "ast_hash": "17b08e29220d1cc543767254c8086cb5",
     "semantic_hash": "17b08e29220d1cc543767254c8086cb5"
   },
   "rheojax/gui/utils/_dependency_guard.py": {
-    "mtime": 1771374330.286826,
+    "mtime": 1783141477.1734242,
     "ast_hash": "8251f5c1b5b1c84530f2630981173f96",
     "semantic_hash": "8251f5c1b5b1c84530f2630981173f96"
   },
   "rheojax/gui/utils/config.py": {
-    "mtime": 1767978634.720401,
+    "mtime": 1783141477.1734242,
     "ast_hash": "f2e0a32a754281dcbc37c03f740c0a81",
     "semantic_hash": "f2e0a32a754281dcbc37c03f740c0a81"
   },
   "rheojax/gui/utils/icons.py": {
-    "mtime": 1782840586.0514202,
+    "mtime": 1783141477.1734242,
     "ast_hash": "dbc353612f6c52671f19389440390304",
     "semantic_hash": "dbc353612f6c52671f19389440390304"
   },
   "rheojax/gui/utils/jax_utils.py": {
-    "mtime": 1768360824.2710142,
+    "mtime": 1783141477.1734242,
     "ast_hash": "640822b90218f0440477c8cd91dacbfe",
     "semantic_hash": "640822b90218f0440477c8cd91dacbfe"
   },
   "rheojax/gui/utils/layout_helpers.py": {
-    "mtime": 1773332567.6729536,
+    "mtime": 1783141477.1734242,
     "ast_hash": "e2b4a3ac8238e9f0c7727ca583d0fe5d",
     "semantic_hash": "e2b4a3ac8238e9f0c7727ca583d0fe5d"
   },
   "rheojax/gui/utils/logging.py": {
-    "mtime": 1767875587.6055427,
+    "mtime": 1783141477.1734242,
     "ast_hash": "8ce07d23dbed721483bc914b2fc8398f",
     "semantic_hash": "8ce07d23dbed721483bc914b2fc8398f"
   },
   "rheojax/gui/utils/pipeline_serializer.py": {
-    "mtime": 1773332567.6729536,
+    "mtime": 1783141477.1744244,
     "ast_hash": "a922f8885155a5095a047b4574ff50e6",
     "semantic_hash": "a922f8885155a5095a047b4574ff50e6"
   },
   "rheojax/gui/utils/provenance.py": {
-    "mtime": 1768360824.2710142,
+    "mtime": 1783141477.1744244,
     "ast_hash": "fb55cbe2dc66ba61fc6e45bb14fd9b5d",
     "semantic_hash": "fb55cbe2dc66ba61fc6e45bb14fd9b5d"
   },
   "rheojax/gui/utils/rheodata.py": {
-    "mtime": 1773332567.6729536,
+    "mtime": 1783141477.1744244,
     "ast_hash": "5cbcf10760910bc021154d6c33f6acb4",
     "semantic_hash": "5cbcf10760910bc021154d6c33f6acb4"
   },
   "rheojax/gui/utils/seeds.py": {
-    "mtime": 1767978634.720401,
+    "mtime": 1783141477.1744244,
     "ast_hash": "c9510b12b56c4647acb30c6529dbaf4b",
     "semantic_hash": "c9510b12b56c4647acb30c6529dbaf4b"
   },
   "rheojax/gui/utils/style_helpers.py": {
-    "mtime": 1773332567.6729536,
+    "mtime": 1783141477.1744244,
     "ast_hash": "433898eb6afea2d5ebe727218d4f9872",
     "semantic_hash": "433898eb6afea2d5ebe727218d4f9872"
   },
   "rheojax/gui/widgets/__init__.py": {
-    "mtime": 1773332567.6729536,
+    "mtime": 1783141477.1744244,
     "ast_hash": "c6499d716bab95045030f6dcc0574b81",
     "semantic_hash": "c6499d716bab95045030f6dcc0574b81"
   },
   "rheojax/gui/widgets/arviz_canvas.py": {
-    "mtime": 1782840586.0514202,
+    "mtime": 1783141477.1744244,
     "ast_hash": "dbda2ff2c22a893b41ddcacc7b359ad3",
     "semantic_hash": "dbda2ff2c22a893b41ddcacc7b359ad3"
   },
   "rheojax/gui/widgets/base_arviz_widget.py": {
-    "mtime": 1773332567.6729536,
+    "mtime": 1783141477.1744244,
     "ast_hash": "6772e5d2f7e4491114537e08437bf013",
     "semantic_hash": "6772e5d2f7e4491114537e08437bf013"
   },
   "rheojax/gui/widgets/batch_panel.py": {
-    "mtime": 1783023586.5740256,
+    "mtime": 1783141477.1744244,
     "ast_hash": "21711cb22181571c4803a3b2a954f83a",
     "semantic_hash": ""
   },
   "rheojax/gui/widgets/dataset_tree.py": {
-    "mtime": 1773332567.6739538,
+    "mtime": 1783141477.1744244,
     "ast_hash": "8cea82708d4cac653d3ca61068b60dc8",
     "semantic_hash": "8cea82708d4cac653d3ca61068b60dc8"
   },
   "rheojax/gui/widgets/empty_state.py": {
-    "mtime": 1777045619.9373703,
+    "mtime": 1783141477.1744244,
     "ast_hash": "54afa08204577f0b47b6fcc3b3288aef",
     "semantic_hash": "54afa08204577f0b47b6fcc3b3288aef"
   },
   "rheojax/gui/widgets/jax_status.py": {
-    "mtime": 1782779014.4742596,
+    "mtime": 1783141477.1744244,
     "ast_hash": "0b8fa8823fe4e52bdb1b5ed4ec89def0",
     "semantic_hash": "0b8fa8823fe4e52bdb1b5ed4ec89def0"
   },
   "rheojax/gui/widgets/multi_view.py": {
-    "mtime": 1773332567.6739538,
+    "mtime": 1783141477.1744244,
     "ast_hash": "aa15d1fd74223b79f5d4db63c68a8cda",
     "semantic_hash": "aa15d1fd74223b79f5d4db63c68a8cda"
   },
   "rheojax/gui/widgets/parameter_form.py": {
-    "mtime": 1782500709.9773912,
+    "mtime": 1783141477.1744244,
     "ast_hash": "ce01651d1342ba27de83ead9a4697092",
     "semantic_hash": "ce01651d1342ba27de83ead9a4697092"
   },
   "rheojax/gui/widgets/parameter_table.py": {
-    "mtime": 1783016198.9773684,
+    "mtime": 1783141477.1744244,
     "ast_hash": "49bdd393cad14e24ec4466df9ed27b32",
     "semantic_hash": "49bdd393cad14e24ec4466df9ed27b32"
   },
   "rheojax/gui/widgets/pipeline_chips.py": {
-    "mtime": 1783023586.5740256,
+    "mtime": 1783141477.1744244,
     "ast_hash": "bfcd402f3746e2b54f2dadfbcf687599",
     "semantic_hash": ""
   },
   "rheojax/gui/widgets/pipeline_sidebar.py": {
-    "mtime": 1783023586.5740256,
+    "mtime": 1783141477.1744244,
     "ast_hash": "b4d8dbc430f5341c7a9660ead98e1a0a",
     "semantic_hash": ""
   },
   "rheojax/gui/widgets/pipeline_step_delegate.py": {
-    "mtime": 1783023586.5740256,
+    "mtime": 1783141477.1744244,
     "ast_hash": "e7920505584a71137099ab4c0b3ad6cc",
     "semantic_hash": ""
   },
   "rheojax/gui/widgets/plot_canvas.py": {
-    "mtime": 1773332567.6739538,
+    "mtime": 1783141477.1744244,
     "ast_hash": "86c5046f160a4a5360fd7a5a58ec365c",
     "semantic_hash": "86c5046f160a4a5360fd7a5a58ec365c"
   },
   "rheojax/gui/widgets/plot_widget.py": {
-    "mtime": 1777045619.9373703,
+    "mtime": 1783141477.1744244,
     "ast_hash": "7f010dcd53285910ff7ee030a46ca5a9",
     "semantic_hash": "7f010dcd53285910ff7ee030a46ca5a9"
   },
   "rheojax/gui/widgets/priors_editor.py": {
-    "mtime": 1782779014.4742596,
+    "mtime": 1783141477.1754243,
     "ast_hash": "997fa3cd7367ee42c70bb1d9335bedf4",
     "semantic_hash": "997fa3cd7367ee42c70bb1d9335bedf4"
   },
   "rheojax/gui/widgets/pyqtgraph_canvas.py": {
-    "mtime": 1782980449.8472135,
+    "mtime": 1783141477.1754243,
     "ast_hash": "e52ccfe69d784d15abed954fdb4bffea",
     "semantic_hash": "e52ccfe69d784d15abed954fdb4bffea"
   },
   "rheojax/gui/widgets/residuals_panel.py": {
-    "mtime": 1773332567.6749537,
+    "mtime": 1783141477.1754243,
     "ast_hash": "cc1796c80c2bc7bbc676eba074762101",
     "semantic_hash": "cc1796c80c2bc7bbc676eba074762101"
   },
   "rheojax/gui/widgets/results_panel.py": {
-    "mtime": 1783023586.5740256,
+    "mtime": 1783141477.1754243,
     "ast_hash": "88f7038d571c3ec91ab3326a4d03622e",
     "semantic_hash": ""
   },
   "rheojax/gui/widgets/workspace_container.py": {
-    "mtime": 1777045619.9383702,
+    "mtime": 1783141477.1754243,
     "ast_hash": "bdf1f81543131bd947eac4de2f083cbb",
     "semantic_hash": "bdf1f81543131bd947eac4de2f083cbb"
   },
   "rheojax/io/__init__.py": {
-    "mtime": 1773332567.6749537,
+    "mtime": 1783141477.1764243,
     "ast_hash": "e3629181a55afe2fc61bae6e4b2f9895",
     "semantic_hash": "e3629181a55afe2fc61bae6e4b2f9895"
   },
   "rheojax/io/_exceptions.py": {
-    "mtime": 1782840586.0514202,
+    "mtime": 1783141477.1764243,
     "ast_hash": "63003bf026025090d0e89fd5b50f0644",
     "semantic_hash": "63003bf026025090d0e89fd5b50f0644"
   },
   "rheojax/io/analysis_exporter.py": {
-    "mtime": 1782840586.0514202,
+    "mtime": 1783141477.1764243,
     "ast_hash": "736bf3ce1c037c1bc4bbf04c6ddd8772",
     "semantic_hash": "736bf3ce1c037c1bc4bbf04c6ddd8772"
   },
   "rheojax/io/json_encoder.py": {
-    "mtime": 1773332567.6749537,
+    "mtime": 1783141477.1764243,
     "ast_hash": "d3bd2826a8b05f40d66fb9676eed473e",
     "semantic_hash": "d3bd2826a8b05f40d66fb9676eed473e"
   },
   "rheojax/io/readers/__init__.py": {
-    "mtime": 1773332567.6749537,
+    "mtime": 1783141477.1764243,
     "ast_hash": "cca6ff05220f2236ba0196cd1009e4d9",
     "semantic_hash": "cca6ff05220f2236ba0196cd1009e4d9"
   },
   "rheojax/io/readers/_column_mapping.py": {
-    "mtime": 1782840586.0514202,
+    "mtime": 1783141477.1764243,
     "ast_hash": "c6573297a2604bee30fe8809cf6bcc33",
     "semantic_hash": "c6573297a2604bee30fe8809cf6bcc33"
   },
   "rheojax/io/readers/_utils.py": {
-    "mtime": 1782840586.0524204,
+    "mtime": 1783141477.1764243,
     "ast_hash": "28a6b3313b23ad0ea53c2648f791be92",
     "semantic_hash": "28a6b3313b23ad0ea53c2648f791be92"
   },
   "rheojax/io/readers/_validation.py": {
-    "mtime": 1777045619.9383702,
+    "mtime": 1783141477.1764243,
     "ast_hash": "7fc5d107ed8803d75f203ec43fb1c222",
     "semantic_hash": "7fc5d107ed8803d75f203ec43fb1c222"
   },
   "rheojax/io/readers/anton_paar.py": {
-    "mtime": 1782840586.0524204,
+    "mtime": 1783141477.1764243,
     "ast_hash": "e979a94ba3169a5ee97288d57a6e4c65",
     "semantic_hash": "e979a94ba3169a5ee97288d57a6e4c65"
   },
   "rheojax/io/readers/auto.py": {
-    "mtime": 1782840586.0524204,
+    "mtime": 1783141477.1764243,
     "ast_hash": "3602ab8957d565314a076c22d9db53f8",
     "semantic_hash": "3602ab8957d565314a076c22d9db53f8"
   },
   "rheojax/io/readers/csv_reader.py": {
-    "mtime": 1782840586.0524204,
+    "mtime": 1783141477.1774242,
     "ast_hash": "836404f7d43e700ca579f97caca4c99c",
     "semantic_hash": "836404f7d43e700ca579f97caca4c99c"
   },
   "rheojax/io/readers/excel_reader.py": {
-    "mtime": 1782840586.0524204,
+    "mtime": 1783141477.1774242,
     "ast_hash": "2960b5ae980e925d8cdbc624294f7ae6",
     "semantic_hash": "2960b5ae980e925d8cdbc624294f7ae6"
   },
   "rheojax/io/readers/multi_file.py": {
-    "mtime": 1777045619.9383702,
+    "mtime": 1783141477.1774242,
     "ast_hash": "2a2dc33ecaee0f4ddaa588f1718362a9",
     "semantic_hash": "2a2dc33ecaee0f4ddaa588f1718362a9"
   },
   "rheojax/io/readers/trios/__init__.py": {
-    "mtime": 1777045619.9383702,
+    "mtime": 1783141477.1774242,
     "ast_hash": "b6bd635c482aec56abe401396aa481f2",
     "semantic_hash": "b6bd635c482aec56abe401396aa481f2"
   },
   "rheojax/io/readers/trios/common.py": {
-    "mtime": 1782840586.0524204,
+    "mtime": 1783141477.1774242,
     "ast_hash": "78e58f1b0be1cecf952f862dc49fb6e9",
     "semantic_hash": "78e58f1b0be1cecf952f862dc49fb6e9"
   },
   "rheojax/io/readers/trios/csv.py": {
-    "mtime": 1782500709.9783912,
+    "mtime": 1783141477.1774242,
     "ast_hash": "6bae715fd45b321d547659f0a809be67",
     "semantic_hash": "6bae715fd45b321d547659f0a809be67"
   },
   "rheojax/io/readers/trios/excel.py": {
-    "mtime": 1782779014.4752595,
+    "mtime": 1783141477.1774242,
     "ast_hash": "f660d6acf67b4e76a6725e9b5e3d8586",
     "semantic_hash": "f660d6acf67b4e76a6725e9b5e3d8586"
   },
   "rheojax/io/readers/trios/json.py": {
-    "mtime": 1777045619.9393702,
+    "mtime": 1783141477.1774242,
     "ast_hash": "66aafc4be074e520647525be3bd730db",
     "semantic_hash": "66aafc4be074e520647525be3bd730db"
   },
   "rheojax/io/readers/trios/schema/TRIOSJSONExportSchema.json": {
-    "mtime": 1766027222.7036524,
+    "mtime": 1783141477.1774242,
     "ast_hash": "83efd753f8c3f841c4471d9eb512ad35",
     "semantic_hash": "83efd753f8c3f841c4471d9eb512ad35"
   },
   "rheojax/io/readers/trios/schema/__init__.py": {
-    "mtime": 1766027222.7036524,
+    "mtime": 1783141477.1774242,
     "ast_hash": "76cd59b2a3a6c3616edcb2db8d109c06",
     "semantic_hash": "76cd59b2a3a6c3616edcb2db8d109c06"
   },
   "rheojax/io/readers/trios/schema/dataset.py": {
-    "mtime": 1767978634.7224011,
+    "mtime": 1783141477.1774242,
     "ast_hash": "e8de4ee917dc9a4086e89ce819a59987",
     "semantic_hash": "e8de4ee917dc9a4086e89ce819a59987"
   },
   "rheojax/io/readers/trios/schema/experiment.py": {
-    "mtime": 1767978634.7224011,
+    "mtime": 1783141477.1774242,
     "ast_hash": "990de59ff56997939a5938f7376fe859",
     "semantic_hash": "990de59ff56997939a5938f7376fe859"
   },
   "rheojax/io/readers/trios/txt.py": {
-    "mtime": 1782840586.0534203,
+    "mtime": 1783141477.1784244,
     "ast_hash": "1ab59fa7e6c4e0b7137c86f22dc305aa",
     "semantic_hash": "1ab59fa7e6c4e0b7137c86f22dc305aa"
   },
   "rheojax/io/spp_export.py": {
-    "mtime": 1782500709.9783912,
+    "mtime": 1783141477.1784244,
     "ast_hash": "0fd3d81dc9f5e8c5adbf91b800f20a45",
     "semantic_hash": "0fd3d81dc9f5e8c5adbf91b800f20a45"
   },
   "rheojax/io/writers/__init__.py": {
-    "mtime": 1773332567.6769536,
+    "mtime": 1783141477.1784244,
     "ast_hash": "3632636103305ce01e31a3afc9f50ed0",
     "semantic_hash": "3632636103305ce01e31a3afc9f50ed0"
   },
   "rheojax/io/writers/excel_writer.py": {
-    "mtime": 1782840586.0534203,
+    "mtime": 1783141477.1784244,
     "ast_hash": "2f571375e4e3b13ded6bbdeb9201971a",
     "semantic_hash": "2f571375e4e3b13ded6bbdeb9201971a"
   },
   "rheojax/io/writers/hdf5_writer.py": {
-    "mtime": 1782840586.0534203,
+    "mtime": 1783141477.1784244,
     "ast_hash": "d28fe4a9f688872e692540c3e4ec9e1d",
     "semantic_hash": "d28fe4a9f688872e692540c3e4ec9e1d"
   },
   "rheojax/io/writers/npz_writer.py": {
-    "mtime": 1777045619.9393702,
+    "mtime": 1783141477.1784244,
     "ast_hash": "fab15af5151f20b37baa11a797343604",
     "semantic_hash": "fab15af5151f20b37baa11a797343604"
   },
   "rheojax/logging/__init__.py": {
-    "mtime": 1782480069.8233995,
+    "mtime": 1783141477.1784244,
     "ast_hash": "826ca4459e19d36ecea4aca9c74c156a",
     "semantic_hash": "826ca4459e19d36ecea4aca9c74c156a"
   },
   "rheojax/logging/config.py": {
-    "mtime": 1782500709.9783912,
+    "mtime": 1783141477.1784244,
     "ast_hash": "bf1b3abc093e1fb361be9b6706ac3b09",
     "semantic_hash": "bf1b3abc093e1fb361be9b6706ac3b09"
   },
   "rheojax/logging/context.py": {
-    "mtime": 1771754195.3519804,
+    "mtime": 1783141477.1784244,
     "ast_hash": "97db23415215df93e1bec68e3e7c609d",
     "semantic_hash": "97db23415215df93e1bec68e3e7c609d"
   },
   "rheojax/logging/formatters.py": {
-    "mtime": 1771973913.1879292,
+    "mtime": 1783141477.1784244,
     "ast_hash": "c5096d649807a7828a5300c87c4b1e60",
     "semantic_hash": "c5096d649807a7828a5300c87c4b1e60"
   },
   "rheojax/logging/handlers.py": {
-    "mtime": 1782500709.9783912,
+    "mtime": 1783141477.1784244,
     "ast_hash": "ac4566ff07ccef947a975fb5765516b0",
     "semantic_hash": "ac4566ff07ccef947a975fb5765516b0"
   },
   "rheojax/logging/logger.py": {
-    "mtime": 1782779014.4762597,
+    "mtime": 1783141477.1784244,
     "ast_hash": "b0fd7270a8b06e14c78b6a92aa140b03",
     "semantic_hash": "b0fd7270a8b06e14c78b6a92aa140b03"
   },
   "rheojax/models/__init__.py": {
-    "mtime": 1771973913.1879292,
+    "mtime": 1783141477.1784244,
     "ast_hash": "27b628621d731f00b7aadaf9e6f5a415",
     "semantic_hash": "27b628621d731f00b7aadaf9e6f5a415"
   },
   "rheojax/models/classical/__init__.py": {
-    "mtime": 1768708239.08026,
+    "mtime": 1783141477.1784244,
     "ast_hash": "cb3fee86630348487c23e69832fa69dd",
     "semantic_hash": "cb3fee86630348487c23e69832fa69dd"
   },
   "rheojax/models/classical/maxwell.py": {
-    "mtime": 1782870323.5689414,
+    "mtime": 1783141477.1784244,
     "ast_hash": "7b9d656f72cc2713fad707409af4ae35",
     "semantic_hash": "7b9d656f72cc2713fad707409af4ae35"
   },
   "rheojax/models/classical/springpot.py": {
-    "mtime": 1782840586.0534203,
+    "mtime": 1783141477.1784244,
     "ast_hash": "d53bc939d6b088f45e8d703f0993a711",
     "semantic_hash": "d53bc939d6b088f45e8d703f0993a711"
   },
   "rheojax/models/classical/zener.py": {
-    "mtime": 1782870323.5689414,
+    "mtime": 1783141477.1784244,
     "ast_hash": "81c24f0186b5fd8d97ac1b80fedc5bb9",
     "semantic_hash": "81c24f0186b5fd8d97ac1b80fedc5bb9"
   },
   "rheojax/models/dmt/__init__.py": {
-    "mtime": 1770953435.5687013,
+    "mtime": 1783141477.1784244,
     "ast_hash": "c2b245b9fdaa0d3a04039493ebd76c54",
     "semantic_hash": "c2b245b9fdaa0d3a04039493ebd76c54"
   },
   "rheojax/models/dmt/_base.py": {
-    "mtime": 1770953435.5687013,
+    "mtime": 1783141477.1794243,
     "ast_hash": "84855b36b35d0e0cba74b2d3999ca6fd",
     "semantic_hash": "84855b36b35d0e0cba74b2d3999ca6fd"
   },
   "rheojax/models/dmt/_kernels.py": {
-    "mtime": 1777045619.9403703,
+    "mtime": 1783141477.1794243,
     "ast_hash": "ca30e95eb341add52d9cb42a046d77e9",
     "semantic_hash": "ca30e95eb341add52d9cb42a046d77e9"
   },
   "rheojax/models/dmt/local.py": {
-    "mtime": 1782870323.5689414,
+    "mtime": 1783141477.1794243,
     "ast_hash": "1b4c2fae3d2016d1e5b7275395db87f0",
     "semantic_hash": "1b4c2fae3d2016d1e5b7275395db87f0"
   },
   "rheojax/models/dmt/nonlocal_model.py": {
-    "mtime": 1782870323.5689414,
+    "mtime": 1783141477.1794243,
     "ast_hash": "263fce75dbc2f53638bfa5cc810edefd",
     "semantic_hash": "263fce75dbc2f53638bfa5cc810edefd"
   },
   "rheojax/models/epm/__init__.py": {
-    "mtime": 1768708239.08026,
+    "mtime": 1783141477.1794243,
     "ast_hash": "86398fe1f9b2a7bfd562e33a644bef6f",
     "semantic_hash": "86398fe1f9b2a7bfd562e33a644bef6f"
   },
   "rheojax/models/epm/base.py": {
-    "mtime": 1782490311.7903426,
+    "mtime": 1783141477.1794243,
     "ast_hash": "90955166b8474e3546111861994d9823",
     "semantic_hash": "90955166b8474e3546111861994d9823"
   },
   "rheojax/models/epm/lattice.py": {
-    "mtime": 1782870323.5689414,
+    "mtime": 1783141477.1794243,
     "ast_hash": "da2c1d29433010600c48fa60bcdd336a",
     "semantic_hash": "da2c1d29433010600c48fa60bcdd336a"
   },
   "rheojax/models/epm/tensor.py": {
-    "mtime": 1782870323.5689414,
+    "mtime": 1783141477.1794243,
     "ast_hash": "ce133c33d4bae56bda9ecf9e4829c1c3",
     "semantic_hash": "ce133c33d4bae56bda9ecf9e4829c1c3"
   },
   "rheojax/models/fikh/__init__.py": {
-    "mtime": 1770953435.5697012,
+    "mtime": 1783141477.1794243,
     "ast_hash": "f0eca08b3823ae918de9465f2ae66b4b",
     "semantic_hash": "f0eca08b3823ae918de9465f2ae66b4b"
   },
   "rheojax/models/fikh/_base.py": {
-    "mtime": 1777873218.8576772,
+    "mtime": 1783141477.1794243,
     "ast_hash": "9f657dbdf5ec75c7dd6c3d92e867527f",
     "semantic_hash": "9f657dbdf5ec75c7dd6c3d92e867527f"
   },
   "rheojax/models/fikh/_caputo.py": {
-    "mtime": 1771754195.3539805,
+    "mtime": 1783141477.1804242,
     "ast_hash": "946d0fd9ec78fe1bd8bf9b46a5c2d608",
     "semantic_hash": "946d0fd9ec78fe1bd8bf9b46a5c2d608"
   },
   "rheojax/models/fikh/_kernels.py": {
-    "mtime": 1777045619.9403703,
+    "mtime": 1783141477.1804242,
     "ast_hash": "1cd3949f7ec89c48116b6ce50c6d94d8",
     "semantic_hash": "1cd3949f7ec89c48116b6ce50c6d94d8"
   },
   "rheojax/models/fikh/_thermal.py": {
-    "mtime": 1770953435.5697012,
+    "mtime": 1783141477.1804242,
     "ast_hash": "f16d6c68a0e0296382648e0b9428ebdc",
     "semantic_hash": "f16d6c68a0e0296382648e0b9428ebdc"
   },
   "rheojax/models/fikh/fikh.py": {
-    "mtime": 1782870323.5699413,
+    "mtime": 1783141477.1804242,
     "ast_hash": "eade00aaf44fd96b31ce0338d37793c9",
     "semantic_hash": "eade00aaf44fd96b31ce0338d37793c9"
   },
   "rheojax/models/fikh/fmlikh.py": {
-    "mtime": 1782870323.5699413,
+    "mtime": 1783141477.1804242,
     "ast_hash": "74fcdb914ad26ba862fc7b46808d7b1d",
     "semantic_hash": "74fcdb914ad26ba862fc7b46808d7b1d"
   },
   "rheojax/models/flow/__init__.py": {
-    "mtime": 1768708239.08026,
+    "mtime": 1783141477.1804242,
     "ast_hash": "04b6b50fc2cddafa76796b4de88693b7",
     "semantic_hash": "04b6b50fc2cddafa76796b4de88693b7"
   },
   "rheojax/models/flow/bingham.py": {
-    "mtime": 1782870323.5699413,
+    "mtime": 1783141477.1804242,
     "ast_hash": "7aad48bb5a390e98e78d1ae1eb4ada4b",
     "semantic_hash": "7aad48bb5a390e98e78d1ae1eb4ada4b"
   },
   "rheojax/models/flow/carreau.py": {
-    "mtime": 1782870323.5699413,
+    "mtime": 1783141477.1804242,
     "ast_hash": "63b4de9caa39e8bfba5ea9a38fb79dbd",
     "semantic_hash": "63b4de9caa39e8bfba5ea9a38fb79dbd"
   },
   "rheojax/models/flow/carreau_yasuda.py": {
-    "mtime": 1782870323.5699413,
+    "mtime": 1783141477.1804242,
     "ast_hash": "7935f7c574b7821e18307de05ab9c40d",
     "semantic_hash": "7935f7c574b7821e18307de05ab9c40d"
   },
   "rheojax/models/flow/cross.py": {
-    "mtime": 1782870323.5699413,
+    "mtime": 1783141477.1804242,
     "ast_hash": "887649b4f68a04744009468e9a3c2bcb",
     "semantic_hash": "887649b4f68a04744009468e9a3c2bcb"
   },
   "rheojax/models/flow/herschel_bulkley.py": {
-    "mtime": 1782870323.5699413,
+    "mtime": 1783141477.1804242,
     "ast_hash": "f11f599b04d93652ee0640bc0ca37bd8",
     "semantic_hash": "f11f599b04d93652ee0640bc0ca37bd8"
   },
   "rheojax/models/flow/power_law.py": {
-    "mtime": 1782870323.5699413,
+    "mtime": 1783141477.1804242,
     "ast_hash": "74648374166729cffb089f33d488f360",
     "semantic_hash": "74648374166729cffb089f33d488f360"
   },
   "rheojax/models/fluidity/__init__.py": {
-    "mtime": 1770953435.5697012,
+    "mtime": 1783141477.1804242,
     "ast_hash": "0863e2dfaa2aea7b2ccef3285301eada",
     "semantic_hash": "0863e2dfaa2aea7b2ccef3285301eada"
   },
   "rheojax/models/fluidity/_base.py": {
-    "mtime": 1777873218.8576772,
+    "mtime": 1783141477.1804242,
     "ast_hash": "aca102bfddc610b4a94f9d20785412bc",
     "semantic_hash": "aca102bfddc610b4a94f9d20785412bc"
   },
   "rheojax/models/fluidity/_kernels.py": {
-    "mtime": 1777045619.9413702,
+    "mtime": 1783141477.1814244,
     "ast_hash": "c9e78619703ecf971a864acd90842dd5",
     "semantic_hash": "c9e78619703ecf971a864acd90842dd5"
   },
   "rheojax/models/fluidity/local.py": {
-    "mtime": 1782870323.5699413,
+    "mtime": 1783141477.1814244,
     "ast_hash": "97a2de0439de8feb2ef3415494b3aeed",
     "semantic_hash": "97a2de0439de8feb2ef3415494b3aeed"
   },
   "rheojax/models/fluidity/nonlocal_model.py": {
-    "mtime": 1782870323.5709412,
+    "mtime": 1783141477.1814244,
     "ast_hash": "a0795b04c5f8a8b348dbc48bb45b676e",
     "semantic_hash": "a0795b04c5f8a8b348dbc48bb45b676e"
   },
   "rheojax/models/fluidity/saramito/__init__.py": {
-    "mtime": 1770953435.5707011,
+    "mtime": 1783141477.1814244,
     "ast_hash": "7cb67c9e45168ad5e5a60652ee11094c",
     "semantic_hash": "7cb67c9e45168ad5e5a60652ee11094c"
   },
   "rheojax/models/fluidity/saramito/_base.py": {
-    "mtime": 1777045619.9423702,
+    "mtime": 1783141477.1814244,
     "ast_hash": "64392135a91f59e538976b82838fbb60",
     "semantic_hash": "64392135a91f59e538976b82838fbb60"
   },
   "rheojax/models/fluidity/saramito/_kernels.py": {
-    "mtime": 1777045619.9423702,
+    "mtime": 1783141477.1814244,
     "ast_hash": "d371edcd84e2ca4a95bb138503972656",
     "semantic_hash": "d371edcd84e2ca4a95bb138503972656"
   },
   "rheojax/models/fluidity/saramito/local.py": {
-    "mtime": 1782870323.5709412,
+    "mtime": 1783141477.1814244,
     "ast_hash": "b85538cfd77f488b1ddb479c724f2c12",
     "semantic_hash": "b85538cfd77f488b1ddb479c724f2c12"
   },
   "rheojax/models/fluidity/saramito/nonlocal_model.py": {
-    "mtime": 1782870323.5709412,
+    "mtime": 1783141477.1814244,
     "ast_hash": "9d0a6218c1103accd0dacce081e1017b",
     "semantic_hash": "9d0a6218c1103accd0dacce081e1017b"
   },
   "rheojax/models/fractional/__init__.py": {
-    "mtime": 1768708239.08126,
+    "mtime": 1783141477.1814244,
     "ast_hash": "6ef314609ae1d1e5a297643b59f55442",
     "semantic_hash": "6ef314609ae1d1e5a297643b59f55442"
   },
   "rheojax/models/fractional/fractional_burgers.py": {
-    "mtime": 1782840586.0564203,
+    "mtime": 1783141477.1824243,
     "ast_hash": "2680280b9bc3eb7803d378807cadbe3e",
     "semantic_hash": "2680280b9bc3eb7803d378807cadbe3e"
   },
   "rheojax/models/fractional/fractional_jeffreys.py": {
-    "mtime": 1782870323.5709412,
+    "mtime": 1783141477.1824243,
     "ast_hash": "7cc004daf109e78c0c57998e50b7ca71",
     "semantic_hash": "7cc004daf109e78c0c57998e50b7ca71"
   },
   "rheojax/models/fractional/fractional_kelvin_voigt.py": {
-    "mtime": 1782840586.0564203,
+    "mtime": 1783141477.1824243,
     "ast_hash": "ff554ac3d62a54258e9061e9882c9235",
     "semantic_hash": "ff554ac3d62a54258e9061e9882c9235"
   },
   "rheojax/models/fractional/fractional_kv_zener.py": {
-    "mtime": 1782840586.0564203,
+    "mtime": 1783141477.1824243,
     "ast_hash": "b699d21a4440b921ed07e0a3c8a6b532",
     "semantic_hash": "b699d21a4440b921ed07e0a3c8a6b532"
   },
   "rheojax/models/fractional/fractional_maxwell_gel.py": {
-    "mtime": 1782840586.0564203,
+    "mtime": 1783141477.1824243,
     "ast_hash": "827540479222d727ad3da2465d8c18a2",
     "semantic_hash": "827540479222d727ad3da2465d8c18a2"
   },
   "rheojax/models/fractional/fractional_maxwell_liquid.py": {
-    "mtime": 1782870323.5709412,
+    "mtime": 1783141477.1824243,
     "ast_hash": "29c651e7db953d4e895ad5428e831789",
     "semantic_hash": "29c651e7db953d4e895ad5428e831789"
   },
   "rheojax/models/fractional/fractional_maxwell_model.py": {
-    "mtime": 1782840586.0564203,
+    "mtime": 1783141477.1824243,
     "ast_hash": "5d6a811f664f07dfdf218eb46a632e06",
     "semantic_hash": "5d6a811f664f07dfdf218eb46a632e06"
   },
   "rheojax/models/fractional/fractional_mixin.py": {
-    "mtime": 1768708239.0822601,
+    "mtime": 1783141477.1824243,
     "ast_hash": "1ee972e75a4db835c0d50e37d8c2a66d",
     "semantic_hash": "1ee972e75a4db835c0d50e37d8c2a66d"
   },
   "rheojax/models/fractional/fractional_poynting_thomson.py": {
-    "mtime": 1782840586.0564203,
+    "mtime": 1783141477.1824243,
     "ast_hash": "06d614405e9e42c544e7c1c7902313cc",
     "semantic_hash": "06d614405e9e42c544e7c1c7902313cc"
   },
   "rheojax/models/fractional/fractional_zener_ll.py": {
-    "mtime": 1782840586.0574203,
+    "mtime": 1783141477.1824243,
     "ast_hash": "b6f9749881add8a1d907ba52309f0cfa",
     "semantic_hash": "b6f9749881add8a1d907ba52309f0cfa"
   },
   "rheojax/models/fractional/fractional_zener_sl.py": {
-    "mtime": 1782840586.0574203,
+    "mtime": 1783141477.1824243,
     "ast_hash": "757cfb6bf818784f594a2aedd95fd0e6",
     "semantic_hash": "757cfb6bf818784f594a2aedd95fd0e6"
   },
   "rheojax/models/fractional/fractional_zener_ss.py": {
-    "mtime": 1782840586.0574203,
+    "mtime": 1783141477.1834242,
     "ast_hash": "7e62b5821828b9699932479e9a3a1532",
     "semantic_hash": "7e62b5821828b9699932479e9a3a1532"
   },
   "rheojax/models/giesekus/__init__.py": {
-    "mtime": 1770953435.571701,
+    "mtime": 1783141477.1834242,
     "ast_hash": "69f10df5ecbd02ad1289966ec5789c1e",
     "semantic_hash": "69f10df5ecbd02ad1289966ec5789c1e"
   },
   "rheojax/models/giesekus/_base.py": {
-    "mtime": 1777045619.9433703,
+    "mtime": 1783141477.1834242,
     "ast_hash": "b51872e5f9cab4d4e1d11cc864bd78ce",
     "semantic_hash": "b51872e5f9cab4d4e1d11cc864bd78ce"
   },
   "rheojax/models/giesekus/_kernels.py": {
-    "mtime": 1777045619.9433703,
+    "mtime": 1783141477.1834242,
     "ast_hash": "c05818cf6d0dd932b67fffdbce0ac54c",
     "semantic_hash": "c05818cf6d0dd932b67fffdbce0ac54c"
   },
   "rheojax/models/giesekus/multi_mode.py": {
-    "mtime": 1782870323.5709412,
+    "mtime": 1783141477.1834242,
     "ast_hash": "eb08f001d61867ec2894b325e0912491",
     "semantic_hash": "eb08f001d61867ec2894b325e0912491"
   },
   "rheojax/models/giesekus/single_mode.py": {
-    "mtime": 1782870323.5719411,
+    "mtime": 1783141477.1834242,
     "ast_hash": "b9830e048be9f42f48fe86495f922535",
     "semantic_hash": "b9830e048be9f42f48fe86495f922535"
   },
   "rheojax/models/hl/__init__.py": {
-    "mtime": 1768708239.0832603,
+    "mtime": 1783141477.1834242,
     "ast_hash": "50ca1bddcd65ddfc84faf60824d114d8",
     "semantic_hash": "50ca1bddcd65ddfc84faf60824d114d8"
   },
   "rheojax/models/hl/hebraud_lequeux.py": {
-    "mtime": 1782870323.5719411,
+    "mtime": 1783141477.1834242,
     "ast_hash": "a0179e51764c4d8f70c86fc9acf56f3d",
     "semantic_hash": "a0179e51764c4d8f70c86fc9acf56f3d"
   },
   "rheojax/models/hvm/__init__.py": {
-    "mtime": 1770953435.5727012,
+    "mtime": 1783141477.1834242,
     "ast_hash": "b5437bfcaa1935fa8ebef55b4473416b",
     "semantic_hash": "b5437bfcaa1935fa8ebef55b4473416b"
   },
   "rheojax/models/hvm/_base.py": {
-    "mtime": 1777045619.9443703,
+    "mtime": 1783141477.1844242,
     "ast_hash": "a4c18eb2ebe07fd442355ad06e6e2967",
     "semantic_hash": "a4c18eb2ebe07fd442355ad06e6e2967"
   },
   "rheojax/models/hvm/_kernels.py": {
-    "mtime": 1777045619.9443703,
+    "mtime": 1783141477.1844242,
     "ast_hash": "22a3be591baf9a889c6a22ff3310c3f2",
     "semantic_hash": "22a3be591baf9a889c6a22ff3310c3f2"
   },
   "rheojax/models/hvm/_kernels_diffrax.py": {
-    "mtime": 1777045619.9443703,
+    "mtime": 1783141477.1844242,
     "ast_hash": "2acaf4d5453590eac15321db50aeae38",
     "semantic_hash": "2acaf4d5453590eac15321db50aeae38"
   },
   "rheojax/models/hvm/local.py": {
-    "mtime": 1782870323.5719411,
+    "mtime": 1783141477.1844242,
     "ast_hash": "1c958e52b2e8878b805f5349ef13bcd3",
     "semantic_hash": "1c958e52b2e8878b805f5349ef13bcd3"
   },
   "rheojax/models/hvnm/__init__.py": {
-    "mtime": 1770953435.5727012,
+    "mtime": 1783141477.1844242,
     "ast_hash": "4cdc8f346e54b357bc7e11f82b61fa4a",
     "semantic_hash": "4cdc8f346e54b357bc7e11f82b61fa4a"
   },
   "rheojax/models/hvnm/_base.py": {
-    "mtime": 1777045619.9443703,
+    "mtime": 1783141477.1844242,
     "ast_hash": "798182d730ad52574e8afc35f4d70ad6",
     "semantic_hash": "798182d730ad52574e8afc35f4d70ad6"
   },
   "rheojax/models/hvnm/_kernels.py": {
-    "mtime": 1777045619.9443703,
+    "mtime": 1783141477.1844242,
     "ast_hash": "5f5ca2936fc0d05f740328cef2d44348",
     "semantic_hash": "5f5ca2936fc0d05f740328cef2d44348"
   },
   "rheojax/models/hvnm/_kernels_diffrax.py": {
-    "mtime": 1777045619.9443703,
+    "mtime": 1783141477.1844242,
     "ast_hash": "e2c78d9391f833d72cb11dbc4a8ca10d",
     "semantic_hash": "e2c78d9391f833d72cb11dbc4a8ca10d"
   },
   "rheojax/models/hvnm/local.py": {
-    "mtime": 1782870323.5719411,
+    "mtime": 1783141477.1844242,
     "ast_hash": "8c8a82c450a0c71f696474e4ccbf7637",
     "semantic_hash": "8c8a82c450a0c71f696474e4ccbf7637"
   },
   "rheojax/models/ikh/__init__.py": {
-    "mtime": 1770953435.5737011,
+    "mtime": 1783141477.1844242,
     "ast_hash": "95d6039410730853f78b63c4217e69da",
     "semantic_hash": "95d6039410730853f78b63c4217e69da"
   },
   "rheojax/models/ikh/_base.py": {
-    "mtime": 1771374330.2948258,
+    "mtime": 1783141477.1844242,
     "ast_hash": "ec1fe715d75c22018e695993670b76da",
     "semantic_hash": "ec1fe715d75c22018e695993670b76da"
   },
   "rheojax/models/ikh/_kernels.py": {
-    "mtime": 1782490311.7913425,
+    "mtime": 1783141477.1844242,
     "ast_hash": "aa7aecf6f86f8c0b9bb9c9eecad8df0f",
     "semantic_hash": "aa7aecf6f86f8c0b9bb9c9eecad8df0f"
   },
   "rheojax/models/ikh/mikh.py": {
-    "mtime": 1782870323.5719411,
+    "mtime": 1783141477.1854243,
     "ast_hash": "44717855bf87ef0611d06a6e7ea1d87d",
     "semantic_hash": "44717855bf87ef0611d06a6e7ea1d87d"
   },
   "rheojax/models/ikh/ml_ikh.py": {
-    "mtime": 1782870323.5729413,
+    "mtime": 1783141477.1854243,
     "ast_hash": "95a23c73336c59b04c869e875be9b546",
     "semantic_hash": "95a23c73336c59b04c869e875be9b546"
   },
   "rheojax/models/itt_mct/__init__.py": {
-    "mtime": 1770953435.5737011,
+    "mtime": 1783141477.1854243,
     "ast_hash": "5a0c7952933e1aae0f1e2c8ab99e79b8",
     "semantic_hash": "5a0c7952933e1aae0f1e2c8ab99e79b8"
   },
   "rheojax/models/itt_mct/_base.py": {
-    "mtime": 1780618617.2393205,
+    "mtime": 1783141477.1854243,
     "ast_hash": "3f0f0b63d4902080805493f267cf71b7",
     "semantic_hash": "3f0f0b63d4902080805493f267cf71b7"
   },
   "rheojax/models/itt_mct/_kernels.py": {
-    "mtime": 1782490311.7913425,
+    "mtime": 1783141477.1854243,
     "ast_hash": "0d98199aa29233eb7f436525caab4016",
     "semantic_hash": "0d98199aa29233eb7f436525caab4016"
   },
   "rheojax/models/itt_mct/_kernels_diffrax.py": {
-    "mtime": 1777045619.9453702,
+    "mtime": 1783141477.1854243,
     "ast_hash": "187d1a67f778c55dfe0ef4af2f599cef",
     "semantic_hash": "187d1a67f778c55dfe0ef4af2f599cef"
   },
   "rheojax/models/itt_mct/isotropic.py": {
-    "mtime": 1782870323.5729413,
+    "mtime": 1783141477.1854243,
     "ast_hash": "54e14ccd26d5365d8b31505c99588288",
     "semantic_hash": "54e14ccd26d5365d8b31505c99588288"
   },
   "rheojax/models/itt_mct/schematic.py": {
-    "mtime": 1782870323.5729413,
+    "mtime": 1783141477.1854243,
     "ast_hash": "327902304692ae4bc18ffa2e6f7a81f7",
     "semantic_hash": "327902304692ae4bc18ffa2e6f7a81f7"
   },
   "rheojax/models/multimode/__init__.py": {
-    "mtime": 1768708239.0832603,
+    "mtime": 1783141477.1854243,
     "ast_hash": "d897f922a2631dbc99fa19886e8649cb",
     "semantic_hash": "d897f922a2631dbc99fa19886e8649cb"
   },
   "rheojax/models/multimode/generalized_maxwell.py": {
-    "mtime": 1782870323.5729413,
+    "mtime": 1783141477.1864243,
     "ast_hash": "95da791628ac4639ded76973a2c9d27f",
     "semantic_hash": "95da791628ac4639ded76973a2c9d27f"
   },
   "rheojax/models/sgr/__init__.py": {
-    "mtime": 1768708239.0832603,
+    "mtime": 1783141477.1864243,
     "ast_hash": "6fb1fd24838377d107c06b6993e7ad48",
     "semantic_hash": "6fb1fd24838377d107c06b6993e7ad48"
   },
   "rheojax/models/sgr/sgr_conventional.py": {
-    "mtime": 1782870323.5739412,
+    "mtime": 1783141477.1864243,
     "ast_hash": "4cb3d3999e476abefa3c0a076cecbe6d",
     "semantic_hash": "4cb3d3999e476abefa3c0a076cecbe6d"
   },
   "rheojax/models/sgr/sgr_generic.py": {
-    "mtime": 1782870323.5739412,
+    "mtime": 1783141477.1864243,
     "ast_hash": "d8bb8730c0b1e3ef6fa7407ba1fbdf05",
     "semantic_hash": "d8bb8730c0b1e3ef6fa7407ba1fbdf05"
   },
   "rheojax/models/spp/__init__.py": {
-    "mtime": 1768708239.0852604,
+    "mtime": 1783141477.1864243,
     "ast_hash": "982796bc212b4aa8215876b20d01364e",
     "semantic_hash": "982796bc212b4aa8215876b20d01364e"
   },
   "rheojax/models/spp/spp_yield_stress.py": {
-    "mtime": 1782870323.5739412,
+    "mtime": 1783141477.1874242,
     "ast_hash": "a5e0ee231a2c63437a09c2c16ef51edf",
     "semantic_hash": "a5e0ee231a2c63437a09c2c16ef51edf"
   },
   "rheojax/models/stz/__init__.py": {
-    "mtime": 1768708239.0852604,
+    "mtime": 1783141477.1874242,
     "ast_hash": "85cac239cca98266065a0a1f2bf730f6",
     "semantic_hash": "85cac239cca98266065a0a1f2bf730f6"
   },
   "rheojax/models/stz/_base.py": {
-    "mtime": 1777045619.9463701,
+    "mtime": 1783141477.1874242,
     "ast_hash": "6f427805bd85edf9aac04c52a7b051f8",
     "semantic_hash": "6f427805bd85edf9aac04c52a7b051f8"
   },
   "rheojax/models/stz/_kernels.py": {
-    "mtime": 1777045619.9463701,
+    "mtime": 1783141477.1874242,
     "ast_hash": "598ff93c20a43a56ff16e16308ebc1e7",
     "semantic_hash": "598ff93c20a43a56ff16e16308ebc1e7"
   },
   "rheojax/models/stz/conventional.py": {
-    "mtime": 1782870323.5739412,
+    "mtime": 1783141477.1874242,
     "ast_hash": "6effd9f42db99e11f73e72f96fae8e7e",
     "semantic_hash": "6effd9f42db99e11f73e72f96fae8e7e"
   },
   "rheojax/models/tnt/__init__.py": {
-    "mtime": 1770953435.574701,
+    "mtime": 1783141477.1874242,
     "ast_hash": "0aca6ab71af0f3dcfbc29aaa15a4041a",
     "semantic_hash": "0aca6ab71af0f3dcfbc29aaa15a4041a"
   },
   "rheojax/models/tnt/_base.py": {
-    "mtime": 1780618617.2413204,
+    "mtime": 1783141477.1874242,
     "ast_hash": "e39f1c82d3f4f56ab0dce21600dea18a",
     "semantic_hash": "e39f1c82d3f4f56ab0dce21600dea18a"
   },
   "rheojax/models/tnt/_kernels.py": {
-    "mtime": 1777045619.9473703,
+    "mtime": 1783141477.1874242,
     "ast_hash": "1d3d7a25e74dc7710e6b8857f4cf5caf",
     "semantic_hash": "1d3d7a25e74dc7710e6b8857f4cf5caf"
   },
   "rheojax/models/tnt/cates.py": {
-    "mtime": 1782870323.5749412,
+    "mtime": 1783141477.1874242,
     "ast_hash": "6e52f48125d6b9e91458102280a5585c",
     "semantic_hash": "6e52f48125d6b9e91458102280a5585c"
   },
   "rheojax/models/tnt/loop_bridge.py": {
-    "mtime": 1782870323.5749412,
+    "mtime": 1783141477.1874242,
     "ast_hash": "bbe118dc75878e030493dd0e3877e88e",
     "semantic_hash": "bbe118dc75878e030493dd0e3877e88e"
   },
   "rheojax/models/tnt/multi_species.py": {
-    "mtime": 1782870323.5749412,
+    "mtime": 1783141477.1874242,
     "ast_hash": "e06ea139597a3ab83ac39ca1663d7c8f",
     "semantic_hash": "e06ea139597a3ab83ac39ca1663d7c8f"
   },
   "rheojax/models/tnt/single_mode.py": {
-    "mtime": 1782870323.5749412,
+    "mtime": 1783141477.1874242,
     "ast_hash": "8432cff6ec0584e1ca8dcb881f2a9838",
     "semantic_hash": "8432cff6ec0584e1ca8dcb881f2a9838"
   },
   "rheojax/models/tnt/sticky_rouse.py": {
-    "mtime": 1782870323.575941,
+    "mtime": 1783141477.1884243,
     "ast_hash": "d490a6a99cb83c4aadf8717944e2ee54",
     "semantic_hash": "d490a6a99cb83c4aadf8717944e2ee54"
   },
   "rheojax/models/vlb/__init__.py": {
-    "mtime": 1770953435.5757012,
+    "mtime": 1783141477.1884243,
     "ast_hash": "1e163ed7ec2dad4d68dcaf72929ce594",
     "semantic_hash": "1e163ed7ec2dad4d68dcaf72929ce594"
   },
   "rheojax/models/vlb/_base.py": {
-    "mtime": 1782779014.4842596,
+    "mtime": 1783141477.1884243,
     "ast_hash": "01a5d570d2062f1ba82780b46467c3db",
     "semantic_hash": "01a5d570d2062f1ba82780b46467c3db"
   },
   "rheojax/models/vlb/_kernels.py": {
-    "mtime": 1777045619.9483702,
+    "mtime": 1783141477.1884243,
     "ast_hash": "5a729f5cde7a0302546f02f9cc728a4a",
     "semantic_hash": "5a729f5cde7a0302546f02f9cc728a4a"
   },
   "rheojax/models/vlb/local.py": {
-    "mtime": 1782870323.575941,
+    "mtime": 1783141477.1884243,
     "ast_hash": "f56f15f6e702cbc737acdabc48ddba6a",
     "semantic_hash": "f56f15f6e702cbc737acdabc48ddba6a"
   },
   "rheojax/models/vlb/multi_network.py": {
-    "mtime": 1782870323.575941,
+    "mtime": 1783141477.1884243,
     "ast_hash": "fdada2ccd34a1bf257c042e82b40fd22",
     "semantic_hash": "fdada2ccd34a1bf257c042e82b40fd22"
   },
   "rheojax/models/vlb/nonlocal_model.py": {
-    "mtime": 1782870323.575941,
+    "mtime": 1783141477.1884243,
     "ast_hash": "9aaad9310f9887eee2721c18c703920c",
     "semantic_hash": "9aaad9310f9887eee2721c18c703920c"
   },
   "rheojax/models/vlb/variant.py": {
-    "mtime": 1782870323.575941,
+    "mtime": 1783141477.1884243,
     "ast_hash": "7106bafc47c4549f6d2088a88c1fc806",
     "semantic_hash": "7106bafc47c4549f6d2088a88c1fc806"
   },
   "rheojax/parallel/__init__.py": {
-    "mtime": 1773332567.6849537,
+    "mtime": 1783141477.1884243,
     "ast_hash": "9a9e511fe52747b21c19986d66ef1b54",
     "semantic_hash": "9a9e511fe52747b21c19986d66ef1b54"
   },
   "rheojax/parallel/api.py": {
-    "mtime": 1773332567.6849537,
+    "mtime": 1783141477.1884243,
     "ast_hash": "962e605d9d87e9c4104477d31dd472f3",
     "semantic_hash": "962e605d9d87e9c4104477d31dd472f3"
   },
   "rheojax/parallel/config.py": {
-    "mtime": 1782500709.9783912,
+    "mtime": 1783141477.1894243,
     "ast_hash": "f28a9ddf3cd8ffad199bf743246eaf7a",
     "semantic_hash": "f28a9ddf3cd8ffad199bf743246eaf7a"
   },
   "rheojax/parallel/pool.py": {
-    "mtime": 1777045619.9483702,
+    "mtime": 1783141477.1894243,
     "ast_hash": "ff715909124cd0aaef01806a1e13d52b",
     "semantic_hash": "ff715909124cd0aaef01806a1e13d52b"
   },
   "rheojax/pipeline/__init__.py": {
-    "mtime": 1773332567.6849537,
+    "mtime": 1783141477.1894243,
     "ast_hash": "e043b530c6f2b8b15fc877ede27d6ee2",
     "semantic_hash": "e043b530c6f2b8b15fc877ede27d6ee2"
   },
   "rheojax/pipeline/base.py": {
-    "mtime": 1782840586.0624204,
+    "mtime": 1783141477.1894243,
     "ast_hash": "af57666db9c036ae08d75e79bdf3c3e9",
     "semantic_hash": "af57666db9c036ae08d75e79bdf3c3e9"
   },
   "rheojax/pipeline/batch.py": {
-    "mtime": 1782840586.0624204,
+    "mtime": 1783141477.1894243,
     "ast_hash": "ff47ccd06c27c6ff76293652f0472cd2",
     "semantic_hash": "ff47ccd06c27c6ff76293652f0472cd2"
   },
   "rheojax/pipeline/bayesian.py": {
-    "mtime": 1782840586.0624204,
+    "mtime": 1783141477.1894243,
     "ast_hash": "d71de7acb18cc22c6535482a9994ea38",
     "semantic_hash": "d71de7acb18cc22c6535482a9994ea38"
   },
   "rheojax/pipeline/builder.py": {
-    "mtime": 1773332567.6859536,
+    "mtime": 1783141477.1894243,
     "ast_hash": "cafd22370f6305950a1f41ae658c0566",
     "semantic_hash": "cafd22370f6305950a1f41ae658c0566"
   },
   "rheojax/pipeline/workflows.py": {
-    "mtime": 1782840586.0624204,
+    "mtime": 1783141477.1894243,
     "ast_hash": "1909ba73c4811e6796e312ca16cfba8d",
     "semantic_hash": "1909ba73c4811e6796e312ca16cfba8d"
   },
   "rheojax/transforms/__init__.py": {
-    "mtime": 1773332567.6859536,
+    "mtime": 1783141477.1894243,
     "ast_hash": "019e7c081542bc3e99a515deedbdb017",
     "semantic_hash": "019e7c081542bc3e99a515deedbdb017"
   },
   "rheojax/transforms/cox_merz.py": {
-    "mtime": 1782779014.4852598,
+    "mtime": 1783141477.1894243,
     "ast_hash": "489d38180328691fdcbcc21b84bfc0ed",
     "semantic_hash": "489d38180328691fdcbcc21b84bfc0ed"
   },
   "rheojax/transforms/fft_analysis.py": {
-    "mtime": 1782500709.979391,
+    "mtime": 1783141477.1904242,
     "ast_hash": "089c0a5852087b48e2198fb0d7d2b7e7",
     "semantic_hash": "089c0a5852087b48e2198fb0d7d2b7e7"
   },
   "rheojax/transforms/lve_envelope.py": {
-    "mtime": 1782779014.4852598,
+    "mtime": 1783141477.1904242,
     "ast_hash": "d40ad63589b589f3cc705044045c3bd4",
     "semantic_hash": "d40ad63589b589f3cc705044045c3bd4"
   },
   "rheojax/transforms/mastercurve.py": {
-    "mtime": 1782500709.979391,
+    "mtime": 1783141477.1904242,
     "ast_hash": "e8805a44d106efe1e8756e53a911b545",
     "semantic_hash": "e8805a44d106efe1e8756e53a911b545"
   },
   "rheojax/transforms/mutation_number.py": {
-    "mtime": 1782500709.980391,
+    "mtime": 1783141477.1904242,
     "ast_hash": "2805695c84657802d330ba42e739f18f",
     "semantic_hash": "2805695c84657802d330ba42e739f18f"
   },
   "rheojax/transforms/owchirp.py": {
-    "mtime": 1777045619.9503703,
+    "mtime": 1783141477.1904242,
     "ast_hash": "446a2ea95b0539f9e25e012506bdb444",
     "semantic_hash": "446a2ea95b0539f9e25e012506bdb444"
   },
   "rheojax/transforms/prony_conversion.py": {
-    "mtime": 1782840586.0634203,
+    "mtime": 1783141477.1904242,
     "ast_hash": "f36752c7cf62167f32aecbfc18e1ca33",
     "semantic_hash": "f36752c7cf62167f32aecbfc18e1ca33"
   },
   "rheojax/transforms/smooth_derivative.py": {
-    "mtime": 1777045619.9503703,
+    "mtime": 1783141477.1904242,
     "ast_hash": "34b6cad8ae9c014a29f2d124e6618734",
     "semantic_hash": "34b6cad8ae9c014a29f2d124e6618734"
   },
   "rheojax/transforms/spectrum_inversion.py": {
-    "mtime": 1777045619.9503703,
+    "mtime": 1783141477.1904242,
     "ast_hash": "e50d7e702a3bf785cbd955ea75b5dc0a",
     "semantic_hash": "e50d7e702a3bf785cbd955ea75b5dc0a"
   },
   "rheojax/transforms/spp_decomposer.py": {
-    "mtime": 1777045619.9503703,
+    "mtime": 1783141477.1904242,
     "ast_hash": "3f1f6cf53e2d941f2f8864f6b73c8ba6",
     "semantic_hash": "3f1f6cf53e2d941f2f8864f6b73c8ba6"
   },
   "rheojax/transforms/srfs.py": {
-    "mtime": 1777045619.9503703,
+    "mtime": 1783141477.1904242,
     "ast_hash": "8fc8741d29ffb2c696fe0b0e802f9787",
     "semantic_hash": "8fc8741d29ffb2c696fe0b0e802f9787"
   },
   "rheojax/utils/__init__.py": {
-    "mtime": 1782840586.0634203,
+    "mtime": 1783141477.1904242,
     "ast_hash": "8c05095f5c3062c5404c66d492b4276a",
     "semantic_hash": "8c05095f5c3062c5404c66d492b4276a"
   },
   "rheojax/utils/compatibility.py": {
-    "mtime": 1782779014.4852598,
+    "mtime": 1783141477.1904242,
     "ast_hash": "771249114d15b37c3d6098180f0e18dd",
     "semantic_hash": "771249114d15b37c3d6098180f0e18dd"
   },
   "rheojax/utils/data_quality.py": {
-    "mtime": 1771973913.1949291,
+    "mtime": 1783141477.1914241,
     "ast_hash": "873067ee74fb2701264e08f3892d8664",
     "semantic_hash": "873067ee74fb2701264e08f3892d8664"
   },
   "rheojax/utils/device.py": {
-    "mtime": 1773332567.6869535,
+    "mtime": 1783141477.1914241,
     "ast_hash": "5f7a97102a6f5d399eed1e43c9d66799",
     "semantic_hash": "5f7a97102a6f5d399eed1e43c9d66799"
   },
   "rheojax/utils/epm_kernels.py": {
-    "mtime": 1777045619.9503703,
+    "mtime": 1783141477.1914241,
     "ast_hash": "913d86cc11d210f6486b12afb120e9a2",
     "semantic_hash": "913d86cc11d210f6486b12afb120e9a2"
   },
   "rheojax/utils/epm_kernels_tensorial.py": {
-    "mtime": 1782779014.4852598,
+    "mtime": 1783141477.1914241,
     "ast_hash": "08879efcc47bbdccd7dede45dd9cc5ea",
     "semantic_hash": "08879efcc47bbdccd7dede45dd9cc5ea"
   },
   "rheojax/utils/hl_kernels.py": {
-    "mtime": 1782490311.7933424,
+    "mtime": 1783141477.1914241,
     "ast_hash": "d36a00c626165f4b73a62ca035f63721",
     "semantic_hash": "d36a00c626165f4b73a62ca035f63721"
   },
   "rheojax/utils/initialization/__init__.py": {
-    "mtime": 1773332567.6869535,
+    "mtime": 1783141477.1914241,
     "ast_hash": "e17955517b885b864bb60eacb4657335",
     "semantic_hash": "e17955517b885b864bb60eacb4657335"
   },
   "rheojax/utils/initialization/auto_p0.py": {
-    "mtime": 1782500709.980391,
+    "mtime": 1783141477.1914241,
     "ast_hash": "b0864621cf5eed390473021431c39dd7",
     "semantic_hash": "b0864621cf5eed390473021431c39dd7"
   },
   "rheojax/utils/initialization/base.py": {
-    "mtime": 1773332567.6879537,
+    "mtime": 1783141477.1914241,
     "ast_hash": "ea1fefa6af2ab0893559bd4107cb473b",
     "semantic_hash": "ea1fefa6af2ab0893559bd4107cb473b"
   },
   "rheojax/utils/initialization/constants.py": {
-    "mtime": 1762927058.0,
+    "mtime": 1783141477.1914241,
     "ast_hash": "f8f29746ecdc08d231e3a61f9e78dea0",
     "semantic_hash": "f8f29746ecdc08d231e3a61f9e78dea0"
   },
   "rheojax/utils/initialization/fractional_burgers.py": {
-    "mtime": 1767978634.727401,
+    "mtime": 1783141477.1914241,
     "ast_hash": "40fee641571c749d8bfeb2c52064e73c",
     "semantic_hash": "40fee641571c749d8bfeb2c52064e73c"
   },
   "rheojax/utils/initialization/fractional_jeffreys.py": {
-    "mtime": 1767978634.7284012,
+    "mtime": 1783141477.1914241,
     "ast_hash": "2d7a0240b288547a729357353f11cb51",
     "semantic_hash": "2d7a0240b288547a729357353f11cb51"
   },
   "rheojax/utils/initialization/fractional_kelvin_voigt.py": {
-    "mtime": 1767978634.7284012,
+    "mtime": 1783141477.1914241,
     "ast_hash": "80b9a7d7eaf7d69a0e5de52469005ca7",
     "semantic_hash": "80b9a7d7eaf7d69a0e5de52469005ca7"
   },
   "rheojax/utils/initialization/fractional_kv_zener.py": {
-    "mtime": 1782500709.980391,
+    "mtime": 1783141477.1914241,
     "ast_hash": "51e75d30a897cb53419d30113bd8d60a",
     "semantic_hash": "51e75d30a897cb53419d30113bd8d60a"
   },
   "rheojax/utils/initialization/fractional_maxwell_gel.py": {
-    "mtime": 1771973913.1949291,
+    "mtime": 1783141477.1914241,
     "ast_hash": "b8ef46934f267917eb73e5d722e699ec",
     "semantic_hash": "b8ef46934f267917eb73e5d722e699ec"
   },
   "rheojax/utils/initialization/fractional_maxwell_liquid.py": {
-    "mtime": 1767978634.7284012,
+    "mtime": 1783141477.1914241,
     "ast_hash": "cbffb35dcbf7c97e73b78bfe1b915a99",
     "semantic_hash": "cbffb35dcbf7c97e73b78bfe1b915a99"
   },
   "rheojax/utils/initialization/fractional_maxwell_model.py": {
-    "mtime": 1767978634.7284012,
+    "mtime": 1783141477.1914241,
     "ast_hash": "7fc6c8994522e12a5792d16f59176a68",
     "semantic_hash": "7fc6c8994522e12a5792d16f59176a68"
   },
   "rheojax/utils/initialization/fractional_poynting_thomson.py": {
-    "mtime": 1767978634.7284012,
+    "mtime": 1783141477.1914241,
     "ast_hash": "4a055fa3982a11c7205e27c6d5cbb24d",
     "semantic_hash": "4a055fa3982a11c7205e27c6d5cbb24d"
   },
   "rheojax/utils/initialization/fractional_zener_ll.py": {
-    "mtime": 1767978634.7284012,
+    "mtime": 1783141477.1914241,
     "ast_hash": "61e548c9c6fa4efe2831dc9256a84b8e",
     "semantic_hash": "61e548c9c6fa4efe2831dc9256a84b8e"
   },
   "rheojax/utils/initialization/fractional_zener_sl.py": {
-    "mtime": 1767978634.7284012,
+    "mtime": 1783141477.1914241,
     "ast_hash": "074299584cd1ad017de74d5d0f476cd3",
     "semantic_hash": "074299584cd1ad017de74d5d0f476cd3"
   },
   "rheojax/utils/initialization/fractional_zener_ss.py": {
-    "mtime": 1767978634.7284012,
+    "mtime": 1783141477.1914241,
     "ast_hash": "b4f0ff97384e938264798716d8ca08bc",
     "semantic_hash": "b4f0ff97384e938264798716d8ca08bc"
   },
   "rheojax/utils/mct_kernels.py": {
-    "mtime": 1782500709.980391,
+    "mtime": 1783141477.1924243,
     "ast_hash": "54c487bf319b4dfc075f2fdf6c2a30ba",
     "semantic_hash": "54c487bf319b4dfc075f2fdf6c2a30ba"
   },
   "rheojax/utils/metrics.py": {
-    "mtime": 1773332567.6879537,
+    "mtime": 1783141477.1924243,
     "ast_hash": "eca185af2734c6914b47428b093cc21b",
     "semantic_hash": "eca185af2734c6914b47428b093cc21b"
   },
   "rheojax/utils/mittag_leffler.py": {
-    "mtime": 1782500709.980391,
+    "mtime": 1783141477.1924243,
     "ast_hash": "0a05e73a2a843f706fcc0c4dd67b9668",
     "semantic_hash": "0a05e73a2a843f706fcc0c4dd67b9668"
   },
   "rheojax/utils/model_selection.py": {
-    "mtime": 1777045619.9513702,
+    "mtime": 1783141477.1924243,
     "ast_hash": "c35c4a4471f3a47bddfe063aac0ef39e",
     "semantic_hash": "c35c4a4471f3a47bddfe063aac0ef39e"
   },
   "rheojax/utils/optimization.py": {
-    "mtime": 1782840586.0634203,
+    "mtime": 1783141477.1924243,
     "ast_hash": "8594c75ccef761633fcf7ee213bcc505",
     "semantic_hash": "8594c75ccef761633fcf7ee213bcc505"
   },
   "rheojax/utils/physics_checks.py": {
-    "mtime": 1777045619.9513702,
+    "mtime": 1783141477.1924243,
     "ast_hash": "aea9f0b9a15305b0de2777a1fe5e9460",
     "semantic_hash": "aea9f0b9a15305b0de2777a1fe5e9460"
   },
   "rheojax/utils/prony.py": {
-    "mtime": 1782840586.0634203,
-    "ast_hash": "b574120d3fc00209f3cef639db0a379d",
-    "semantic_hash": "b574120d3fc00209f3cef639db0a379d"
+    "mtime": 1783141477.1924243,
+    "ast_hash": "74b00691627c6b4e7a75742416872de3",
+    "semantic_hash": ""
   },
   "rheojax/utils/protocol_preprocessing.py": {
-    "mtime": 1777045619.9523702,
+    "mtime": 1783141477.1934242,
     "ast_hash": "b612b207d5244cd685169d6d01b0634a",
     "semantic_hash": "b612b207d5244cd685169d6d01b0634a"
   },
   "rheojax/utils/sgr_kernels.py": {
-    "mtime": 1773332567.6899536,
+    "mtime": 1783141477.1934242,
     "ast_hash": "222c9407c535f130f95f6073d58025d0",
     "semantic_hash": "222c9407c535f130f95f6073d58025d0"
   },
   "rheojax/utils/sgr_monte_carlo.py": {
-    "mtime": 1771973913.1959293,
+    "mtime": 1783141477.1934242,
     "ast_hash": "445d64669b60b591d96624bf86c067d8",
     "semantic_hash": "445d64669b60b591d96624bf86c067d8"
   },
   "rheojax/utils/sgr_population_balance.py": {
-    "mtime": 1771973913.1959293,
+    "mtime": 1783141477.1934242,
     "ast_hash": "b7cac60c06092ee5d10d9cfb4faba72f",
     "semantic_hash": "b7cac60c06092ee5d10d9cfb4faba72f"
   },
   "rheojax/utils/spp_kernels.py": {
-    "mtime": 1777045619.9523702,
+    "mtime": 1783141477.1934242,
     "ast_hash": "8b995cfc3a70e6a22528edf78b9ba442",
     "semantic_hash": "8b995cfc3a70e6a22528edf78b9ba442"
   },
   "rheojax/utils/structure_factor.py": {
-    "mtime": 1773332567.6899536,
+    "mtime": 1783141477.1934242,
     "ast_hash": "580c899830dee6e6a3e7fd513802f92f",
     "semantic_hash": "580c899830dee6e6a3e7fd513802f92f"
   },
   "rheojax/utils/uncertainty.py": {
-    "mtime": 1782500709.981391,
+    "mtime": 1783141477.1934242,
     "ast_hash": "651fced20da7d77fecbad27b66d31c80",
     "semantic_hash": "651fced20da7d77fecbad27b66d31c80"
   },
   "rheojax/utils/volterra_creep.py": {
-    "mtime": 1780618617.2423205,
+    "mtime": 1783141477.1934242,
     "ast_hash": "d7ce4b30c1105000740e77ee601f4e72",
     "semantic_hash": "d7ce4b30c1105000740e77ee601f4e72"
   },
   "rheojax/visualization/__init__.py": {
-    "mtime": 1773332567.6899536,
+    "mtime": 1783141477.1934242,
     "ast_hash": "4d35f44b99a80c67a8cab3944f9731ab",
     "semantic_hash": "4d35f44b99a80c67a8cab3944f9731ab"
   },
   "rheojax/visualization/epm_plots.py": {
-    "mtime": 1773332567.6909535,
+    "mtime": 1783141477.1934242,
     "ast_hash": "fa91d7f22a2785e27a30fee3cdeecfa5",
     "semantic_hash": "fa91d7f22a2785e27a30fee3cdeecfa5"
   },
   "rheojax/visualization/fit_plotter.py": {
-    "mtime": 1782840586.0644205,
+    "mtime": 1783141477.1944242,
     "ast_hash": "1a35f2aebf0d47997a5418566c9f1cf9",
     "semantic_hash": "1a35f2aebf0d47997a5418566c9f1cf9"
   },
   "rheojax/visualization/plotter.py": {
-    "mtime": 1782840586.0644205,
+    "mtime": 1783141477.1944242,
     "ast_hash": "753e8ff5ee9058a9c511a9d39f436687",
     "semantic_hash": "753e8ff5ee9058a9c511a9d39f436687"
   },
   "rheojax/visualization/spp_plots.py": {
-    "mtime": 1773332567.6909535,
+    "mtime": 1783141477.1944242,
     "ast_hash": "9d98d310956a7bb4940fbd6ce7505746",
     "semantic_hash": "9d98d310956a7bb4940fbd6ce7505746"
   },
   "rheojax/visualization/templates.py": {
-    "mtime": 1782840586.0644205,
+    "mtime": 1783141477.1944242,
     "ast_hash": "f4d6f1141f198358eea1fbb7e43a7901",
     "semantic_hash": "f4d6f1141f198358eea1fbb7e43a7901"
   },
   "rheojax/visualization/transform_plotter.py": {
-    "mtime": 1782779014.4862597,
+    "mtime": 1783141477.1944242,
     "ast_hash": "12a0f5c7dbc859ac1292c225a08c8566",
     "semantic_hash": "12a0f5c7dbc859ac1292c225a08c8566"
   },
   "scripts/check_notebook_execution.py": {
-    "mtime": 1782779014.4862597,
+    "mtime": 1783141477.1944242,
     "ast_hash": "7e7c030cc89b1aeeb6b3b97c310d0e70",
     "semantic_hash": "7e7c030cc89b1aeeb6b3b97c310d0e70"
   },
   "scripts/clean_notebook_outputs.py": {
-    "mtime": 1773332567.6919537,
+    "mtime": 1783141477.1944242,
     "ast_hash": "91d4335c8801aa87b5c0a79ecd14f8b2",
     "semantic_hash": "91d4335c8801aa87b5c0a79ecd14f8b2"
   },
   "scripts/gen_inputs.py": {
-    "mtime": 1764879938.0,
+    "mtime": 1783141477.1944242,
     "ast_hash": "538d7875e9a117f2059282c9087cce72",
     "semantic_hash": "538d7875e9a117f2059282c9087cce72"
   },
   "scripts/micro_benchmarks.py": {
-    "mtime": 1782779014.4862597,
+    "mtime": 1783141477.1954243,
     "ast_hash": "e84a2455f801ec8228f6c6480165b151",
     "semantic_hash": "e84a2455f801ec8228f6c6480165b151"
   },
   "scripts/run_all_notebooks.py": {
-    "mtime": 1782840586.0644205,
+    "mtime": 1783141477.1954243,
     "ast_hash": "31817590088dfff9988611e71b512138",
     "semantic_hash": "31817590088dfff9988611e71b512138"
   },
   "scripts/run_oreo.R": {
-    "mtime": 1764801284.0,
+    "mtime": 1783141477.1954243,
     "ast_hash": "e10c7d78bced3fa9ec8159e021d78277",
     "semantic_hash": "e10c7d78bced3fa9ec8159e021d78277"
   },
   "scripts/run_profiling.py": {
-    "mtime": 1782779014.4862597,
+    "mtime": 1783141477.1954243,
     "ast_hash": "76ec5cd98d905177ca403e49e27c75a9",
     "semantic_hash": "76ec5cd98d905177ca403e49e27c75a9"
   },
   "scripts/run_rheojax.py": {
-    "mtime": 1764879940.0,
+    "mtime": 1783141477.1954243,
     "ast_hash": "ffc8d3c2ce57b25c5f7f6e54b600d5f0",
     "semantic_hash": "ffc8d3c2ce57b25c5f7f6e54b600d5f0"
   },
   "scripts/run_single_notebook_96h.py": {
-    "mtime": 1773332567.6919537,
+    "mtime": 1783141477.1954243,
     "ast_hash": "e91d5ad3db108077f0fec0ea61c4afb5",
     "semantic_hash": "e91d5ad3db108077f0fec0ea61c4afb5"
   },
   "scripts/run_sppplus_v2p1.m": {
-    "mtime": 1764801290.0,
+    "mtime": 1783141477.1954243,
     "ast_hash": "8d4ff7c69ec14c1ad1a94140bf3f8ae9",
     "semantic_hash": "8d4ff7c69ec14c1ad1a94140bf3f8ae9"
   },
   "scripts/validate_model_docs.py": {
-    "mtime": 1782779014.4872596,
+    "mtime": 1783141477.1954243,
     "ast_hash": "77f5cabc8795ed4fb6f2ce9e7dfb059b",
     "semantic_hash": "77f5cabc8795ed4fb6f2ce9e7dfb059b"
   },
   "tests/__init__.py": {
-    "mtime": 1771374330.3038259,
+    "mtime": 1783141477.1954243,
     "ast_hash": "fe7dd3c0bcc917afd389302ace7ee6a7",
     "semantic_hash": "fe7dd3c0bcc917afd389302ace7ee6a7"
   },
   "tests/benchmarks/test_gmm_element_search.py": {
-    "mtime": 1782840586.0644205,
+    "mtime": 1783141477.1954243,
     "ast_hash": "088df8ad1a1d5d6e2c956a906f63f9a8",
     "semantic_hash": "088df8ad1a1d5d6e2c956a906f63f9a8"
   },
   "tests/benchmarks/test_mastercurve_vmap.py": {
-    "mtime": 1782779014.4872596,
+    "mtime": 1783141477.1954243,
     "ast_hash": "e5c5886960dae29dbf049055625fc58e",
     "semantic_hash": "e5c5886960dae29dbf049055625fc58e"
   },
   "tests/benchmarks/test_phase2_performance.py": {
-    "mtime": 1782840586.0644205,
+    "mtime": 1783141477.1954243,
     "ast_hash": "8d5b02205311a8de2c374871fe1c73cc",
     "semantic_hash": "8d5b02205311a8de2c374871fe1c73cc"
   },
   "tests/cli/__init__.py": {
-    "mtime": 1773332567.6919537,
+    "mtime": 1783141477.1954243,
     "ast_hash": "d41d8cd98f00b204e9800998ecf8427e",
     "semantic_hash": "d41d8cd98f00b204e9800998ecf8427e"
   },
   "tests/cli/test_cmd_batch.py": {
-    "mtime": 1773332567.6919537,
+    "mtime": 1783141477.1954243,
     "ast_hash": "64cd8ee800a036567a32d58f263c03d8",
     "semantic_hash": "64cd8ee800a036567a32d58f263c03d8"
   },
   "tests/cli/test_cmd_export.py": {
-    "mtime": 1773332567.6919537,
+    "mtime": 1783141477.1954243,
     "ast_hash": "d8c6df5afdeb9f5212cba160c99e41c3",
     "semantic_hash": "d8c6df5afdeb9f5212cba160c99e41c3"
   },
   "tests/cli/test_cmd_load.py": {
-    "mtime": 1773332567.6919537,
+    "mtime": 1783141477.1954243,
     "ast_hash": "88d61255e3acc654619161cedd1e5062",
     "semantic_hash": "88d61255e3acc654619161cedd1e5062"
   },
   "tests/cli/test_cmd_pipeline.py": {
-    "mtime": 1773332567.6919537,
+    "mtime": 1783141477.1954243,
     "ast_hash": "5a50d9f629b2786ca34c82200e1419c2",
     "semantic_hash": "5a50d9f629b2786ca34c82200e1419c2"
   },
   "tests/cli/test_cmd_run.py": {
-    "mtime": 1773332567.6919537,
+    "mtime": 1783141477.1954243,
     "ast_hash": "07e62e12d6fe29e92f38449a7fc4d86d",
     "semantic_hash": "07e62e12d6fe29e92f38449a7fc4d86d"
   },
   "tests/cli/test_cmd_transform.py": {
-    "mtime": 1773332567.6919537,
+    "mtime": 1783141477.1964242,
     "ast_hash": "78e34d70c2067cb44a1d84086b2964ae",
     "semantic_hash": "78e34d70c2067cb44a1d84086b2964ae"
   },
   "tests/cli/test_envelope.py": {
-    "mtime": 1773332567.6919537,
+    "mtime": 1783141477.1964242,
     "ast_hash": "009f3b311ad41b3a885bc36d38cb7cbb",
     "semantic_hash": "009f3b311ad41b3a885bc36d38cb7cbb"
   },
   "tests/cli/test_globals.py": {
-    "mtime": 1773332567.6929536,
+    "mtime": 1783141477.1964242,
     "ast_hash": "66d4e99ea56b34268fece23bfa200a5f",
     "semantic_hash": "66d4e99ea56b34268fece23bfa200a5f"
   },
   "tests/cli/test_main_dispatch.py": {
-    "mtime": 1773332567.6929536,
+    "mtime": 1783141477.1964242,
     "ast_hash": "7f8403d970aff185d6bb9b626011816f",
     "semantic_hash": "7f8403d970aff185d6bb9b626011816f"
   },
   "tests/cli/test_output.py": {
-    "mtime": 1773332567.6929536,
+    "mtime": 1783141477.1964242,
     "ast_hash": "0da5a6109b7b9de1e99a60eb00ff3e0c",
     "semantic_hash": "0da5a6109b7b9de1e99a60eb00ff3e0c"
   },
   "tests/cli/test_templates.py": {
-    "mtime": 1773332567.6929536,
+    "mtime": 1783141477.1964242,
     "ast_hash": "212bfd5fc83cdfcc85edd885cd0f3650",
     "semantic_hash": "212bfd5fc83cdfcc85edd885cd0f3650"
   },
   "tests/cli/test_yaml_runner.py": {
-    "mtime": 1773332567.6929536,
+    "mtime": 1783141477.1964242,
     "ast_hash": "56c754a63c6a491145b5de3a3622f884",
     "semantic_hash": "56c754a63c6a491145b5de3a3622f884"
   },
   "tests/cli/test_yaml_schema.py": {
-    "mtime": 1782840586.0644205,
+    "mtime": 1783141477.1964242,
     "ast_hash": "e50befc5eee607de4e6391232e29b5f9",
     "semantic_hash": "e50befc5eee607de4e6391232e29b5f9"
   },
   "tests/conftest.py": {
-    "mtime": 1773332567.6929536,
+    "mtime": 1783141477.1964242,
     "ast_hash": "ca0f2fa367addf1b114bca27a64f34f3",
     "semantic_hash": "ca0f2fa367addf1b114bca27a64f34f3"
   },
   "tests/core/__init__.py": {
-    "mtime": 1771374330.3038259,
+    "mtime": 1783141477.1964242,
     "ast_hash": "7cffa47fe5b2fc2cdb7f0b70316697cc",
     "semantic_hash": "7cffa47fe5b2fc2cdb7f0b70316697cc"
   },
   "tests/core/test_base.py": {
-    "mtime": 1763167734.0,
+    "mtime": 1783141477.1964242,
     "ast_hash": "1b689a30ec38f1b878e869ad210498a1",
     "semantic_hash": "1b689a30ec38f1b878e869ad210498a1"
   },
   "tests/core/test_base_edge_cases.py": {
-    "mtime": 1777045619.9523702,
+    "mtime": 1783141477.1964242,
     "ast_hash": "f527e899150d814511c5c3d00a590032",
     "semantic_hash": "f527e899150d814511c5c3d00a590032"
   },
   "tests/core/test_basemodel_integration.py": {
-    "mtime": 1782840586.0644205,
+    "mtime": 1783141477.1964242,
     "ast_hash": "b408628598ed4e927765cdbfc7149d7b",
     "semantic_hash": "b408628598ed4e927765cdbfc7149d7b"
   },
   "tests/core/test_bayesian.py": {
-    "mtime": 1782779014.4872596,
+    "mtime": 1783141477.1964242,
     "ast_hash": "e2e37976e077e76b5b18cbb6f0fb3f7a",
     "semantic_hash": "e2e37976e077e76b5b18cbb6f0fb3f7a"
   },
   "tests/core/test_bayesian_diagnostics.py": {
-    "mtime": 1771973913.1979291,
+    "mtime": 1783141477.1964242,
     "ast_hash": "927e88cb83971a46c1aafa1663fcb232",
     "semantic_hash": "927e88cb83971a46c1aafa1663fcb232"
   },
   "tests/core/test_bayesian_edge_cases.py": {
-    "mtime": 1782779014.4872596,
+    "mtime": 1783141477.1964242,
     "ast_hash": "358a693a40ca7639d79402f4c5db9b3c",
     "semantic_hash": "358a693a40ca7639d79402f4c5db9b3c"
   },
   "tests/core/test_bayesian_mode_closure.py": {
-    "mtime": 1782779014.4872596,
+    "mtime": 1783141477.1964242,
     "ast_hash": "d4131a5c7c57c5e32e5a227b525bd406",
     "semantic_hash": "d4131a5c7c57c5e32e5a227b525bd406"
   },
   "tests/core/test_data.py": {
-    "mtime": 1782840586.0654204,
+    "mtime": 1783141477.1964242,
     "ast_hash": "e6bc023d000f3d9b04c11a90bea0a7b0",
     "semantic_hash": "e6bc023d000f3d9b04c11a90bea0a7b0"
   },
   "tests/core/test_fit_result.py": {
-    "mtime": 1777045619.9523702,
+    "mtime": 1783141477.1964242,
     "ast_hash": "847ab2dd0217ac1f7dfddd812517b689",
     "semantic_hash": "847ab2dd0217ac1f7dfddd812517b689"
   },
   "tests/core/test_float64_precision.py": {
-    "mtime": 1771374330.3038259,
+    "mtime": 1783141477.1964242,
     "ast_hash": "1d88162dd2806f6cc715423bfe4f6b3e",
     "semantic_hash": "1d88162dd2806f6cc715423bfe4f6b3e"
   },
   "tests/core/test_jax_config.py": {
-    "mtime": 1777045619.9523702,
+    "mtime": 1783141477.1964242,
     "ast_hash": "de0519975bc45c0d75cf23f2a5f38244",
     "semantic_hash": "de0519975bc45c0d75cf23f2a5f38244"
   },
   "tests/core/test_model_transform_registry.py": {
-    "mtime": 1770953435.5787013,
+    "mtime": 1783141477.1974242,
     "ast_hash": "248c1da3ae461763552b89ea13e401b3",
     "semantic_hash": "248c1da3ae461763552b89ea13e401b3"
   },
   "tests/core/test_parameters.py": {
-    "mtime": 1768360824.276014,
+    "mtime": 1783141477.1974242,
     "ast_hash": "df75579ce78088433e43adfea7b390c5",
     "semantic_hash": "df75579ce78088433e43adfea7b390c5"
   },
   "tests/core/test_registry.py": {
-    "mtime": 1782840586.0654204,
+    "mtime": 1783141477.1974242,
     "ast_hash": "04c9d69269b1ae0be01f3ab74c59c5e0",
     "semantic_hash": "04c9d69269b1ae0be01f3ab74c59c5e0"
   },
   "tests/core/test_registry_consistency.py": {
-    "mtime": 1771568157.1163287,
+    "mtime": 1783141477.1974242,
     "ast_hash": "5b9087a9c2ebe5780b2657ea0350a5be",
     "semantic_hash": "5b9087a9c2ebe5780b2657ea0350a5be"
   },
   "tests/core/test_test_modes.py": {
-    "mtime": 1782779014.4872596,
+    "mtime": 1783141477.1974242,
     "ast_hash": "f7bdbd5d02af7e9198e11d3e819db409",
     "semantic_hash": "f7bdbd5d02af7e9198e11d3e819db409"
   },
   "tests/examples/test_hl_fast_overlays.py": {
-    "mtime": 1780618617.2423205,
+    "mtime": 1783141477.1974242,
     "ast_hash": "5975885ac745ffaba1f7aae0879a3275",
     "semantic_hash": "5975885ac745ffaba1f7aae0879a3275"
   },
   "tests/examples/test_hvm_fit_demo.py": {
-    "mtime": 1780618617.2423205,
+    "mtime": 1783141477.1974242,
     "ast_hash": "865ed7572a8fea46707ed288d8b3ee36",
     "semantic_hash": "865ed7572a8fea46707ed288d8b3ee36"
   },
   "tests/fixtures/generate_test_data.py": {
-    "mtime": 1782779014.4872596,
+    "mtime": 1783141477.1974242,
     "ast_hash": "383fe37972af0d0554051932e2942a3c",
     "semantic_hash": "383fe37972af0d0554051932e2942a3c"
   },
   "tests/fixtures/trios/relaxation.json": {
-    "mtime": 1767875582.209576,
+    "mtime": 1783141477.1974242,
     "ast_hash": "5965d90736a98213f490c4e16a679659",
     "semantic_hash": "5965d90736a98213f490c4e16a679659"
   },
   "tests/gui/__init__.py": {
-    "mtime": 1764929836.0,
+    "mtime": 1783141477.2064242,
     "ast_hash": "807fa2da51227d6da03f1fba560ce5c3",
     "semantic_hash": "807fa2da51227d6da03f1fba560ce5c3"
   },
   "tests/gui/conftest.py": {
-    "mtime": 1773332567.6929536,
+    "mtime": 1783141477.2064242,
     "ast_hash": "c3fe67822b5d43b02087b08350212a7e",
     "semantic_hash": "c3fe67822b5d43b02087b08350212a7e"
   },
   "tests/gui/test_batch_panel.py": {
-    "mtime": 1773332567.6929536,
+    "mtime": 1783141477.208424,
     "ast_hash": "61c7870e747bde736ce72121ec5a2aac",
     "semantic_hash": "61c7870e747bde736ce72121ec5a2aac"
   },
   "tests/gui/test_bayesian_fit_plot_only.py": {
-    "mtime": 1773332567.6929536,
+    "mtime": 1783141477.208424,
     "ast_hash": "dd3965f7b5b4045cfa6dd4ada53c16df",
     "semantic_hash": "dd3965f7b5b4045cfa6dd4ada53c16df"
   },
   "tests/gui/test_bayesian_full_parity.py": {
-    "mtime": 1782840586.0654204,
+    "mtime": 1783141477.208424,
     "ast_hash": "4a5aa1a77ab517bec6a03240ace17a66",
     "semantic_hash": "4a5aa1a77ab517bec6a03240ace17a66"
   },
   "tests/gui/test_bayesian_full_parity_gmm.py": {
-    "mtime": 1782868060.7443554,
+    "mtime": 1783141477.208424,
     "ast_hash": "aeb686c319088a14cc702f598443b06b",
     "semantic_hash": "aeb686c319088a14cc702f598443b06b"
   },
   "tests/gui/test_bayesian_headless.py": {
-    "mtime": 1767875587.6165428,
+    "mtime": 1783141477.208424,
     "ast_hash": "4a4c321f7055efda69570d0f1d11634a",
     "semantic_hash": "4a4c321f7055efda69570d0f1d11634a"
   },
   "tests/gui/test_bayesian_integration_short.py": {
-    "mtime": 1767875587.6045427,
+    "mtime": 1783141477.208424,
     "ast_hash": "890c07ecd2dfb0f7a881ef9877e920d2",
     "semantic_hash": "890c07ecd2dfb0f7a881ef9877e920d2"
   },
   "tests/gui/test_bayesian_long_parity.py": {
-    "mtime": 1773332567.6929536,
+    "mtime": 1783141477.208424,
     "ast_hash": "b3168b98b7c8df2317dcaeee06da10f2",
     "semantic_hash": "b3168b98b7c8df2317dcaeee06da10f2"
   },
   "tests/gui/test_bayesian_presets_config.py": {
-    "mtime": 1768360824.276014,
+    "mtime": 1783141477.208424,
     "ast_hash": "a6565a59218d9573201d438a19db6c47",
     "semantic_hash": "a6565a59218d9573201d438a19db6c47"
   },
   "tests/gui/test_bayesian_visual_parity.py": {
-    "mtime": 1777045619.9533703,
+    "mtime": 1783141477.208424,
     "ast_hash": "a43764d434039b69e9c52acafe4870bd",
     "semantic_hash": "a43764d434039b69e9c52acafe4870bd"
   },
   "tests/gui/test_crash_prevention.py": {
-    "mtime": 1782840586.0654204,
+    "mtime": 1783141477.208424,
     "ast_hash": "728f7fd62be8d9b9397d575d8e1399be",
     "semantic_hash": "728f7fd62be8d9b9397d575d8e1399be"
   },
   "tests/gui/test_design_tokens_accessibility.py": {
-    "mtime": 1782779014.4882598,
+    "mtime": 1783141477.208424,
     "ast_hash": "754cb32cad6d39543b7ca3be75caa695",
     "semantic_hash": "754cb32cad6d39543b7ca3be75caa695"
   },
   "tests/gui/test_diagnostics_bayesian_transfer.py": {
-    "mtime": 1767875586.2035513,
+    "mtime": 1783141477.208424,
     "ast_hash": "5571de97e48309b358c788fe7cb221b9",
     "semantic_hash": "5571de97e48309b358c788fe7cb221b9"
   },
   "tests/gui/test_fit_page_parameters.py": {
-    "mtime": 1766027222.7046523,
+    "mtime": 1783141477.208424,
     "ast_hash": "5aa5cb6bd468dd7c0b94d1003ce89893",
     "semantic_hash": "5aa5cb6bd468dd7c0b94d1003ce89893"
   },
   "tests/gui/test_fit_subprocess_no_segfault.py": {
-    "mtime": 1767875582.208576,
+    "mtime": 1783141477.208424,
     "ast_hash": "62e79371d477a9fdc94f29cc438beec6",
     "semantic_hash": "62e79371d477a9fdc94f29cc438beec6"
   },
   "tests/gui/test_gui_integration.py": {
-    "mtime": 1782840586.0654204,
+    "mtime": 1783141477.2094243,
     "ast_hash": "2d3cfb7e3c3f9e5990e61398cf707d58",
     "semantic_hash": "2d3cfb7e3c3f9e5990e61398cf707d58"
   },
   "tests/gui/test_gui_performance.py": {
-    "mtime": 1767875586.4725497,
+    "mtime": 1783141477.2094243,
     "ast_hash": "51620b882519a07362ae5b1921ba9ebe",
     "semantic_hash": "51620b882519a07362ae5b1921ba9ebe"
   },
   "tests/gui/test_gui_smoke.py": {
-    "mtime": 1782882854.1221592,
+    "mtime": 1783141477.2094243,
     "ast_hash": "c78791c0ef6abf3337207bbab0071b5c",
     "semantic_hash": "c78791c0ef6abf3337207bbab0071b5c"
   },
   "tests/gui/test_icons.py": {
-    "mtime": 1782840586.0654204,
+    "mtime": 1783141477.2094243,
     "ast_hash": "76ca2cba2ac107df376ce98eaa8f5f62",
     "semantic_hash": "76ca2cba2ac107df376ce98eaa8f5f62"
   },
   "tests/gui/test_logging_utils.py": {
-    "mtime": 1777045619.9533703,
+    "mtime": 1783141477.2094243,
     "ast_hash": "edc0562364fc0d4d038c721d9e992c4c",
     "semantic_hash": "edc0562364fc0d4d038c721d9e992c4c"
   },
   "tests/gui/test_menu_actions.py": {
-    "mtime": 1782779014.4882598,
+    "mtime": 1783141477.2094243,
     "ast_hash": "abb4d79aa1d5beb12966f5be868d76d7",
     "semantic_hash": "abb4d79aa1d5beb12966f5be868d76d7"
   },
   "tests/gui/test_parameter_form.py": {
-    "mtime": 1773332567.6939535,
+    "mtime": 1783141477.2094243,
     "ast_hash": "dc7ea75bc6465be6d82951f019408efb",
     "semantic_hash": "dc7ea75bc6465be6d82951f019408efb"
   },
   "tests/gui/test_pipeline_execution_service.py": {
-    "mtime": 1782779014.4882598,
+    "mtime": 1783141477.2094243,
     "ast_hash": "a77fc77a5aa8a2386f65e48fdf841f41",
     "semantic_hash": "a77fc77a5aa8a2386f65e48fdf841f41"
   },
   "tests/gui/test_pipeline_serializer.py": {
-    "mtime": 1782779014.4882598,
+    "mtime": 1783141477.2094243,
     "ast_hash": "a511c150ef960d1fd2b3ad45311fdd15",
     "semantic_hash": "a511c150ef960d1fd2b3ad45311fdd15"
   },
   "tests/gui/test_pipeline_step_config.py": {
-    "mtime": 1782868060.7443554,
+    "mtime": 1783141477.2094243,
     "ast_hash": "ddf5742088fcea34d6df97b5165d97cd",
     "semantic_hash": "ddf5742088fcea34d6df97b5165d97cd"
   },
   "tests/gui/test_process_worker.py": {
-    "mtime": 1782840586.0654204,
+    "mtime": 1783141477.2094243,
     "ast_hash": "32b4884d86ba3a5f239673e76ef03b43",
     "semantic_hash": "32b4884d86ba3a5f239673e76ef03b43"
   },
   "tests/gui/test_regressions_stability.py": {
-    "mtime": 1783016198.9783685,
+    "mtime": 1783141477.2094243,
     "ast_hash": "a717cab5aded16c6bf136030287dc470",
     "semantic_hash": "a717cab5aded16c6bf136030287dc470"
   },
   "tests/gui/test_sidebar_and_navigate.py": {
-    "mtime": 1773332567.6939535,
+    "mtime": 1783141477.2094243,
     "ast_hash": "b3081984c4b528f5330b84300dfb3e55",
     "semantic_hash": "b3081984c4b528f5330b84300dfb3e55"
   },
   "tests/gui/test_transform_page_redesign.py": {
-    "mtime": 1777045619.9533703,
+    "mtime": 1783141477.2094243,
     "ast_hash": "84f53d01042ae4e93236fa08e5082b81",
     "semantic_hash": "84f53d01042ae4e93236fa08e5082b81"
   },
   "tests/gui/test_transform_presets.py": {
-    "mtime": 1767875586.249551,
+    "mtime": 1783141477.2094243,
     "ast_hash": "ec4c124e7c43d5300d220773fc17a774",
     "semantic_hash": "ec4c124e7c43d5300d220773fc17a774"
   },
   "tests/gui/test_transform_service_params.py": {
-    "mtime": 1782868060.7443554,
+    "mtime": 1783141477.2094243,
     "ast_hash": "29cd36a0d2570c587a9c6e786d793c04",
     "semantic_hash": "29cd36a0d2570c587a9c6e786d793c04"
   },
   "tests/gui/test_visual_pipeline_state.py": {
-    "mtime": 1783016198.9783685,
+    "mtime": 1783141477.2094243,
     "ast_hash": "fcd287c0aeeddb9905ed39b1e6d7eadb",
     "semantic_hash": "fcd287c0aeeddb9905ed39b1e6d7eadb"
   },
   "tests/gui/test_visual_regression.py": {
-    "mtime": 1782779014.4882598,
+    "mtime": 1783141477.2104242,
     "ast_hash": "7b1d8a28067f28ab477c34c6f976872c",
     "semantic_hash": "7b1d8a28067f28ab477c34c6f976872c"
   },
   "tests/gui/test_workflow_switching.py": {
-    "mtime": 1773332567.6949537,
+    "mtime": 1783141477.2104242,
     "ast_hash": "542730a65f408f62eb8d6153652a6456",
     "semantic_hash": "542730a65f408f62eb8d6153652a6456"
   },
   "tests/gui/visual/capture_golden_screens.py": {
-    "mtime": 1765002432.0,
+    "mtime": 1783141477.2104242,
     "ast_hash": "2379794008ae18d6e5d24a62ee152fae",
     "semantic_hash": "2379794008ae18d6e5d24a62ee152fae"
   },
   "tests/gui/visual/test_plot_service_golden.py": {
-    "mtime": 1771754195.3629806,
+    "mtime": 1783141477.2104242,
     "ast_hash": "76670947d1155cbafe779177d48dbb74",
     "semantic_hash": "76670947d1155cbafe779177d48dbb74"
   },
   "tests/gui/visual/test_visual_regression_spec_scaffold.py": {
-    "mtime": 1765001890.0,
+    "mtime": 1783141477.2104242,
     "ast_hash": "783dd1fb31aac1b8128e9c850bd634b2",
     "semantic_hash": "783dd1fb31aac1b8128e9c850bd634b2"
   },
   "tests/hypothesis/__init__.py": {
-    "mtime": 1764735940.0,
+    "mtime": 1783141477.211424,
     "ast_hash": "c25d91f55741a270a578df1522848f93",
     "semantic_hash": "c25d91f55741a270a578df1522848f93"
   },
   "tests/hypothesis/test_sgr_properties.py": {
-    "mtime": 1782779014.4882598,
+    "mtime": 1783141477.211424,
     "ast_hash": "3283fb12ec86724db4a346b1e2b6c0e8",
     "semantic_hash": "3283fb12ec86724db4a346b1e2b6c0e8"
   },
   "tests/integration/__init__.py": {
-    "mtime": 1771374330.304826,
+    "mtime": 1783141477.211424,
     "ast_hash": "3ac49245e3fbf4b8ec2b38b6ac30cd47",
     "semantic_hash": "3ac49245e3fbf4b8ec2b38b6ac30cd47"
   },
   "tests/integration/test_bayesian_dataset_state.py": {
-    "mtime": 1765522476.6963189,
+    "mtime": 1783141477.211424,
     "ast_hash": "cd59320c0e5726da0275f35bb510aee4",
     "semantic_hash": "cd59320c0e5726da0275f35bb510aee4"
   },
   "tests/integration/test_cli_yaml_roundtrip.py": {
-    "mtime": 1777045619.9533703,
+    "mtime": 1783141477.211424,
     "ast_hash": "94937835346dbaf5d9a3646e622b7b4a",
     "semantic_hash": "94937835346dbaf5d9a3646e622b7b4a"
   },
   "tests/integration/test_epm_pipeline.py": {
-    "mtime": 1770953435.5797012,
+    "mtime": 1783141477.211424,
     "ast_hash": "786c7ca9ccb7e65b624c26d101f377b4",
     "semantic_hash": "786c7ca9ccb7e65b624c26d101f377b4"
   },
   "tests/integration/test_export_and_project.py": {
-    "mtime": 1771374330.304826,
+    "mtime": 1783141477.211424,
     "ast_hash": "4f7f50668bab6da43ac8eda5c1e6e740",
     "semantic_hash": "4f7f50668bab6da43ac8eda5c1e6e740"
   },
   "tests/integration/test_gmm_element_search_workflow.py": {
-    "mtime": 1782840586.0654204,
+    "mtime": 1783141477.211424,
     "ast_hash": "7ec3cf0638d87318d5430bab66ef0eb4",
     "semantic_hash": "7ec3cf0638d87318d5430bab66ef0eb4"
   },
   "tests/integration/test_io_roundtrip.py": {
-    "mtime": 1763167734.0,
+    "mtime": 1783141477.211424,
     "ast_hash": "fc1603de5075aad196f8865feeb14cd5",
     "semantic_hash": "fc1603de5075aad196f8865feeb14cd5"
   },
   "tests/integration/test_load_bayesian_smoke.py": {
-    "mtime": 1767875582.204576,
+    "mtime": 1783141477.211424,
     "ast_hash": "874a24fa2490d8231a6dd382a4e1fa64",
     "semantic_hash": "874a24fa2490d8231a6dd382a4e1fa64"
   },
   "tests/integration/test_load_fit_smoke.py": {
-    "mtime": 1767875582.213576,
+    "mtime": 1783141477.2124243,
     "ast_hash": "9ab0b729d5ad26369af73dba7e4ed96f",
     "semantic_hash": "9ab0b729d5ad26369af73dba7e4ed96f"
   },
   "tests/integration/test_mode_aware_bayesian_workflow.py": {
-    "mtime": 1782840586.0654204,
+    "mtime": 1783141477.2124243,
     "ast_hash": "ff8eb95088b65fefdea1331772eea7a6",
     "semantic_hash": "ff8eb95088b65fefdea1331772eea7a6"
   },
   "tests/integration/test_nlsq_numpyro_workflow.py": {
-    "mtime": 1782779014.4892597,
+    "mtime": 1783141477.2124243,
     "ast_hash": "33d7e1bff6ecd164b7a1465bc2ac91cb",
     "semantic_hash": "33d7e1bff6ecd164b7a1465bc2ac91cb"
   },
   "tests/integration/test_sgr_integration.py": {
-    "mtime": 1782779014.4892597,
+    "mtime": 1783141477.2124243,
     "ast_hash": "c24e7ca5df058c41e6dbfa5031b90dcd",
     "semantic_hash": "c24e7ca5df058c41e6dbfa5031b90dcd"
   },
   "tests/integration/test_sgr_parity.py": {
-    "mtime": 1782779014.4892597,
+    "mtime": 1783141477.2124243,
     "ast_hash": "65e925a3237b985b28b8044ad9b7fde7",
     "semantic_hash": "65e925a3237b985b28b8044ad9b7fde7"
   },
   "tests/integration/test_spp_golden_parity.py": {
-    "mtime": 1764879940.0,
+    "mtime": 1783141477.2124243,
     "ast_hash": "62e1d7e53394b36c4c82540ceedd6477",
     "semantic_hash": "62e1d7e53394b36c4c82540ceedd6477"
   },
   "tests/integration/test_spp_integration.py": {
-    "mtime": 1764779256.0,
+    "mtime": 1783141477.2124243,
     "ast_hash": "ad595cb34c5846b5ba995ece9d90fffc",
     "semantic_hash": "ad595cb34c5846b5ba995ece9d90fffc"
   },
   "tests/integration/test_spp_integration_spp_yield.py": {
-    "mtime": 1773332567.6949537,
+    "mtime": 1783141477.2124243,
     "ast_hash": "a3e663f332fc2c6e47ae08279326bd86",
     "semantic_hash": "a3e663f332fc2c6e47ae08279326bd86"
   },
   "tests/integration/test_transform_flow.py": {
-    "mtime": 1765522476.6963189,
+    "mtime": 1783141477.2124243,
     "ast_hash": "85e21f700819253b20c749a2c9ffd0d9",
     "semantic_hash": "85e21f700819253b20c749a2c9ffd0d9"
   },
   "tests/integration/test_v0_3_2_performance.py": {
-    "mtime": 1782779014.4892597,
+    "mtime": 1783141477.2124243,
     "ast_hash": "dde1b9a0914fc41108a63685f006d10d",
     "semantic_hash": "dde1b9a0914fc41108a63685f006d10d"
   },
   "tests/io/conftest.py": {
-    "mtime": 1777045619.9533703,
+    "mtime": 1783141477.2124243,
     "ast_hash": "578c313b99e27532a178a53221c8cb59",
     "semantic_hash": "578c313b99e27532a178a53221c8cb59"
   },
   "tests/io/test_analysis_exporter.py": {
-    "mtime": 1773332567.6949537,
+    "mtime": 1783141477.2124243,
     "ast_hash": "c0ed3fd52610d7ba9ef1a45ee314c626",
     "semantic_hash": "c0ed3fd52610d7ba9ef1a45ee314c626"
   },
   "tests/io/test_anton_paar.py": {
-    "mtime": 1767875587.0255463,
+    "mtime": 1783141477.2124243,
     "ast_hash": "7511d9e43d1c196405c02db1154960f9",
     "semantic_hash": "7511d9e43d1c196405c02db1154960f9"
   },
   "tests/io/test_column_mapping.py": {
-    "mtime": 1782840586.0654204,
+    "mtime": 1783141477.2124243,
     "ast_hash": "2d21e2f2b009bfcd096e49bf5bb05f80",
     "semantic_hash": "2d21e2f2b009bfcd096e49bf5bb05f80"
   },
   "tests/io/test_csv_detection.py": {
-    "mtime": 1773332567.6949537,
+    "mtime": 1783141477.2124243,
     "ast_hash": "371f9a072e5d7236e9af032b5d2c020a",
     "semantic_hash": "371f9a072e5d7236e9af032b5d2c020a"
   },
   "tests/io/test_io_fixes.py": {
-    "mtime": 1782840586.0664203,
+    "mtime": 1783141477.2124243,
     "ast_hash": "9827bd495d5bab9e5f06a1fc05eb3510",
     "semantic_hash": "9827bd495d5bab9e5f06a1fc05eb3510"
   },
   "tests/io/test_multi_file.py": {
-    "mtime": 1773332567.6959536,
+    "mtime": 1783141477.2124243,
     "ast_hash": "47a0c0d70c99d7532be3a5f5da4947d5",
     "semantic_hash": "47a0c0d70c99d7532be3a5f5da4947d5"
   },
   "tests/io/test_npz_writer.py": {
-    "mtime": 1773332567.6959536,
+    "mtime": 1783141477.2134242,
     "ast_hash": "af0645d99c486c56aa675de553b2ed2f",
     "semantic_hash": "af0645d99c486c56aa675de553b2ed2f"
   },
   "tests/io/test_protocol_metadata.py": {
-    "mtime": 1773332567.6959536,
+    "mtime": 1783141477.2134242,
     "ast_hash": "68bfb153d8aa5cf5fa94185bfb98de23",
     "semantic_hash": "68bfb153d8aa5cf5fa94185bfb98de23"
   },
   "tests/io/test_readers.py": {
-    "mtime": 1773332567.6959536,
+    "mtime": 1783141477.2134242,
     "ast_hash": "7cce284f5e61ce684c91ba6ebcf676b5",
     "semantic_hash": "7cce284f5e61ce684c91ba6ebcf676b5"
   },
   "tests/io/test_spp_export.py": {
-    "mtime": 1773332567.6959536,
+    "mtime": 1783141477.2134242,
     "ast_hash": "5976bda3f7cad633a7ca4150a598cc3b",
     "semantic_hash": "5976bda3f7cad633a7ca4150a598cc3b"
   },
   "tests/io/test_trios_auto_chunk.py": {
-    "mtime": 1782779014.4892597,
+    "mtime": 1783141477.2134242,
     "ast_hash": "e37453828f862faabf24db44d02c22cc",
     "semantic_hash": "e37453828f862faabf24db44d02c22cc"
   },
   "tests/io/test_trios_chunked.py": {
-    "mtime": 1782779014.4892597,
+    "mtime": 1783141477.2134242,
     "ast_hash": "c577b616a4185754cdf47a2c4fc6611e",
     "semantic_hash": "c577b616a4185754cdf47a2c4fc6611e"
   },
   "tests/io/test_trios_chunked_integrity.py": {
-    "mtime": 1782779014.4892597,
+    "mtime": 1783141477.2134242,
     "ast_hash": "cff0b3c75f8511b2ee2655fe3049b024",
     "semantic_hash": "cff0b3c75f8511b2ee2655fe3049b024"
   },
   "tests/io/test_trios_memory_profiling.py": {
-    "mtime": 1782779014.4892597,
+    "mtime": 1783141477.2134242,
     "ast_hash": "b99503b096c315554332615ea18b0e3d",
     "semantic_hash": "b99503b096c315554332615ea18b0e3d"
   },
   "tests/io/test_trios_real_data.py": {
-    "mtime": 1771523131.5690203,
+    "mtime": 1783141477.2134242,
     "ast_hash": "74278cdf986d93f56e3d9818f91ab138",
     "semantic_hash": "74278cdf986d93f56e3d9818f91ab138"
   },
   "tests/io/test_unit_conversion.py": {
-    "mtime": 1773332567.6959536,
+    "mtime": 1783141477.2134242,
     "ast_hash": "6c88e8ce44dc75fdee628068ee6aecba",
     "semantic_hash": "6c88e8ce44dc75fdee628068ee6aecba"
   },
   "tests/io/test_validation.py": {
-    "mtime": 1773332567.6959536,
+    "mtime": 1783141477.2134242,
     "ast_hash": "e8fa179ee041d0a0421fd65fd8779e8f",
     "semantic_hash": "e8fa179ee041d0a0421fd65fd8779e8f"
   },
   "tests/io/test_writers.py": {
-    "mtime": 1782840586.0664203,
+    "mtime": 1783141477.2134242,
     "ast_hash": "994377736983bd42a58aaf6ef42b80cf",
     "semantic_hash": "994377736983bd42a58aaf6ef42b80cf"
   },
   "tests/logging/__init__.py": {
-    "mtime": 1764971708.0,
+    "mtime": 1783141477.2134242,
     "ast_hash": "8f4c385649d955a5d0722a3bfb6e63ac",
     "semantic_hash": "8f4c385649d955a5d0722a3bfb6e63ac"
   },
   "tests/logging/test_config.py": {
-    "mtime": 1767875586.6415486,
+    "mtime": 1783141477.2134242,
     "ast_hash": "610e5a42c6c4c72ecae8c2f4be4bfc1a",
     "semantic_hash": "610e5a42c6c4c72ecae8c2f4be4bfc1a"
   },
   "tests/logging/test_context.py": {
-    "mtime": 1767875587.6115427,
+    "mtime": 1783141477.2134242,
     "ast_hash": "be65d83dc5264b5f628f74b0ac5609ea",
     "semantic_hash": "be65d83dc5264b5f628f74b0ac5609ea"
   },
   "tests/logging/test_logger.py": {
-    "mtime": 1767875586.6795485,
+    "mtime": 1783141477.2134242,
     "ast_hash": "5863c3406e74e779d6629e26f66e32f8",
     "semantic_hash": "5863c3406e74e779d6629e26f66e32f8"
   },
   "tests/logging/test_logging_integration.py": {
-    "mtime": 1782480119.29291,
+    "mtime": 1783141477.2134242,
     "ast_hash": "5686a63d419cb36054c90a17ba004434",
     "semantic_hash": "5686a63d419cb36054c90a17ba004434"
   },
   "tests/models/__init__.py": {
-    "mtime": 1762927058.0,
+    "mtime": 1783141477.2134242,
     "ast_hash": "09789325da1adfbfcee4451877d2022e",
     "semantic_hash": "09789325da1adfbfcee4451877d2022e"
   },
   "tests/models/classical/__init__.py": {
-    "mtime": 1770953435.5797012,
+    "mtime": 1783141477.2134242,
     "ast_hash": "fc6d1114230957d75e5efe7aa76add60",
     "semantic_hash": "fc6d1114230957d75e5efe7aa76add60"
   },
   "tests/models/classical/test_maxwell.py": {
-    "mtime": 1773332567.6959536,
+    "mtime": 1783141477.2134242,
     "ast_hash": "8483dd14a8d58c3789cf59fdc935f3c2",
     "semantic_hash": "8483dd14a8d58c3789cf59fdc935f3c2"
   },
   "tests/models/classical/test_springpot.py": {
-    "mtime": 1770953435.5797012,
+    "mtime": 1783141477.2134242,
     "ast_hash": "372b9196c7d4b59e8532ea034089c7c6",
     "semantic_hash": "372b9196c7d4b59e8532ea034089c7c6"
   },
   "tests/models/classical/test_zener.py": {
-    "mtime": 1773332567.6969535,
+    "mtime": 1783141477.2134242,
     "ast_hash": "f0448b92dd5698f34607ca8b66188917",
     "semantic_hash": "f0448b92dd5698f34607ca8b66188917"
   },
   "tests/models/dmt/__init__.py": {
-    "mtime": 1770953435.5797012,
+    "mtime": 1783141477.2134242,
     "ast_hash": "8fb1c30946468cd70d918611cc363c2f",
     "semantic_hash": "8fb1c30946468cd70d918611cc363c2f"
   },
   "tests/models/dmt/test_dmt.py": {
-    "mtime": 1782779014.4902596,
+    "mtime": 1783141477.2144241,
     "ast_hash": "50180314c51468c61bcc46c258822897",
     "semantic_hash": "50180314c51468c61bcc46c258822897"
   },
   "tests/models/epm/__init__.py": {
-    "mtime": 1770953435.5797012,
+    "mtime": 1783141477.2144241,
     "ast_hash": "63dda2e0afc31bb5ed9f3782ad08e7ce",
     "semantic_hash": "63dda2e0afc31bb5ed9f3782ad08e7ce"
   },
   "tests/models/epm/test_epm_base.py": {
-    "mtime": 1770953435.5797012,
+    "mtime": 1783141477.2144241,
     "ast_hash": "8a6291db5bc537b84926d95dcb963e37",
     "semantic_hash": "8a6291db5bc537b84926d95dcb963e37"
   },
   "tests/models/epm/test_lattice_epm.py": {
-    "mtime": 1782840586.0664203,
+    "mtime": 1783141477.2144241,
     "ast_hash": "82a1f69a539f0a3db6026f35e5fae728",
     "semantic_hash": "82a1f69a539f0a3db6026f35e5fae728"
   },
   "tests/models/epm/test_tensorial_epm.py": {
-    "mtime": 1782779014.4902596,
+    "mtime": 1783141477.2144241,
     "ast_hash": "17c27206de96f64368cdb8da8865357f",
     "semantic_hash": "17c27206de96f64368cdb8da8865357f"
   },
   "tests/models/fikh/__init__.py": {
-    "mtime": 1770953435.580701,
+    "mtime": 1783141477.2144241,
     "ast_hash": "96c0eadfb0983238a2d060db139f726d",
     "semantic_hash": "96c0eadfb0983238a2d060db139f726d"
   },
   "tests/models/fikh/test_fikh.py": {
-    "mtime": 1782779014.4902596,
+    "mtime": 1783141477.2144241,
     "ast_hash": "4ff46fd8fef28f84472260ea21039646",
     "semantic_hash": "4ff46fd8fef28f84472260ea21039646"
   },
   "tests/models/fikh/test_fikh_caputo.py": {
-    "mtime": 1770953435.580701,
+    "mtime": 1783141477.2144241,
     "ast_hash": "ac28ba794d9212089e331b6a7cd8d9c1",
     "semantic_hash": "ac28ba794d9212089e331b6a7cd8d9c1"
   },
   "tests/models/fikh/test_fikh_thermal.py": {
-    "mtime": 1770953435.580701,
+    "mtime": 1783141477.2144241,
     "ast_hash": "576d0cd79a5f3303d1072b4428eb9219",
     "semantic_hash": "576d0cd79a5f3303d1072b4428eb9219"
   },
   "tests/models/fikh/test_fmlikh.py": {
-    "mtime": 1777873218.8596773,
+    "mtime": 1783141477.2144241,
     "ast_hash": "79651aebc129f281e816d01611718392",
     "semantic_hash": "79651aebc129f281e816d01611718392"
   },
   "tests/models/flow/__init__.py": {
-    "mtime": 1770953435.580701,
+    "mtime": 1783141477.2144241,
     "ast_hash": "c135fd29ae5423d70b6223664bc66bc1",
     "semantic_hash": "c135fd29ae5423d70b6223664bc66bc1"
   },
   "tests/models/flow/test_bingham.py": {
-    "mtime": 1771754195.3629806,
+    "mtime": 1783141477.2144241,
     "ast_hash": "7495db7d4770de781fa44f0e950a44a2",
     "semantic_hash": "7495db7d4770de781fa44f0e950a44a2"
   },
   "tests/models/flow/test_carreau.py": {
-    "mtime": 1771754195.3629806,
+    "mtime": 1783141477.2144241,
     "ast_hash": "84ed3130fa87abd22ce0ddddf17e913b",
     "semantic_hash": "84ed3130fa87abd22ce0ddddf17e913b"
   },
   "tests/models/flow/test_carreau_yasuda.py": {
-    "mtime": 1771754195.3629806,
+    "mtime": 1783141477.2144241,
     "ast_hash": "98db15081227b67cde4ae88079a93cbb",
     "semantic_hash": "98db15081227b67cde4ae88079a93cbb"
   },
   "tests/models/flow/test_cross.py": {
-    "mtime": 1771754195.3629806,
+    "mtime": 1783141477.2144241,
     "ast_hash": "d1147c06f1b90cf2b100cc303ed537a1",
     "semantic_hash": "d1147c06f1b90cf2b100cc303ed537a1"
   },
   "tests/models/flow/test_herschel_bulkley.py": {
-    "mtime": 1771754195.3629806,
+    "mtime": 1783141477.2144241,
     "ast_hash": "dc97a54e76dfa45c269c6efba64d6d00",
     "semantic_hash": "dc97a54e76dfa45c269c6efba64d6d00"
   },
   "tests/models/flow/test_power_law.py": {
-    "mtime": 1771754195.3629806,
+    "mtime": 1783141477.2144241,
     "ast_hash": "10606ae81257123887a2738f14925529",
     "semantic_hash": "10606ae81257123887a2738f14925529"
   },
   "tests/models/fluidity/__init__.py": {
-    "mtime": 1769187879.6273978,
+    "mtime": 1783141477.2144241,
     "ast_hash": "cdaf98b7e185ca4d5a371dd1e69af567",
     "semantic_hash": "cdaf98b7e185ca4d5a371dd1e69af567"
   },
   "tests/models/fluidity/saramito/__init__.py": {
-    "mtime": 1770953435.580701,
+    "mtime": 1783141477.2144241,
     "ast_hash": "b8c2b50823ecc5bf845aebb8bafa6c2b",
     "semantic_hash": "b8c2b50823ecc5bf845aebb8bafa6c2b"
   },
   "tests/models/fluidity/saramito/test_kernels.py": {
-    "mtime": 1771754195.3639805,
+    "mtime": 1783141477.215424,
     "ast_hash": "2f559aa80d1e463d9601c5b93e5d4975",
     "semantic_hash": "2f559aa80d1e463d9601c5b93e5d4975"
   },
   "tests/models/fluidity/saramito/test_local.py": {
-    "mtime": 1782840586.0664203,
+    "mtime": 1783141477.215424,
     "ast_hash": "5a68f70e1da5ffcbeb1faca4030a7c5d",
     "semantic_hash": "5a68f70e1da5ffcbeb1faca4030a7c5d"
   },
   "tests/models/fluidity/saramito/test_nonlocal.py": {
-    "mtime": 1779067889.578516,
+    "mtime": 1783141477.215424,
     "ast_hash": "1a260d46ee9ca90a3a91d725ec85b076",
     "semantic_hash": "1a260d46ee9ca90a3a91d725ec85b076"
   },
   "tests/models/fluidity/saramito/test_physics.py": {
-    "mtime": 1771754195.3639805,
+    "mtime": 1783141477.215424,
     "ast_hash": "9f59ff8e37e6ddd0712ae004e7b6b56b",
     "semantic_hash": "9f59ff8e37e6ddd0712ae004e7b6b56b"
   },
   "tests/models/fluidity/test_identifiability.py": {
-    "mtime": 1777873218.8596773,
+    "mtime": 1783141477.215424,
     "ast_hash": "e11cb95b25e63f4161837965d10d2229",
     "semantic_hash": "e11cb95b25e63f4161837965d10d2229"
   },
   "tests/models/fluidity/test_integration.py": {
-    "mtime": 1782840586.0664203,
+    "mtime": 1783141477.215424,
     "ast_hash": "18ecdfeab39b0b41b14a394bc302353a",
     "semantic_hash": "18ecdfeab39b0b41b14a394bc302353a"
   },
   "tests/models/fluidity/test_kernels.py": {
-    "mtime": 1771754195.3639805,
+    "mtime": 1783141477.215424,
     "ast_hash": "ae517d77519bcd8cdd57737cfb084f05",
     "semantic_hash": "ae517d77519bcd8cdd57737cfb084f05"
   },
   "tests/models/fluidity/test_local.py": {
-    "mtime": 1773332567.6969535,
+    "mtime": 1783141477.215424,
     "ast_hash": "6d9e63e045c8359653d3f58bb62adc0a",
     "semantic_hash": "6d9e63e045c8359653d3f58bb62adc0a"
   },
   "tests/models/fluidity/test_nonlocal.py": {
-    "mtime": 1771754195.3639805,
+    "mtime": 1783141477.215424,
     "ast_hash": "8a845d84d4298853952f149060df6084",
     "semantic_hash": "8a845d84d4298853952f149060df6084"
   },
   "tests/models/fluidity/test_parameter_schema.py": {
-    "mtime": 1777873218.8596773,
+    "mtime": 1783141477.215424,
     "ast_hash": "8692e5cdf392ee4a0188e84ff1a8a3d6",
     "semantic_hash": "8692e5cdf392ee4a0188e84ff1a8a3d6"
   },
   "tests/models/fluidity/test_predict_without_fit.py": {
-    "mtime": 1777873218.8606772,
+    "mtime": 1783141477.215424,
     "ast_hash": "9170480348154c4cc7e6769968e2f297",
     "semantic_hash": "9170480348154c4cc7e6769968e2f297"
   },
   "tests/models/fractional/__init__.py": {
-    "mtime": 1770953435.5817013,
+    "mtime": 1783141477.215424,
     "ast_hash": "a1f778fb0112ecf9d3f4f70d62ef5060",
     "semantic_hash": "a1f778fb0112ecf9d3f4f70d62ef5060"
   },
   "tests/models/fractional/test_fractional_maxwell_liquid.py": {
-    "mtime": 1771973913.1989293,
+    "mtime": 1783141477.215424,
     "ast_hash": "c709ed997586c9cc26a7f1a0ad1fe9e6",
     "semantic_hash": "c709ed997586c9cc26a7f1a0ad1fe9e6"
   },
   "tests/models/fractional/test_fractional_maxwell_model.py": {
-    "mtime": 1777045619.9543703,
+    "mtime": 1783141477.215424,
     "ast_hash": "4e72e72a917cd7fc8dce1324db113592",
     "semantic_hash": "4e72e72a917cd7fc8dce1324db113592"
   },
   "tests/models/fractional/test_fractional_mixin.py": {
-    "mtime": 1782779014.4902596,
+    "mtime": 1783141477.215424,
     "ast_hash": "31a23118554de129cd370f9916b96996",
     "semantic_hash": "31a23118554de129cd370f9916b96996"
   },
   "tests/models/fractional/test_fractional_variants.py": {
-    "mtime": 1777045619.9543703,
+    "mtime": 1783141477.215424,
     "ast_hash": "80455ee32c766958e304d622bb977c65",
     "semantic_hash": "80455ee32c766958e304d622bb977c65"
   },
   "tests/models/fractional/test_fractional_zener_family.py": {
-    "mtime": 1770953435.5827012,
+    "mtime": 1783141477.215424,
     "ast_hash": "221c662c527b95656f3800f41ce70d81",
     "semantic_hash": "221c662c527b95656f3800f41ce70d81"
   },
   "tests/models/fractional/test_fractional_zener_sl.py": {
-    "mtime": 1777045619.9543703,
+    "mtime": 1783141477.215424,
     "ast_hash": "9cd67d2b4ed3e0c980157d11d852dc93",
     "semantic_hash": "9cd67d2b4ed3e0c980157d11d852dc93"
   },
   "tests/models/fractional/test_optimization_validation.py": {
-    "mtime": 1782779014.4902596,
+    "mtime": 1783141477.215424,
     "ast_hash": "f2e4cb928c08464ba8fee3e2de4fa831",
     "semantic_hash": "f2e4cb928c08464ba8fee3e2de4fa831"
   },
   "tests/models/giesekus/__init__.py": {
-    "mtime": 1770953435.5827012,
+    "mtime": 1783141477.2164242,
     "ast_hash": "3bf52e706cb3ed736333df10fac160b0",
     "semantic_hash": "3bf52e706cb3ed736333df10fac160b0"
   },
   "tests/models/giesekus/test_bayesian.py": {
-    "mtime": 1777873218.8606772,
+    "mtime": 1783141477.2164242,
     "ast_hash": "9e20f672a7c78bd531490ba552f66362",
     "semantic_hash": "9e20f672a7c78bd531490ba552f66362"
   },
   "tests/models/giesekus/test_kernels.py": {
-    "mtime": 1782779014.4902596,
+    "mtime": 1783141477.2164242,
     "ast_hash": "eb62f2de5f1746fcc6081b13a6d677b4",
     "semantic_hash": "eb62f2de5f1746fcc6081b13a6d677b4"
   },
   "tests/models/giesekus/test_multi_mode.py": {
-    "mtime": 1771973913.1989293,
+    "mtime": 1783141477.2164242,
     "ast_hash": "a12ad639d602a1eea0598ec4eea8b8c0",
     "semantic_hash": "a12ad639d602a1eea0598ec4eea8b8c0"
   },
   "tests/models/giesekus/test_physics.py": {
-    "mtime": 1782779014.4902596,
+    "mtime": 1783141477.2164242,
     "ast_hash": "ca4dbbe0e5f581b12afd15dd4c0ca57a",
     "semantic_hash": "ca4dbbe0e5f581b12afd15dd4c0ca57a"
   },
   "tests/models/giesekus/test_single_mode.py": {
-    "mtime": 1777873218.8606772,
+    "mtime": 1783141477.2164242,
     "ast_hash": "bee42eea49d215dfb1552942ce6c7e41",
     "semantic_hash": "bee42eea49d215dfb1552942ce6c7e41"
   },
   "tests/models/hl/__init__.py": {
-    "mtime": 1770953435.5837011,
+    "mtime": 1783141477.2164242,
     "ast_hash": "b01418cf53f1af8f50a98d2fd38d572c",
     "semantic_hash": "b01418cf53f1af8f50a98d2fd38d572c"
   },
   "tests/models/hl/test_hebraud_lequeux.py": {
-    "mtime": 1777045619.9543703,
+    "mtime": 1783141477.2164242,
     "ast_hash": "52c3113b31aadc117a8d98e208258851",
     "semantic_hash": "52c3113b31aadc117a8d98e208258851"
   },
   "tests/models/hvm/__init__.py": {
-    "mtime": 1770953435.5837011,
+    "mtime": 1783141477.2164242,
     "ast_hash": "1cbdc386dbb9dccc401019f3151e6623",
     "semantic_hash": "1cbdc386dbb9dccc401019f3151e6623"
   },
   "tests/models/hvm/test_hvm.py": {
-    "mtime": 1771754195.3649807,
+    "mtime": 1783141477.2164242,
     "ast_hash": "41f860e0ded6d9cecff54cbf1522e81e",
     "semantic_hash": "41f860e0ded6d9cecff54cbf1522e81e"
   },
   "tests/models/hvnm/__init__.py": {
-    "mtime": 1770953435.5837011,
+    "mtime": 1783141477.2164242,
     "ast_hash": "d41d8cd98f00b204e9800998ecf8427e",
     "semantic_hash": "d41d8cd98f00b204e9800998ecf8427e"
   },
   "tests/models/hvnm/test_hvnm.py": {
-    "mtime": 1771523131.5700202,
+    "mtime": 1783141477.2164242,
     "ast_hash": "fa51d843bab2e6fb1593defb0adcc782",
     "semantic_hash": "fa51d843bab2e6fb1593defb0adcc782"
   },
   "tests/models/ikh/__init__.py": {
-    "mtime": 1770953435.5837011,
+    "mtime": 1783141477.2164242,
     "ast_hash": "61937022a11d4854c76f72845a4faa6c",
     "semantic_hash": "61937022a11d4854c76f72845a4faa6c"
   },
   "tests/models/ikh/test_ikh.py": {
-    "mtime": 1782779014.4912598,
+    "mtime": 1783141477.2164242,
     "ast_hash": "a0d57691f5b8a730a5b8c1492eee76fc",
     "semantic_hash": "a0d57691f5b8a730a5b8c1492eee76fc"
   },
   "tests/models/ikh/test_ikh_fitting.py": {
-    "mtime": 1782779014.4912598,
+    "mtime": 1783141477.2164242,
     "ast_hash": "b5cf560b3023aa117626b0db3648ad1a",
     "semantic_hash": "b5cf560b3023aa117626b0db3648ad1a"
   },
   "tests/models/ikh/test_ikh_variants.py": {
-    "mtime": 1777045619.9543703,
+    "mtime": 1783141477.2164242,
     "ast_hash": "7b3c9101c05d49cfefe0c941621955ce",
     "semantic_hash": "7b3c9101c05d49cfefe0c941621955ce"
   },
   "tests/models/itt_mct/__init__.py": {
-    "mtime": 1770953435.5837011,
+    "mtime": 1783141477.2164242,
     "ast_hash": "a846afff2281dd06bf99e531b733575a",
     "semantic_hash": "a846afff2281dd06bf99e531b733575a"
   },
   "tests/models/itt_mct/test_isotropic.py": {
-    "mtime": 1780618617.2423205,
+    "mtime": 1783141477.2174242,
     "ast_hash": "69986b02a86ffe6de097e674389e9be4",
     "semantic_hash": "69986b02a86ffe6de097e674389e9be4"
   },
   "tests/models/itt_mct/test_method_scipy_default.py": {
-    "mtime": 1780618617.2423205,
+    "mtime": 1783141477.2174242,
     "ast_hash": "1326a2fc25c6385cfe29a2d25c220ee2",
     "semantic_hash": "1326a2fc25c6385cfe29a2d25c220ee2"
   },
   "tests/models/itt_mct/test_performance.py": {
-    "mtime": 1782779014.4912598,
+    "mtime": 1783141477.2174242,
     "ast_hash": "f7b6b79651f48db999559d3e731891bf",
     "semantic_hash": "f7b6b79651f48db999559d3e731891bf"
   },
   "tests/models/itt_mct/test_protocols.py": {
-    "mtime": 1777045619.9553702,
+    "mtime": 1783141477.2174242,
     "ast_hash": "3bdc9b56ab35032936a3b937c27387bd",
     "semantic_hash": "3bdc9b56ab35032936a3b937c27387bd"
   },
   "tests/models/itt_mct/test_schematic.py": {
-    "mtime": 1777045619.9553702,
+    "mtime": 1783141477.2174242,
     "ast_hash": "cefadc4777910faac453e8f6b2f2e809",
     "semantic_hash": "cefadc4777910faac453e8f6b2f2e809"
   },
   "tests/models/itt_mct/test_two_time_memory.py": {
-    "mtime": 1777045619.9553702,
+    "mtime": 1783141477.2174242,
     "ast_hash": "643e2d5833eaf506828f095ff76d8664",
     "semantic_hash": "643e2d5833eaf506828f095ff76d8664"
   },
   "tests/models/multimode/__init__.py": {
-    "mtime": 1770953435.5847013,
+    "mtime": 1783141477.2174242,
     "ast_hash": "78821a745198b42ee78a7f037b333f1b",
     "semantic_hash": "78821a745198b42ee78a7f037b333f1b"
   },
   "tests/models/multimode/test_generalized_maxwell.py": {
-    "mtime": 1782840586.0664203,
+    "mtime": 1783141477.2174242,
     "ast_hash": "4642346f23e57320db02dde8ad89f258",
     "semantic_hash": "4642346f23e57320db02dde8ad89f258"
   },
   "tests/models/multimode/test_generalized_maxwell_warm_start.py": {
-    "mtime": 1782779014.4912598,
+    "mtime": 1783141477.2174242,
     "ast_hash": "75740de823419d367392a0076bd5e22c",
     "semantic_hash": "75740de823419d367392a0076bd5e22c"
   },
   "tests/models/multimode/test_gmm_bayesian.py": {
-    "mtime": 1782840586.0664203,
+    "mtime": 1783141477.2174242,
     "ast_hash": "c7c0cab76270cd2f8adaa1e3b9f9f094",
     "semantic_hash": "c7c0cab76270cd2f8adaa1e3b9f9f094"
   },
   "tests/models/multimode/test_gmm_bayesian_safety.py": {
-    "mtime": 1782840586.0664203,
+    "mtime": 1783141477.2174242,
     "ast_hash": "73cc92242b3dbb207744340561fe6af1",
     "semantic_hash": "73cc92242b3dbb207744340561fe6af1"
   },
   "tests/models/sgr/__init__.py": {
-    "mtime": 1770953435.5847013,
+    "mtime": 1783141477.2174242,
     "ast_hash": "4083fd583fc0c0eb308b7cc1816993d2",
     "semantic_hash": "4083fd583fc0c0eb308b7cc1816993d2"
   },
   "tests/models/sgr/test_sgr_conventional.py": {
-    "mtime": 1782779014.4912598,
+    "mtime": 1783141477.2174242,
     "ast_hash": "ef23d2616f78dafec7d2af69167829e5",
     "semantic_hash": "ef23d2616f78dafec7d2af69167829e5"
   },
   "tests/models/sgr/test_sgr_generic.py": {
-    "mtime": 1782779014.4912598,
+    "mtime": 1783141477.2174242,
     "ast_hash": "0b0f7ee7a25540434d1454c27392f2b3",
     "semantic_hash": "0b0f7ee7a25540434d1454c27392f2b3"
   },
   "tests/models/sgr/test_sgr_generic_extended.py": {
-    "mtime": 1782779014.4912598,
+    "mtime": 1783141477.2174242,
     "ast_hash": "8d9f1407cd2f4ad455c6f49a67ed51c0",
     "semantic_hash": "8d9f1407cd2f4ad455c6f49a67ed51c0"
   },
   "tests/models/spp/__init__.py": {
-    "mtime": 1770953435.5847013,
+    "mtime": 1783141477.218424,
     "ast_hash": "6451c4e594e864fbeb8de8db5deb3b87",
     "semantic_hash": "6451c4e594e864fbeb8de8db5deb3b87"
   },
   "tests/models/spp/test_spp_yield_stress.py": {
-    "mtime": 1770953435.5847013,
+    "mtime": 1783141477.218424,
     "ast_hash": "85b7f17a43b48c24eb7b190f5f411e72",
     "semantic_hash": "85b7f17a43b48c24eb7b190f5f411e72"
   },
   "tests/models/stz/__init__.py": {
-    "mtime": 1768708239.0882607,
+    "mtime": 1783141477.218424,
     "ast_hash": "fc2d1b7fdab3ee79228dcacbc708aa4f",
     "semantic_hash": "fc2d1b7fdab3ee79228dcacbc708aa4f"
   },
   "tests/models/stz/test_coverage.py": {
-    "mtime": 1782779014.4912598,
+    "mtime": 1783141477.218424,
     "ast_hash": "91d938f0365be8e1957593799a4878ec",
     "semantic_hash": "91d938f0365be8e1957593799a4878ec"
   },
   "tests/models/stz/test_creep_elastic_offset.py": {
-    "mtime": 1782779014.4912598,
+    "mtime": 1783141477.218424,
     "ast_hash": "c0f584f882caf5e124d078a73954c703",
     "semantic_hash": "c0f584f882caf5e124d078a73954c703"
   },
   "tests/models/stz/test_flow_transient.py": {
-    "mtime": 1780618617.2423205,
+    "mtime": 1783141477.218424,
     "ast_hash": "451f65db43b81ab20f38c9f1971ef736",
     "semantic_hash": "451f65db43b81ab20f38c9f1971ef736"
   },
   "tests/models/stz/test_integration.py": {
-    "mtime": 1777045619.9553702,
+    "mtime": 1783141477.218424,
     "ast_hash": "21ee37e3a158ad6b7f80dcf7345dd320",
     "semantic_hash": "21ee37e3a158ad6b7f80dcf7345dd320"
   },
   "tests/models/stz/test_kernels.py": {
-    "mtime": 1771754195.3649807,
+    "mtime": 1783141477.218424,
     "ast_hash": "a14d72c862002e197ccd6418dd0ea23d",
     "semantic_hash": "a14d72c862002e197ccd6418dd0ea23d"
   },
   "tests/models/stz/test_oscillatory.py": {
-    "mtime": 1771754195.3659806,
+    "mtime": 1783141477.218424,
     "ast_hash": "b717c6a2f8d83b81dd129fb972a543aa",
     "semantic_hash": "b717c6a2f8d83b81dd129fb972a543aa"
   },
   "tests/models/test_model_imports.py": {
-    "mtime": 1782779014.4922597,
+    "mtime": 1783141477.218424,
     "ast_hash": "6ede992dcc37b285e919aa55e13199ac",
     "semantic_hash": "6ede992dcc37b285e919aa55e13199ac"
   },
   "tests/models/tnt/__init__.py": {
-    "mtime": 1770953435.5857012,
+    "mtime": 1783141477.218424,
     "ast_hash": "d41d8cd98f00b204e9800998ecf8427e",
     "semantic_hash": "d41d8cd98f00b204e9800998ecf8427e"
   },
   "tests/models/tnt/test_cates.py": {
-    "mtime": 1773332567.6979535,
+    "mtime": 1783141477.218424,
     "ast_hash": "2f5b182cc4dcdcdd871e7936c7e6ff69",
     "semantic_hash": "2f5b182cc4dcdcdd871e7936c7e6ff69"
   },
   "tests/models/tnt/test_loop_bridge.py": {
-    "mtime": 1777045619.9553702,
+    "mtime": 1783141477.218424,
     "ast_hash": "96d46ea573fd2feb7edb6995f6062f78",
     "semantic_hash": "96d46ea573fd2feb7edb6995f6062f78"
   },
   "tests/models/tnt/test_multi_species.py": {
-    "mtime": 1773332567.6979535,
+    "mtime": 1783141477.218424,
     "ast_hash": "753bf4470b91e507a58dd284509bb1c9",
     "semantic_hash": "753bf4470b91e507a58dd284509bb1c9"
   },
   "tests/models/tnt/test_single_mode.py": {
-    "mtime": 1782779014.4922597,
+    "mtime": 1783141477.218424,
     "ast_hash": "ba9344336fb2f2bf4f86d703607c6012",
     "semantic_hash": "ba9344336fb2f2bf4f86d703607c6012"
   },
   "tests/models/tnt/test_sticky_rouse.py": {
-    "mtime": 1777045619.9553702,
+    "mtime": 1783141477.2194242,
     "ast_hash": "255594d53b516d321aa7338b6b142251",
     "semantic_hash": "255594d53b516d321aa7338b6b142251"
   },
   "tests/models/vlb/__init__.py": {
-    "mtime": 1770953435.5857012,
+    "mtime": 1783141477.2194242,
     "ast_hash": "e91ada4e1cbb27e7c8283558b44564b8",
     "semantic_hash": "e91ada4e1cbb27e7c8283558b44564b8"
   },
   "tests/models/vlb/test_vlb.py": {
-    "mtime": 1777045619.9553702,
+    "mtime": 1783141477.2194242,
     "ast_hash": "d871e30a02a01d181ffc230d748cf0ff",
     "semantic_hash": "d871e30a02a01d181ffc230d748cf0ff"
   },
   "tests/models/vlb/test_vlb_nonlocal.py": {
-    "mtime": 1771523131.5710204,
+    "mtime": 1783141477.2194242,
     "ast_hash": "3112013bc68d8c88e4899a5e2fab5c45",
     "semantic_hash": "3112013bc68d8c88e4899a5e2fab5c45"
   },
   "tests/models/vlb/test_vlb_variant.py": {
-    "mtime": 1779067889.5795162,
+    "mtime": 1783141477.2194242,
     "ast_hash": "266f4d830e736951c34464d2e4203dda",
     "semantic_hash": "266f4d830e736951c34464d2e4203dda"
   },
   "tests/parallel/__init__.py": {
-    "mtime": 1773332567.6979535,
+    "mtime": 1783141477.2194242,
     "ast_hash": "d41d8cd98f00b204e9800998ecf8427e",
     "semantic_hash": "d41d8cd98f00b204e9800998ecf8427e"
   },
   "tests/parallel/conftest.py": {
-    "mtime": 1773332567.6979535,
+    "mtime": 1783141477.2194242,
     "ast_hash": "2cf64b5de031c493c7a6b46f07bf0b4c",
     "semantic_hash": "2cf64b5de031c493c7a6b46f07bf0b4c"
   },
   "tests/parallel/test_api.py": {
-    "mtime": 1773332567.6979535,
+    "mtime": 1783141477.2194242,
     "ast_hash": "bf26d846f6063bf620123dc5f9206dff",
     "semantic_hash": "bf26d846f6063bf620123dc5f9206dff"
   },
   "tests/parallel/test_config.py": {
-    "mtime": 1777045619.9553702,
+    "mtime": 1783141477.2194242,
     "ast_hash": "1294f213e602218b4e26aa7859a2f39a",
     "semantic_hash": "1294f213e602218b4e26aa7859a2f39a"
   },
   "tests/parallel/test_imports.py": {
-    "mtime": 1773332567.6979535,
+    "mtime": 1783141477.2194242,
     "ast_hash": "9b5cb1e9b4bd6ec1dc45f1ddb5e2ec1a",
     "semantic_hash": "9b5cb1e9b4bd6ec1dc45f1ddb5e2ec1a"
   },
   "tests/parallel/test_integration.py": {
-    "mtime": 1773332567.6979535,
+    "mtime": 1783141477.2194242,
     "ast_hash": "e740e2f2010b7fa9f0fdd9e6dabdb1ce",
     "semantic_hash": "e740e2f2010b7fa9f0fdd9e6dabdb1ce"
   },
   "tests/parallel/test_pool.py": {
-    "mtime": 1773332567.6979535,
+    "mtime": 1783141477.2194242,
     "ast_hash": "f6f9dbd9e4e22a49f0bad8b85fc80523",
     "semantic_hash": "f6f9dbd9e4e22a49f0bad8b85fc80523"
   },
   "tests/parallel/test_warmup.py": {
-    "mtime": 1773332567.6979535,
+    "mtime": 1783141477.2194242,
     "ast_hash": "26c44cab039f4f79e497a030a9926f78",
     "semantic_hash": "26c44cab039f4f79e497a030a9926f78"
   },
   "tests/pipeline/__init__.py": {
-    "mtime": 1771374330.304826,
+    "mtime": 1783141477.2194242,
     "ast_hash": "33fc98f27629c378ce11304ce64a9a7a",
     "semantic_hash": "33fc98f27629c378ce11304ce64a9a7a"
   },
   "tests/pipeline/test_arviz_diagnostics.py": {
-    "mtime": 1764613290.0,
+    "mtime": 1783141477.2194242,
     "ast_hash": "0e0af7bc3650a80fc951c558ed2572cb",
     "semantic_hash": "0e0af7bc3650a80fc951c558ed2572cb"
   },
   "tests/pipeline/test_batch.py": {
-    "mtime": 1763167734.0,
+    "mtime": 1783141477.2194242,
     "ast_hash": "9c6d3ca867cbe07fdd79de329f804434",
     "semantic_hash": "9c6d3ca867cbe07fdd79de329f804434"
   },
   "tests/pipeline/test_batch_parallel.py": {
-    "mtime": 1773332567.6979535,
+    "mtime": 1783141477.2194242,
     "ast_hash": "7ca38cb1bd647e15fdede2a21e49ee37",
     "semantic_hash": "7ca38cb1bd647e15fdede2a21e49ee37"
   },
   "tests/pipeline/test_batch_vectorize.py": {
-    "mtime": 1777045619.9553702,
+    "mtime": 1783141477.2204242,
     "ast_hash": "295615d580b9d2c0117ead485454f9fd",
     "semantic_hash": "295615d580b9d2c0117ead485454f9fd"
   },
   "tests/pipeline/test_bayesian_pipeline.py": {
-    "mtime": 1782779014.4922597,
+    "mtime": 1783141477.2204242,
     "ast_hash": "2efad644cfb13fa27a4ff96f23aad0c0",
     "semantic_hash": "2efad644cfb13fa27a4ff96f23aad0c0"
   },
   "tests/pipeline/test_builder.py": {
-    "mtime": 1782779014.4922597,
+    "mtime": 1783141477.2204242,
     "ast_hash": "d8d85f96d409f7bf76ef4696cd8d1e85",
     "semantic_hash": "d8d85f96d409f7bf76ef4696cd8d1e85"
   },
   "tests/pipeline/test_builder_extensions.py": {
-    "mtime": 1773332567.6979535,
+    "mtime": 1783141477.2204242,
     "ast_hash": "39bf91f8aa74ea39f847126d7a3f955b",
     "semantic_hash": "39bf91f8aa74ea39f847126d7a3f955b"
   },
   "tests/pipeline/test_device_memory.py": {
-    "mtime": 1770953435.5857012,
+    "mtime": 1783141477.2204242,
     "ast_hash": "cd49cf621420116d6ebfa809ff9b4da2",
     "semantic_hash": "cd49cf621420116d6ebfa809ff9b4da2"
   },
   "tests/pipeline/test_mastercurve_parallel.py": {
-    "mtime": 1773332567.6979535,
+    "mtime": 1783141477.2204242,
     "ast_hash": "82ed5f7d8bc520c4ed499db029d1470c",
     "semantic_hash": "82ed5f7d8bc520c4ed499db029d1470c"
   },
   "tests/pipeline/test_model_comparison_parallel.py": {
-    "mtime": 1782779014.4922597,
+    "mtime": 1783141477.2204242,
     "ast_hash": "faf73084e4fdf99780f8e9d1fdc840f9",
     "semantic_hash": "faf73084e4fdf99780f8e9d1fdc840f9"
   },
   "tests/pipeline/test_pipeline_base.py": {
-    "mtime": 1773332567.6989536,
+    "mtime": 1783141477.2204242,
     "ast_hash": "589e2381eeb8c8026e406f62afcd9fea",
     "semantic_hash": "589e2381eeb8c8026e406f62afcd9fea"
   },
   "tests/pipeline/test_pipeline_visualization.py": {
-    "mtime": 1773332567.6989536,
+    "mtime": 1783141477.2204242,
     "ast_hash": "f02d11ba36451b9980de1f6a5dec1550",
     "semantic_hash": "f02d11ba36451b9980de1f6a5dec1550"
   },
   "tests/pipeline/test_spp_pipeline_defaults.py": {
-    "mtime": 1764879936.0,
+    "mtime": 1783141477.2204242,
     "ast_hash": "b4df88a55e9c43098b54b786e0e57a5f",
     "semantic_hash": "b4df88a55e9c43098b54b786e0e57a5f"
   },
   "tests/pipeline/test_workflows.py": {
-    "mtime": 1763165698.0,
+    "mtime": 1783141477.2204242,
     "ast_hash": "5e362f8fbf1a774a54f0fecb2ab6d0f2",
     "semantic_hash": "5e362f8fbf1a774a54f0fecb2ab6d0f2"
   },
   "tests/regression/__init__.py": {
-    "mtime": 1773332567.6989536,
+    "mtime": 1783141477.2204242,
     "ast_hash": "d41d8cd98f00b204e9800998ecf8427e",
     "semantic_hash": "d41d8cd98f00b204e9800998ecf8427e"
   },
   "tests/regression/test_round9_prevention.py": {
-    "mtime": 1782840586.0674205,
+    "mtime": 1783141477.2204242,
     "ast_hash": "aabb4dc223a0297feb3e4e85d4f2d733",
     "semantic_hash": "aabb4dc223a0297feb3e4e85d4f2d733"
   },
   "tests/test_fit_result.py": {
-    "mtime": 1782840586.0674205,
+    "mtime": 1783141477.2204242,
     "ast_hash": "6671687ff69374a124a18f94c165e296",
     "semantic_hash": "6671687ff69374a124a18f94c165e296"
   },
   "tests/test_import.py": {
-    "mtime": 1777045619.9553702,
+    "mtime": 1783141477.2204242,
     "ast_hash": "95ba2c669d87e71d7ba0a31aaf1b9327",
     "semantic_hash": "95ba2c669d87e71d7ba0a31aaf1b9327"
   },
   "tests/test_notebook_execution_consistency.py": {
-    "mtime": 1782840586.0674205,
+    "mtime": 1783141477.2204242,
     "ast_hash": "003ef08615de17b1c33c17ffd7cff66b",
     "semantic_hash": "003ef08615de17b1c33c17ffd7cff66b"
   },
   "tests/test_performance_f9.py": {
-    "mtime": 1782779014.4922597,
+    "mtime": 1783141477.2204242,
     "ast_hash": "ee6de8fe5bea67b68ede40eebb3453c8",
     "semantic_hash": "ee6de8fe5bea67b68ede40eebb3453c8"
   },
   "tests/test_project_structure.py": {
-    "mtime": 1782840586.0674205,
+    "mtime": 1783141477.2204242,
     "ast_hash": "c76e0c54185d66069e7741a9d7dbfef0",
     "semantic_hash": "c76e0c54185d66069e7741a9d7dbfef0"
   },
   "tests/transforms/__init__.py": {
-    "mtime": 1762927058.0,
+    "mtime": 1783141477.2204242,
     "ast_hash": "95bec7d6a8ca5f8c714020df0efc2c8e",
     "semantic_hash": "95bec7d6a8ca5f8c714020df0efc2c8e"
   },
   "tests/transforms/test_batch_transform.py": {
-    "mtime": 1773332567.6989536,
+    "mtime": 1783141477.2204242,
     "ast_hash": "c526b851859269705dfe1574645a01a2",
     "semantic_hash": "c526b851859269705dfe1574645a01a2"
   },
   "tests/transforms/test_cox_merz.py": {
-    "mtime": 1773332567.6989536,
+    "mtime": 1783141477.221424,
     "ast_hash": "e0bc32a2a3ffffe5a3ceff23e5155014",
     "semantic_hash": "e0bc32a2a3ffffe5a3ceff23e5155014"
   },
   "tests/transforms/test_fft_analysis.py": {
-    "mtime": 1764744888.0,
+    "mtime": 1783141477.221424,
     "ast_hash": "7136032e9b8ede911a5dce697524462f",
     "semantic_hash": "7136032e9b8ede911a5dce697524462f"
   },
   "tests/transforms/test_lve_envelope.py": {
-    "mtime": 1773332567.6989536,
+    "mtime": 1783141477.221424,
     "ast_hash": "7e4fbde30620bcab6b12d65ed756d9b8",
     "semantic_hash": "7e4fbde30620bcab6b12d65ed756d9b8"
   },
   "tests/transforms/test_mastercurve.py": {
-    "mtime": 1763165676.0,
+    "mtime": 1783141477.221424,
     "ast_hash": "107b166ebcd03fa11abfa3d59c0f1c37",
     "semantic_hash": "107b166ebcd03fa11abfa3d59c0f1c37"
   },
   "tests/transforms/test_mastercurve_autoshift.py": {
-    "mtime": 1763235356.0,
+    "mtime": 1783141477.221424,
     "ast_hash": "95516c5e0f52b4979b45142a9a09bf6a",
     "semantic_hash": "95516c5e0f52b4979b45142a9a09bf6a"
   },
   "tests/transforms/test_mutation_number.py": {
-    "mtime": 1764744842.0,
+    "mtime": 1783141477.221424,
     "ast_hash": "5c00513dabc6f1611abb59f1d4fc4047",
     "semantic_hash": "5c00513dabc6f1611abb59f1d4fc4047"
   },
   "tests/transforms/test_owchirp.py": {
-    "mtime": 1764744902.0,
+    "mtime": 1783141477.221424,
     "ast_hash": "6ca40cd5f9dd817b96d20cc08c6ab962",
     "semantic_hash": "6ca40cd5f9dd817b96d20cc08c6ab962"
   },
   "tests/transforms/test_prony_conversion.py": {
-    "mtime": 1773332567.6989536,
+    "mtime": 1783141477.221424,
     "ast_hash": "1a84031c4499e7be668a591d814bab1a",
     "semantic_hash": "1a84031c4499e7be668a591d814bab1a"
   },
   "tests/transforms/test_smooth_derivative.py": {
-    "mtime": 1762943764.0,
+    "mtime": 1783141477.221424,
     "ast_hash": "bd041d22a2bc6fdcb3e70fa4e098d274",
     "semantic_hash": "bd041d22a2bc6fdcb3e70fa4e098d274"
   },
   "tests/transforms/test_spectrum_inversion.py": {
-    "mtime": 1773332567.6989536,
+    "mtime": 1783141477.221424,
     "ast_hash": "557f1cb97c96d8686bf5d4cd09724794",
     "semantic_hash": "557f1cb97c96d8686bf5d4cd09724794"
   },
   "tests/transforms/test_spp_decomposer.py": {
-    "mtime": 1764783682.0,
+    "mtime": 1783141477.221424,
     "ast_hash": "7b19743666140cb8a48aaf598af775b5",
     "semantic_hash": "7b19743666140cb8a48aaf598af775b5"
   },
   "tests/transforms/test_srfs.py": {
-    "mtime": 1782779014.4922597,
+    "mtime": 1783141477.221424,
     "ast_hash": "43e083120ac1d49bfdb08f68784534e7",
     "semantic_hash": "43e083120ac1d49bfdb08f68784534e7"
   },
   "tests/utils/__init__.py": {
-    "mtime": 1762927058.0,
+    "mtime": 1783141477.221424,
     "ast_hash": "d41d8cd98f00b204e9800998ecf8427e",
     "semantic_hash": "d41d8cd98f00b204e9800998ecf8427e"
   },
   "tests/utils/initialization/test_base_initializer.py": {
-    "mtime": 1762927058.0,
+    "mtime": 1783141477.221424,
     "ast_hash": "636b0149150c399ec81d3e4a25a6f194",
     "semantic_hash": "636b0149150c399ec81d3e4a25a6f194"
   },
   "tests/utils/initialization/test_fractional_initializers.py": {
-    "mtime": 1768708239.092261,
+    "mtime": 1783141477.221424,
     "ast_hash": "04f3cb56431bb611c0b0f9738a96ff83",
     "semantic_hash": "04f3cb56431bb611c0b0f9738a96ff83"
   },
   "tests/utils/test_auto_p0.py": {
-    "mtime": 1777045619.9553702,
+    "mtime": 1783141477.221424,
     "ast_hash": "94037a18498cb9b16a541c595a9446aa",
     "semantic_hash": "94037a18498cb9b16a541c595a9446aa"
   },
   "tests/utils/test_compatibility.py": {
-    "mtime": 1768708239.092261,
+    "mtime": 1783141477.221424,
     "ast_hash": "32e46d66eaaf601db3e4219f12460715",
     "semantic_hash": "32e46d66eaaf601db3e4219f12460715"
   },
   "tests/utils/test_data_quality.py": {
-    "mtime": 1777045619.9553702,
+    "mtime": 1783141477.221424,
     "ast_hash": "146db780eef101b288d7018db705891e",
     "semantic_hash": "146db780eef101b288d7018db705891e"
   },
   "tests/utils/test_device.py": {
-    "mtime": 1777045619.9553702,
+    "mtime": 1783141477.221424,
     "ast_hash": "7c295d651f85885c0a526ce84d4e104c",
     "semantic_hash": "7c295d651f85885c0a526ce84d4e104c"
   },
   "tests/utils/test_epm_kernels.py": {
-    "mtime": 1777873218.8606772,
+    "mtime": 1783141477.221424,
     "ast_hash": "d0d369c25cf317efefdfc51387620055",
     "semantic_hash": "d0d369c25cf317efefdfc51387620055"
   },
   "tests/utils/test_epm_kernels_tensorial.py": {
-    "mtime": 1782779014.4932597,
+    "mtime": 1783141477.2224243,
     "ast_hash": "0360dddcc76513520944d920171ed05c",
     "semantic_hash": "0360dddcc76513520944d920171ed05c"
   },
   "tests/utils/test_gmm_alias_and_decay.py": {
-    "mtime": 1767875586.9085472,
+    "mtime": 1783141477.2224243,
     "ast_hash": "baf501e137716b731799225980d81340",
     "semantic_hash": "baf501e137716b731799225980d81340"
   },
   "tests/utils/test_hl_kernels.py": {
-    "mtime": 1777045619.9563704,
+    "mtime": 1783141477.2224243,
     "ast_hash": "fe023041c27b2e75fe1528e7cb2c5ac3",
     "semantic_hash": "fe023041c27b2e75fe1528e7cb2c5ac3"
   },
   "tests/utils/test_initialization.py": {
-    "mtime": 1777045619.9563704,
+    "mtime": 1783141477.2224243,
     "ast_hash": "d3a0a747342575d29d7a0878c54df5c1",
     "semantic_hash": "d3a0a747342575d29d7a0878c54df5c1"
   },
   "tests/utils/test_initialization_backward_compat.py": {
-    "mtime": 1763092968.0,
+    "mtime": 1783141477.2224243,
     "ast_hash": "f497ee76c00683d6459c584e21c06e81",
     "semantic_hash": "f497ee76c00683d6459c584e21c06e81"
   },
   "tests/utils/test_mct_kernels.py": {
-    "mtime": 1777045619.9563704,
+    "mtime": 1783141477.2224243,
     "ast_hash": "f87d4c282015fcef299c23169645ce72",
     "semantic_hash": "f87d4c282015fcef299c23169645ce72"
   },
   "tests/utils/test_metrics.py": {
-    "mtime": 1777045619.9563704,
+    "mtime": 1783141477.2224243,
     "ast_hash": "e7e311e54d28ea0a278bc144d550a1fb",
     "semantic_hash": "e7e311e54d28ea0a278bc144d550a1fb"
   },
   "tests/utils/test_mittag_leffler.py": {
-    "mtime": 1782779014.4932597,
+    "mtime": 1783141477.2224243,
     "ast_hash": "dd07e4f0061d405dd0ee0bbf732e1af8",
     "semantic_hash": "dd07e4f0061d405dd0ee0bbf732e1af8"
   },
   "tests/utils/test_ml_convergence.py": {
-    "mtime": 1763405390.0,
+    "mtime": 1783141477.2224243,
     "ast_hash": "8743d94fdee0de469fe66e426bfbd718",
     "semantic_hash": "8743d94fdee0de469fe66e426bfbd718"
   },
   "tests/utils/test_model_selection.py": {
-    "mtime": 1773332567.6989536,
+    "mtime": 1783141477.2224243,
     "ast_hash": "d923b02b1781f02937910ab0d137d9fc",
     "semantic_hash": "d923b02b1781f02937910ab0d137d9fc"
   },
   "tests/utils/test_nlsq_optimization.py": {
-    "mtime": 1782779014.4932597,
+    "mtime": 1783141477.2224243,
     "ast_hash": "077bd8e455a92194638525f59dffcc09",
     "semantic_hash": "077bd8e455a92194638525f59dffcc09"
   },
   "tests/utils/test_optimization.py": {
-    "mtime": 1782779014.4932597,
+    "mtime": 1783141477.2224243,
     "ast_hash": "8e4dcdc0e97dc60328d1d05577896cf8",
     "semantic_hash": "8e4dcdc0e97dc60328d1d05577896cf8"
   },
   "tests/utils/test_physics_checks.py": {
-    "mtime": 1773332567.6989536,
+    "mtime": 1783141477.2224243,
     "ast_hash": "e7d4b689c1c6af58cf4dd0143c7d7360",
     "semantic_hash": "e7d4b689c1c6af58cf4dd0143c7d7360"
   },
   "tests/utils/test_placeholder_model_guard.py": {
-    "mtime": 1767875582.207576,
+    "mtime": 1783141477.2224243,
     "ast_hash": "012c9cce88c35e835b51a6c84b425f10",
     "semantic_hash": "012c9cce88c35e835b51a6c84b425f10"
   },
   "tests/utils/test_prony.py": {
-    "mtime": 1782840586.0674205,
+    "mtime": 1783141477.2224243,
     "ast_hash": "87350a83a8020a0ecfe74316b3442d07",
     "semantic_hash": "87350a83a8020a0ecfe74316b3442d07"
   },
   "tests/utils/test_protocol_preprocessing.py": {
-    "mtime": 1777045619.9563704,
+    "mtime": 1783141477.2224243,
     "ast_hash": "ff2eee93ed03163fd7f946bd2657d1d6",
     "semantic_hash": "ff2eee93ed03163fd7f946bd2657d1d6"
   },
   "tests/utils/test_sgr_kernels.py": {
-    "mtime": 1782779014.4932597,
+    "mtime": 1783141477.2224243,
     "ast_hash": "0c2e89bf9ebf25bebfc13c90c9903d49",
     "semantic_hash": "0c2e89bf9ebf25bebfc13c90c9903d49"
   },
   "tests/utils/test_sgr_monte_carlo.py": {
-    "mtime": 1777045619.9563704,
+    "mtime": 1783141477.2224243,
     "ast_hash": "3a77f52a7ff5a4d8f72f13c6580cc53e",
     "semantic_hash": "3a77f52a7ff5a4d8f72f13c6580cc53e"
   },
   "tests/utils/test_sgr_population_balance.py": {
-    "mtime": 1777045619.9563704,
+    "mtime": 1783141477.2224243,
     "ast_hash": "47c4711938ae275dad97a0cb939436e3",
     "semantic_hash": "47c4711938ae275dad97a0cb939436e3"
   },
   "tests/utils/test_spp_kernels.py": {
-    "mtime": 1764879938.0,
+    "mtime": 1783141477.2224243,
     "ast_hash": "c1c278eae5721cd05a4bc976146684e6",
     "semantic_hash": "c1c278eae5721cd05a4bc976146684e6"
   },
   "tests/utils/test_structure_factor.py": {
-    "mtime": 1777045619.9563704,
+    "mtime": 1783141477.2224243,
     "ast_hash": "57001f5057132ff05bad49b336f98128",
     "semantic_hash": "57001f5057132ff05bad49b336f98128"
   },
   "tests/utils/test_uncertainty.py": {
-    "mtime": 1782840586.0674205,
+    "mtime": 1783141477.2224243,
     "ast_hash": "42c1cd58b00f0ceae9b5e99e8707efae",
     "semantic_hash": "42c1cd58b00f0ceae9b5e99e8707efae"
   },
   "tests/utils/test_volterra_creep.py": {
-    "mtime": 1780618617.2433205,
+    "mtime": 1783141477.2234242,
     "ast_hash": "e49ccbc27841b2da85d6a329dbf13233",
     "semantic_hash": "e49ccbc27841b2da85d6a329dbf13233"
   },
   "tests/validation/test_bayesian_ansys_apdl.py": {
-    "mtime": 1782779014.4932597,
+    "mtime": 1783141477.2234242,
     "ast_hash": "96a8e768dda12e1d6b871e933a1fe0da",
     "semantic_hash": "96a8e768dda12e1d6b871e933a1fe0da"
   },
   "tests/validation/test_bayesian_mode_aware.py": {
-    "mtime": 1782779014.4932597,
+    "mtime": 1783141477.2234242,
     "ast_hash": "fb5ddc66adfcf5eb579b457e3542f819",
     "semantic_hash": "fb5ddc66adfcf5eb579b457e3542f819"
   },
   "tests/validation/test_epm_nlsq_nuts_pipeline.py": {
-    "mtime": 1770953435.5867012,
+    "mtime": 1783141477.2234242,
     "ast_hash": "f9ab4064d02709661ed3e9e6491881d6",
     "semantic_hash": "f9ab4064d02709661ed3e9e6491881d6"
   },
   "tests/validation/test_fluidity_nlsq_nuts_pipeline.py": {
-    "mtime": 1782779014.4932597,
+    "mtime": 1783141477.2234242,
     "ast_hash": "8c233b06ec6ae5595c9b4664b7631cfe",
     "semantic_hash": "8c233b06ec6ae5595c9b4664b7631cfe"
   },
   "tests/validation/test_migrated_notebooks.py": {
-    "mtime": 1782779014.4942598,
+    "mtime": 1783141477.2234242,
     "ast_hash": "ff2008ef3085dfe6237453e541234682",
     "semantic_hash": "ff2008ef3085dfe6237453e541234682"
   },
   "tests/validation/test_protocol_validation.py": {
-    "mtime": 1782779014.4942598,
+    "mtime": 1783141477.2234242,
     "ast_hash": "252b297454509e9e502259901696256f",
     "semantic_hash": "252b297454509e9e502259901696256f"
   },
   "tests/validation/test_tensorial_epm_validation.py": {
-    "mtime": 1782779014.4942598,
+    "mtime": 1783141477.2234242,
     "ast_hash": "46c7bdccc1868f2ebdeb4798469d3663",
     "semantic_hash": "46c7bdccc1868f2ebdeb4798469d3663"
   },
   "tests/visualization/__init__.py": {
-    "mtime": 1762927058.0,
+    "mtime": 1783141477.2234242,
     "ast_hash": "aa06c670e647d99e9c78fc00842874f5",
     "semantic_hash": "aa06c670e647d99e9c78fc00842874f5"
   },
   "tests/visualization/test_epm_plots_tensorial.py": {
-    "mtime": 1773332567.6999536,
+    "mtime": 1783141477.2234242,
     "ast_hash": "197b731d8942c6baedfbe1c396e294e4",
     "semantic_hash": "197b731d8942c6baedfbe1c396e294e4"
   },
   "tests/visualization/test_fit_plotter.py": {
-    "mtime": 1782840586.0674205,
+    "mtime": 1783141477.2234242,
     "ast_hash": "d5e22b89a92f38a1122a88a32db10f9b",
     "semantic_hash": "d5e22b89a92f38a1122a88a32db10f9b"
   },
   "tests/visualization/test_plotter.py": {
-    "mtime": 1782840586.0674205,
+    "mtime": 1783141477.2244241,
     "ast_hash": "6331ef0f63da5341dbdda3b41ae079e7",
     "semantic_hash": "6331ef0f63da5341dbdda3b41ae079e7"
   },
   "tests/visualization/test_spp_plots.py": {
-    "mtime": 1773332567.6999536,
+    "mtime": 1783141477.2244241,
     "ast_hash": "10820266679f72abc474979fa25fbc65",
     "semantic_hash": "10820266679f72abc474979fa25fbc65"
   },
   "tests/visualization/test_templates.py": {
-    "mtime": 1773332567.6999536,
+    "mtime": 1783141477.2244241,
     "ast_hash": "d0e204a0c636d16b1e82cc60fc1a0ae5",
     "semantic_hash": "d0e204a0c636d16b1e82cc60fc1a0ae5"
   },
   "tests/visualization/test_transform_plotter.py": {
-    "mtime": 1782779014.4942598,
+    "mtime": 1783141477.2244241,
     "ast_hash": "4fc2f46d628f76a6bb542732846b3459",
     "semantic_hash": "4fc2f46d628f76a6bb542732846b3459"
   },
   "docs/README.md": {
-    "mtime": 1771523131.54502,
+    "mtime": 1783141475.647429,
     "ast_hash": "669b288369ff9bf2e6c814f7b6b3d419",
     "semantic_hash": "669b288369ff9bf2e6c814f7b6b3d419"
   },
   "docs/STRUCTURE.md": {
-    "mtime": 1783024099.7041078,
+    "mtime": 1783141475.647429,
     "ast_hash": "cdf37bc4afa511a6a3cb09ef7c201d71",
     "semantic_hash": ""
   },
   "docs/architecture-overview.md": {
-    "mtime": 1783024099.705108,
+    "mtime": 1783141475.647429,
     "ast_hash": "0b50c98e1dfe269f01a94f5b16a70aae",
     "semantic_hash": ""
   },
   "docs/architecture-review-2026-04-06.md": {
-    "mtime": 1782840585.9934196,
+    "mtime": 1783141475.647429,
     "ast_hash": "69a47fe984777bc2221d9d6a1caeed09",
     "semantic_hash": "69a47fe984777bc2221d9d6a1caeed09"
   },
   "docs/examples/README.md": {
-    "mtime": 1771374330.2118251,
+    "mtime": 1783141475.647429,
     "ast_hash": "3153b2e14fa00a94ac0a8698b00c01b9",
     "semantic_hash": "3153b2e14fa00a94ac0a8698b00c01b9"
   },
   "docs/internal/spp_parity_reference.md": {
-    "mtime": 1764801300.0,
+    "mtime": 1783141475.647429,
     "ast_hash": "3138c395d0303901a49f3083aea01812",
     "semantic_hash": "3138c395d0303901a49f3083aea01812"
   },
   "docs/internal/spp_parity_status.md": {
-    "mtime": 1764798624.0,
+    "mtime": 1783141475.647429,
     "ast_hash": "9eb34d4e8fd3c3aa1b7b5eda94e28408",
     "semantic_hash": "9eb34d4e8fd3c3aa1b7b5eda94e28408"
   },
   "docs/model-test-mode-compatibility.md": {
-    "mtime": 1770953435.4057007,
+    "mtime": 1783141475.6484292,
     "ast_hash": "d77ac1c7095714e5653b3cafc9d39137",
     "semantic_hash": "d77ac1c7095714e5653b3cafc9d39137"
   },
   "docs/source/_guides/model_documentation_style.rst": {
-    "mtime": 1771374330.2118251,
+    "mtime": 1783141475.6484292,
     "ast_hash": "eb82cd3889389ff38cab6ffcb725c9c8",
     "semantic_hash": "eb82cd3889389ff38cab6ffcb725c9c8"
   },
   "docs/source/_includes/bayesian_workflow.rst": {
-    "mtime": 1770953435.491701,
+    "mtime": 1783141475.6484292,
     "ast_hash": "03f6d52d2691e4db7d54237c45fa5554",
     "semantic_hash": "03f6d52d2691e4db7d54237c45fa5554"
   },
   "docs/source/_includes/fractional_seealso.rst": {
-    "mtime": 1771374330.2118251,
+    "mtime": 1783141475.6484292,
     "ast_hash": "ceadc70c2dffbe307c10df600d09ac87",
     "semantic_hash": "ceadc70c2dffbe307c10df600d09ac87"
   },
   "docs/source/_includes/glass_transition_physics.rst": {
-    "mtime": 1771374330.212825,
+    "mtime": 1783141475.6484292,
     "ast_hash": "fb9d3202eeaff74d98b0311bcfdc771d",
     "semantic_hash": "fb9d3202eeaff74d98b0311bcfdc771d"
   },
   "docs/source/_includes/thixotropy_foundations.rst": {
-    "mtime": 1771374330.212825,
+    "mtime": 1783141475.6484292,
     "ast_hash": "8ac3eec0246f24cc0aeec69c82378e10",
     "semantic_hash": "8ac3eec0246f24cc0aeec69c82378e10"
   },
   "docs/source/_includes/transient_network_foundations.rst": {
-    "mtime": 1771374330.212825,
+    "mtime": 1783141475.6484292,
     "ast_hash": "cb178fc969a37229c522709f3458b70c",
     "semantic_hash": "cb178fc969a37229c522709f3458b70c"
   },
   "docs/source/_templates/model_handbook_template.rst": {
-    "mtime": 1770953435.491701,
+    "mtime": 1783141475.649429,
     "ast_hash": "682b36eb28ddedea9dfa8f5b71ff9773",
     "semantic_hash": "682b36eb28ddedea9dfa8f5b71ff9773"
   },
   "docs/source/api/core.rst": {
-    "mtime": 1782840585.9934196,
+    "mtime": 1783141475.649429,
     "ast_hash": "0d0fa5fe40aafd04bc6f037a70e20bbd",
     "semantic_hash": "0d0fa5fe40aafd04bc6f037a70e20bbd"
   },
   "docs/source/api/io.rst": {
-    "mtime": 1768708239.069259,
+    "mtime": 1783141475.649429,
     "ast_hash": "f58b6c20239f3837b04bedfabaac05cc",
     "semantic_hash": "f58b6c20239f3837b04bedfabaac05cc"
   },
   "docs/source/api/logging.rst": {
-    "mtime": 1782481338.7321723,
+    "mtime": 1783141475.649429,
     "ast_hash": "9cee2768fc3571127965125f2e38e687",
     "semantic_hash": "9cee2768fc3571127965125f2e38e687"
   },
   "docs/source/api/models.rst": {
-    "mtime": 1771374330.212825,
+    "mtime": 1783141475.650429,
     "ast_hash": "619d0cd1dc712bfb72c6f368e9b33f96",
     "semantic_hash": "619d0cd1dc712bfb72c6f368e9b33f96"
   },
   "docs/source/api/pipeline.rst": {
-    "mtime": 1763000978.0,
+    "mtime": 1783141475.650429,
     "ast_hash": "dc44219938f14d1357587ce17664f8ff",
     "semantic_hash": "dc44219938f14d1357587ce17664f8ff"
   },
   "docs/source/api/spp_models.rst": {
-    "mtime": 1771374330.212825,
+    "mtime": 1783141475.650429,
     "ast_hash": "de82c204ce0eee754d4d25507a6bbe0d",
     "semantic_hash": "de82c204ce0eee754d4d25507a6bbe0d"
   },
   "docs/source/api/transforms.rst": {
-    "mtime": 1771374330.212825,
+    "mtime": 1783141475.650429,
     "ast_hash": "fd63c8e990f0cd11eb1d417d8b08463b",
     "semantic_hash": "fd63c8e990f0cd11eb1d417d8b08463b"
   },
   "docs/source/api/utils.rst": {
-    "mtime": 1782840585.9944196,
+    "mtime": 1783141475.651429,
     "ast_hash": "5b21c3d1870098612b5e4d46396559d3",
     "semantic_hash": "5b21c3d1870098612b5e4d46396559d3"
   },
   "docs/source/api/visualization.rst": {
-    "mtime": 1771374330.212825,
+    "mtime": 1783141475.651429,
     "ast_hash": "9f6bfdc43f8c3547903d6d197dd777a2",
     "semantic_hash": "9f6bfdc43f8c3547903d6d197dd777a2"
   },
   "docs/source/api_reference.rst": {
-    "mtime": 1782840585.9944196,
+    "mtime": 1783141475.651429,
     "ast_hash": "8bbd565e7ed32225b80a66b04c74daf4",
     "semantic_hash": "8bbd565e7ed32225b80a66b04c74daf4"
   },
   "docs/source/architecture/fitting_transforms_prompt.md": {
-    "mtime": 1782840585.9944196,
+    "mtime": 1783141475.651429,
     "ast_hash": "efa9d3fd715e6718ee1dacba67500f49",
     "semantic_hash": "efa9d3fd715e6718ee1dacba67500f49"
   },
   "docs/source/architecture/io_architecture.rst": {
-    "mtime": 1782840585.9944196,
+    "mtime": 1783141475.652429,
     "ast_hash": "f2877f07b2ab69832f1c9ba6804bd262",
     "semantic_hash": "f2877f07b2ab69832f1c9ba6804bd262"
   },
   "docs/source/developer/architecture.rst": {
-    "mtime": 1783024099.7061079,
+    "mtime": 1783141475.652429,
     "ast_hash": "cfd7e6c1f94ebc1f64a1b7ea8fa413c0",
     "semantic_hash": ""
   },
   "docs/source/developer/contributing.rst": {
-    "mtime": 1777045619.6583703,
+    "mtime": 1783141475.652429,
     "ast_hash": "d75ab47ae2285961f1ff1190722184a5",
     "semantic_hash": "d75ab47ae2285961f1ff1190722184a5"
   },
   "docs/source/development_status.rst": {
-    "mtime": 1782840585.9944196,
+    "mtime": 1783141475.652429,
     "ast_hash": "577019bd08b6020fd41c66b0f2bba1fc",
     "semantic_hash": "577019bd08b6020fd41c66b0f2bba1fc"
   },
   "docs/source/examples/index.rst": {
-    "mtime": 1782840585.9944196,
+    "mtime": 1783141475.653429,
     "ast_hash": "717def7605440ccae20968ad5e23c9c3",
     "semantic_hash": "717def7605440ccae20968ad5e23c9c3"
   },
   "docs/source/index.rst": {
-    "mtime": 1782840585.9954197,
+    "mtime": 1783141475.653429,
     "ast_hash": "8f4dd2abd5bead91f483eb28053e042d",
     "semantic_hash": "8f4dd2abd5bead91f483eb28053e042d"
   },
   "docs/source/installation.rst": {
-    "mtime": 1777045619.6593702,
+    "mtime": 1783141475.653429,
     "ast_hash": "bc5a87ac391fb98d13d436c965b356d6",
     "semantic_hash": "bc5a87ac391fb98d13d436c965b356d6"
   },
   "docs/source/models/classical/index.rst": {
-    "mtime": 1771374330.2138252,
+    "mtime": 1783141475.653429,
     "ast_hash": "1c85d586ec3f0247132b9cc5fe1fe03c",
     "semantic_hash": "1c85d586ec3f0247132b9cc5fe1fe03c"
   },
   "docs/source/models/classical/maxwell.rst": {
-    "mtime": 1771374330.2138252,
+    "mtime": 1783141475.653429,
     "ast_hash": "ed4c1105fef982bbc44f8c1c2566690e",
     "semantic_hash": "ed4c1105fef982bbc44f8c1c2566690e"
   },
   "docs/source/models/classical/springpot.rst": {
-    "mtime": 1771374330.2148252,
+    "mtime": 1783141475.653429,
     "ast_hash": "05f209f66f97467b63df207ca94177fe",
     "semantic_hash": "05f209f66f97467b63df207ca94177fe"
   },
   "docs/source/models/classical/zener.rst": {
-    "mtime": 1777045619.6593702,
+    "mtime": 1783141475.654429,
     "ast_hash": "333d9a6bdcc2782bf822dfc4b593df44",
     "semantic_hash": "333d9a6bdcc2782bf822dfc4b593df44"
   },
   "docs/source/models/dmt/dmt.rst": {
-    "mtime": 1777045619.6593702,
+    "mtime": 1783141475.654429,
     "ast_hash": "104fdfc50512651ce9b9cd6bdbd1e16c",
     "semantic_hash": "104fdfc50512651ce9b9cd6bdbd1e16c"
   },
   "docs/source/models/dmt/index.rst": {
-    "mtime": 1771523131.54502,
+    "mtime": 1783141475.654429,
     "ast_hash": "e217268bc086ab02cc932f745c3612b8",
     "semantic_hash": "e217268bc086ab02cc932f745c3612b8"
   },
   "docs/source/models/epm/index.rst": {
-    "mtime": 1771374330.215825,
+    "mtime": 1783141475.654429,
     "ast_hash": "84915bf9466ffd18bf7780737e291262",
     "semantic_hash": "84915bf9466ffd18bf7780737e291262"
   },
   "docs/source/models/epm/lattice_epm.rst": {
-    "mtime": 1777045619.66037,
+    "mtime": 1783141475.6554291,
     "ast_hash": "346f1c6bcbbf86fe70fd03fd9da9fbb9",
     "semantic_hash": "346f1c6bcbbf86fe70fd03fd9da9fbb9"
   },
   "docs/source/models/epm/tensorial_epm.rst": {
-    "mtime": 1777045619.66037,
+    "mtime": 1783141475.6554291,
     "ast_hash": "c5671aa2d73ee09f1916aa825b41b122",
     "semantic_hash": "c5671aa2d73ee09f1916aa825b41b122"
   },
   "docs/source/models/fikh/fikh.rst": {
-    "mtime": 1777045619.66037,
+    "mtime": 1783141475.6554291,
     "ast_hash": "1bac3cd0540e73859580a5f5cabd9829",
     "semantic_hash": "1bac3cd0540e73859580a5f5cabd9829"
   },
   "docs/source/models/fikh/fmlikh.rst": {
-    "mtime": 1777045619.66037,
+    "mtime": 1783141475.6554291,
     "ast_hash": "fa1f0bc7dc66cb2d5fd0ade60444edb1",
     "semantic_hash": "fa1f0bc7dc66cb2d5fd0ade60444edb1"
   },
   "docs/source/models/fikh/index.rst": {
-    "mtime": 1771374330.2168252,
+    "mtime": 1783141475.6554291,
     "ast_hash": "3fc5d75858bf8da946c72f8740a96913",
     "semantic_hash": "3fc5d75858bf8da946c72f8740a96913"
   },
   "docs/source/models/flow/bingham.rst": {
-    "mtime": 1770953435.494701,
+    "mtime": 1783141475.656429,
     "ast_hash": "b14bb3e01df2c81d5b76b4f947cd54f9",
     "semantic_hash": "b14bb3e01df2c81d5b76b4f947cd54f9"
   },
   "docs/source/models/flow/carreau.rst": {
-    "mtime": 1771374330.2168252,
+    "mtime": 1783141475.656429,
     "ast_hash": "b97976b9982a47a81c23039ad1779ae6",
     "semantic_hash": "b97976b9982a47a81c23039ad1779ae6"
   },
   "docs/source/models/flow/carreau_yasuda.rst": {
-    "mtime": 1770953435.494701,
+    "mtime": 1783141475.656429,
     "ast_hash": "626620fdd62371617558943ac926bcd1",
     "semantic_hash": "626620fdd62371617558943ac926bcd1"
   },
   "docs/source/models/flow/cross.rst": {
-    "mtime": 1771374330.2168252,
+    "mtime": 1783141475.656429,
     "ast_hash": "f0d88d0937765135db8d7697b1ce506c",
     "semantic_hash": "f0d88d0937765135db8d7697b1ce506c"
   },
   "docs/source/models/flow/herschel_bulkley.rst": {
-    "mtime": 1770953435.494701,
+    "mtime": 1783141475.656429,
     "ast_hash": "8e17deb3a959bd774583df2d1bac6afc",
     "semantic_hash": "8e17deb3a959bd774583df2d1bac6afc"
   },
   "docs/source/models/flow/index.rst": {
-    "mtime": 1770953435.494701,
+    "mtime": 1783141475.656429,
     "ast_hash": "4ff2ac7e188c89346ff4639109e207e6",
     "semantic_hash": "4ff2ac7e188c89346ff4639109e207e6"
   },
   "docs/source/models/flow/power_law.rst": {
-    "mtime": 1770953435.4957008,
+    "mtime": 1783141475.656429,
     "ast_hash": "04aa7b0388d48a1b399e94dd0b2022f9",
     "semantic_hash": "04aa7b0388d48a1b399e94dd0b2022f9"
   },
   "docs/source/models/fluidity/fluidity_local.rst": {
-    "mtime": 1771374330.2168252,
+    "mtime": 1783141475.657429,
     "ast_hash": "f2839b949c92052c90a60438e9c9d088",
     "semantic_hash": "f2839b949c92052c90a60438e9c9d088"
   },
   "docs/source/models/fluidity/fluidity_nonlocal.rst": {
-    "mtime": 1771374330.2178252,
+    "mtime": 1783141475.657429,
     "ast_hash": "b1cc11a9864057cadf8d57665ae38d4b",
     "semantic_hash": "b1cc11a9864057cadf8d57665ae38d4b"
   },
   "docs/source/models/fluidity/identifiability.rst": {
-    "mtime": 1777045619.66037,
+    "mtime": 1783141475.657429,
     "ast_hash": "bdc29e06b9ed75fbf61f869b81d56372",
     "semantic_hash": "bdc29e06b9ed75fbf61f869b81d56372"
   },
   "docs/source/models/fluidity/index.rst": {
-    "mtime": 1777045619.6613703,
+    "mtime": 1783141475.657429,
     "ast_hash": "b59d15559dc955e464300c046a9a53a5",
     "semantic_hash": "b59d15559dc955e464300c046a9a53a5"
   },
   "docs/source/models/fluidity/saramito_evp.rst": {
-    "mtime": 1777045619.6613703,
+    "mtime": 1783141475.657429,
     "ast_hash": "0275bb972883576112f888ca5e55ccdd",
     "semantic_hash": "0275bb972883576112f888ca5e55ccdd"
   },
   "docs/source/models/fractional/fractional_burgers.rst": {
-    "mtime": 1771374330.2178252,
+    "mtime": 1783141475.657429,
     "ast_hash": "2dd9e5c7738476cf5881bdfbb3793d33",
     "semantic_hash": "2dd9e5c7738476cf5881bdfbb3793d33"
   },
   "docs/source/models/fractional/fractional_jeffreys.rst": {
-    "mtime": 1771523131.54502,
+    "mtime": 1783141475.6584291,
     "ast_hash": "b5b73c45bcb814b92b67075bb0c1351a",
     "semantic_hash": "b5b73c45bcb814b92b67075bb0c1351a"
   },
   "docs/source/models/fractional/fractional_kelvin_voigt.rst": {
-    "mtime": 1771523131.54502,
+    "mtime": 1783141475.6584291,
     "ast_hash": "ae169d4741f7f553a4a8861df9c7acfc",
     "semantic_hash": "ae169d4741f7f553a4a8861df9c7acfc"
   },
   "docs/source/models/fractional/fractional_kv_zener.rst": {
-    "mtime": 1771523131.54502,
+    "mtime": 1783141475.6584291,
     "ast_hash": "68b225c99238a7153a9ee0537a1e0b55",
     "semantic_hash": "68b225c99238a7153a9ee0537a1e0b55"
   },
   "docs/source/models/fractional/fractional_maxwell_gel.rst": {
-    "mtime": 1771374330.2178252,
+    "mtime": 1783141475.6584291,
     "ast_hash": "342e2f38f515ad360feb1a1b2e35d2f6",
     "semantic_hash": "342e2f38f515ad360feb1a1b2e35d2f6"
   },
   "docs/source/models/fractional/fractional_maxwell_liquid.rst": {
-    "mtime": 1771374330.218825,
+    "mtime": 1783141475.6584291,
     "ast_hash": "2927b79dea402cfc79124b21d0722970",
     "semantic_hash": "2927b79dea402cfc79124b21d0722970"
   },
   "docs/source/models/fractional/fractional_maxwell_model.rst": {
-    "mtime": 1771374330.218825,
+    "mtime": 1783141475.6584291,
     "ast_hash": "58443a5cf3380a9c12e9a927583b4cc1",
     "semantic_hash": "58443a5cf3380a9c12e9a927583b4cc1"
   },
   "docs/source/models/fractional/fractional_poynting_thomson.rst": {
-    "mtime": 1771523131.54502,
+    "mtime": 1783141475.6584291,
     "ast_hash": "8da29054f14d17c44a45d6c71248e4cb",
     "semantic_hash": "8da29054f14d17c44a45d6c71248e4cb"
   },
   "docs/source/models/fractional/fractional_zener_ll.rst": {
-    "mtime": 1771523131.54602,
+    "mtime": 1783141475.6584291,
     "ast_hash": "96d86a64e1be32b46047313e7d94939b",
     "semantic_hash": "96d86a64e1be32b46047313e7d94939b"
   },
   "docs/source/models/fractional/fractional_zener_sl.rst": {
-    "mtime": 1771523131.54602,
+    "mtime": 1783141475.659429,
     "ast_hash": "9d18a43bf62ee4755e0c4cac817a8045",
     "semantic_hash": "9d18a43bf62ee4755e0c4cac817a8045"
   },
   "docs/source/models/fractional/fractional_zener_ss.rst": {
-    "mtime": 1771374330.218825,
+    "mtime": 1783141475.659429,
     "ast_hash": "4b074c11cdacaa5acfa35757fc68c3e7",
     "semantic_hash": "4b074c11cdacaa5acfa35757fc68c3e7"
   },
   "docs/source/models/fractional/index.rst": {
-    "mtime": 1771374330.218825,
+    "mtime": 1783141475.659429,
     "ast_hash": "19cb8c1fdd88975f83fdb6463ba179f9",
     "semantic_hash": "19cb8c1fdd88975f83fdb6463ba179f9"
   },
   "docs/source/models/giesekus/giesekus.rst": {
-    "mtime": 1771374330.2198253,
+    "mtime": 1783141475.659429,
     "ast_hash": "6ca5d45ed901d252c753b9504b652366",
     "semantic_hash": "6ca5d45ed901d252c753b9504b652366"
   },
   "docs/source/models/giesekus/index.rst": {
-    "mtime": 1771374330.2198253,
+    "mtime": 1783141475.659429,
     "ast_hash": "1f6b6a2528cce36fd3da325fbbffbe8e",
     "semantic_hash": "1f6b6a2528cce36fd3da325fbbffbe8e"
   },
   "docs/source/models/hl/hebraud_lequeux.rst": {
-    "mtime": 1771374330.2198253,
+    "mtime": 1783141475.659429,
     "ast_hash": "7a49b78cafbf560aa98db7e2bf3ea94f",
     "semantic_hash": "7a49b78cafbf560aa98db7e2bf3ea94f"
   },
   "docs/source/models/hl/index.rst": {
-    "mtime": 1771374330.2198253,
+    "mtime": 1783141475.659429,
     "ast_hash": "d6966138b6af1504514bcb4cf1e8db4b",
     "semantic_hash": "d6966138b6af1504514bcb4cf1e8db4b"
   },
   "docs/source/models/hvm/hvm.rst": {
-    "mtime": 1770953435.497701,
+    "mtime": 1783141475.659429,
     "ast_hash": "e8ea82033d6cf673afcd121f6f760ff4",
     "semantic_hash": "e8ea82033d6cf673afcd121f6f760ff4"
   },
   "docs/source/models/hvm/hvm_advanced.rst": {
-    "mtime": 1773332566.9259565,
+    "mtime": 1783141475.659429,
     "ast_hash": "d9b1896828f949ce8e2b5c2ab707a3ce",
     "semantic_hash": "d9b1896828f949ce8e2b5c2ab707a3ce"
   },
   "docs/source/models/hvm/hvm_knowledge.rst": {
-    "mtime": 1770953435.497701,
+    "mtime": 1783141475.660429,
     "ast_hash": "4d62b501d665369d02efa71865fd8561",
     "semantic_hash": "4d62b501d665369d02efa71865fd8561"
   },
   "docs/source/models/hvm/hvm_protocols.rst": {
-    "mtime": 1777045619.6613703,
+    "mtime": 1783141475.660429,
     "ast_hash": "a64c7ab5906dbdc80a1f371895a199f7",
     "semantic_hash": "a64c7ab5906dbdc80a1f371895a199f7"
   },
   "docs/source/models/hvm/index.rst": {
-    "mtime": 1771374330.2198253,
+    "mtime": 1783141475.660429,
     "ast_hash": "4ff596880fd885b529b9a983a9e7e106",
     "semantic_hash": "4ff596880fd885b529b9a983a9e7e106"
   },
   "docs/source/models/hvnm/hvnm.rst": {
-    "mtime": 1777045619.6613703,
+    "mtime": 1783141475.660429,
     "ast_hash": "3c3a9619acb435559f95ac07bf55e870",
     "semantic_hash": "3c3a9619acb435559f95ac07bf55e870"
   },
   "docs/source/models/hvnm/hvnm_advanced.rst": {
-    "mtime": 1773332566.9259565,
+    "mtime": 1783141475.660429,
     "ast_hash": "fe08fbdc7ef08aa813699aa1457578dd",
     "semantic_hash": "fe08fbdc7ef08aa813699aa1457578dd"
   },
   "docs/source/models/hvnm/hvnm_knowledge.rst": {
-    "mtime": 1771374330.2198253,
+    "mtime": 1783141475.660429,
     "ast_hash": "37a97cf5b7ed88f786d9847460f3188f",
     "semantic_hash": "37a97cf5b7ed88f786d9847460f3188f"
   },
   "docs/source/models/hvnm/hvnm_protocols.rst": {
-    "mtime": 1777045619.6613703,
+    "mtime": 1783141475.660429,
     "ast_hash": "57e0800a624c63133112788ec3185b51",
     "semantic_hash": "57e0800a624c63133112788ec3185b51"
   },
   "docs/source/models/hvnm/index.rst": {
-    "mtime": 1773332566.9259565,
+    "mtime": 1783141475.660429,
     "ast_hash": "70aba7c0b175d03156f2a860eb4987d4",
     "semantic_hash": "70aba7c0b175d03156f2a860eb4987d4"
   },
   "docs/source/models/ikh/index.rst": {
-    "mtime": 1773332566.9259565,
+    "mtime": 1783141475.660429,
     "ast_hash": "d1d45fcac0a5791345b856163754febc",
     "semantic_hash": "d1d45fcac0a5791345b856163754febc"
   },
   "docs/source/models/ikh/mikh.rst": {
-    "mtime": 1777045619.6613703,
-    "ast_hash": "bcecb3ae70ae97b49f9a5d2200cbd151",
-    "semantic_hash": "bcecb3ae70ae97b49f9a5d2200cbd151"
+    "mtime": 1783141475.660429,
+    "ast_hash": "a7ef07cada34dd0d8c9387e59ab57686",
+    "semantic_hash": ""
   },
   "docs/source/models/ikh/ml_ikh.rst": {
-    "mtime": 1777045619.6613703,
-    "ast_hash": "19d33a23fca1776c5100f2003c7e64ce",
-    "semantic_hash": "19d33a23fca1776c5100f2003c7e64ce"
+    "mtime": 1783141475.661429,
+    "ast_hash": "b6761077390c18d7cac3e0f792e130f1",
+    "semantic_hash": ""
   },
   "docs/source/models/index.rst": {
-    "mtime": 1782840585.9954197,
+    "mtime": 1783141475.661429,
     "ast_hash": "7e4e7ac13ed7e918757d198f69651514",
     "semantic_hash": "7e4e7ac13ed7e918757d198f69651514"
   },
   "docs/source/models/itt_mct/index.rst": {
-    "mtime": 1771374330.2208252,
+    "mtime": 1783141475.661429,
     "ast_hash": "3b632a6fffaa8d63da0435ffd0ee77be",
     "semantic_hash": "3b632a6fffaa8d63da0435ffd0ee77be"
   },
   "docs/source/models/itt_mct/itt_mct_isotropic.rst": {
-    "mtime": 1771523131.54602,
+    "mtime": 1783141475.661429,
     "ast_hash": "8cc84a218f691c972364fb7490a394d1",
     "semantic_hash": "8cc84a218f691c972364fb7490a394d1"
   },
   "docs/source/models/itt_mct/itt_mct_protocols.rst": {
-    "mtime": 1771374330.2218251,
+    "mtime": 1783141475.661429,
     "ast_hash": "59439b079498c6bb8058b6ee7ac25d64",
     "semantic_hash": "59439b079498c6bb8058b6ee7ac25d64"
   },
   "docs/source/models/itt_mct/itt_mct_schematic.rst": {
-    "mtime": 1777045619.6623702,
+    "mtime": 1783141475.661429,
     "ast_hash": "e938c4b2fe29798ab4798122d11f25b4",
     "semantic_hash": "e938c4b2fe29798ab4798122d11f25b4"
   },
   "docs/source/models/multi_mode/generalized_maxwell.rst": {
-    "mtime": 1782840585.9954197,
+    "mtime": 1783141475.661429,
     "ast_hash": "62d5faa8c7b57a80d6c37f826c20f2f2",
     "semantic_hash": "62d5faa8c7b57a80d6c37f826c20f2f2"
   },
   "docs/source/models/sgr/index.rst": {
-    "mtime": 1777045619.6623702,
+    "mtime": 1783141475.661429,
     "ast_hash": "4c157e0bcc591f6c52bf72c8bf6ea116",
     "semantic_hash": "4c157e0bcc591f6c52bf72c8bf6ea116"
   },
   "docs/source/models/sgr/sgr_conventional.rst": {
-    "mtime": 1777045619.6623702,
+    "mtime": 1783141475.662429,
     "ast_hash": "a74e6bcb215ad648754b02ab6b8707bc",
     "semantic_hash": "a74e6bcb215ad648754b02ab6b8707bc"
   },
   "docs/source/models/sgr/sgr_generic.rst": {
-    "mtime": 1777045619.6623702,
+    "mtime": 1783141475.662429,
     "ast_hash": "24f1d1e7b730ca234abffa4903923941",
     "semantic_hash": "24f1d1e7b730ca234abffa4903923941"
   },
   "docs/source/models/spp/index.rst": {
-    "mtime": 1777045619.6623702,
+    "mtime": 1783141475.662429,
     "ast_hash": "096fe25a1a3efc514ae7759f146610be",
     "semantic_hash": "096fe25a1a3efc514ae7759f146610be"
   },
   "docs/source/models/spp/spp_decomposer.rst": {
-    "mtime": 1773332566.9279566,
+    "mtime": 1783141475.662429,
     "ast_hash": "c4148e6a41ea4fa80510bd0181d6cfa4",
     "semantic_hash": "c4148e6a41ea4fa80510bd0181d6cfa4"
   },
   "docs/source/models/spp/spp_yield_stress.rst": {
-    "mtime": 1773332566.9279566,
+    "mtime": 1783141475.662429,
     "ast_hash": "d01bf353a0a9e672f50122eeee998f49",
     "semantic_hash": "d01bf353a0a9e672f50122eeee998f49"
   },
   "docs/source/models/stz/index.rst": {
-    "mtime": 1773332566.9289565,
+    "mtime": 1783141475.663429,
     "ast_hash": "de2fe0afe4b08a02e388bf573924163a",
     "semantic_hash": "de2fe0afe4b08a02e388bf573924163a"
   },
   "docs/source/models/stz/stz_conventional.rst": {
-    "mtime": 1777045619.6633701,
+    "mtime": 1783141475.663429,
     "ast_hash": "3bd1054dc6073497582c88bade7d3021",
     "semantic_hash": "3bd1054dc6073497582c88bade7d3021"
   },
   "docs/source/models/summary.rst": {
-    "mtime": 1782840585.9954197,
+    "mtime": 1783141475.663429,
     "ast_hash": "45d2a6743a250d4ab974a7fcce49b204",
     "semantic_hash": "45d2a6743a250d4ab974a7fcce49b204"
   },
   "docs/source/models/tnt/index.rst": {
-    "mtime": 1773332566.9289565,
+    "mtime": 1783141475.663429,
     "ast_hash": "5faf8f88715f2d6fe459a157624c44d2",
     "semantic_hash": "5faf8f88715f2d6fe459a157624c44d2"
   },
   "docs/source/models/tnt/tnt_bell.rst": {
-    "mtime": 1771374330.2238252,
+    "mtime": 1783141475.663429,
     "ast_hash": "54fe64c5533516d5a298c60b5034f985",
     "semantic_hash": "54fe64c5533516d5a298c60b5034f985"
   },
   "docs/source/models/tnt/tnt_cates.rst": {
-    "mtime": 1771374330.2238252,
+    "mtime": 1783141475.663429,
     "ast_hash": "343b8d163cd331f9684e495217d21f1b",
     "semantic_hash": "343b8d163cd331f9684e495217d21f1b"
   },
   "docs/source/models/tnt/tnt_fene_p.rst": {
-    "mtime": 1771374330.2248251,
+    "mtime": 1783141475.664429,
     "ast_hash": "b68f25f48b0a4619916d5babdd278043",
     "semantic_hash": "b68f25f48b0a4619916d5babdd278043"
   },
   "docs/source/models/tnt/tnt_knowledge_extraction.rst": {
-    "mtime": 1771374330.2248251,
+    "mtime": 1783141475.664429,
     "ast_hash": "abbaac575958f20df5e4b08cdd0dc2d9",
     "semantic_hash": "abbaac575958f20df5e4b08cdd0dc2d9"
   },
   "docs/source/models/tnt/tnt_loop_bridge.rst": {
-    "mtime": 1771374330.2248251,
+    "mtime": 1783141475.664429,
     "ast_hash": "736a32b857edfb0c9030ed773c8e4438",
     "semantic_hash": "736a32b857edfb0c9030ed773c8e4438"
   },
   "docs/source/models/tnt/tnt_multi_species.rst": {
-    "mtime": 1771374330.2248251,
+    "mtime": 1783141475.665429,
     "ast_hash": "8919404f4428cb7984e90c5166889658",
     "semantic_hash": "8919404f4428cb7984e90c5166889658"
   },
   "docs/source/models/tnt/tnt_non_affine.rst": {
-    "mtime": 1773332566.9289565,
+    "mtime": 1783141475.665429,
     "ast_hash": "58fa55f3aa38c49043cd5479258069bf",
     "semantic_hash": "58fa55f3aa38c49043cd5479258069bf"
   },
   "docs/source/models/tnt/tnt_protocols.rst": {
-    "mtime": 1771374330.2258253,
+    "mtime": 1783141475.665429,
     "ast_hash": "6e4ddff379ad446aa243ac36a664b773",
     "semantic_hash": "6e4ddff379ad446aa243ac36a664b773"
   },
   "docs/source/models/tnt/tnt_sticky_rouse.rst": {
-    "mtime": 1771374330.2258253,
+    "mtime": 1783141475.665429,
     "ast_hash": "fecab540e9bd89e976011e2535562a68",
     "semantic_hash": "fecab540e9bd89e976011e2535562a68"
   },
   "docs/source/models/tnt/tnt_stretch_creation.rst": {
-    "mtime": 1773332566.9289565,
+    "mtime": 1783141475.666429,
     "ast_hash": "b90eef8dc25ecad37129f00f2f898b7c",
     "semantic_hash": "b90eef8dc25ecad37129f00f2f898b7c"
   },
   "docs/source/models/tnt/tnt_tanaka_edwards.rst": {
-    "mtime": 1771374330.2268252,
+    "mtime": 1783141475.666429,
     "ast_hash": "b1721716163882a6974feb9d376d3331",
     "semantic_hash": "b1721716163882a6974feb9d376d3331"
   },
   "docs/source/models/vlb/index.rst": {
-    "mtime": 1771374330.2268252,
+    "mtime": 1783141475.667429,
     "ast_hash": "0a04fa37a3e699a78f6377d2b23ddbc0",
     "semantic_hash": "0a04fa37a3e699a78f6377d2b23ddbc0"
   },
   "docs/source/models/vlb/vlb.rst": {
-    "mtime": 1771374330.2268252,
+    "mtime": 1783141475.667429,
     "ast_hash": "a85041aec8b55e6c752aa7190d066fab",
     "semantic_hash": "a85041aec8b55e6c752aa7190d066fab"
   },
   "docs/source/models/vlb/vlb_advanced.rst": {
-    "mtime": 1773332566.9289565,
+    "mtime": 1783141475.667429,
     "ast_hash": "992f31f8b67e83ab02828ca1ddda2f2c",
     "semantic_hash": "992f31f8b67e83ab02828ca1ddda2f2c"
   },
   "docs/source/models/vlb/vlb_knowledge.rst": {
-    "mtime": 1770953435.504701,
+    "mtime": 1783141475.667429,
     "ast_hash": "adf4baa63fdc34febfafae55e9968f22",
     "semantic_hash": "adf4baa63fdc34febfafae55e9968f22"
   },
   "docs/source/models/vlb/vlb_nonlocal.rst": {
-    "mtime": 1770953435.504701,
+    "mtime": 1783141475.667429,
     "ast_hash": "8515b2ff72040a7d52ae6973489900e6",
     "semantic_hash": "8515b2ff72040a7d52ae6973489900e6"
   },
   "docs/source/models/vlb/vlb_protocols.rst": {
-    "mtime": 1770953435.504701,
+    "mtime": 1783141475.667429,
     "ast_hash": "1b1cfac319bf31516dcd881ece985b8b",
     "semantic_hash": "1b1cfac319bf31516dcd881ece985b8b"
   },
   "docs/source/models/vlb/vlb_variant.rst": {
-    "mtime": 1771374330.2268252,
+    "mtime": 1783141475.667429,
     "ast_hash": "36bf27cafc5f9051ac668c7a1d05148d",
     "semantic_hash": "36bf27cafc5f9051ac668c7a1d05148d"
   },
   "docs/source/quickstart.rst": {
-    "mtime": 1782840585.9954197,
+    "mtime": 1783141475.667429,
     "ast_hash": "92d7946968d79181f106384b8e531647",
     "semantic_hash": "92d7946968d79181f106384b8e531647"
   },
   "docs/source/transforms/cox_merz.rst": {
-    "mtime": 1773332566.9289565,
+    "mtime": 1783141475.667429,
     "ast_hash": "66306ebd641a36db1c4958fb81d61dd3",
     "semantic_hash": "66306ebd641a36db1c4958fb81d61dd3"
   },
   "docs/source/transforms/fft.rst": {
-    "mtime": 1771374330.2268252,
+    "mtime": 1783141475.667429,
     "ast_hash": "de5d3c95a656a5d84bf94b8d7559979c",
     "semantic_hash": "de5d3c95a656a5d84bf94b8d7559979c"
   },
   "docs/source/transforms/index.rst": {
-    "mtime": 1773332566.9289565,
+    "mtime": 1783141475.667429,
     "ast_hash": "a34ee80159a33d2f1bf180536b0f4379",
     "semantic_hash": "a34ee80159a33d2f1bf180536b0f4379"
   },
   "docs/source/transforms/lve_envelope.rst": {
-    "mtime": 1773332566.9299564,
+    "mtime": 1783141475.667429,
     "ast_hash": "f9bebcbfe2a3d56e5c6d6ca29b4bc4f7",
     "semantic_hash": "f9bebcbfe2a3d56e5c6d6ca29b4bc4f7"
   },
   "docs/source/transforms/mastercurve.rst": {
-    "mtime": 1782840585.9954197,
+    "mtime": 1783141475.667429,
     "ast_hash": "fc67cca6f33313d3fc50a96467d24a9d",
     "semantic_hash": "fc67cca6f33313d3fc50a96467d24a9d"
   },
   "docs/source/transforms/mutation_number.rst": {
-    "mtime": 1771374330.2278252,
+    "mtime": 1783141475.668429,
     "ast_hash": "0e8fdc73caf078216f9cea470784dd99",
     "semantic_hash": "0e8fdc73caf078216f9cea470784dd99"
   },
   "docs/source/transforms/owchirp.rst": {
-    "mtime": 1771374330.2278252,
+    "mtime": 1783141475.668429,
     "ast_hash": "f86b73a8d611b96840969ef0b3f6aadf",
     "semantic_hash": "f86b73a8d611b96840969ef0b3f6aadf"
   },
   "docs/source/transforms/prony_conversion.rst": {
-    "mtime": 1773332566.9299564,
+    "mtime": 1783141475.668429,
     "ast_hash": "c71605dacf513b0a564ecc64324abc4a",
     "semantic_hash": "c71605dacf513b0a564ecc64324abc4a"
   },
   "docs/source/transforms/smooth_derivative.rst": {
-    "mtime": 1771374330.2278252,
+    "mtime": 1783141475.668429,
     "ast_hash": "c5838df13b1eb60b002923a1019edf4f",
     "semantic_hash": "c5838df13b1eb60b002923a1019edf4f"
   },
   "docs/source/transforms/spectrum_inversion.rst": {
-    "mtime": 1773332566.9299564,
+    "mtime": 1783141475.668429,
     "ast_hash": "364beeade05378e456e3dc61ddc0cf99",
     "semantic_hash": "364beeade05378e456e3dc61ddc0cf99"
   },
   "docs/source/transforms/spp.rst": {
-    "mtime": 1773332566.9299564,
+    "mtime": 1783141475.668429,
     "ast_hash": "a65cc569cc7e49c354dffbd1be7018ad",
     "semantic_hash": "a65cc569cc7e49c354dffbd1be7018ad"
   },
   "docs/source/transforms/srfs.rst": {
-    "mtime": 1773332566.9299564,
+    "mtime": 1783141475.668429,
     "ast_hash": "d585bd13c7df2796e08ea960b3d7f24e",
     "semantic_hash": "d585bd13c7df2796e08ea960b3d7f24e"
   },
   "docs/source/transforms/summary.rst": {
-    "mtime": 1773332566.9299564,
+    "mtime": 1783141475.669429,
     "ast_hash": "0d5bf474ece099a73ed5c14b394098af",
     "semantic_hash": "0d5bf474ece099a73ed5c14b394098af"
   },
   "docs/source/user_guide/01_fundamentals/index.rst": {
-    "mtime": 1771374330.2278252,
+    "mtime": 1783141475.669429,
     "ast_hash": "b44b9ffd48153363e3a36fa658010fbc",
     "semantic_hash": "b44b9ffd48153363e3a36fa658010fbc"
   },
   "docs/source/user_guide/01_fundamentals/material_classification.rst": {
-    "mtime": 1771374330.2278252,
+    "mtime": 1783141475.669429,
     "ast_hash": "8480a2a5dfbd0534102bd8cc8668ee83",
     "semantic_hash": "8480a2a5dfbd0534102bd8cc8668ee83"
   },
   "docs/source/user_guide/01_fundamentals/model_capabilities.rst": {
-    "mtime": 1782840585.9954197,
+    "mtime": 1783141475.669429,
     "ast_hash": "8897e92b6a5b13d4cd3003f397d766c9",
     "semantic_hash": "8897e92b6a5b13d4cd3003f397d766c9"
   },
   "docs/source/user_guide/01_fundamentals/parameter_interpretation.rst": {
-    "mtime": 1771374330.2278252,
+    "mtime": 1783141475.669429,
     "ast_hash": "f2767275d273567256ab1abe6b1197ca",
     "semantic_hash": "f2767275d273567256ab1abe6b1197ca"
   },
   "docs/source/user_guide/01_fundamentals/test_modes.rst": {
-    "mtime": 1782840585.9964197,
+    "mtime": 1783141475.669429,
     "ast_hash": "913237a6ead02b7dee7f50fd0d17995e",
     "semantic_hash": "913237a6ead02b7dee7f50fd0d17995e"
   },
   "docs/source/user_guide/01_fundamentals/what_is_rheology.rst": {
-    "mtime": 1771374330.2288253,
+    "mtime": 1783141475.669429,
     "ast_hash": "3f532bb787d34974fe6926f78cd5b3e2",
     "semantic_hash": "3f532bb787d34974fe6926f78cd5b3e2"
   },
   "docs/source/user_guide/02_model_usage/fitting_strategies.rst": {
-    "mtime": 1771374330.2288253,
+    "mtime": 1783141475.669429,
     "ast_hash": "7c215c545201a5f3df3241c0ab8c454e",
     "semantic_hash": "7c215c545201a5f3df3241c0ab8c454e"
   },
   "docs/source/user_guide/02_model_usage/getting_started.rst": {
-    "mtime": 1771374330.2288253,
+    "mtime": 1783141475.669429,
     "ast_hash": "4ef28fecd44f8a0858589673db313275",
     "semantic_hash": "4ef28fecd44f8a0858589673db313275"
   },
   "docs/source/user_guide/02_model_usage/index.rst": {
-    "mtime": 1771374330.2288253,
+    "mtime": 1783141475.669429,
     "ast_hash": "a44f3bb994e42c7a398388eeec4cbc67",
     "semantic_hash": "a44f3bb994e42c7a398388eeec4cbc67"
   },
   "docs/source/user_guide/02_model_usage/model_families.rst": {
-    "mtime": 1782840585.9964197,
+    "mtime": 1783141475.670429,
     "ast_hash": "4e6ab66798998663d731bdfab268af49",
     "semantic_hash": "4e6ab66798998663d731bdfab268af49"
   },
   "docs/source/user_guide/02_model_usage/model_selection.rst": {
-    "mtime": 1771374330.2288253,
+    "mtime": 1783141475.670429,
     "ast_hash": "e42fe2971897dbbb2c4cc0ed67f89c38",
     "semantic_hash": "e42fe2971897dbbb2c4cc0ed67f89c38"
   },
   "docs/source/user_guide/03_advanced_topics/bayesian_inference.rst": {
-    "mtime": 1771374330.2288253,
+    "mtime": 1783141475.670429,
     "ast_hash": "633e1b775812697f4b22185a310ba500",
     "semantic_hash": "633e1b775812697f4b22185a310ba500"
   },
   "docs/source/user_guide/03_advanced_topics/constitutive_ode_models.rst": {
-    "mtime": 1771374330.2298253,
+    "mtime": 1783141475.670429,
     "ast_hash": "05c687f8df67a2f4f9dfbee155988217",
     "semantic_hash": "05c687f8df67a2f4f9dfbee155988217"
   },
   "docs/source/user_guide/03_advanced_topics/dense_suspensions_glasses.rst": {
-    "mtime": 1771374330.2298253,
-    "ast_hash": "459cab975e23feea4cbca732c985280c",
-    "semantic_hash": "459cab975e23feea4cbca732c985280c"
+    "mtime": 1783141475.670429,
+    "ast_hash": "d844c6724ffaac174ff79b10353c69a8",
+    "semantic_hash": ""
   },
   "docs/source/user_guide/03_advanced_topics/fractional_viscoelasticity_reference.rst": {
-    "mtime": 1771374330.2298253,
+    "mtime": 1783141475.670429,
     "ast_hash": "03bfdd0988b6d583841c8313a6be0381",
     "semantic_hash": "03bfdd0988b6d583841c8313a6be0381"
   },
   "docs/source/user_guide/03_advanced_topics/index.rst": {
-    "mtime": 1771374330.2298253,
+    "mtime": 1783141475.670429,
     "ast_hash": "0aef63dcca25bdb9db852693e759e804",
     "semantic_hash": "0aef63dcca25bdb9db852693e759e804"
   },
   "docs/source/user_guide/03_advanced_topics/multi_technique_fitting.rst": {
-    "mtime": 1771374330.2298253,
+    "mtime": 1783141475.670429,
     "ast_hash": "32ce40185ac1fee455fd8e53143e92a7",
     "semantic_hash": "32ce40185ac1fee455fd8e53143e92a7"
   },
   "docs/source/user_guide/03_advanced_topics/polymer_network_models.rst": {
-    "mtime": 1771523131.54702,
+    "mtime": 1783141475.671429,
     "ast_hash": "6c14c6fc3232feb36dd3a72c5a64a5a0",
     "semantic_hash": "6c14c6fc3232feb36dd3a72c5a64a5a0"
   },
   "docs/source/user_guide/03_advanced_topics/sgr_analysis.rst": {
-    "mtime": 1771374330.2298253,
+    "mtime": 1783141475.671429,
     "ast_hash": "cfddac396f145b9f00d0935b38f2c329",
     "semantic_hash": "cfddac396f145b9f00d0935b38f2c329"
   },
   "docs/source/user_guide/03_advanced_topics/spp_analysis.rst": {
-    "mtime": 1771374330.2308252,
+    "mtime": 1783141475.671429,
     "ast_hash": "fa5f305212e19c176b1e644cf7c33163",
     "semantic_hash": "fa5f305212e19c176b1e644cf7c33163"
   },
   "docs/source/user_guide/03_advanced_topics/thixotropy_yielding.rst": {
-    "mtime": 1771374330.2308252,
+    "mtime": 1783141475.671429,
     "ast_hash": "19761c9c4f9264b3fa374848c748defd",
     "semantic_hash": "19761c9c4f9264b3fa374848c748defd"
   },
   "docs/source/user_guide/03_advanced_topics/time_temperature_superposition.rst": {
-    "mtime": 1773332566.9299564,
+    "mtime": 1783141475.671429,
     "ast_hash": "d729709fbdc91e4ee552e25ba9c62992",
     "semantic_hash": "d729709fbdc91e4ee552e25ba9c62992"
   },
   "docs/source/user_guide/03_advanced_topics/transforms_complete.rst": {
-    "mtime": 1771374330.2308252,
+    "mtime": 1783141475.671429,
     "ast_hash": "6ba7c1f4bb3775938fc33de071bac5b8",
     "semantic_hash": "6ba7c1f4bb3775938fc33de071bac5b8"
   },
   "docs/source/user_guide/03_advanced_topics/vitrimer_models.rst": {
-    "mtime": 1782840585.9964197,
+    "mtime": 1783141475.672429,
     "ast_hash": "5bfd092eee610cd5b2cbedab9f3ff341",
     "semantic_hash": "5bfd092eee610cd5b2cbedab9f3ff341"
   },
   "docs/source/user_guide/04_practical_guides/batch_processing.rst": {
-    "mtime": 1771374330.2318254,
+    "mtime": 1783141475.672429,
     "ast_hash": "06948033ffe276129ea89a6fde66ac70",
     "semantic_hash": "06948033ffe276129ea89a6fde66ac70"
   },
   "docs/source/user_guide/04_practical_guides/data_formats.rst": {
-    "mtime": 1782840585.9964197,
+    "mtime": 1783141475.672429,
     "ast_hash": "31ade4e43a16d6d6bd1312cfd3fddecc",
     "semantic_hash": "31ade4e43a16d6d6bd1312cfd3fddecc"
   },
   "docs/source/user_guide/04_practical_guides/data_io.rst": {
-    "mtime": 1766027222.6996524,
+    "mtime": 1783141475.672429,
     "ast_hash": "9c10ffbfbea93c69f56eae8ef6a7eed4",
     "semantic_hash": "9c10ffbfbea93c69f56eae8ef6a7eed4"
   },
   "docs/source/user_guide/04_practical_guides/index.rst": {
-    "mtime": 1768708239.070259,
+    "mtime": 1783141475.672429,
     "ast_hash": "9e8002e1c0936df5268e874c4c013343",
     "semantic_hash": "9e8002e1c0936df5268e874c4c013343"
   },
   "docs/source/user_guide/04_practical_guides/model_inventory.rst": {
-    "mtime": 1782840585.9964197,
+    "mtime": 1783141475.672429,
     "ast_hash": "030cc3510f6f1221932de04e26f08ffd",
     "semantic_hash": "030cc3510f6f1221932de04e26f08ffd"
   },
   "docs/source/user_guide/04_practical_guides/modular_api.rst": {
-    "mtime": 1771374330.2318254,
+    "mtime": 1783141475.672429,
     "ast_hash": "118ea9457466f6e5b39fde81a08c71fe",
     "semantic_hash": "118ea9457466f6e5b39fde81a08c71fe"
   },
   "docs/source/user_guide/04_practical_guides/pipeline_api.rst": {
-    "mtime": 1771374330.2318254,
+    "mtime": 1783141475.672429,
     "ast_hash": "02aa01aa7fac3f45b49c1b5f6a9d6ac8",
     "semantic_hash": "02aa01aa7fac3f45b49c1b5f6a9d6ac8"
   },
   "docs/source/user_guide/04_practical_guides/trios_format.rst": {
-    "mtime": 1771374330.2318254,
+    "mtime": 1783141475.672429,
     "ast_hash": "4585f825252885872ba2060278edd160",
     "semantic_hash": "4585f825252885872ba2060278edd160"
   },
   "docs/source/user_guide/04_practical_guides/visualization.rst": {
-    "mtime": 1763104424.0,
+    "mtime": 1783141475.672429,
     "ast_hash": "dc035ab7bbf877dcbbd65d770709e711",
     "semantic_hash": "dc035ab7bbf877dcbbd65d770709e711"
   },
   "docs/source/user_guide/05_appendices/experimental_design.rst": {
-    "mtime": 1771374330.2318254,
+    "mtime": 1783141475.672429,
     "ast_hash": "74827f7c5f9ca822eeb4a578d9cc4cb4",
     "semantic_hash": "74827f7c5f9ca822eeb4a578d9cc4cb4"
   },
   "docs/source/user_guide/05_appendices/glossary.rst": {
-    "mtime": 1782840585.9964197,
+    "mtime": 1783141475.672429,
     "ast_hash": "5ee4c1802d9f803430a1d1d3fce4f7cf",
     "semantic_hash": "5ee4c1802d9f803430a1d1d3fce4f7cf"
   },
   "docs/source/user_guide/05_appendices/index.rst": {
-    "mtime": 1771374330.2318254,
+    "mtime": 1783141475.672429,
     "ast_hash": "919ae8af7a851787a7c2bab299a8956e",
     "semantic_hash": "919ae8af7a851787a7c2bab299a8956e"
   },
   "docs/source/user_guide/05_appendices/material_database.rst": {
-    "mtime": 1771374330.2318254,
+    "mtime": 1783141475.672429,
     "ast_hash": "47b7c694824e877c1cc726481225d143",
     "semantic_hash": "47b7c694824e877c1cc726481225d143"
   },
   "docs/source/user_guide/05_appendices/troubleshooting.rst": {
-    "mtime": 1763101194.0,
+    "mtime": 1783141475.672429,
     "ast_hash": "1f3fb1f2b9cb5ca1a817ebdba4da4275",
     "semantic_hash": "1f3fb1f2b9cb5ca1a817ebdba4da4275"
   },
   "docs/source/user_guide/06_gui/bayesian_inference.rst": {
-    "mtime": 1764943390.0,
+    "mtime": 1783141475.672429,
     "ast_hash": "273f199cd4fc7b6affdbc847a509fcc1",
     "semantic_hash": "273f199cd4fc7b6affdbc847a509fcc1"
   },
   "docs/source/user_guide/06_gui/data_loading.rst": {
-    "mtime": 1771374330.2318254,
+    "mtime": 1783141475.673429,
     "ast_hash": "f0af5fc22b78d3a348fab3fe6c33aadf",
     "semantic_hash": "f0af5fc22b78d3a348fab3fe6c33aadf"
   },
   "docs/source/user_guide/06_gui/diagnostics.rst": {
-    "mtime": 1766027222.7006524,
+    "mtime": 1783141475.673429,
     "ast_hash": "275423b5d6cb00de18ba9e6861922718",
     "semantic_hash": "275423b5d6cb00de18ba9e6861922718"
   },
   "docs/source/user_guide/06_gui/exporting.rst": {
-    "mtime": 1771374330.2328253,
+    "mtime": 1783141475.673429,
     "ast_hash": "737c937f4b983d6d0d35958bfaae10d8",
     "semantic_hash": "737c937f4b983d6d0d35958bfaae10d8"
   },
   "docs/source/user_guide/06_gui/getting_started.rst": {
-    "mtime": 1777045619.6633701,
-    "ast_hash": "5e1bd9934f5cdcbe9ee828059c80818e",
-    "semantic_hash": "5e1bd9934f5cdcbe9ee828059c80818e"
+    "mtime": 1783141475.673429,
+    "ast_hash": "91a24b2a8f8f4ecbc8f371b6dcffce07",
+    "semantic_hash": ""
   },
   "docs/source/user_guide/06_gui/index.rst": {
-    "mtime": 1777045619.6633701,
-    "ast_hash": "c1e6614b37c2b9c22c3d85cae8865d10",
-    "semantic_hash": "c1e6614b37c2b9c22c3d85cae8865d10"
+    "mtime": 1783141475.673429,
+    "ast_hash": "3ca90baf3e8ab26269079ba6d5a23b85",
+    "semantic_hash": ""
   },
   "docs/source/user_guide/06_gui/keyboard_shortcuts.rst": {
-    "mtime": 1764943476.0,
+    "mtime": 1783141475.673429,
     "ast_hash": "43b75cd0ad82921c10e4dc4ea98fa697",
     "semantic_hash": "43b75cd0ad82921c10e4dc4ea98fa697"
   },
   "docs/source/user_guide/06_gui/menu_reference.rst": {
-    "mtime": 1773332566.9309566,
+    "mtime": 1783141475.673429,
     "ast_hash": "0a85faa66e2e4164f1e2b384c9318299",
     "semantic_hash": "0a85faa66e2e4164f1e2b384c9318299"
   },
   "docs/source/user_guide/06_gui/model_fitting.rst": {
-    "mtime": 1783024099.7061079,
+    "mtime": 1783141475.673429,
     "ast_hash": "61b0fe68949669c208a415501d238368",
     "semantic_hash": ""
   },
   "docs/source/user_guide/06_gui/transforms.rst": {
-    "mtime": 1783024099.7061079,
+    "mtime": 1783141475.673429,
     "ast_hash": "e727baef0258514364d74f41f73d7c84",
     "semantic_hash": ""
   },
   "docs/source/user_guide/index.rst": {
-    "mtime": 1782840585.9964197,
+    "mtime": 1783141475.673429,
     "ast_hash": "db2791f0eb2fd5870f9e48e5950f5817",
     "semantic_hash": "db2791f0eb2fd5870f9e48e5950f5817"
   },
   "docs/source/verification/index.rst": {
-    "mtime": 1777045619.6633701,
+    "mtime": 1783141475.673429,
     "ast_hash": "6136c514d09c520f9c30f4b9652d4260",
     "semantic_hash": "6136c514d09c520f9c30f4b9652d4260"
   },
   "docs/tech-stack.md": {
-    "mtime": 1782840585.9974198,
+    "mtime": 1783141475.673429,
     "ast_hash": "13583e16696fe6e0222adbac1a2dc25d",
     "semantic_hash": "13583e16696fe6e0222adbac1a2dc25d"
   },
   "docs/verification/classical_lve_equations.md": {
-    "mtime": 1777045619.6633701,
+    "mtime": 1783141475.673429,
     "ast_hash": "6e73cb01fa15d417b9be5b8d75f538d8",
     "semantic_hash": "6e73cb01fa15d417b9be5b8d75f538d8"
   },
   "docs/verification/dmt_literature_verification.md": {
-    "mtime": 1777045619.6633701,
-    "ast_hash": "c2058e1717a49cdf9cc11cd9c9236dba",
-    "semantic_hash": "c2058e1717a49cdf9cc11cd9c9236dba"
+    "mtime": 1783141475.673429,
+    "ast_hash": "1c202f5bb387b3e79513fc2e71e5d049",
+    "semantic_hash": ""
   },
   "docs/verification/epm_validation_report_2026-03-29.md": {
-    "mtime": 1777045619.6633701,
-    "ast_hash": "0a80700ab8960c842021279379fd17ba",
-    "semantic_hash": "0a80700ab8960c842021279379fd17ba"
+    "mtime": 1783141475.673429,
+    "ast_hash": "fa4f3076c310d6a766a8a114c2f90a6e",
+    "semantic_hash": ""
   },
   "docs/verification/fikh_validation_report_2026-03-29.md": {
-    "mtime": 1777045619.6633701,
+    "mtime": 1783141475.673429,
     "ast_hash": "0672eadc8e98c3a528c9fc37cae4f93f",
     "semantic_hash": "0672eadc8e98c3a528c9fc37cae4f93f"
   },
   "docs/verification/fluidity_saramito_equations.rst": {
-    "mtime": 1777045619.6633701,
+    "mtime": 1783141475.674429,
     "ast_hash": "0e285630538ea0724ad23c4df65f5242",
     "semantic_hash": "0e285630538ea0724ad23c4df65f5242"
   },
   "docs/verification/fractional_models_equation_verification.md": {
-    "mtime": 1777045619.6633701,
+    "mtime": 1783141475.674429,
     "ast_hash": "6833fe0d700f0b04a42f7e90e7ada236",
     "semantic_hash": "6833fe0d700f0b04a42f7e90e7ada236"
   },
   "docs/verification/giesekus_math_verification.md": {
-    "mtime": 1777045619.6633701,
+    "mtime": 1783141475.674429,
     "ast_hash": "7041fd530b579422552da2e3e3a5ca87",
     "semantic_hash": "7041fd530b579422552da2e3e3a5ca87"
   },
   "docs/verification/gmm_canonical_equations.rst": {
-    "mtime": 1777045619.6643703,
+    "mtime": 1783141475.674429,
     "ast_hash": "a059f7c9968c61410b643b2209b34b70",
     "semantic_hash": "a059f7c9968c61410b643b2209b34b70"
   },
   "docs/verification/hl_model_equations.md": {
-    "mtime": 1777045619.6643703,
+    "mtime": 1783141475.674429,
     "ast_hash": "f5414bce495ff794137c1f0d63765368",
     "semantic_hash": "f5414bce495ff794137c1f0d63765368"
   },
   "docs/verification/hvm_literature_review.md": {
-    "mtime": 1777045619.6643703,
+    "mtime": 1783141475.674429,
     "ast_hash": "26272a0b183e27e5ad2ce34f48fce1e9",
     "semantic_hash": "26272a0b183e27e5ad2ce34f48fce1e9"
   },
   "docs/verification/itt_mct_literature_equations.md": {
-    "mtime": 1777045619.6643703,
+    "mtime": 1783141475.674429,
     "ast_hash": "185b2ba8c18d817bf8ca8e8624428f26",
     "semantic_hash": "185b2ba8c18d817bf8ca8e8624428f26"
   },
   "docs/verification/saos_validity_transient_networks.md": {
-    "mtime": 1777045619.6643703,
+    "mtime": 1783141475.674429,
     "ast_hash": "055d7185d747e053703c281b360d89e0",
     "semantic_hash": "055d7185d747e053703c281b360d89e0"
   },
   "docs/verification/tnt_equations_verification.rst": {
-    "mtime": 1777045619.6643703,
+    "mtime": 1783141475.674429,
     "ast_hash": "57fc911a253a27ccaf0f59c3e63d8541",
     "semantic_hash": "57fc911a253a27ccaf0f59c3e63d8541"
   },
   "docs/verification/vlb_equation_verification.md": {
-    "mtime": 1777045619.6643703,
+    "mtime": 1783141475.674429,
     "ast_hash": "6f6ede0b327a0f4546ee96ee331d6428",
     "semantic_hash": "6f6ede0b327a0f4546ee96ee331d6428"
   },
   "rheojax/gui/README.md": {
-    "mtime": 1777045619.9333704,
-    "ast_hash": "4dd90cce53e1a215214e7a5f94023617",
-    "semantic_hash": "4dd90cce53e1a215214e7a5f94023617"
+    "mtime": 1783141477.1674244,
+    "ast_hash": "91eeec4ccf7f65030a00834695ea89ff",
+    "semantic_hash": ""
   },
   "rheojax/gui/STRUCTURE_VALIDATION.md": {
-    "mtime": 1767875582.0165772,
+    "mtime": 1783141477.1674244,
     "ast_hash": "d895a60322db8a1c00636e1f445e6f49",
     "semantic_hash": "d895a60322db8a1c00636e1f445e6f49"
   },
   "rheojax/gui/jobs/IMPLEMENTATION_SUMMARY.md": {
-    "mtime": 1764929096.0,
+    "mtime": 1783141477.1694243,
     "ast_hash": "1b40cf8877d5b657941cf71967976441",
     "semantic_hash": "1b40cf8877d5b657941cf71967976441"
   },
   "rheojax/gui/jobs/README.md": {
-    "mtime": 1764928976.0,
+    "mtime": 1783141477.1694243,
     "ast_hash": "460b96f9eccb64d10dcb42416cb49b3f",
     "semantic_hash": "460b96f9eccb64d10dcb42416cb49b3f"
   },
   "rheojax/gui/resources/styles/README.md": {
-    "mtime": 1767875582.029577,
+    "mtime": 1783141477.1714244,
     "ast_hash": "07f6e9f680c4963bd546746e1c5d4dde",
     "semantic_hash": "07f6e9f680c4963bd546746e1c5d4dde"
   },
   "rheojax/gui/state/USAGE.md": {
-    "mtime": 1764928318.0,
-    "ast_hash": "ebae36c80cdfcf7d700082b901d27625",
-    "semantic_hash": "ebae36c80cdfcf7d700082b901d27625"
+    "mtime": 1783141477.1724243,
+    "ast_hash": "2e4df18825603cfc0465256316968cc5",
+    "semantic_hash": ""
   },
   "scripts/notebook_execution_baseline.txt": {
-    "mtime": 1782840586.0644205,
+    "mtime": 1783141477.1954243,
     "ast_hash": "d87c3ac11356258ecbeb3e928573c944",
     "semantic_hash": "d87c3ac11356258ecbeb3e928573c944"
   },
   "tests/fixtures/BASELINE_REPORT.md": {
-    "mtime": 1763352566.0,
+    "mtime": 1783141477.1974242,
     "ast_hash": "13b9af261f76164f9d9c1152915bff34",
     "semantic_hash": "13b9af261f76164f9d9c1152915bff34"
   },
   "tests/fixtures/README.md": {
-    "mtime": 1777045619.9533703,
+    "mtime": 1783141477.1974242,
     "ast_hash": "262fc4e88b37a3107b35c7dafb799aa3",
     "semantic_hash": "262fc4e88b37a3107b35c7dafb799aa3"
   },
   "tests/fixtures/readers/space_delimited.txt": {
-    "mtime": 1766368938.9847894,
+    "mtime": 1783141477.1974242,
     "ast_hash": "9b63256afd37b3b01d84f320ca38c227",
     "semantic_hash": "9b63256afd37b3b01d84f320ca38c227"
   },
   "tests/fixtures/readers/tab_delimited.txt": {
-    "mtime": 1766368938.9847894,
+    "mtime": 1783141477.1974242,
     "ast_hash": "27f1360b13f5df35b9373b108e20c02d",
     "semantic_hash": "27f1360b13f5df35b9373b108e20c02d"
   },
   "tests/fixtures/trios/flow_ramp.txt": {
-    "mtime": 1766027222.7046523,
+    "mtime": 1783141477.1974242,
     "ast_hash": "9d083a938b6b7ce40f78624e74fcfb5e",
     "semantic_hash": "9d083a938b6b7ce40f78624e74fcfb5e"
   },
   "tests/fixtures/trios_synthetic_10mb.txt": {
-    "mtime": 1763405388.0,
+    "mtime": 1783141477.2034242,
     "ast_hash": "0f63b5325bbe0d439f8b5d0c197da710",
     "semantic_hash": "0f63b5325bbe0d439f8b5d0c197da710"
   },
   "tests/fixtures/trios_synthetic_1mb.txt": {
-    "mtime": 1763405388.0,
+    "mtime": 1783141477.2044241,
     "ast_hash": "8f6bc5fb7c7766647f38fc47d06b4f2b",
     "semantic_hash": "8f6bc5fb7c7766647f38fc47d06b4f2b"
   },
   "tests/fixtures/trios_synthetic_5mb.txt": {
-    "mtime": 1763405388.0,
+    "mtime": 1783141477.2064242,
     "ast_hash": "da44f059bd2409948f4e232161db9fb1",
     "semantic_hash": "da44f059bd2409948f4e232161db9fb1"
   },
   "tests/gui/README.md": {
-    "mtime": 1764930096.0,
+    "mtime": 1783141477.2064242,
     "ast_hash": "6d48774e82afe3e5202c5334e2891637",
     "semantic_hash": "6d48774e82afe3e5202c5334e2891637"
   },
   "tests/validation/README.md": {
-    "mtime": 1763144762.0,
+    "mtime": 1783141477.2234242,
     "ast_hash": "cc1fc31424361a6c65fb680e7063d5df",
     "semantic_hash": "cc1fc31424361a6c65fb680e7063d5df"
   },
   "docs/verification/ikh_literature_verification.md": {
-    "mtime": 1777045619.6643703,
-    "ast_hash": "ed2f3617645f2e4762e2f7160adb25c8",
-    "semantic_hash": "ed2f3617645f2e4762e2f7160adb25c8"
+    "mtime": 1783141475.674429,
+    "ast_hash": "d69e405f575a864106219e4f1ad92a31",
+    "semantic_hash": ""
   },
   "docs/verification/spp_equations_verification.md": {
-    "mtime": 1777045619.6643703,
+    "mtime": 1783141475.674429,
     "ast_hash": "dae63d9cdebd5ba1b5195a0c78518b2d",
     "semantic_hash": "dae63d9cdebd5ba1b5195a0c78518b2d"
   },
   "docs/verification/vitrimer_nanocomposite_constitutive_models.md": {
-    "mtime": 1777045619.6643703,
+    "mtime": 1783141475.674429,
     "ast_hash": "059302be0aac293f16ec4008aedd448f",
     "semantic_hash": "059302be0aac293f16ec4008aedd448f"
   },
   "rheojax/gui/resources/icons/bayesian.svg": {
-    "mtime": 1764999642.0,
+    "mtime": 1783141477.1714244,
     "ast_hash": "0d41553e705a3c45463796de9d266cc9",
     "semantic_hash": "0d41553e705a3c45463796de9d266cc9"
   },
   "rheojax/gui/resources/icons/check-white.svg": {
-    "mtime": 1765003606.0,
+    "mtime": 1783141477.1714244,
     "ast_hash": "556109a7b5c687a1b38fdf8729efdc7e",
     "semantic_hash": "556109a7b5c687a1b38fdf8729efdc7e"
   },
   "rheojax/gui/resources/icons/chevron-down.svg": {
-    "mtime": 1765003572.0,
+    "mtime": 1783141477.1714244,
     "ast_hash": "96c725274a7277d3b76cda99386cd2da",
     "semantic_hash": "96c725274a7277d3b76cda99386cd2da"
   },
   "rheojax/gui/resources/icons/chevron-right.svg": {
-    "mtime": 1766372120.013337,
+    "mtime": 1783141477.1714244,
     "ast_hash": "446834b2a72ee8325bb46f114c3cd628",
     "semantic_hash": "446834b2a72ee8325bb46f114c3cd628"
   },
   "rheojax/gui/resources/icons/close.svg": {
-    "mtime": 1765003216.0,
+    "mtime": 1783141477.1714244,
     "ast_hash": "2e8b73f3da64e42019b99567e3e08d95",
     "semantic_hash": "2e8b73f3da64e42019b99567e3e08d95"
   },
   "rheojax/gui/resources/icons/export.svg": {
-    "mtime": 1764999646.0,
+    "mtime": 1783141477.1714244,
     "ast_hash": "34e9e34cfec6caae47c2af9d6ba82325",
     "semantic_hash": "34e9e34cfec6caae47c2af9d6ba82325"
   },
   "rheojax/gui/resources/icons/fit.svg": {
-    "mtime": 1764999634.0,
+    "mtime": 1783141477.1714244,
     "ast_hash": "2a665897191d039589a108e1f6e9546c",
     "semantic_hash": "2a665897191d039589a108e1f6e9546c"
   },
   "rheojax/gui/resources/icons/load.svg": {
-    "mtime": 1764999614.0,
+    "mtime": 1783141477.1714244,
     "ast_hash": "d02a33b11d630cb171541105001f29cb",
     "semantic_hash": "d02a33b11d630cb171541105001f29cb"
   },
   "rheojax/gui/resources/icons/rheojax.svg": {
-    "mtime": 1766372137.211444,
+    "mtime": 1783141477.1714244,
     "ast_hash": "54f36f6f93c739bca3fac1e9eff3685a",
     "semantic_hash": "54f36f6f93c739bca3fac1e9eff3685a"
   },
   "rheojax/gui/resources/icons/window.svg": {
-    "mtime": 1765003222.0,
+    "mtime": 1783141477.1714244,
     "ast_hash": "4f75a7203de0312b7a9c56902a9bd127",
     "semantic_hash": "4f75a7203de0312b7a9c56902a9bd127"
   },
   "tests/gui/golden_images/arviz_canvas_empty.png": {
-    "mtime": 1764941794.0,
+    "mtime": 1783141477.2074242,
     "ast_hash": "4f4c2c97492bc6d6bf2e21db6cb6fce1",
     "semantic_hash": "4f4c2c97492bc6d6bf2e21db6cb6fce1"
   },
   "tests/gui/golden_images/bayesian_page.png": {
-    "mtime": 1765001672.0,
+    "mtime": 1783141477.2074242,
     "ast_hash": "77b70f3855c47529b7f2873e76fc3fb6",
     "semantic_hash": "77b70f3855c47529b7f2873e76fc3fb6"
   },
   "tests/gui/golden_images/export_page.png": {
-    "mtime": 1765001672.0,
+    "mtime": 1783141477.2074242,
     "ast_hash": "77b70f3855c47529b7f2873e76fc3fb6",
     "semantic_hash": "77b70f3855c47529b7f2873e76fc3fb6"
   },
   "tests/gui/golden_images/fit_page_with_results.png": {
-    "mtime": 1765001672.0,
+    "mtime": 1783141477.2074242,
     "ast_hash": "77b70f3855c47529b7f2873e76fc3fb6",
     "semantic_hash": "77b70f3855c47529b7f2873e76fc3fb6"
   },
   "tests/gui/golden_images/home_page_dark.png": {
-    "mtime": 1765001672.0,
+    "mtime": 1783141477.2074242,
     "ast_hash": "77b70f3855c47529b7f2873e76fc3fb6",
     "semantic_hash": "77b70f3855c47529b7f2873e76fc3fb6"
   },
   "tests/gui/golden_images/home_page_light.png": {
-    "mtime": 1765001672.0,
+    "mtime": 1783141477.2074242,
     "ast_hash": "77b70f3855c47529b7f2873e76fc3fb6",
     "semantic_hash": "77b70f3855c47529b7f2873e76fc3fb6"
   },
   "tests/gui/golden_images/multiview_panel0.png": {
-    "mtime": 1764941794.0,
+    "mtime": 1783141477.2074242,
     "ast_hash": "ec2cd55a3452f077a14b942dca88b2f2",
     "semantic_hash": "ec2cd55a3452f077a14b942dca88b2f2"
   },
   "tests/gui/golden_images/plot_canvas_line.png": {
-    "mtime": 1764941844.0,
+    "mtime": 1783141477.2074242,
     "ast_hash": "ccf0a654885abe1e698be3357c8020b8",
     "semantic_hash": "ccf0a654885abe1e698be3357c8020b8"
   },
   "tests/gui/golden_images/plot_canvas_loglog.png": {
-    "mtime": 1764941844.0,
+    "mtime": 1783141477.2074242,
     "ast_hash": "8b015c1dc9d061c431c2685e52de1340",
     "semantic_hash": "8b015c1dc9d061c431c2685e52de1340"
   },
   "tests/gui/golden_images/plot_canvas_scatter.png": {
-    "mtime": 1764941844.0,
+    "mtime": 1783141477.2074242,
     "ast_hash": "f1796a992f7d5cd9fe496799c8a919c8",
     "semantic_hash": "f1796a992f7d5cd9fe496799c8a919c8"
   },
   "tests/gui/golden_images/residuals_histogram.png": {
-    "mtime": 1764941794.0,
+    "mtime": 1783141477.208424,
     "ast_hash": "a8422f8ce53df230de8e453ca917bb85",
     "semantic_hash": "a8422f8ce53df230de8e453ca917bb85"
   },
   "tests/gui/golden_images/residuals_qq.png": {
-    "mtime": 1764941794.0,
+    "mtime": 1783141477.208424,
     "ast_hash": "f3e00022fcbb983a627f528670e9276e",
     "semantic_hash": "f3e00022fcbb983a627f528670e9276e"
   },
   "tests/gui/golden_images/residuals_vs_fitted.png": {
-    "mtime": 1764941794.0,
+    "mtime": 1783141477.208424,
     "ast_hash": "623cab1c65c132ef428dd8e91546f042",
     "semantic_hash": "623cab1c65c132ef428dd8e91546f042"
   },
   "tests/gui/golden_images/transform_page.png": {
-    "mtime": 1765001672.0,
+    "mtime": 1783141477.208424,
     "ast_hash": "77b70f3855c47529b7f2873e76fc3fb6",
     "semantic_hash": "77b70f3855c47529b7f2873e76fc3fb6"
   },
   "tests/gui/visual/golden_images/bayesian_page.png": {
-    "mtime": 1765002084.0,
+    "mtime": 1783141477.2104242,
     "ast_hash": "b63218b51a014ec432e1413fc29b169c",
     "semantic_hash": "b63218b51a014ec432e1413fc29b169c"
   },
   "tests/gui/visual/golden_images/export_page.png": {
-    "mtime": 1765002084.0,
+    "mtime": 1783141477.2104242,
     "ast_hash": "b63218b51a014ec432e1413fc29b169c",
     "semantic_hash": "b63218b51a014ec432e1413fc29b169c"
   },
   "tests/gui/visual/golden_images/fit_page_with_results.png": {
-    "mtime": 1765002084.0,
+    "mtime": 1783141477.2104242,
     "ast_hash": "b63218b51a014ec432e1413fc29b169c",
     "semantic_hash": "b63218b51a014ec432e1413fc29b169c"
   },
   "tests/gui/visual/golden_images/fit_plot.png": {
-    "mtime": 1765002078.0,
+    "mtime": 1783141477.2104242,
     "ast_hash": "81883221b4ecfe82dc31f4e2edc1f24a",
     "semantic_hash": "81883221b4ecfe82dc31f4e2edc1f24a"
   },
   "tests/gui/visual/golden_images/home_page_dark.png": {
-    "mtime": 1765002084.0,
+    "mtime": 1783141477.2104242,
     "ast_hash": "b63218b51a014ec432e1413fc29b169c",
     "semantic_hash": "b63218b51a014ec432e1413fc29b169c"
   },
   "tests/gui/visual/golden_images/home_page_light.png": {
-    "mtime": 1765002084.0,
+    "mtime": 1783141477.2104242,
     "ast_hash": "b63218b51a014ec432e1413fc29b169c",
     "semantic_hash": "b63218b51a014ec432e1413fc29b169c"
   },
   "tests/gui/visual/golden_images/transform_page.png": {
-    "mtime": 1765002084.0,
+    "mtime": 1783141477.2104242,
     "ast_hash": "b63218b51a014ec432e1413fc29b169c",
     "semantic_hash": "b63218b51a014ec432e1413fc29b169c"
   },
   "tests/core/test_arviz_utils.py": {
-    "mtime": 1782840586.0644205,
+    "mtime": 1783141477.1964242,
     "ast_hash": "f98195a9ac67eaa5c09136df70442d0e",
     "semantic_hash": "f98195a9ac67eaa5c09136df70442d0e"
   },
   "tests/refactor/__init__.py": {
-    "mtime": 1782840586.0674205,
+    "mtime": 1783141477.2204242,
     "ast_hash": "d41d8cd98f00b204e9800998ecf8427e",
     "semantic_hash": "d41d8cd98f00b204e9800998ecf8427e"
   },
   "tests/refactor/test_dmta_removal.py": {
-    "mtime": 1782840586.0674205,
+    "mtime": 1783141477.2204242,
     "ast_hash": "238854cb3059d82dde29f9daaf3b0c40",
     "semantic_hash": "238854cb3059d82dde29f9daaf3b0c40"
   },
   "tests/io/test_dmta_rejection.py": {
-    "mtime": 1782840586.0654204,
+    "mtime": 1783141477.2124243,
     "ast_hash": "870e2aee05362a4e04c48045000e87bd",
     "semantic_hash": "870e2aee05362a4e04c48045000e87bd"
   },
   "tests/cli/test_dmta_cli.py": {
-    "mtime": 1782840586.0644205,
+    "mtime": 1783141477.1964242,
     "ast_hash": "5b4c609549377ed89260d3929b2c8b09",
     "semantic_hash": "5b4c609549377ed89260d3929b2c8b09"
   },
   "tests/gui/test_dmta_gui.py": {
-    "mtime": 1782840586.0654204,
+    "mtime": 1783141477.208424,
     "ast_hash": "0bc84ae6ac3de35b506fce91a33a6e5b",
     "semantic_hash": "0bc84ae6ac3de35b506fce91a33a6e5b"
   },
   "tests/pipeline/test_removed_dmta_kwargs.py": {
-    "mtime": 1782840586.0664203,
+    "mtime": 1783141477.2204242,
     "ast_hash": "dc9c3c9c4ae0b48929b395582d54695f",
     "semantic_hash": "dc9c3c9c4ae0b48929b395582d54695f"
   },
   "rheojax/core/_validation.py": {
-    "mtime": 1782840586.04642,
+    "mtime": 1783141477.1664243,
     "ast_hash": "deb10f75e6a1426d1115d80fd9461d2b",
     "semantic_hash": "deb10f75e6a1426d1115d80fd9461d2b"
   },
   "tests/core/test_validation.py": {
-    "mtime": 1782840586.0654204,
+    "mtime": 1783141477.1974242,
     "ast_hash": "6af1b04da5621d53620c1f155f104f80",
     "semantic_hash": "6af1b04da5621d53620c1f155f104f80"
   },
   "docs/source/verification/classical_lve_equations.md": {
-    "mtime": 1777045619.6633701,
+    "mtime": 1783141475.673429,
     "ast_hash": "6e73cb01fa15d417b9be5b8d75f538d8",
     "semantic_hash": "6e73cb01fa15d417b9be5b8d75f538d8"
   },
   "docs/source/verification/dmt_literature_verification.md": {
-    "mtime": 1777045619.6633701,
-    "ast_hash": "c2058e1717a49cdf9cc11cd9c9236dba",
-    "semantic_hash": "c2058e1717a49cdf9cc11cd9c9236dba"
+    "mtime": 1783141475.673429,
+    "ast_hash": "1c202f5bb387b3e79513fc2e71e5d049",
+    "semantic_hash": ""
   },
   "docs/source/verification/epm_validation_report_2026-03-29.md": {
-    "mtime": 1777045619.6633701,
-    "ast_hash": "0a80700ab8960c842021279379fd17ba",
-    "semantic_hash": "0a80700ab8960c842021279379fd17ba"
+    "mtime": 1783141475.673429,
+    "ast_hash": "fa4f3076c310d6a766a8a114c2f90a6e",
+    "semantic_hash": ""
   },
   "docs/source/verification/fikh_validation_report_2026-03-29.md": {
-    "mtime": 1777045619.6633701,
+    "mtime": 1783141475.673429,
     "ast_hash": "0672eadc8e98c3a528c9fc37cae4f93f",
     "semantic_hash": "0672eadc8e98c3a528c9fc37cae4f93f"
   },
   "docs/source/verification/fluidity_saramito_equations.rst": {
-    "mtime": 1777045619.6633701,
+    "mtime": 1783141475.674429,
     "ast_hash": "0e285630538ea0724ad23c4df65f5242",
     "semantic_hash": "0e285630538ea0724ad23c4df65f5242"
   },
   "docs/source/verification/fractional_models_equation_verification.md": {
-    "mtime": 1777045619.6633701,
+    "mtime": 1783141475.674429,
     "ast_hash": "6833fe0d700f0b04a42f7e90e7ada236",
     "semantic_hash": "6833fe0d700f0b04a42f7e90e7ada236"
   },
   "docs/source/verification/giesekus_math_verification.md": {
-    "mtime": 1777045619.6633701,
+    "mtime": 1783141475.674429,
     "ast_hash": "7041fd530b579422552da2e3e3a5ca87",
     "semantic_hash": "7041fd530b579422552da2e3e3a5ca87"
   },
   "docs/source/verification/gmm_canonical_equations.rst": {
-    "mtime": 1777045619.6643703,
+    "mtime": 1783141475.674429,
     "ast_hash": "a059f7c9968c61410b643b2209b34b70",
     "semantic_hash": "a059f7c9968c61410b643b2209b34b70"
   },
   "docs/source/verification/hl_model_equations.md": {
-    "mtime": 1777045619.6643703,
+    "mtime": 1783141475.674429,
     "ast_hash": "f5414bce495ff794137c1f0d63765368",
     "semantic_hash": "f5414bce495ff794137c1f0d63765368"
   },
   "docs/source/verification/hvm_literature_review.md": {
-    "mtime": 1777045619.6643703,
+    "mtime": 1783141475.674429,
     "ast_hash": "26272a0b183e27e5ad2ce34f48fce1e9",
     "semantic_hash": "26272a0b183e27e5ad2ce34f48fce1e9"
   },
   "docs/source/verification/itt_mct_literature_equations.md": {
-    "mtime": 1777045619.6643703,
+    "mtime": 1783141475.674429,
     "ast_hash": "185b2ba8c18d817bf8ca8e8624428f26",
     "semantic_hash": "185b2ba8c18d817bf8ca8e8624428f26"
   },
   "docs/source/verification/saos_validity_transient_networks.md": {
-    "mtime": 1777045619.6643703,
+    "mtime": 1783141475.674429,
     "ast_hash": "055d7185d747e053703c281b360d89e0",
     "semantic_hash": "055d7185d747e053703c281b360d89e0"
   },
   "docs/source/verification/tnt_equations_verification.rst": {
-    "mtime": 1777045619.6643703,
+    "mtime": 1783141475.674429,
     "ast_hash": "57fc911a253a27ccaf0f59c3e63d8541",
     "semantic_hash": "57fc911a253a27ccaf0f59c3e63d8541"
   },
   "docs/source/verification/vlb_equation_verification.md": {
-    "mtime": 1777045619.6643703,
+    "mtime": 1783141475.674429,
     "ast_hash": "6f6ede0b327a0f4546ee96ee331d6428",
     "semantic_hash": "6f6ede0b327a0f4546ee96ee331d6428"
   },
   "docs/source/verification/ikh_literature_verification.md": {
-    "mtime": 1777045619.6643703,
-    "ast_hash": "ed2f3617645f2e4762e2f7160adb25c8",
-    "semantic_hash": "ed2f3617645f2e4762e2f7160adb25c8"
+    "mtime": 1783141475.674429,
+    "ast_hash": "d69e405f575a864106219e4f1ad92a31",
+    "semantic_hash": ""
   },
   "docs/source/verification/spp_equations_verification.md": {
-    "mtime": 1777045619.6643703,
+    "mtime": 1783141475.674429,
     "ast_hash": "dae63d9cdebd5ba1b5195a0c78518b2d",
     "semantic_hash": "dae63d9cdebd5ba1b5195a0c78518b2d"
   },
   "docs/source/verification/vitrimer_nanocomposite_constitutive_models.md": {
-    "mtime": 1777045619.6643703,
+    "mtime": 1783141475.674429,
     "ast_hash": "059302be0aac293f16ec4008aedd448f",
     "semantic_hash": "059302be0aac293f16ec4008aedd448f"
   },
   "rheojax/gui/foundation/__init__.py": {
-    "mtime": 1782868060.7233555,
+    "mtime": 1783141477.1684244,
     "ast_hash": "d41d8cd98f00b204e9800998ecf8427e",
     "semantic_hash": "d41d8cd98f00b204e9800998ecf8427e"
   },
   "rheojax/gui/foundation/contract.py": {
-    "mtime": 1782870323.5679414,
+    "mtime": 1783141477.1684244,
     "ast_hash": "1c3b2ba0600007997e4c3f410c5a4312",
     "semantic_hash": "1c3b2ba0600007997e4c3f410c5a4312"
   },
   "rheojax/gui/foundation/invalidation.py": {
-    "mtime": 1783010562.6021957,
+    "mtime": 1783141477.1684244,
     "ast_hash": "0950420409e0c2a63dfdd32b7fa450e5",
     "semantic_hash": "0950420409e0c2a63dfdd32b7fa450e5"
   },
   "rheojax/gui/foundation/library.py": {
-    "mtime": 1783096292.3382773,
+    "mtime": 1783141477.1694243,
     "ast_hash": "8a0431703fd8ca80c29deb308454869f",
     "semantic_hash": ""
   },
   "rheojax/gui/foundation/metrics.py": {
-    "mtime": 1782868060.7233555,
+    "mtime": 1783141477.1694243,
     "ast_hash": "c0aecb1fce89b575198547ee4fc553f8",
     "semantic_hash": "c0aecb1fce89b575198547ee4fc553f8"
   },
   "rheojax/gui/foundation/pipeline_bridge.py": {
-    "mtime": 1783096292.3382773,
+    "mtime": 1783141477.1694243,
     "ast_hash": "03f64782c4cd275472555f1482341195",
     "semantic_hash": ""
   },
   "rheojax/gui/foundation/priors.py": {
-    "mtime": 1782870323.5679414,
+    "mtime": 1783141477.1694243,
     "ast_hash": "2a1dcdaf325537562bae142fb2ca9112",
     "semantic_hash": "2a1dcdaf325537562bae142fb2ca9112"
   },
   "rheojax/gui/foundation/state.py": {
-    "mtime": 1783096292.3392773,
+    "mtime": 1783141477.1694243,
     "ast_hash": "6e6a2259865fb751587f733423cbd09a",
     "semantic_hash": ""
   },
   "rheojax/gui/workspace/__init__.py": {
-    "mtime": 1782879933.5884144,
+    "mtime": 1783141477.1754243,
     "ast_hash": "d41d8cd98f00b204e9800998ecf8427e",
     "semantic_hash": "d41d8cd98f00b204e9800998ecf8427e"
   },
   "rheojax/gui/workspace/controller.py": {
-    "mtime": 1782892418.912076,
+    "mtime": 1783141477.1754243,
     "ast_hash": "3b2455c3b77189ea63ebaef22e581928",
     "semantic_hash": "3b2455c3b77189ea63ebaef22e581928"
   },
   "rheojax/gui/workspace/inspector.py": {
-    "mtime": 1783023586.5740256,
+    "mtime": 1783141477.1754243,
     "ast_hash": "64f4f608c3fb9fe67caa485710d28b29",
     "semantic_hash": ""
   },
   "rheojax/gui/workspace/library_rail.py": {
-    "mtime": 1783023586.5750258,
+    "mtime": 1783141477.1754243,
     "ast_hash": "ee5c019e49256ec5ca6bddbd1f20c89c",
     "semantic_hash": ""
   },
   "rheojax/gui/workspace/stepper_canvas.py": {
-    "mtime": 1783023586.5750258,
+    "mtime": 1783141477.1754243,
     "ast_hash": "7042c23ba7f8a4e4d7b4ec390b31bf6d",
     "semantic_hash": ""
   },
   "rheojax/gui/workspace/window.py": {
-    "mtime": 1783096292.3442771,
-    "ast_hash": "27c09a62e13b3163b1565961123ecd0b",
+    "mtime": 1783142046.0655801,
+    "ast_hash": "607c8e391a6746eae3292d34b7e4d6e3",
     "semantic_hash": ""
   },
   "tests/gui/foundation/__init__.py": {
-    "mtime": 1782868060.7423556,
+    "mtime": 1783141477.2064242,
     "ast_hash": "d41d8cd98f00b204e9800998ecf8427e",
     "semantic_hash": "d41d8cd98f00b204e9800998ecf8427e"
   },
   "tests/gui/foundation/test_contract.py": {
-    "mtime": 1782870323.575941,
+    "mtime": 1783141477.2064242,
     "ast_hash": "43cf3f58743eb99e0bac01260a423353",
     "semantic_hash": "43cf3f58743eb99e0bac01260a423353"
   },
   "tests/gui/foundation/test_flow_quantity.py": {
-    "mtime": 1782868060.7433555,
+    "mtime": 1783141477.2064242,
     "ast_hash": "82700f512b2d4e8af9c2a5d29cd1ff03",
     "semantic_hash": "82700f512b2d4e8af9c2a5d29cd1ff03"
   },
   "tests/gui/foundation/test_library.py": {
-    "mtime": 1783096292.3452773,
+    "mtime": 1783141477.2074242,
     "ast_hash": "ff0a1bbbdbe75876342d54755fec74c1",
     "semantic_hash": ""
   },
   "tests/gui/foundation/test_metrics.py": {
-    "mtime": 1782868060.7433555,
+    "mtime": 1783141477.2074242,
     "ast_hash": "7f96621880fecc75516423e67daa608b",
     "semantic_hash": "7f96621880fecc75516423e67daa608b"
   },
   "tests/gui/foundation/test_model_config.py": {
-    "mtime": 1782868060.7433555,
+    "mtime": 1783141477.2074242,
     "ast_hash": "f62767dbba16092532b34be3b45e20f7",
     "semantic_hash": "f62767dbba16092532b34be3b45e20f7"
   },
   "tests/gui/foundation/test_pipeline_bridge.py": {
-    "mtime": 1782868060.7433555,
+    "mtime": 1783141477.2074242,
     "ast_hash": "74d75f47bb180f5731989a1be9adad7b",
     "semantic_hash": "74d75f47bb180f5731989a1be9adad7b"
   },
   "tests/gui/foundation/test_priors.py": {
-    "mtime": 1782868060.7433555,
+    "mtime": 1783141477.2074242,
     "ast_hash": "b4b8563ccbf24852519013f7a5de3f40",
     "semantic_hash": "b4b8563ccbf24852519013f7a5de3f40"
   },
   "tests/gui/foundation/test_state.py": {
-    "mtime": 1783096292.3452773,
+    "mtime": 1783141477.2074242,
     "ast_hash": "21c41a04df99302eeb75bfda03fb6cc6",
     "semantic_hash": ""
   },
   "tests/gui/foundation/test_target_accept.py": {
-    "mtime": 1782868060.7433555,
+    "mtime": 1783141477.2074242,
     "ast_hash": "7c2b4d0b7b36e62ce60a7c03df9eeb07",
     "semantic_hash": "7c2b4d0b7b36e62ce60a7c03df9eeb07"
   },
   "tests/gui/foundation/test_transform_keys.py": {
-    "mtime": 1782870323.575941,
+    "mtime": 1783141477.2074242,
     "ast_hash": "eef4a4842b353ef5c8835b76c3d961f8",
     "semantic_hash": "eef4a4842b353ef5c8835b76c3d961f8"
   },
   "tests/gui/workspace/__init__.py": {
-    "mtime": 1782879933.5894144,
+    "mtime": 1783141477.2104242,
     "ast_hash": "d41d8cd98f00b204e9800998ecf8427e",
     "semantic_hash": "d41d8cd98f00b204e9800998ecf8427e"
   },
   "tests/gui/workspace/test_controller.py": {
-    "mtime": 1782892418.9370756,
+    "mtime": 1783141477.211424,
     "ast_hash": "c41c1d81776e0197ceee9dd619412062",
     "semantic_hash": "c41c1d81776e0197ceee9dd619412062"
   },
   "tests/gui/workspace/test_widgets.py": {
-    "mtime": 1783096292.3462772,
+    "mtime": 1783141477.211424,
     "ast_hash": "5d1ef98916e9348266abf439556623f9",
     "semantic_hash": ""
   },
   "rheojax/gui/workspace/fit/__init__.py": {
-    "mtime": 1782931710.7590752,
+    "mtime": 1783141477.1754243,
     "ast_hash": "d41d8cd98f00b204e9800998ecf8427e",
     "semantic_hash": "d41d8cd98f00b204e9800998ecf8427e"
   },
   "rheojax/gui/workspace/fit/fit_controller.py": {
-    "mtime": 1783018783.0847447,
+    "mtime": 1783141477.1754243,
     "ast_hash": "1560b9f740d3678117dfd99fd59e702e",
     "semantic_hash": "1560b9f740d3678117dfd99fd59e702e"
   },
   "rheojax/gui/workspace/fit/step1_protocol_model.py": {
-    "mtime": 1783023586.5740256,
+    "mtime": 1783141477.1754243,
     "ast_hash": "e6b3c3674a0f204a1f43695dab55b498",
     "semantic_hash": ""
   },
   "rheojax/gui/workspace/fit/step2_data.py": {
-    "mtime": 1783096292.3412771,
+    "mtime": 1783141477.1754243,
     "ast_hash": "900dc1bf71ec072e31ee6ca20897f4e5",
     "semantic_hash": ""
   },
   "rheojax/gui/workspace/fit/step3_nlsq.py": {
-    "mtime": 1783023586.5740256,
+    "mtime": 1783141477.1754243,
     "ast_hash": "88123f66300452c99f877c87245a4ad8",
     "semantic_hash": ""
   },
   "rheojax/gui/workspace/fit/step4_nuts.py": {
-    "mtime": 1783023586.5740256,
+    "mtime": 1783141477.1754243,
     "ast_hash": "1a75a662b4092f64ea253acfb3a14eca",
     "semantic_hash": ""
   },
   "rheojax/gui/workspace/fit/step5_visualize.py": {
-    "mtime": 1783023586.5740256,
+    "mtime": 1783141477.1754243,
     "ast_hash": "de4eca7bd6b69400358c6936d6f58f11",
     "semantic_hash": ""
   },
   "rheojax/gui/workspace/fit/step6_export.py": {
-    "mtime": 1783096292.3422773,
+    "mtime": 1783141477.1754243,
     "ast_hash": "d7fa8451154647909f33f1206ef79b2c",
     "semantic_hash": ""
   },
   "rheojax/gui/workspace/transform/__init__.py": {
-    "mtime": 1782962110.1028078,
+    "mtime": 1783141477.1754243,
     "ast_hash": "d41d8cd98f00b204e9800998ecf8427e",
     "semantic_hash": "d41d8cd98f00b204e9800998ecf8427e"
   },
   "rheojax/gui/workspace/transform/slots_spec.py": {
-    "mtime": 1782962110.1028078,
+    "mtime": 1783141477.1754243,
     "ast_hash": "474e883f1c4abbbbccb3cbe4ae4c3d4d",
     "semantic_hash": "474e883f1c4abbbbccb3cbe4ae4c3d4d"
   },
   "rheojax/gui/workspace/transform/step1_pick.py": {
-    "mtime": 1783023586.5750258,
+    "mtime": 1783141477.1754243,
     "ast_hash": "d63c4c89784d75d8b089f4e509bbba96",
     "semantic_hash": ""
   },
   "rheojax/gui/workspace/transform/step2_slots.py": {
-    "mtime": 1783023586.5750258,
+    "mtime": 1783141477.1754243,
     "ast_hash": "4b3f4014cea608d4771ceb452667b35c",
     "semantic_hash": ""
   },
   "rheojax/gui/workspace/transform/step3_run.py": {
-    "mtime": 1783023586.5750258,
+    "mtime": 1783141477.1764243,
     "ast_hash": "2d7e570db1b2faece59a5c20c7315e06",
     "semantic_hash": ""
   },
   "rheojax/gui/workspace/transform/step4_visualize.py": {
-    "mtime": 1783023586.5750258,
+    "mtime": 1783141477.1764243,
     "ast_hash": "0dffdce9ae623f90fe85507502230a39",
     "semantic_hash": ""
   },
   "rheojax/gui/workspace/transform/step5_export.py": {
-    "mtime": 1783096292.3442771,
+    "mtime": 1783141477.1764243,
     "ast_hash": "1cc0be05e7aa690743d4b58eb0c1c4d1",
     "semantic_hash": ""
   },
   "rheojax/gui/workspace/transform/transform_controller.py": {
-    "mtime": 1783096292.3442771,
+    "mtime": 1783141477.1764243,
     "ast_hash": "c331c0be9b0161468d9c16157eb6f7ee",
     "semantic_hash": ""
   },
   "tests/gui/foundation/test_pipeline_bridge_context.py": {
-    "mtime": 1783096292.3452773,
+    "mtime": 1783141477.2074242,
     "ast_hash": "c69dafb2bfd0ecd146971706ade0b08b",
     "semantic_hash": ""
   },
   "tests/gui/workspace/fit/__init__.py": {
-    "mtime": 1782931710.7600753,
+    "mtime": 1783141477.2104242,
     "ast_hash": "d41d8cd98f00b204e9800998ecf8427e",
     "semantic_hash": "d41d8cd98f00b204e9800998ecf8427e"
   },
   "tests/gui/workspace/fit/test_fit_controller.py": {
-    "mtime": 1783006151.4676244,
+    "mtime": 1783141477.2104242,
     "ast_hash": "71cae0ad89cfaf9f5e2540d6ab466b6e",
     "semantic_hash": "71cae0ad89cfaf9f5e2540d6ab466b6e"
   },
   "tests/gui/workspace/fit/test_step1.py": {
-    "mtime": 1782931710.7600753,
+    "mtime": 1783141477.2104242,
     "ast_hash": "8d9edc69ab46597d09ed131919b9e50a",
     "semantic_hash": "8d9edc69ab46597d09ed131919b9e50a"
   },
   "tests/gui/workspace/fit/test_step1_config.py": {
-    "mtime": 1783002867.870239,
+    "mtime": 1783141477.2104242,
     "ast_hash": "3c566b26588e461dbb51ccf1731536f0",
     "semantic_hash": "3c566b26588e461dbb51ccf1731536f0"
   },
   "tests/gui/workspace/fit/test_step2.py": {
-    "mtime": 1782943417.224894,
+    "mtime": 1783141477.2104242,
     "ast_hash": "7991b3e638bfbfd7bbe0ece2e19e9502",
     "semantic_hash": "7991b3e638bfbfd7bbe0ece2e19e9502"
   },
   "tests/gui/workspace/fit/test_step2_validation.py": {
-    "mtime": 1783002867.870239,
+    "mtime": 1783141477.2104242,
     "ast_hash": "fc0555d1e8006600c09bc8dbdc553a85",
     "semantic_hash": "fc0555d1e8006600c09bc8dbdc553a85"
   },
   "tests/gui/workspace/fit/test_step3.py": {
-    "mtime": 1783016198.9783685,
+    "mtime": 1783141477.2104242,
     "ast_hash": "d003a54ec28f97ff02cf3bf3ce5b24d5",
     "semantic_hash": "d003a54ec28f97ff02cf3bf3ce5b24d5"
   },
   "tests/gui/workspace/fit/test_step4.py": {
-    "mtime": 1783016198.9783685,
+    "mtime": 1783141477.2104242,
     "ast_hash": "7d398ac41207f1b305d888212352337f",
     "semantic_hash": "7d398ac41207f1b305d888212352337f"
   },
   "tests/gui/workspace/fit/test_step5.py": {
-    "mtime": 1782943417.225894,
+    "mtime": 1783141477.2104242,
     "ast_hash": "e62f69b53e0f8d2ebb002c3faca45a84",
     "semantic_hash": "e62f69b53e0f8d2ebb002c3faca45a84"
   },
   "tests/gui/workspace/fit/test_step6.py": {
-    "mtime": 1783096292.3462772,
+    "mtime": 1783141477.2104242,
     "ast_hash": "270ce8ed933c3b367a055487e7582684",
     "semantic_hash": ""
   },
   "tests/gui/workspace/fit/test_step6_store_payload.py": {
-    "mtime": 1783096292.3462772,
+    "mtime": 1783141477.2104242,
     "ast_hash": "b59da09f21c3df724e95233f8ef9352b",
     "semantic_hash": ""
   },
   "tests/gui/workspace/transform/__init__.py": {
-    "mtime": 1782962110.1028078,
+    "mtime": 1783141477.211424,
     "ast_hash": "d41d8cd98f00b204e9800998ecf8427e",
     "semantic_hash": "d41d8cd98f00b204e9800998ecf8427e"
   },
   "tests/gui/workspace/transform/test_end_to_end_slot_to_library.py": {
-    "mtime": 1783096292.3472772,
+    "mtime": 1783141477.211424,
     "ast_hash": "677c948953d40c295e0e782ccca23be1",
     "semantic_hash": ""
   },
   "tests/gui/workspace/transform/test_run_step_wiring.py": {
-    "mtime": 1783016198.9783685,
+    "mtime": 1783141477.211424,
     "ast_hash": "7a7ed4b668ec924d3591b8df2fe29fb1",
     "semantic_hash": "7a7ed4b668ec924d3591b8df2fe29fb1"
   },
   "tests/gui/workspace/transform/test_slots_spec.py": {
-    "mtime": 1782962110.1038077,
+    "mtime": 1783141477.211424,
     "ast_hash": "720358ab01634f153944357201a83f8b",
     "semantic_hash": "720358ab01634f153944357201a83f8b"
   },
   "tests/gui/workspace/transform/test_step1.py": {
-    "mtime": 1782962110.1038077,
+    "mtime": 1783141477.211424,
     "ast_hash": "27c0ae0fb234435fe676419640dc6a03",
     "semantic_hash": "27c0ae0fb234435fe676419640dc6a03"
   },
   "tests/gui/workspace/transform/test_step2.py": {
-    "mtime": 1782962110.1038077,
+    "mtime": 1783141477.211424,
     "ast_hash": "dda5a23f5fca0ab8a04d9395d7ef7687",
     "semantic_hash": "dda5a23f5fca0ab8a04d9395d7ef7687"
   },
   "tests/gui/workspace/transform/test_step2_selectors.py": {
-    "mtime": 1782980449.8482137,
+    "mtime": 1783141477.211424,
     "ast_hash": "6565e93fe08f54a867ffd4208b1712eb",
     "semantic_hash": "6565e93fe08f54a867ffd4208b1712eb"
   },
   "tests/gui/workspace/transform/test_step3.py": {
-    "mtime": 1783016198.9793684,
+    "mtime": 1783141477.211424,
     "ast_hash": "5f27212da83c5d62c5c768e3aa8ebbdf",
     "semantic_hash": "5f27212da83c5d62c5c768e3aa8ebbdf"
   },
   "tests/gui/workspace/transform/test_step4.py": {
-    "mtime": 1782980449.8482137,
+    "mtime": 1783141477.211424,
     "ast_hash": "e36c9d73171eebc6f331e11e9fa4bebe",
     "semantic_hash": "e36c9d73171eebc6f331e11e9fa4bebe"
   },
   "tests/gui/workspace/transform/test_step5.py": {
-    "mtime": 1783096292.3482773,
-    "ast_hash": "c677f5b32a2478eb2d854f97caa9b69c",
+    "mtime": 1783141477.211424,
+    "ast_hash": "fd44c0eb7249abbde3186538110b6da7",
     "semantic_hash": ""
   },
   "tests/gui/workspace/transform/test_step5_store_payload.py": {
-    "mtime": 1783096292.3482773,
+    "mtime": 1783141477.211424,
     "ast_hash": "de695100779fb3bfc79c50d503bbc60a",
     "semantic_hash": ""
   },
   "tests/gui/workspace/transform/test_step5_writers.py": {
-    "mtime": 1782980449.8482137,
+    "mtime": 1783141477.211424,
     "ast_hash": "1fdb58334acf711d395a68a2723dc7a1",
     "semantic_hash": "1fdb58334acf711d395a68a2723dc7a1"
   },
   "tests/gui/workspace/transform/test_transform_controller.py": {
-    "mtime": 1783096292.3482773,
-    "ast_hash": "558ae92c82984329e09dfea0f2de6350",
+    "mtime": 1783141477.211424,
+    "ast_hash": "96078ffb3e7140b489d435f43ce09aaa",
     "semantic_hash": ""
   },
   "tests/gui/workspace/transform/test_transform_controller_validate.py": {
-    "mtime": 1782980449.8482137,
+    "mtime": 1783141477.211424,
     "ast_hash": "a79c0ee7b25e6f03b021a025a2782b91",
     "semantic_hash": "a79c0ee7b25e6f03b021a025a2782b91"
   },
   "tests/gui/workspace/fit/test_step3_wiring.py": {
-    "mtime": 1783018783.0857449,
+    "mtime": 1783141477.2104242,
     "ast_hash": "938fcf94e20da1e69becf560147937f3",
     "semantic_hash": "938fcf94e20da1e69becf560147937f3"
   },
   "tests/gui/services/__init__.py": {
-    "mtime": 1782980449.8472135,
+    "mtime": 1783141477.208424,
     "ast_hash": "d41d8cd98f00b204e9800998ecf8427e",
     "semantic_hash": "d41d8cd98f00b204e9800998ecf8427e"
   },
   "tests/gui/services/test_export_service_netcdf.py": {
-    "mtime": 1782980449.8472135,
+    "mtime": 1783141477.208424,
     "ast_hash": "298c75ff47e63d1d327c46bc59115909",
     "semantic_hash": "298c75ff47e63d1d327c46bc59115909"
   },
   "tests/gui/workspace/fit/test_step4_priors.py": {
-    "mtime": 1782980449.8482137,
+    "mtime": 1783141477.2104242,
     "ast_hash": "28af18dab2448ca37c9ccad01b5aaba5",
     "semantic_hash": "28af18dab2448ca37c9ccad01b5aaba5"
   },
   "tests/gui/workspace/fit/test_step5_diagnostics.py": {
-    "mtime": 1783006151.4676244,
+    "mtime": 1783141477.2104242,
     "ast_hash": "cf9178f2c9677da2144e5be4b262dbf4",
     "semantic_hash": "cf9178f2c9677da2144e5be4b262dbf4"
   },
   "tests/gui/workspace/fit/test_step6_writers.py": {
-    "mtime": 1783002867.8712392,
+    "mtime": 1783141477.2104242,
     "ast_hash": "8405da85863fff782a311dd11ec16f63",
     "semantic_hash": "8405da85863fff782a311dd11ec16f63"
   },
   "tests/gui/services/test_bayesian_service_model_config.py": {
-    "mtime": 1783002867.869239,
+    "mtime": 1783141477.208424,
     "ast_hash": "9146bdea6f6794053c24948326e3ac95",
     "semantic_hash": "9146bdea6f6794053c24948326e3ac95"
   },
   "tests/gui/workspace/fit/test_end_to_end_fit_to_export.py": {
-    "mtime": 1783002867.870239,
+    "mtime": 1783141477.2104242,
     "ast_hash": "09cebbf9b0f545ffa7c7389835fc81d7",
     "semantic_hash": "09cebbf9b0f545ffa7c7389835fc81d7"
   },
   "tests/gui/workspace/fit/test_fit_controller_validate.py": {
-    "mtime": 1782980449.8472135,
+    "mtime": 1783141477.2104242,
     "ast_hash": "73fbb81118e996c781feac39989ab267",
     "semantic_hash": "73fbb81118e996c781feac39989ab267"
   },
   "rheojax/gui/foundation/import_service.py": {
-    "mtime": 1783096292.3382773,
+    "mtime": 1783141477.1684244,
     "ast_hash": "b06a9db18047a9d1431efcb2844a8968",
     "semantic_hash": ""
   },
   "rheojax/gui/foundation/notifier.py": {
-    "mtime": 1783096292.3382773,
+    "mtime": 1783141477.1694243,
     "ast_hash": "dd21baf86e20544d8659100dc90f11bb",
     "semantic_hash": ""
   },
   "rheojax/gui/foundation/project_codec.py": {
-    "mtime": 1783096292.3392773,
-    "ast_hash": "5611d795ab4dd8aaa7883bf9eb6d1a3d",
+    "mtime": 1783141477.1694243,
+    "ast_hash": "720bc457db61e4f2dcd02bff7d07804c",
     "semantic_hash": ""
   },
   "rheojax/gui/workspace/pipeline/__init__.py": {
-    "mtime": 1783096292.3422773,
+    "mtime": 1783141477.1754243,
     "ast_hash": "d41d8cd98f00b204e9800998ecf8427e",
     "semantic_hash": ""
   },
   "rheojax/gui/workspace/pipeline/batch_runner.py": {
-    "mtime": 1783096292.3422773,
-    "ast_hash": "bbc779fbe5e616ebd0d42c3def419c33",
+    "mtime": 1783141477.1754243,
+    "ast_hash": "52c8fc2bb2c10b09661ad1a98fb4bfb1",
     "semantic_hash": ""
   },
   "rheojax/gui/workspace/pipeline/cancel_runnable.py": {
-    "mtime": 1783096292.3432772,
+    "mtime": 1783141477.1754243,
     "ast_hash": "1eea4092bb6aaa11d8ee7fc7cd6a9b8b",
     "semantic_hash": ""
   },
   "rheojax/gui/workspace/pipeline/controller.py": {
-    "mtime": 1783096292.3432772,
-    "ast_hash": "718a08d8f15b57c59ac140cec4dab4e3",
+    "mtime": 1783141477.1754243,
+    "ast_hash": "1499c9adb98a1fd3d09600177ab0493b",
     "semantic_hash": ""
   },
   "rheojax/gui/workspace/pipeline/models.py": {
-    "mtime": 1783096292.3432772,
+    "mtime": 1783141477.1754243,
     "ast_hash": "fda7340e6b07501f1d6acc61b103a970",
     "semantic_hash": ""
   },
   "rheojax/gui/workspace/pipeline/step1_configure_run.py": {
-    "mtime": 1783096292.3432772,
+    "mtime": 1783141477.1754243,
     "ast_hash": "328c9ce057277a6914efa55379bfcd0b",
     "semantic_hash": ""
   },
   "tests/gui/foundation/test_import_service.py": {
-    "mtime": 1783096292.3442771,
+    "mtime": 1783141477.2064242,
     "ast_hash": "dba72b7ccd592e05203c7fafbb7d236a",
     "semantic_hash": ""
   },
   "tests/gui/foundation/test_notifier.py": {
-    "mtime": 1783096292.3452773,
+    "mtime": 1783141477.2074242,
     "ast_hash": "27c5f290fe6cac2182ffbe77a4b8f52a",
     "semantic_hash": ""
   },
   "tests/gui/foundation/test_project_codec.py": {
-    "mtime": 1783096292.3452773,
-    "ast_hash": "992b93197f7c54bde78602b26e25dd5f",
+    "mtime": 1783141477.2074242,
+    "ast_hash": "53dd5b66d07f6516b917527804be0236",
     "semantic_hash": ""
   },
   "tests/gui/test_main_cli_wiring.py": {
-    "mtime": 1783096292.3452773,
+    "mtime": 1783141477.2094243,
     "ast_hash": "e3885351a6acef139eb6d505bdde3613",
     "semantic_hash": ""
   },
   "tests/gui/test_pipeline_execution_service_execute.py": {
-    "mtime": 1783096292.3452773,
-    "ast_hash": "e62047847664103de83123b252b5719e",
+    "mtime": 1783141477.2094243,
+    "ast_hash": "7d55eae378b70836f6fe62a84b706b5e",
     "semantic_hash": ""
   },
   "tests/gui/workspace/pipeline/__init__.py": {
-    "mtime": 1783096292.3462772,
+    "mtime": 1783141477.2104242,
     "ast_hash": "d41d8cd98f00b204e9800998ecf8427e",
     "semantic_hash": ""
   },
   "tests/gui/workspace/pipeline/test_batch_runner.py": {
-    "mtime": 1783096292.3462772,
-    "ast_hash": "a0de4484a9bbd4b35bbb63a0cbcea19c",
+    "mtime": 1783141477.2104242,
+    "ast_hash": "df5d2fd5e75d905810ae7065d32f5c44",
     "semantic_hash": ""
   },
   "tests/gui/workspace/pipeline/test_cancel_runnable.py": {
-    "mtime": 1783096292.3462772,
+    "mtime": 1783141477.211424,
     "ast_hash": "4cb7c83576590afd7dcfd8c52ddf2a19",
     "semantic_hash": ""
   },
   "tests/gui/workspace/pipeline/test_controller.py": {
-    "mtime": 1783096292.3462772,
-    "ast_hash": "43873142c25cd148819879c10dea67a4",
+    "mtime": 1783141477.211424,
+    "ast_hash": "d32f4c5cf29a6d52c885f1abb002e6b6",
     "semantic_hash": ""
   },
   "tests/gui/workspace/pipeline/test_models.py": {
-    "mtime": 1783096292.3462772,
+    "mtime": 1783141477.211424,
     "ast_hash": "d98d26b372bce7b1ba64edb4e7defa0c",
     "semantic_hash": ""
   },
   "tests/gui/workspace/pipeline/test_step1_configure_run.py": {
-    "mtime": 1783096292.3462772,
+    "mtime": 1783141477.211424,
     "ast_hash": "c9683ad2324f4eab58b909df3ac11e57",
     "semantic_hash": ""
   },
   "tests/gui/workspace/test_window_active_jobs_dialog.py": {
-    "mtime": 1783096292.3472772,
-    "ast_hash": "c52068cd3e16750bbee11d8740c98774",
+    "mtime": 1783141477.211424,
+    "ast_hash": "231b5b63df7b322dcb3235bd5dab246e",
     "semantic_hash": ""
   },
   "tests/gui/workspace/test_window_commit_dataset.py": {
-    "mtime": 1783096292.3472772,
-    "ast_hash": "53c63a160469485a9caf0de42036e739",
+    "mtime": 1783141477.211424,
+    "ast_hash": "039e6f500fd10d277962f88ccb4fc87e",
     "semantic_hash": ""
   },
   "tests/gui/workspace/test_window_file_menu.py": {
-    "mtime": 1783096292.3472772,
-    "ast_hash": "788871ba80ae5fa8d64eaf7d6cfaf95e",
+    "mtime": 1783141477.211424,
+    "ast_hash": "e8b5b12a270ee6a4a3eda340a6cceae7",
     "semantic_hash": ""
   },
   "tests/gui/workspace/test_window_pipeline_mode.py": {
-    "mtime": 1783096292.3472772,
+    "mtime": 1783141477.211424,
     "ast_hash": "abf6cd68675d9f99e5e9d78a95766645",
     "semantic_hash": ""
   },
   "tests/gui/workspace/test_window_rebuild.py": {
-    "mtime": 1783096292.3472772,
+    "mtime": 1783141477.211424,
     "ast_hash": "cad9f0c3e3cbb075ba52538cd9c00c22",
     "semantic_hash": ""
   },
   "tests/gui/workspace/transform/test_infer_output_protocol.py": {
-    "mtime": 1783096292.3472772,
+    "mtime": 1783141477.211424,
     "ast_hash": "e79e3ad49d28fc2281d9a3c584129641",
+    "semantic_hash": ""
+  },
+  "tests/gui/workspace/test_window_import.py": {
+    "mtime": 1783142017.3425677,
+    "ast_hash": "1e7bb1a2e1dd971d5722891d9067b99f",
+    "semantic_hash": ""
+  },
+  "docs/source/user_guide/06_gui/workspace_getting_started.rst": {
+    "mtime": 1783141475.673429,
+    "ast_hash": "34c7730e89fac6f1240b01f826f00b41",
+    "semantic_hash": ""
+  },
+  "rheojax/gui/workspace/README.md": {
+    "mtime": 1783141477.1754243,
+    "ast_hash": "a1f9ca7c78bd1d68051cd22f4e9ca828",
     "semantic_hash": ""
   }
 }

--- a/rheojax/gui/workspace/window.py
+++ b/rheojax/gui/workspace/window.py
@@ -125,6 +125,7 @@ class WorkspaceWindow(QMainWindow):
         # any commit path (interactive export or a Pipeline job) never appears until the
         # next full _rebuild() (Open/New/Close).
         self._notifier.changed.connect(self._rail.refresh)
+        self._rail.import_requested.connect(self._on_import_requested)
         self._inspector = InspectorPanel(self)
         self._canvas = StepperCanvas(self._controllers[self._mode], self)
         self._wire_canvas(self._canvas)
@@ -168,6 +169,10 @@ class WorkspaceWindow(QMainWindow):
             body.deleteLater()
         try:
             self._notifier.changed.disconnect(self._rail.refresh)
+        except (RuntimeError, TypeError):
+            pass
+        try:
+            self._rail.import_requested.disconnect(self._on_import_requested)
         except (RuntimeError, TypeError):
             pass
         for widget in (self._canvas, self._rail, self._inspector, self._splitter):
@@ -404,6 +409,95 @@ class WorkspaceWindow(QMainWindow):
         if payload is not None:
             self._state.library.store_payload(ref.id, payload)
         self._notifier.changed.emit()
+
+    # detect_test_mode() reports "flow" for flow-curve data (F-IO-R... naming
+    # predates Protocol.FLOW_CURVE), which never equality-matches
+    # DatasetLibrary.datasets_of_type("flow_curve") -- normalize it here so
+    # imported flow-curve datasets actually show up in the Fit/Transform Data
+    # step instead of silently landing in no protocol bucket at all.
+    _IMPORT_TEST_MODE_ALIASES = {"flow": "flow_curve"}
+
+    def _on_import_requested(self) -> None:
+        """Handle LibraryRail's "+ Import data..." button."""
+        from PySide6.QtWidgets import QFileDialog
+
+        paths, _ = QFileDialog.getOpenFileNames(
+            self,
+            "Import Data",
+            "",
+            "All Supported (*.csv *.txt *.xlsx *.xls *.tri *.dat *.json);;All Files (*.*)",
+        )
+        if not paths:
+            return
+
+        from PySide6.QtCore import QThreadPool
+
+        from rheojax.gui.jobs.import_worker import ImportWorker
+        from rheojax.gui.services.data_service import DataService
+
+        file_paths = [Path(p) for p in paths]
+        worker = ImportWorker(
+            data_service=DataService(), file_path=file_paths[0], file_paths=file_paths
+        )
+        # QueuedConnection guarantees the callback runs on the main thread --
+        # ImportWorker emits its signals from a QThreadPool worker thread.
+        worker.signals.completed.connect(
+            self._on_import_completed, Qt.ConnectionType.QueuedConnection
+        )
+        worker.signals.failed.connect(
+            self._on_import_failed, Qt.ConnectionType.QueuedConnection
+        )
+        # Keep a reference alive for the worker's lifetime -- nothing else
+        # holds the ImportWorker/ImportWorkerSignals QObject, so it would
+        # otherwise be garbage-collected mid-run and drop the signal.
+        self._active_import_worker = worker
+        QThreadPool.globalInstance().start(worker)
+
+    def _on_import_completed(self, datasets: list) -> None:
+        import hashlib
+        import uuid
+
+        from rheojax.gui.foundation.library import DatasetRef
+        from rheojax.gui.services.data_service import DataService
+
+        service = DataService()
+        hash_cache: dict[str, str] = {}
+        # ponytail: multiple segments from one source file all get that
+        # file's stem as their name -- add "_segment_N" suffixing if that
+        # proves confusing in practice.
+        for rheo_data in datasets:
+            meta = rheo_data.metadata
+            source_file = meta.pop("_source_file", None)
+            test_mode = meta.get("test_mode") or service.detect_test_mode(rheo_data)
+            test_mode = self._IMPORT_TEST_MODE_ALIASES.get(test_mode, test_mode)
+            meta["test_mode"] = test_mode
+
+            if source_file and source_file not in hash_cache:
+                hash_cache[source_file] = hashlib.sha256(
+                    Path(source_file).read_bytes()
+                ).hexdigest()
+
+            ref = DatasetRef(
+                id=uuid.uuid4().hex,
+                name=Path(source_file).stem if source_file else "imported",
+                protocol_type=test_mode,
+                origin="imported",
+                units={
+                    k: v
+                    for k, v in (("x", rheo_data.x_units), ("y", rheo_data.y_units))
+                    if v
+                },
+                row_count=len(rheo_data.x),
+                hash=hash_cache.get(source_file, ""),
+                provenance={"source": "gui_import", "path": source_file},
+                lineage=[],
+            )
+            self._commit_dataset(ref, rheo_data, overwrite=False)
+
+    def _on_import_failed(self, error_msg: str) -> None:
+        from PySide6.QtWidgets import QMessageBox
+
+        QMessageBox.critical(self, "Import Failed", error_msg)
 
     def _sync_mode_buttons(self) -> None:
         self._fit_btn.setChecked(self._mode == "fit")

--- a/tests/gui/workspace/test_window_import.py
+++ b/tests/gui/workspace/test_window_import.py
@@ -1,0 +1,95 @@
+import numpy as np
+import pytest
+
+pytest.importorskip("PySide6")
+
+from PySide6.QtWidgets import QFileDialog, QMessageBox
+
+from rheojax.core.data import RheoData
+from rheojax.gui.foundation.state import AppState
+from rheojax.gui.workspace.window import WorkspaceWindow
+
+
+def test_library_rail_import_click_invokes_file_dialog(qtbot, monkeypatch):
+    # Regression: LibraryRail's "+ Import data..." button emitted
+    # import_requested, but WorkspaceWindow never connected it to anything,
+    # so clicking it silently did nothing.
+    calls = []
+    monkeypatch.setattr(
+        QFileDialog,
+        "getOpenFileNames",
+        lambda *a, **k: (calls.append(1), ([], ""))[1],
+    )
+
+    state = AppState()
+    win = WorkspaceWindow(state)
+    qtbot.addWidget(win)
+
+    win._rail._import.click()
+
+    assert calls == [1]
+
+
+def test_import_completed_adds_dataset_to_library(qtbot, tmp_path):
+    state = AppState()
+    win = WorkspaceWindow(state)
+    qtbot.addWidget(win)
+    assert win._rail.count() == 0
+
+    source = tmp_path / "sample.csv"
+    source.write_text("omega,g_prime\n1.0,2.0\n2.0,3.0\n")
+    data = RheoData(
+        x=np.array([1.0, 2.0]),
+        y=np.array([2.0, 3.0]),
+        domain="frequency",
+        metadata={"_source_file": str(source)},
+    )
+
+    win._on_import_completed([data])
+
+    assert win._rail.count() == 1
+    ref = next(iter(state.library.all()))
+    assert ref.name == "sample"
+    assert ref.protocol_type == "oscillation"
+    assert ref.row_count == 2
+    assert state.library.load_payload(ref.id) is data
+    assert "_source_file" not in data.metadata
+
+
+def test_import_completed_maps_flow_test_mode_to_flow_curve_protocol(qtbot, tmp_path):
+    # DataService.detect_test_mode() returns "flow", but the Protocol enum
+    # (and DatasetLibrary.datasets_of_type filtering) uses "flow_curve" --
+    # without normalizing, imported flow-curve data would never match any
+    # protocol's Data step.
+    state = AppState()
+    win = WorkspaceWindow(state)
+    qtbot.addWidget(win)
+
+    source = tmp_path / "flow.csv"
+    source.write_text("shear_rate,viscosity\n1.0,10.0\n")
+    data = RheoData(
+        x=np.array([1.0, 10.0, 100.0]),
+        y=np.array([100.0, 10.0, 1.0]),
+        domain="time",
+        metadata={"_source_file": str(source), "test_mode": "flow"},
+    )
+
+    win._on_import_completed([data])
+
+    ref = next(iter(state.library.all()))
+    assert ref.protocol_type == "flow_curve"
+
+
+def test_import_failed_shows_message_box(qtbot, monkeypatch):
+    messages = []
+    monkeypatch.setattr(
+        QMessageBox, "critical", lambda *a, **k: messages.append(a[-1])
+    )
+
+    state = AppState()
+    win = WorkspaceWindow(state)
+    qtbot.addWidget(win)
+
+    win._on_import_failed("boom")
+
+    assert messages == ["boom"]


### PR DESCRIPTION
## Summary
- `WorkspaceWindow` built `LibraryRail` and wired its dataset-list refresh, but never connected the `import_requested` signal emitted by the "+ Import data…" button — clicking it silently did nothing. Reported as "the import data function is still not working."
- Wires `import_requested` to a new `_on_import_requested` handler that opens a file dialog and imports via the existing `ImportWorker`/`DataService` background-thread machinery (same pattern already used by the legacy `DataPage`), committing each resulting dataset into the workspace's `DatasetLibrary` via the existing `_commit_dataset` path.
- Normalizes `DataService.detect_test_mode()`'s `"flow"` result to `Protocol.FLOW_CURVE`'s `"flow_curve"` so imported flow-curve data actually appears in the Fit/Transform Data step's dataset picker (which filters by exact `protocol_type` match).

## Test plan
- [x] New regression tests in `tests/gui/workspace/test_window_import.py` (click → file dialog invoked, completed → dataset added to library, `flow`→`flow_curve` protocol mapping, failure → error dialog). Verified all 4 fail against the pre-fix code and pass after the fix.
- [x] `uv run pytest tests/gui -q --no-cov` — 524 passed; the only 10 failures are pre-existing, unrelated matplotlib/freetype `FT_Render_Glyph`/`MemoryError` issues in this sandbox, reproducible before this change.
- [x] `uv run ruff check` on changed files — clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)