### PR TITLE
fix(gui): resolve 12 more bugs found by a fresh codex + agy review

### DIFF
--- a/rheojax/gui/app/main_window.py
+++ b/rheojax/gui/app/main_window.py
@@ -938,6 +938,14 @@ class RheoJAXMainWindow(QMainWindow):
         except Exception:
             logger.debug("BayesianPage close prep failed", exc_info=True)
 
+        try:
+            if hasattr(self, "export_page") and hasattr(
+                self.export_page, "prepare_for_close"
+            ):
+                self.export_page.prepare_for_close()
+        except Exception:
+            logger.debug("ExportPage close prep failed", exc_info=True)
+
         # Attempt graceful worker shutdown with a generous timeout.
         # If workers are still running after the timeout (e.g. NUTS sampling
         # stuck in JIT-compiled XLA code that cannot be interrupted), schedule

--- a/rheojax/gui/app/status_bar.py
+++ b/rheojax/gui/app/status_bar.py
@@ -5,7 +5,14 @@ Status Bar
 Application status bar with progress indicators, JAX device status, and memory monitoring.
 """
 
-from rheojax.gui.compat import QLabel, QProgressBar, QStatusBar, QTimer, QWidget
+from rheojax.gui.compat import (
+    QLabel,
+    QProgressBar,
+    QStatusBar,
+    QTimer,
+    QWidget,
+    _is_qobject_alive,
+)
 from rheojax.logging import get_logger
 
 logger = get_logger(__name__)
@@ -95,6 +102,8 @@ class StatusBar(QStatusBar):
 
     def _clear_timed_message(self, token: int, message: str) -> None:
         """Clear message_label if it still shows the message that timed out."""
+        if not _is_qobject_alive(self):
+            return
         if token == self._message_token and self.message_label.text() == message:
             self.message_label.setText("")
 

--- a/rheojax/gui/foundation/state.py
+++ b/rheojax/gui/foundation/state.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import threading
 from dataclasses import dataclass, field, replace
 from typing import Any
 
@@ -91,6 +92,14 @@ class JobResultRef:
 @dataclass
 class ActiveJobsState:
     by_id: dict[str, dict] = field(default_factory=dict)
+    # PipelineBatchRunner.run() writes into `by_id` from a QThreadPool worker
+    # thread (see batch_runner.py) while GUI-thread code reads/iterates it --
+    # this lock is the one piece of real cross-thread synchronization for that
+    # shared dict; GUI-thread-only mutators (fit_controller.py, controller.py)
+    # don't need it since the Qt event loop already serializes them.
+    lock: threading.Lock = field(
+        default_factory=threading.Lock, repr=False, compare=False
+    )
 
 
 @dataclass

--- a/rheojax/gui/jobs/process_adapter.py
+++ b/rheojax/gui/jobs/process_adapter.py
@@ -353,6 +353,14 @@ class ProcessWorkerAdapter(QRunnable):
             # Process was already .close()'d — it's dead.
             return False
 
+    @staticmethod
+    def _safe_join(proc: mp.Process, timeout: float | None = None) -> None:
+        """Join *proc*, tolerating a concurrent .close() from another thread."""
+        try:
+            proc.join(timeout=timeout)
+        except ValueError:
+            pass  # Already closed by a concurrent _ensure_process_dead()
+
     def _escalate_kill(self) -> None:
         """Escalation chain: cancel event -> SIGTERM -> SIGKILL."""
         proc = self._process
@@ -361,19 +369,22 @@ class ProcessWorkerAdapter(QRunnable):
 
         # Step 1: cooperative cancellation already set via _cancel_token.cancel()
         # Wait for the process to exit on its own.
-        proc.join(timeout=self._process_timeout)
+        self._safe_join(proc, self._process_timeout)
         if not self._proc_is_alive(proc):
             return
 
         # Step 2: SIGTERM
         logger.debug("Subprocess did not exit cooperatively; sending SIGTERM")
-        pid = proc.pid
+        try:
+            pid = proc.pid
+        except ValueError:
+            return  # Already closed by a concurrent _ensure_process_dead()
         if pid is not None:
             try:
                 os.kill(pid, signal.SIGTERM)
             except OSError:
                 return  # Process already gone
-        proc.join(timeout=self._kill_timeout)
+        self._safe_join(proc, self._kill_timeout)
         if not self._proc_is_alive(proc):
             return
 
@@ -381,9 +392,9 @@ class ProcessWorkerAdapter(QRunnable):
         logger.debug("Subprocess did not respond to SIGTERM; sending SIGKILL")
         try:
             proc.kill()  # SIGKILL on Unix, TerminateProcess on Windows
-        except OSError:
-            pass  # Already dead
-        proc.join(timeout=2.0)
+        except (OSError, ValueError):
+            pass  # Already dead or already closed
+        self._safe_join(proc, 2.0)
 
     def _ensure_process_dead(self) -> None:
         """Best-effort cleanup called in the finally block of run().
@@ -397,9 +408,9 @@ class ProcessWorkerAdapter(QRunnable):
                 logger.warning("Process still alive in cleanup; killing")
                 try:
                     proc.kill()
-                except OSError:
+                except (OSError, ValueError):
                     pass
-                proc.join(timeout=2.0)
+                self._safe_join(proc, 2.0)
             # Close the process handle to free resources
             try:
                 proc.close()

--- a/rheojax/gui/pages/export_page.py
+++ b/rheojax/gui/pages/export_page.py
@@ -1096,7 +1096,11 @@ class ExportPage(QWidget):
         # before the main-thread event loop can deliver it.
         worker.setAutoDelete(False)
         worker.signals.progress.connect(
-            lambda pct, label: progress.setLabelText(label),
+            lambda pct, label: (
+                None
+                if self._closing or not _is_qobject_alive(self)
+                else progress.setLabelText(label)
+            ),
             Qt.ConnectionType.QueuedConnection,
         )
         worker.signals.completed.connect(

--- a/rheojax/gui/pages/export_page.py
+++ b/rheojax/gui/pages/export_page.py
@@ -28,6 +28,7 @@ from rheojax.gui.compat import (
     QWidget,
     Signal,
     Slot,
+    _is_qobject_alive,
 )
 from rheojax.gui.resources.styles.tokens import Spacing, Typography, button_style
 from rheojax.gui.services.export_service import ExportService
@@ -64,6 +65,11 @@ class ExportPage(QWidget):
         # concurrently); each worker is discarded from this set on its own
         # completion/failure so it never clobbers a sibling worker's lifetime.
         self._active_export_workers: set[Any] = set()
+        # Cancellation events for in-flight exports, so prepare_for_close()
+        # can stop them (they run on QThreadPool.globalInstance(), which
+        # MainWindow's WorkerPool.shutdown() does not manage).
+        self._active_cancel_events: set[Any] = set()
+        self._closing = False
         self.setup_ui()
         # R6-GUI-001: Use QueuedConnection so _perform_export runs after the
         # current event handler returns, preventing button-click blocking.
@@ -753,6 +759,11 @@ class ExportPage(QWidget):
         import threading as _threading
 
         _cancelled = _threading.Event()
+        self._active_cancel_events.add(_cancelled)
+
+        # Names of figures that failed to render/export, so the completion
+        # message doesn't claim full success when some were silently skipped.
+        skipped_figures: list[str] = []
 
         def _run_export(progress_emit: Any) -> list[str]:
             """All blocking work runs here — called from ExportWorker thread."""
@@ -891,6 +902,7 @@ class ExportPage(QWidget):
                             logger.warning(
                                 f"Failed to export fit plots for {result_id}: {exc}"
                             )
+                            skipped_figures.append(f"fit/residual plot ({result_id})")
 
                 for result_id, bayes_result in state.bayesian_results.items():
                     if _maybe_cancel():
@@ -915,6 +927,7 @@ class ExportPage(QWidget):
                         logger.warning(
                             f"Failed to export Bayesian plots for {result_id}: {exc}"
                         )
+                        skipped_figures.append(f"Bayesian plots ({result_id})")
 
             if _maybe_cancel():
                 return exported_files
@@ -1021,10 +1034,13 @@ class ExportPage(QWidget):
 
         # ---- Wire up completion/failure callbacks (run on GUI thread) -------
         def _on_completed(exported_files: list[str]) -> None:
-            progress.close()
             # Release only this worker's reference; siblings from a batch
             # export may still be running.
             self._active_export_workers.discard(worker)
+            self._active_cancel_events.discard(_cancelled)
+            if self._closing or not _is_qobject_alive(self):
+                return
+            progress.close()
             if export_btn is not None and not self._active_export_workers:
                 export_btn.setEnabled(True)
             if _cancelled.is_set():
@@ -1043,22 +1059,28 @@ class ExportPage(QWidget):
             total_size = sum(
                 Path(f).stat().st_size for f in exported_files if Path(f).exists()
             )
-            QMessageBox.information(
-                self,
-                "Export Complete",
-                f"Successfully exported {len(exported_files)} files to:\n{output_dir}",
-            )
+            message = f"Successfully exported {len(exported_files)} files to:\n{output_dir}"
+            if skipped_figures:
+                message += (
+                    f"\n\n{len(skipped_figures)} figure(s) could not be generated "
+                    f"and were skipped:\n" + "\n".join(skipped_figures)
+                )
+            QMessageBox.information(self, "Export Complete", message)
             self.export_completed.emit(str(output_dir))
             logger.info(
                 "Export completed",
                 file_count=len(exported_files),
                 total_size_bytes=total_size,
+                skipped_figure_count=len(skipped_figures),
                 output_dir=str(output_dir),
             )
 
         def _on_failed(error_msg: str) -> None:
-            progress.close()
             self._active_export_workers.discard(worker)
+            self._active_cancel_events.discard(_cancelled)
+            if self._closing or not _is_qobject_alive(self):
+                return
+            progress.close()
             if export_btn is not None and not self._active_export_workers:
                 export_btn.setEnabled(True)
             full_msg = f"Export failed: {error_msg}"
@@ -1090,6 +1112,19 @@ class ExportPage(QWidget):
         # batch-export workers each keep their own reference alive.
         self._active_export_workers.add(worker)
         QThreadPool.globalInstance().start(worker)
+
+    def prepare_for_close(self) -> None:
+        """Prepare this page for parent window close.
+
+        Called by MainWindow.closeEvent *before* worker_pool.shutdown().
+        Exports run via QThreadPool.globalInstance(), which WorkerPool does
+        not manage, so this signals in-flight exports to stop and flips a
+        guard so their queued completed/failed callbacks become no-ops
+        instead of touching widgets mid-teardown.
+        """
+        self._closing = True
+        for cancel_event in self._active_cancel_events:
+            cancel_event.set()
 
     def export_results(
         self,

--- a/rheojax/gui/utils/config.py
+++ b/rheojax/gui/utils/config.py
@@ -82,8 +82,15 @@ class Config:
     def save(self) -> None:
         """Save configuration to file."""
         logger.debug("Saving configuration to file")
-        self.config_path.parent.mkdir(parents=True, exist_ok=True)
-        self.config_path.write_text(json.dumps(self._data, indent=2))
+        try:
+            self.config_path.parent.mkdir(parents=True, exist_ok=True)
+            self.config_path.write_text(json.dumps(self._data, indent=2))
+        except (OSError, TypeError, ValueError) as exc:
+            logger.warning(
+                "Failed to save config",
+                config_path=str(self.config_path),
+                error=str(exc),
+            )
 
     def load(self) -> None:
         """Load configuration from file."""
@@ -92,8 +99,13 @@ class Config:
             self._data = {}
             return
         try:
-            self._data = json.loads(self.config_path.read_text())
-        except (OSError, json.JSONDecodeError) as exc:
+            loaded = json.loads(self.config_path.read_text())
+            if not isinstance(loaded, dict):
+                raise ValueError(
+                    f"Config root must be an object, got {type(loaded).__name__}"
+                )
+            self._data = loaded
+        except (OSError, ValueError) as exc:
             logger.warning(
                 "Failed to load config, using empty config",
                 config_path=str(self.config_path),

--- a/rheojax/gui/widgets/pyqtgraph_canvas.py
+++ b/rheojax/gui/widgets/pyqtgraph_canvas.py
@@ -400,7 +400,7 @@ class PyQtGraphCanvas(QWidget):
 
             # Convert from log10 space back to data coordinates for display
             display_x, display_y = x, y
-            log_x, log_y = self._plot_item.vb.state["log"]
+            log_x, log_y = self._plot_item.vb.state["logMode"]
             if log_x:
                 display_x = 10**x
             if log_y:

--- a/rheojax/gui/widgets/residuals_panel.py
+++ b/rheojax/gui/widgets/residuals_panel.py
@@ -203,11 +203,12 @@ class ResidualsPanel(QWidget):
         self._y_pred = np.asarray(y_pred).flatten()
         self._x_values = np.asarray(x).flatten() if x is not None else None
 
-        # Handle complex data
-        if np.iscomplexobj(self._y_true) or np.iscomplexobj(self._y_pred):
-            self._residuals = np.abs(self._y_true - self._y_pred)
-        else:
-            self._residuals = self._y_true - self._y_pred
+        # Keep the signed (complex) residual. Oscillation-mode fits carry
+        # y = G' + i*G'' as a genuine complex array; collapsing to
+        # np.abs() here would lose directionality and make the mean/std,
+        # Q-Q, and histogram diagnostics meaningless. _residual_parts()
+        # splits complex residuals into real/imag components for display.
+        self._residuals = self._y_true - self._y_pred
 
         self._update_statistics()
         self._refresh_plot()
@@ -237,17 +238,41 @@ class ResidualsPanel(QWidget):
         self._refresh_plot()
         self._empty_label.hide()
 
+    def _residual_parts(self) -> list[tuple[str, np.ndarray]]:
+        """Split residuals into labeled, real-valued parts.
+
+        Returns ``[("", residuals)]`` for real-valued residuals, or
+        ``[("Re", real_part), ("Im", imag_part)]`` for complex (e.g.
+        oscillation-mode G'+iG'') residuals, so every diagnostic operates
+        on signed values instead of a collapsed magnitude.
+        """
+        if self._residuals is None:
+            return []
+        if np.iscomplexobj(self._residuals):
+            return [("Re", self._residuals.real), ("Im", self._residuals.imag)]
+        return [("", self._residuals)]
+
+    def _fitted_part(self, label: str) -> np.ndarray | None:
+        """Return the fitted-value array matching a residual part's label."""
+        if self._y_pred is None:
+            return None
+        if np.iscomplexobj(self._y_pred):
+            return self._y_pred.imag if label == "Im" else self._y_pred.real
+        return self._y_pred
+
     def _update_statistics(self) -> None:
         """Update statistics display."""
         if self._residuals is None or len(self._residuals) == 0:
             self._stats_label.setText("")
             return
 
-        mean = np.mean(self._residuals)
-        std = np.std(self._residuals)
         n = len(self._residuals)
-
-        self._stats_label.setText(f"n={n} | mean={mean:.3g} | std={std:.3g}")
+        stats = " | ".join(
+            f"mean{f'({label})' if label else ''}={np.mean(r):.3g} "
+            f"std{f'({label})' if label else ''}={np.std(r):.3g}"
+            for label, r in self._residual_parts()
+        )
+        self._stats_label.setText(f"n={n} | {stats}")
 
     def _refresh_plot(self) -> None:
         """Refresh the current plot."""
@@ -300,32 +325,45 @@ class ResidualsPanel(QWidget):
     def _plot_residuals_vs_fitted(self) -> None:
         """Plot residuals vs fitted values."""
         ax = self._figure.add_subplot(111)
+        parts = self._residual_parts()
+        multi = len(parts) > 1
 
-        if self._y_pred is not None:
-            fitted = self._y_pred
-        else:
-            fitted = np.arange(len(self._residuals))
+        for label, residuals in parts:
+            fitted = self._fitted_part(label)
+            if fitted is None:
+                fitted = np.arange(len(residuals))
 
-        ax.scatter(fitted, self._residuals, alpha=0.6, edgecolors="none")
+            sc = ax.scatter(
+                fitted, residuals, alpha=0.6, edgecolors="none",
+                label=label if multi else None,
+            )
+
+            # Add smoothed trend line
+            if len(residuals) > 10:
+                try:
+                    from scipy.ndimage import uniform_filter1d
+
+                    sorted_idx = np.argsort(fitted)
+                    smoothed = uniform_filter1d(
+                        residuals[sorted_idx], size=max(5, len(residuals) // 20)
+                    )
+                    ax.plot(
+                        fitted[sorted_idx],
+                        smoothed,
+                        color=sc.get_facecolor()[0],
+                        alpha=0.5,
+                        linewidth=2,
+                    )
+                except ImportError as exc:
+                    logger.debug(
+                        "uniform_filter1d unavailable",
+                        widget=self.__class__.__name__,
+                        error=str(exc),
+                    )
+
         ax.axhline(y=0, color="r", linestyle="--", linewidth=1)
-
-        # Add smoothed trend line
-        if len(self._residuals) > 10:
-            try:
-                from scipy.ndimage import uniform_filter1d
-
-                sorted_idx = np.argsort(fitted)
-                smoothed = uniform_filter1d(
-                    self._residuals[sorted_idx], size=max(5, len(self._residuals) // 20)
-                )
-                ax.plot(fitted[sorted_idx], smoothed, "r-", alpha=0.5, linewidth=2)
-            except ImportError as exc:
-                logger.debug(
-                    "uniform_filter1d unavailable",
-                    widget=self.__class__.__name__,
-                    error=str(exc),
-                )
-
+        if multi:
+            ax.legend()
         ax.set_xlabel("Fitted Values")
         ax.set_ylabel("Residuals")
         ax.set_title("Residuals vs Fitted")
@@ -333,72 +371,97 @@ class ResidualsPanel(QWidget):
     def _plot_qq(self) -> None:
         """Generate Q-Q plot."""
         ax = self._figure.add_subplot(111)
+        parts = self._residual_parts()
+        multi = len(parts) > 1
 
         try:
             from scipy import stats
-
-            # VIS-017: Guard against zero std (perfect fit)
-            std = np.std(self._residuals)
-            if std < 1e-15:
-                ax.text(
-                    0.5,
-                    0.5,
-                    "Perfect fit\n(zero residuals)",
-                    ha="center",
-                    va="center",
-                    transform=ax.transAxes,
-                )
-                ax.set_title("Normal Q-Q Plot")
-                return
-            # Standardize residuals
-            standardized = (self._residuals - np.mean(self._residuals)) / std
-
-            # Q-Q plot
-            stats.probplot(standardized, dist="norm", plot=ax)
-            ax.set_title("Normal Q-Q Plot")
         except ImportError as exc:
+            stats = None
             logger.debug(
                 "scipy.stats unavailable for QQ plot",
                 widget=self.__class__.__name__,
                 error=str(exc),
             )
-            # Fallback without scipy
-            sorted_res = np.sort(self._residuals)
-            n = len(sorted_res)
-            theoretical = np.linspace(-2, 2, n)
 
-            ax.scatter(theoretical, sorted_res, alpha=0.6)
-            ax.plot([-3, 3], [-3, 3], "r--", linewidth=1)
-            ax.set_xlabel("Theoretical Quantiles")
-            ax.set_ylabel("Sample Quantiles")
-            ax.set_title("Q-Q Plot (simplified)")
+        # VIS-017: Guard against zero std (perfect fit) across all parts
+        if all(np.std(r) < 1e-15 for _, r in parts):
+            ax.text(
+                0.5,
+                0.5,
+                "Perfect fit\n(zero residuals)",
+                ha="center",
+                va="center",
+                transform=ax.transAxes,
+            )
+            ax.set_title("Normal Q-Q Plot")
+            return
+
+        for label, residuals in parts:
+            std = np.std(residuals)
+            if std < 1e-15:
+                continue
+            if stats is not None:
+                standardized = (residuals - np.mean(residuals)) / std
+                stats.probplot(standardized, dist="norm", plot=ax)
+                if multi:
+                    ax.lines[-2].set_label(label)
+            else:
+                # Fallback without scipy
+                sorted_res = np.sort(residuals)
+                n = len(sorted_res)
+                theoretical = np.linspace(-2, 2, n)
+
+                ax.scatter(
+                    theoretical, sorted_res, alpha=0.6, label=label if multi else None
+                )
+                ax.plot([-3, 3], [-3, 3], "r--", linewidth=1)
+                ax.set_xlabel("Theoretical Quantiles")
+                ax.set_ylabel("Sample Quantiles")
+
+        if multi:
+            ax.legend()
+        ax.set_title("Normal Q-Q Plot" if stats is not None else "Q-Q Plot (simplified)")
 
     def _plot_histogram(self) -> None:
         """Plot histogram of residuals."""
         ax = self._figure.add_subplot(111)
+        parts = self._residual_parts()
+        multi = len(parts) > 1
 
-        # Histogram
-        n, bins, patches = ax.hist(
-            self._residuals, bins="auto", density=True, alpha=0.7, edgecolor="black"
-        )
-
-        # Fit normal distribution
         try:
             from scipy import stats
-
-            mu, std = np.mean(self._residuals), np.std(self._residuals)
-            x = np.linspace(bins[0], bins[-1], 100)
-            ax.plot(
-                x, stats.norm.pdf(x, mu, std), "r-", linewidth=2, label="Normal fit"
-            )
-            ax.legend()
         except ImportError as exc:
+            stats = None
             logger.debug(
                 "scipy.stats unavailable for histogram fit",
                 widget=self.__class__.__name__,
                 error=str(exc),
             )
 
+        for label, residuals in parts:
+            _n, bins, _patches = ax.hist(
+                residuals,
+                bins="auto",
+                density=True,
+                alpha=0.5 if multi else 0.7,
+                edgecolor="black",
+                label=f"Residuals ({label})" if multi else None,
+            )
+
+            # Fit normal distribution
+            if stats is not None:
+                mu, std = np.mean(residuals), np.std(residuals)
+                x = np.linspace(bins[0], bins[-1], 100)
+                ax.plot(
+                    x,
+                    stats.norm.pdf(x, mu, std),
+                    linewidth=2,
+                    label=f"Normal fit ({label})" if multi else "Normal fit",
+                )
+
+        if multi or stats is not None:
+            ax.legend()
         ax.set_xlabel("Residual Value")
         ax.set_ylabel("Density")
         ax.set_title("Residual Distribution")
@@ -406,33 +469,46 @@ class ResidualsPanel(QWidget):
     def _plot_scale_location(self) -> None:
         """Plot scale-location (sqrt |residuals| vs fitted)."""
         ax = self._figure.add_subplot(111)
+        parts = self._residual_parts()
+        multi = len(parts) > 1
 
-        if self._y_pred is not None:
-            fitted = self._y_pred
-        else:
-            fitted = np.arange(len(self._residuals))
+        for label, residuals in parts:
+            fitted = self._fitted_part(label)
+            if fitted is None:
+                fitted = np.arange(len(residuals))
 
-        sqrt_abs_res = np.sqrt(np.abs(self._residuals))
+            sqrt_abs_res = np.sqrt(np.abs(residuals))
 
-        ax.scatter(fitted, sqrt_abs_res, alpha=0.6, edgecolors="none")
+            sc = ax.scatter(
+                fitted, sqrt_abs_res, alpha=0.6, edgecolors="none",
+                label=label if multi else None,
+            )
 
-        # Add smoothed trend line
-        if len(self._residuals) > 10:
-            try:
-                from scipy.ndimage import uniform_filter1d
+            # Add smoothed trend line
+            if len(residuals) > 10:
+                try:
+                    from scipy.ndimage import uniform_filter1d
 
-                sorted_idx = np.argsort(fitted)
-                smoothed = uniform_filter1d(
-                    sqrt_abs_res[sorted_idx], size=max(5, len(self._residuals) // 20)
-                )
-                ax.plot(fitted[sorted_idx], smoothed, "r-", alpha=0.5, linewidth=2)
-            except ImportError as exc:
-                logger.debug(
-                    "uniform_filter1d unavailable",
-                    widget=self.__class__.__name__,
-                    error=str(exc),
-                )
+                    sorted_idx = np.argsort(fitted)
+                    smoothed = uniform_filter1d(
+                        sqrt_abs_res[sorted_idx], size=max(5, len(residuals) // 20)
+                    )
+                    ax.plot(
+                        fitted[sorted_idx],
+                        smoothed,
+                        color=sc.get_facecolor()[0],
+                        alpha=0.5,
+                        linewidth=2,
+                    )
+                except ImportError as exc:
+                    logger.debug(
+                        "uniform_filter1d unavailable",
+                        widget=self.__class__.__name__,
+                        error=str(exc),
+                    )
 
+        if multi:
+            ax.legend()
         ax.set_xlabel("Fitted Values")
         ax.set_ylabel("√|Residuals|")
         ax.set_title("Scale-Location Plot")
@@ -440,15 +516,23 @@ class ResidualsPanel(QWidget):
     def _plot_residuals_vs_x(self) -> None:
         """Plot residuals vs X values."""
         ax = self._figure.add_subplot(111)
+        parts = self._residual_parts()
+        multi = len(parts) > 1
 
-        if self._x_values is not None:
-            x = self._x_values
-        else:
-            x = np.arange(len(self._residuals))
+        for label, residuals in parts:
+            x = (
+                self._x_values
+                if self._x_values is not None
+                else np.arange(len(residuals))
+            )
+            ax.scatter(
+                x, residuals, alpha=0.6, edgecolors="none",
+                label=label if multi else None,
+            )
 
-        ax.scatter(x, self._residuals, alpha=0.6, edgecolors="none")
         ax.axhline(y=0, color="r", linestyle="--", linewidth=1)
-
+        if multi:
+            ax.legend()
         ax.set_xlabel("X Values")
         ax.set_ylabel("Residuals")
         ax.set_title("Residuals vs X")
@@ -456,6 +540,8 @@ class ResidualsPanel(QWidget):
     def _plot_autocorr(self) -> None:
         """Plot residual autocorrelation."""
         ax = self._figure.add_subplot(111)
+        parts = self._residual_parts()
+        multi = len(parts) > 1
 
         n = len(self._residuals)
         if n < 10:
@@ -471,20 +557,21 @@ class ResidualsPanel(QWidget):
 
         # Compute autocorrelation
         max_lag = min(40, n // 4)
-        autocorr = np.correlate(
-            self._residuals - np.mean(self._residuals),
-            self._residuals - np.mean(self._residuals),
-            mode="full",
-        )
-        autocorr = autocorr[n - 1 : n - 1 + max_lag]
-        # VIS-018: Guard against zero normalization (perfect fit / constant residuals)
-        if autocorr[0] < 1e-15:
-            autocorr = np.zeros_like(autocorr)
-        else:
-            autocorr = autocorr / autocorr[0]  # Normalize
+        width = 0.8 / len(parts)
+        for i, (label, residuals) in enumerate(parts):
+            centered = residuals - np.mean(residuals)
+            autocorr = np.correlate(centered, centered, mode="full")
+            autocorr = autocorr[n - 1 : n - 1 + max_lag]
+            # VIS-018: Guard against zero normalization (perfect fit / constant residuals)
+            if autocorr[0] < 1e-15:
+                autocorr = np.zeros_like(autocorr)
+            else:
+                autocorr = autocorr / autocorr[0]  # Normalize
 
-        lags = np.arange(max_lag)
-        ax.bar(lags, autocorr, width=0.8, alpha=0.7)
+            lags = np.arange(max_lag) + i * width
+            ax.bar(
+                lags, autocorr, width=width, alpha=0.7, label=label if multi else None
+            )
 
         # Confidence bounds (approximate)
         conf_bound = 1.96 / np.sqrt(n)
@@ -492,6 +579,8 @@ class ResidualsPanel(QWidget):
         ax.axhline(y=-conf_bound, color="r", linestyle="--", linewidth=1)
         ax.axhline(y=0, color="k", linestyle="-", linewidth=0.5)
 
+        if multi:
+            ax.legend()
         ax.set_xlabel("Lag")
         ax.set_ylabel("Autocorrelation")
         ax.set_title("Residual Autocorrelation")
@@ -540,18 +629,33 @@ class ResidualsPanel(QWidget):
         Returns
         -------
         dict
-            Statistics dictionary with keys: mean, std, n, min, max
+            Statistics dictionary with keys: mean, std, n, min, max. For
+            complex (e.g. oscillation-mode G'+iG'') residuals, real/imaginary
+            components are reported separately as ``mean_re``/``mean_im``, etc.
         """
         if self._residuals is None:
             return {}
 
-        return {
-            "n": len(self._residuals),
-            "mean": float(np.mean(self._residuals)),
-            "std": float(np.std(self._residuals)),
-            "min": float(np.min(self._residuals)),
-            "max": float(np.max(self._residuals)),
-        }
+        n = len(self._residuals)
+        parts = self._residual_parts()
+        if len(parts) == 1:
+            _, r = parts[0]
+            return {
+                "n": n,
+                "mean": float(np.mean(r)),
+                "std": float(np.std(r)),
+                "min": float(np.min(r)),
+                "max": float(np.max(r)),
+            }
+
+        stats: dict[str, float] = {"n": n}
+        for label, r in parts:
+            suffix = label.lower()
+            stats[f"mean_{suffix}"] = float(np.mean(r))
+            stats[f"std_{suffix}"] = float(np.std(r))
+            stats[f"min_{suffix}"] = float(np.min(r))
+            stats[f"max_{suffix}"] = float(np.max(r))
+        return stats
 
     def export_figure(self, filepath: str, dpi: int = 150) -> None:
         """Export figure to file.

--- a/rheojax/gui/workspace/fit/fit_controller.py
+++ b/rheojax/gui/workspace/fit/fit_controller.py
@@ -186,7 +186,7 @@ def _fit_fn_body(
         progress_queue = multiprocessing.Queue()
         try:
             result = _run_on_thread(
-                lambda start_params=start_params: run_fit_isolated(
+                lambda start_params=start_params, progress_queue=progress_queue: run_fit_isolated(
                     model_key,
                     rheo_data.x,
                     rheo_data.y,

--- a/rheojax/gui/workspace/fit/step5_visualize.py
+++ b/rheojax/gui/workspace/fit/step5_visualize.py
@@ -116,9 +116,21 @@ class VisualizeStep(QWidget):
             lo = np.asarray(lo)
             hi = np.asarray(hi)
             if np.iscomplexobj(lo) or np.iscomplexobj(hi):
-                lo, hi = np.abs(lo), np.abs(hi)
-            self._overlay.plot_line(x, lo, name="Posterior lo", line_style="dash")
-            self._overlay.plot_line(x, hi, name="Posterior hi", line_style="dash")
+                self._overlay.plot_line(
+                    x, lo.real, name="Posterior lo (G')", line_style="dash"
+                )
+                self._overlay.plot_line(
+                    x, hi.real, name="Posterior hi (G')", line_style="dash"
+                )
+                self._overlay.plot_line(
+                    x, lo.imag, name="Posterior lo (G'')", line_style="dash"
+                )
+                self._overlay.plot_line(
+                    x, hi.imag, name="Posterior hi (G'')", line_style="dash"
+                )
+            else:
+                self._overlay.plot_line(x, lo, name="Posterior lo", line_style="dash")
+                self._overlay.plot_line(x, hi, name="Posterior hi", line_style="dash")
 
     def _refresh_residuals(self) -> None:
         result = self._state.nlsq_result or {}

--- a/rheojax/gui/workspace/pipeline/batch_runner.py
+++ b/rheojax/gui/workspace/pipeline/batch_runner.py
@@ -53,7 +53,8 @@ class PipelineBatchRunner(QRunnable):
             # concurrently writing to it. `app_state` is optional so tests that
             # construct this runner directly (with no AppState) are unaffected.
             if self._app_state is not None:
-                self._app_state.active_jobs.by_id[dataset_id] = {"status": "running"}
+                with self._app_state.active_jobs.lock:
+                    self._app_state.active_jobs.by_id[dataset_id] = {"status": "running"}
             self._service.dataset_run_started.emit(dataset_id)
             ctx = pipeline_context_from_library(self._library, [dataset_id])
             steps_for_dataset = self._substitute_dataset_id(self._steps, dataset_id)

--- a/rheojax/gui/workspace/window.py
+++ b/rheojax/gui/workspace/window.py
@@ -4,6 +4,7 @@ import threading
 from pathlib import Path
 
 from PySide6.QtCore import Qt, Signal
+from PySide6.QtGui import QCloseEvent
 from PySide6.QtWidgets import (
     QLabel,
     QMainWindow,
@@ -37,6 +38,7 @@ class WorkspaceWindow(QMainWindow):
         self._pipeline_service = PipelineExecutionService()
         self._pipeline_stop_event: threading.Event | None = None
         self._active_jobs_action_pending = False
+        self._close_confirmed = False
         # Keyed by job_id, not a single scalar -- a second concurrent import
         # launched before the first one finishes must not drop the only
         # Python reference to the first ImportWorker/ImportWorkerSignals
@@ -241,6 +243,18 @@ class WorkspaceWindow(QMainWindow):
         except (RuntimeError, TypeError):
             pass
         try:
+            self._notifier.changed.disconnect(self._fit_bodies[1].refresh)
+        except (RuntimeError, TypeError):
+            pass
+        try:
+            self._notifier.changed.disconnect(self._transform_bodies[1].refresh)
+        except (RuntimeError, TypeError):
+            pass
+        try:
+            self._notifier.changed.disconnect(self._pipeline_bodies[0].refresh)
+        except (RuntimeError, TypeError):
+            pass
+        try:
             self._rail.import_requested.disconnect(self._on_import_requested)
         except (RuntimeError, TypeError):
             pass
@@ -303,14 +317,16 @@ class WorkspaceWindow(QMainWindow):
         # a worker thread, so a concurrent Save could serialize a torn, inconsistent
         # snapshot. Unlike Close/New/Open (which offer to cancel jobs and proceed), Save
         # is a hard block: there is no safe "discard the running job" option here.
-        if not self._state.active_jobs.by_id:
+        with self._state.active_jobs.lock:
+            job_count = len(self._state.active_jobs.by_id)
+        if job_count == 0:
             return False
         from PySide6.QtWidgets import QMessageBox
 
         QMessageBox.information(
             self,
             "Jobs Running",
-            f"Cannot {action} while {len(self._state.active_jobs.by_id)} job(s) are still "
+            f"Cannot {action} while {job_count} job(s) are still "
             "running. Wait for them to finish, or cancel them via Close/New/Open first.",
         )
         return True
@@ -359,8 +375,32 @@ class WorkspaceWindow(QMainWindow):
             )
         )
 
+    def closeEvent(self, event: QCloseEvent) -> None:
+        # Closing via the OS window controls (X button, Alt+F4, Cmd+Q) hits
+        # this instead of the File>Close menu action, which is wired to
+        # _on_close. Without this override Qt's default closeEvent just
+        # accepts and closes immediately, skipping the active-jobs
+        # cancel/confirm chain and orphaning running QThreadPool workers.
+        # Reuse that same chain here; only accept once it has actually run
+        # to completion (job cancellation may finish asynchronously via
+        # _poll_active_jobs_then), then re-issue close() to get a second,
+        # now-trivial closeEvent that accepts.
+        if self._close_confirmed:
+            event.accept()
+            return
+        event.ignore()
+        self._maybe_confirm_active_jobs(
+            lambda: self._maybe_confirm_unsaved_changes(self._confirmed_close)
+        )
+
+    def _confirmed_close(self) -> None:
+        self._close_confirmed = True
+        self.close()
+
     def _maybe_confirm_active_jobs(self, proceed) -> None:
-        if not self._state.active_jobs.by_id:
+        with self._state.active_jobs.lock:
+            job_count = len(self._state.active_jobs.by_id)
+        if job_count == 0:
             proceed()
             return
         if self._active_jobs_action_pending:
@@ -375,7 +415,7 @@ class WorkspaceWindow(QMainWindow):
         choice = QMessageBox.question(
             self,
             "Jobs Running",
-            f"{len(self._state.active_jobs.by_id)} job(s) still running. Cancel them and continue?",
+            f"{job_count} job(s) still running. Cancel them and continue?",
             QMessageBox.StandardButton.Yes | QMessageBox.StandardButton.Cancel,
             QMessageBox.StandardButton.Cancel,
         )
@@ -390,12 +430,14 @@ class WorkspaceWindow(QMainWindow):
         if self._pipeline_stop_event is not None:
             self._pipeline_stop_event.set()  # stops PipelineBatchRunner from advancing to
             # further queued datasets (Task 7's run() loop)
-        # Snapshot before iterating: PipelineBatchRunner writes directly into
+        # Snapshot under the lock: PipelineBatchRunner writes directly into
         # this same plain dict from a QThreadPool worker thread (see its
         # comment), so iterating the live dict here risks
         # "RuntimeError: dictionary changed size during iteration" if a new
         # job is registered mid-loop.
-        for job in list(self._state.active_jobs.by_id.values()):
+        with self._state.active_jobs.lock:
+            jobs_snapshot = list(self._state.active_jobs.by_id.values())
+        for job in jobs_snapshot:
             worker = job.get("worker")
             if worker is not None:
                 QThreadPool.globalInstance().start(CancelWorkerRunnable(worker))

--- a/tests/gui/conftest.py
+++ b/tests/gui/conftest.py
@@ -442,6 +442,34 @@ def reset_state_store():
 
 
 @pytest.fixture(autouse=True)
+def _no_blocking_message_boxes(monkeypatch):
+    """Stub QMessageBox statics so a stray modal never hangs the suite.
+
+    WorkspaceWindow.closeEvent pops a real QMessageBox.question when
+    project.dirty is True. qtbot.addWidget() calls .close() on teardown --
+    with no user present to click a button, an unstubbed exec() there
+    blocks past pytest's 120s signal-based timeout (Qt's native event loop
+    swallows SIGALRM), hanging every test after it in the same file.
+    Default to a safe, non-destructive answer; tests that need a specific
+    choice can still monkeypatch these themselves (their patch simply runs
+    later and wins).
+    """
+    if not HAS_PYSIDE6:
+        return
+    from PySide6.QtWidgets import QMessageBox
+
+    monkeypatch.setattr(
+        QMessageBox,
+        "question",
+        staticmethod(lambda *a, **k: QMessageBox.StandardButton.Discard),
+    )
+    for name in ("information", "warning", "critical"):
+        monkeypatch.setattr(
+            QMessageBox, name, staticmethod(lambda *a, **k: QMessageBox.StandardButton.Ok)
+        )
+
+
+@pytest.fixture(autouse=True)
 def reset_plot_metrics():
     """Reset PlotMetrics and close matplotlib figures between tests.
 

--- a/tests/gui/test_regressions_stability.py
+++ b/tests/gui/test_regressions_stability.py
@@ -104,6 +104,22 @@ def test_export_raw_data_converts_dataset(qtbot, tmp_path):
     assert out.exists()
 
 
+def test_export_page_prepare_for_close_cancels_and_guards_callbacks(qtbot):
+    import threading
+
+    page = ExportPage()
+    qtbot.addWidget(page)
+
+    cancel_event = threading.Event()
+    page._active_cancel_events.add(cancel_event)
+    assert page._closing is False
+
+    page.prepare_for_close()
+
+    assert page._closing is True
+    assert cancel_event.is_set()
+
+
 def test_bayesian_warm_start_picks_matching_fit(qtbot):
     store = StateStore()
     ds = DatasetState(id="d1", name="ds", file_path=None, test_mode="oscillation")


### PR DESCRIPTION
## Summary

Second independent codex+agy adversarial review pass over `rheojax/gui`, following up on #42's 45-bug fix round. This round was scoped to find what that one missed rather than re-litigating fixed categories — 14 raw findings from codex + agy in parallel, 12 confirmed real after an independent adversarial re-verification pass against the current code (2 were false positives / already-fixed and dropped), all fixed.

- **`pyqtgraph_canvas.py`**: mouse-hover coordinate readout crashed with `KeyError` against the installed pyqtgraph — `ViewBox.state` uses key `"logMode"`, not `"log"`.
- **`export_page.py`**: per-figure export failures were caught, logged, and silently dropped while the completion dialog still reported full success (silent data loss); export worker jobs on the global `QThreadPool` were untracked and uncancelled on app close.
- **`status_bar.py`**: a deferred `QTimer.singleShot` callback had no lifetime binding and could fire against an already-destroyed Qt widget.
- **`config.py`**: `load()` silently accepted non-dict JSON roots (crashing later on first `get`/`set`); `save()` had no exception handling around disk/serialization errors, unlike `load()`.
- **`workspace/window.py`**: `WorkspaceWindow` never overrode `closeEvent`, so closing via the OS window button (not the File>Close menu) bypassed active-job cancellation and unsaved-changes checks entirely, orphaning background workers; the notifier→body `.refresh` disconnect on workspace rebuild missed 3 of the 4 connected bodies, leaking signal connections to deleted widgets.
- **`process_adapter.py`**: unguarded `proc.join()`/`.pid`/`.kill()` calls could race a concurrent `proc.close()` from the worker thread and raise an unhandled `ValueError`.
- **`batch_runner.py` / `foundation/state.py`**: `active_jobs.by_id` was mutated from a background thread with no lock.
- **`residuals_panel.py` / `step5_visualize.py`**: complex (G'+iG'') residuals and posterior bands were collapsed via `np.abs()`, destroying sign information the residual diagnostics (mean/std, Q-Q, histogram) depend on.

The fix pass also introduced and then caught+fixed its own regressions before this commit: a ruff B023 closure-capture bug, and a test-hang (the new `closeEvent` popping a blocking `QMessageBox` during pytest-qt teardown), resolved via an autouse fixture stubbing `QMessageBox` in `tests/gui/conftest.py`.

## Test plan

- [x] `uv run ruff check rheojax/gui` — clean
- [x] `uv run pytest tests/gui` — 740/754 passing; the 14 failures are pre-existing `FT_Render_Glyph raster overflow` FreeType errors (environment font issue, not code)
- [x] Verified the one order-dependent segfault (`test_main_cli_wiring.py::test_legacy_flag_constructs_main_window`, crashing inside untouched `main.py`'s `app.setStyleSheet()`) reproduces identically on the pre-fix baseline commit (`84139030`) — confirmed pre-existing and unrelated to this change
- [x] Spot-checked the `closeEvent` ignore/confirm/reclose pattern and the complex-residual real/imag split diff by hand

🤖 Generated with [Claude Code](https://claude.com/claude-code)