### PR TITLE
fix(gui): recover from CSV column auto-detect failure in workspace import

### DIFF
--- a/rheojax/gui/workspace/window.py
+++ b/rheojax/gui/workspace/window.py
@@ -430,14 +430,29 @@ class WorkspaceWindow(QMainWindow):
         if not paths:
             return
 
+        self._launch_import([Path(p) for p in paths])
+
+    def _launch_import(
+        self,
+        file_paths: list,
+        x_col: str | None = None,
+        y_col: str | None = None,
+        y2_col: str | None = None,
+        temp_col: str | None = None,
+    ) -> None:
         from PySide6.QtCore import QThreadPool
 
         from rheojax.gui.jobs.import_worker import ImportWorker
         from rheojax.gui.services.data_service import DataService
 
-        file_paths = [Path(p) for p in paths]
         worker = ImportWorker(
-            data_service=DataService(), file_path=file_paths[0], file_paths=file_paths
+            data_service=DataService(),
+            file_path=file_paths[0],
+            file_paths=file_paths,
+            x_col=x_col,
+            y_col=y_col,
+            y2_col=y2_col,
+            temp_col=temp_col,
         )
         # QueuedConnection guarantees the callback runs on the main thread --
         # ImportWorker emits its signals from a QThreadPool worker thread.
@@ -451,6 +466,7 @@ class WorkspaceWindow(QMainWindow):
         # holds the ImportWorker/ImportWorkerSignals QObject, so it would
         # otherwise be garbage-collected mid-run and drop the signal.
         self._active_import_worker = worker
+        self._pending_import_paths = file_paths
         QThreadPool.globalInstance().start(worker)
 
     def _on_import_completed(self, datasets: list) -> None:
@@ -495,7 +511,32 @@ class WorkspaceWindow(QMainWindow):
             self._commit_dataset(ref, rheo_data, overwrite=False)
 
     def _on_import_failed(self, error_msg: str) -> None:
-        from PySide6.QtWidgets import QMessageBox
+        from PySide6.QtWidgets import QDialog, QMessageBox
+
+        # Root cause: this import path has no column-mapping step, so a CSV
+        # whose headers don't match auto_load's heuristic name list (see
+        # rheojax/io/readers/auto.py::_try_csv) fails with no way for the
+        # user to specify columns. Give them one via the existing (until now
+        # unwired) ColumnMapperDialog, then retry with the chosen mapping.
+        # ponytail: matched on message text rather than a typed exception --
+        # auto_load raises plain ValueError for every failure mode. Upgrade
+        # to a dedicated exception type if more branches need to key off it.
+        paths = getattr(self, "_pending_import_paths", None) or []
+        if len(paths) == 1 and "auto-detect" in error_msg.lower():
+            from rheojax.gui.dialogs.column_mapper import ColumnMapperDialog
+
+            dialog = ColumnMapperDialog(str(paths[0]), parent=self)
+            if dialog.exec() == QDialog.DialogCode.Accepted:
+                mapping = dialog.get_mapping()
+                if mapping.get("x") and mapping.get("y"):
+                    self._launch_import(
+                        paths,
+                        x_col=mapping["x"],
+                        y_col=mapping["y"],
+                        y2_col=mapping.get("y2"),
+                        temp_col=mapping.get("temperature"),
+                    )
+                    return
 
         QMessageBox.critical(self, "Import Failed", error_msg)
 

--- a/rheojax/gui/workspace/window.py
+++ b/rheojax/gui/workspace/window.py
@@ -434,7 +434,7 @@ class WorkspaceWindow(QMainWindow):
 
     def _launch_import(
         self,
-        file_paths: list,
+        file_paths: list[Path],
         x_col: str | None = None,
         y_col: str | None = None,
         y2_col: str | None = None,
@@ -459,14 +459,18 @@ class WorkspaceWindow(QMainWindow):
         worker.signals.completed.connect(
             self._on_import_completed, Qt.ConnectionType.QueuedConnection
         )
+        # file_paths is bound per-connection (not read from shared instance
+        # state) so that a second import launched before this worker's
+        # "failed" signal is delivered can never make the failure handler
+        # act on the wrong file's paths.
         worker.signals.failed.connect(
-            self._on_import_failed, Qt.ConnectionType.QueuedConnection
+            lambda msg, fp=file_paths: self._on_import_failed(msg, fp),
+            Qt.ConnectionType.QueuedConnection,
         )
         # Keep a reference alive for the worker's lifetime -- nothing else
         # holds the ImportWorker/ImportWorkerSignals QObject, so it would
         # otherwise be garbage-collected mid-run and drop the signal.
         self._active_import_worker = worker
-        self._pending_import_paths = file_paths
         QThreadPool.globalInstance().start(worker)
 
     def _on_import_completed(self, datasets: list) -> None:
@@ -510,7 +514,15 @@ class WorkspaceWindow(QMainWindow):
             )
             self._commit_dataset(ref, rheo_data, overwrite=False)
 
-    def _on_import_failed(self, error_msg: str) -> None:
+    # Extensions ColumnMapperDialog can actually parse (see its _load_data) --
+    # anything else (.tri, .json, .dat, ...) falls back to a raw pd.read_csv
+    # attempt there too, so offering the dialog for those would just stack a
+    # second, more confusing failure on top of the original one.
+    _COLUMN_MAPPABLE_SUFFIXES = {".csv", ".txt", ".xlsx", ".xls"}
+
+    def _on_import_failed(
+        self, error_msg: str, file_paths: list[Path] | None = None
+    ) -> None:
         from PySide6.QtWidgets import QDialog, QMessageBox
 
         # Root cause: this import path has no column-mapping step, so a CSV
@@ -521,8 +533,13 @@ class WorkspaceWindow(QMainWindow):
         # ponytail: matched on message text rather than a typed exception --
         # auto_load raises plain ValueError for every failure mode. Upgrade
         # to a dedicated exception type if more branches need to key off it.
-        paths = getattr(self, "_pending_import_paths", None) or []
-        if len(paths) == 1 and "auto-detect" in error_msg.lower():
+        paths = file_paths or []
+        offer_mapper = (
+            len(paths) == 1
+            and paths[0].suffix.lower() in self._COLUMN_MAPPABLE_SUFFIXES
+            and "auto-detect" in error_msg.lower()
+        )
+        if offer_mapper:
             from rheojax.gui.dialogs.column_mapper import ColumnMapperDialog
 
             dialog = ColumnMapperDialog(str(paths[0]), parent=self)

--- a/tests/gui/workspace/test_window_import.py
+++ b/tests/gui/workspace/test_window_import.py
@@ -3,6 +3,7 @@ import pytest
 
 pytest.importorskip("PySide6")
 
+from PySide6.QtCore import QThreadPool
 from PySide6.QtWidgets import QDialog, QFileDialog, QMessageBox
 
 from rheojax.core.data import RheoData
@@ -109,7 +110,6 @@ def test_import_failed_with_undetected_columns_offers_column_mapper(
     state = AppState()
     win = WorkspaceWindow(state)
     qtbot.addWidget(win)
-    win._pending_import_paths = [source]
 
     monkeypatch.setattr(
         ColumnMapperDialog, "exec", lambda self: QDialog.DialogCode.Accepted
@@ -125,7 +125,8 @@ def test_import_failed_with_undetected_columns_offers_column_mapper(
     win._on_import_failed(
         "Could not parse CSV as TRIOS or generic CSV: Could not auto-detect "
         "columns: Could not auto-detect x and y columns. "
-        "Please specify x_col and y_col.. Please specify x_col and y_col."
+        "Please specify x_col and y_col.. Please specify x_col and y_col.",
+        [source],
     )
 
     assert len(relaunches) == 1
@@ -148,7 +149,6 @@ def test_import_failed_undetected_columns_cancelled_shows_message_box(
     state = AppState()
     win = WorkspaceWindow(state)
     qtbot.addWidget(win)
-    win._pending_import_paths = [source]
 
     monkeypatch.setattr(
         ColumnMapperDialog, "exec", lambda self: QDialog.DialogCode.Rejected
@@ -158,6 +158,82 @@ def test_import_failed_undetected_columns_cancelled_shows_message_box(
         QMessageBox, "critical", lambda *a, **k: messages.append(a[-1])
     )
 
-    win._on_import_failed("Could not auto-detect x and y columns.")
+    win._on_import_failed("Could not auto-detect x and y columns.", [source])
 
     assert messages == ["Could not auto-detect x and y columns."]
+
+
+def test_import_failed_non_mappable_extension_skips_column_mapper(
+    qtbot, tmp_path, monkeypatch
+):
+    # Regression: auto_load's unknown-extension fallback (_try_all_readers)
+    # aggregates every reader's error into one message, so a corrupt/
+    # unsupported .tri file can still produce a message containing
+    # "auto-detect" from the CSV reader's fallback attempt even though the
+    # real failure has nothing to do with CSV column mapping.
+    # ColumnMapperDialog can't parse this file either (no branch for .tri in
+    # its _load_data) -- don't offer it for extensions it doesn't understand.
+    source = tmp_path / "weird.tri"
+    source.write_bytes(b"not real trios data")
+
+    state = AppState()
+    win = WorkspaceWindow(state)
+    qtbot.addWidget(win)
+
+    opened = []
+    monkeypatch.setattr(
+        ColumnMapperDialog, "__init__", lambda self, *a, **k: opened.append(1)
+    )
+    monkeypatch.setattr(
+        ColumnMapperDialog, "exec", lambda self: QDialog.DialogCode.Rejected
+    )
+    messages = []
+    monkeypatch.setattr(
+        QMessageBox, "critical", lambda *a, **k: messages.append(a[-1])
+    )
+
+    win._on_import_failed(
+        "Could not parse file with any available reader:\n"
+        "csv: Could not auto-detect columns: ...",
+        [source],
+    )
+
+    assert opened == []
+    assert messages == [
+        "Could not parse file with any available reader:\n"
+        "csv: Could not auto-detect columns: ..."
+    ]
+
+
+def test_overlapping_imports_do_not_cross_wire_failure_paths(
+    qtbot, tmp_path, monkeypatch
+):
+    # Regression: _on_import_failed used to read a single shared
+    # `_pending_import_paths` instance attribute set by _launch_import. If a
+    # second import was launched before the first worker's queued "failed"
+    # signal was delivered, the second call's paths silently overwrote the
+    # first's, so the failure handler retried against the wrong file.
+    # file_paths must now be bound per-connection so each worker's failure
+    # always carries its own paths regardless of what else launched after it.
+    monkeypatch.setattr(QThreadPool.globalInstance(), "start", lambda worker: None)
+
+    state = AppState()
+    win = WorkspaceWindow(state)
+    qtbot.addWidget(win)
+
+    source_a = tmp_path / "a.csv"
+    source_a.write_text("foo,bar\n1.0,2.0\n")
+    source_b = tmp_path / "b.csv"
+    source_b.write_text("foo,bar\n1.0,2.0\n")
+
+    win._launch_import([source_a])
+    worker_a = win._active_import_worker
+    win._launch_import([source_b])
+
+    calls = []
+    monkeypatch.setattr(win, "_on_import_failed", lambda *a, **k: calls.append(a))
+
+    worker_a.signals.failed.emit("boom")
+    qtbot.wait(50)
+
+    assert calls == [("boom", [source_a])]

--- a/tests/gui/workspace/test_window_import.py
+++ b/tests/gui/workspace/test_window_import.py
@@ -3,9 +3,10 @@ import pytest
 
 pytest.importorskip("PySide6")
 
-from PySide6.QtWidgets import QFileDialog, QMessageBox
+from PySide6.QtWidgets import QDialog, QFileDialog, QMessageBox
 
 from rheojax.core.data import RheoData
+from rheojax.gui.dialogs.column_mapper import ColumnMapperDialog
 from rheojax.gui.foundation.state import AppState
 from rheojax.gui.workspace.window import WorkspaceWindow
 
@@ -93,3 +94,70 @@ def test_import_failed_shows_message_box(qtbot, monkeypatch):
     win._on_import_failed("boom")
 
     assert messages == ["boom"]
+
+
+def test_import_failed_with_undetected_columns_offers_column_mapper(
+    qtbot, tmp_path, monkeypatch
+):
+    # Regression: a single-file import whose headers don't match auto_load's
+    # heuristic column-name list used to dead-end with a raw error dialog
+    # and no way to specify columns. It should offer ColumnMapperDialog and
+    # retry with the user's mapping instead.
+    source = tmp_path / "weird.csv"
+    source.write_text("foo,bar\n1.0,2.0\n2.0,3.0\n")
+
+    state = AppState()
+    win = WorkspaceWindow(state)
+    qtbot.addWidget(win)
+    win._pending_import_paths = [source]
+
+    monkeypatch.setattr(
+        ColumnMapperDialog, "exec", lambda self: QDialog.DialogCode.Accepted
+    )
+    monkeypatch.setattr(
+        ColumnMapperDialog, "get_mapping", lambda self: {"x": "foo", "y": "bar"}
+    )
+    relaunches = []
+    monkeypatch.setattr(
+        win, "_launch_import", lambda *a, **k: relaunches.append((a, k))
+    )
+
+    win._on_import_failed(
+        "Could not parse CSV as TRIOS or generic CSV: Could not auto-detect "
+        "columns: Could not auto-detect x and y columns. "
+        "Please specify x_col and y_col.. Please specify x_col and y_col."
+    )
+
+    assert len(relaunches) == 1
+    args, kwargs = relaunches[0]
+    assert args == ([source],)
+    assert kwargs == {
+        "x_col": "foo",
+        "y_col": "bar",
+        "y2_col": None,
+        "temp_col": None,
+    }
+
+
+def test_import_failed_undetected_columns_cancelled_shows_message_box(
+    qtbot, tmp_path, monkeypatch
+):
+    source = tmp_path / "weird.csv"
+    source.write_text("foo,bar\n1.0,2.0\n")
+
+    state = AppState()
+    win = WorkspaceWindow(state)
+    qtbot.addWidget(win)
+    win._pending_import_paths = [source]
+
+    monkeypatch.setattr(
+        ColumnMapperDialog, "exec", lambda self: QDialog.DialogCode.Rejected
+    )
+    messages = []
+    monkeypatch.setattr(
+        QMessageBox, "critical", lambda *a, **k: messages.append(a[-1])
+    )
+
+    win._on_import_failed("Could not auto-detect x and y columns.")
+
+    assert messages == ["Could not auto-detect x and y columns."]


### PR DESCRIPTION
## Summary
- The Workspace window's "+ Import data..." button (wired in #36) goes straight from the file picker to `ImportWorker` with no column mapping, unlike the legacy `main_window.py` import path (`ImportWizard`) or `DataPage`'s mapping panel.
- Any file whose headers don't match `auto_load`'s hardcoded heuristic list (`rheojax/io/readers/auto.py::_try_csv`) fails with a raw `"Could not auto-detect x and y columns"` `ValueError` and no way for the user to recover — this was the reported crash.
- Fix: reuse the existing, previously-unwired `ColumnMapperDialog`. On a single-file import whose auto-detection fails, offer the dialog and retry the import with the user-selected `x`/`y`/`y2`/`temperature` columns instead of dead-ending on a `QMessageBox.critical`.
- Multi-file batch imports are unchanged (still auto-detect only); this targets the common single-file case that matches the reported traceback.

## Test plan
- [x] `uv run pytest tests/gui/workspace/test_window_import.py -v` — 6 passed (4 existing + 2 new regression tests covering the column-mapper offer/accept and offer/cancel paths)
- [x] `uv run pytest tests/gui/workspace/` — no new failures (2 pre-existing failures in `fit/` are unrelated font-rendering/Qt-event-loop issues, reproduced identically on `main`)
- [x] `uv run ruff check` on changed files — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)