### PR TITLE
feat(gui): make logging visible for debugging (workspace log dock + excepthook)

### DIFF
--- a/rheojax/gui/app/main_window.py
+++ b/rheojax/gui/app/main_window.py
@@ -7,6 +7,7 @@ Central window coordinating pages, state, and services with dock-based layout.
 
 from __future__ import annotations
 
+import logging
 import os
 import threading
 import time
@@ -22,7 +23,6 @@ from rheojax.gui.app.status_bar import StatusBar
 from rheojax.gui.compat import (
     QApplication,
     QCloseEvent,
-    QDockWidget,
     QFileDialog,
     QInputDialog,
     QKeySequence,
@@ -31,7 +31,6 @@ from rheojax.gui.compat import (
     QShortcut,
     QSplitter,
     Qt,
-    QTextEdit,
     QToolBar,
     QWidget,
     Signal,
@@ -65,6 +64,7 @@ from rheojax.gui.state.store import (
     WorkflowMode,
 )
 from rheojax.gui.widgets.dataset_tree import DatasetTree
+from rheojax.gui.widgets.log_dock import LogDockWidget
 from rheojax.gui.widgets.pipeline_chips import PipelineChips
 from rheojax.gui.widgets.pipeline_sidebar import PipelineSidebar
 from rheojax.gui.widgets.workspace_container import WorkspaceContainer
@@ -208,13 +208,7 @@ class RheoJAXMainWindow(QMainWindow):
         self.data_dock = None
 
         # Bottom dock: Log panel (collapsible)
-        self.log_dock = QDockWidget("Log", self)
-        self.log_dock.setObjectName("LogDock")
-        self.log_panel = QTextEdit(self)
-        self.log_panel.setReadOnly(True)
-        self.log_panel.setMaximumHeight(200)
-        self.log_panel.setPlaceholderText("Application logs will appear here...")
-        self.log_dock.setWidget(self.log_panel)
+        self.log_dock = LogDockWidget(self)
         self.addDockWidget(Qt.DockWidgetArea.BottomDockWidgetArea, self.log_dock)
 
         # Start with log panel hidden
@@ -839,14 +833,14 @@ class RheoJAXMainWindow(QMainWindow):
             self._navigating = False
 
     def log(self, message: str) -> None:
-        """Append message to log panel.
+        """Append message to log panel at INFO level.
 
         Parameters
         ----------
         message : str
             Log message
         """
-        self.log_panel.append(message)
+        self.log_dock.append_record(logging.INFO, message)
 
     def closeEvent(self, event: QCloseEvent) -> None:
         """Handle window close event with cleanup.

--- a/rheojax/gui/main.py
+++ b/rheojax/gui/main.py
@@ -247,6 +247,13 @@ def main(argv: list[str] | None = None) -> int:
 
     # Setup logging
     setup_logging(args.verbose)
+
+    def _log_uncaught_exception(exc_type, exc_value, exc_tb) -> None:
+        logger.critical("Uncaught exception", exc_info=(exc_type, exc_value, exc_tb))
+        sys.__excepthook__(exc_type, exc_value, exc_tb)
+
+    sys.excepthook = _log_uncaught_exception
+
     logger.info("RheoJAX GUI starting", version=__version__)
 
     # Check dependencies
@@ -414,6 +421,14 @@ def main(argv: list[str] | None = None) -> int:
             print(f"ERROR: Failed to create workspace window: {e}", file=sys.stderr)
             return 1
 
+        gui_handler = install_gui_log_handler(
+            workspace_window.log_dock.append_record,
+            level=logging.DEBUG if args.verbose else logging.INFO,
+        )
+        workspace_window.destroyed.connect(
+            lambda *_: logging.getLogger().removeHandler(gui_handler)
+        )
+
         app.setWindowIcon(QIcon(str(get_icon_path("rheojax"))))
         _show_main_window(workspace_window, args.maximized)
         logger.info("RheoJAX GUI workspace shell ready", version=__version__)
@@ -474,7 +489,7 @@ def main(argv: list[str] | None = None) -> int:
         logger.debug("Creating main window", maximized=args.maximized)
         window = RheoJAXMainWindow(start_maximized=args.maximized)
         gui_handler = install_gui_log_handler(
-            window.log,
+            window.log_dock.append_record,
             level=logging.DEBUG if args.verbose else logging.INFO,
         )
         logger.debug("GUI log handler attached")

--- a/rheojax/gui/utils/logging.py
+++ b/rheojax/gui/utils/logging.py
@@ -15,7 +15,7 @@ try:  # Delay Qt dependency for environments without PySide6
     from PySide6.QtCore import QObject, Signal
 
     class _LogEmitter(QObject):
-        message_emitted = Signal(str)
+        message_emitted = Signal(int, str)
 
     _HAS_QT = True
 except Exception:  # pragma: no cover - PySide6 optional in headless tests
@@ -26,7 +26,7 @@ except Exception:  # pragma: no cover - PySide6 optional in headless tests
 class GuiLogHandler(logging.Handler):
     """Route log records into the GUI log panel safely."""
 
-    def __init__(self, append_fn: Callable[[str], None]) -> None:
+    def __init__(self, append_fn: Callable[[int, str], None]) -> None:
         super().__init__()
         self._append_fn = append_fn
         self._emitter = _LogEmitter() if _HAS_QT and _LogEmitter is not None else None
@@ -37,15 +37,15 @@ class GuiLogHandler(logging.Handler):
         message = self.format(record)
         try:
             if self._emitter is not None:
-                self._emitter.message_emitted.emit(message)
+                self._emitter.message_emitted.emit(record.levelno, message)
             else:
-                self._append_fn(message)
+                self._append_fn(record.levelno, message)
         except Exception:
             self.handleError(record)
 
 
 def install_gui_log_handler(
-    append_fn: Callable[[str], None],
+    append_fn: Callable[[int, str], None],
     level: int = logging.INFO,
     formatter: logging.Formatter | None = None,
 ) -> GuiLogHandler:

--- a/rheojax/gui/widgets/log_dock.py
+++ b/rheojax/gui/widgets/log_dock.py
@@ -1,0 +1,104 @@
+"""
+Shared GUI Log Dock
+===================
+
+A dockable, filterable, severity-colored log viewer shared by both the
+workspace shell (`WorkspaceWindow`) and the legacy `RheoJAXMainWindow`.
+Fed by `rheojax.gui.utils.logging.install_gui_log_handler`.
+"""
+
+from __future__ import annotations
+
+import logging
+from collections import deque
+
+from rheojax.gui.compat import (
+    QComboBox,
+    QDockWidget,
+    QFileDialog,
+    QHBoxLayout,
+    QLabel,
+    QPushButton,
+    QTextEdit,
+    QVBoxLayout,
+    QWidget,
+)
+
+_MAX_RECORDS = 2000
+
+_LEVEL_NAMES = ("DEBUG", "INFO", "WARNING", "ERROR", "CRITICAL")
+
+_LEVEL_COLORS = {
+    logging.DEBUG: "#8a8a8a",
+    logging.INFO: None,  # default text color
+    logging.WARNING: "#b8860b",
+    logging.ERROR: "#cc3333",
+    logging.CRITICAL: "#cc3333",
+}
+
+
+class LogDockWidget(QDockWidget):
+    """Bottom dock: buffered, filterable, severity-colored log viewer."""
+
+    def __init__(self, parent: QWidget | None = None) -> None:
+        super().__init__("Log", parent)
+        self.setObjectName("LogDock")
+
+        self._records: deque[tuple[int, str]] = deque(maxlen=_MAX_RECORDS)
+
+        container = QWidget(self)
+        layout = QVBoxLayout(container)
+        layout.setContentsMargins(4, 4, 4, 4)
+
+        toolbar = QHBoxLayout()
+        toolbar.addWidget(QLabel("Level:", container))
+        self.level_combo = QComboBox(container)
+        self.level_combo.addItems(_LEVEL_NAMES)
+        self.level_combo.setCurrentText("INFO")
+        self.level_combo.currentTextChanged.connect(self._rerender)
+        toolbar.addWidget(self.level_combo)
+        toolbar.addStretch(1)
+        self.save_button = QPushButton("Save...", container)
+        self.save_button.clicked.connect(self._on_save_clicked)
+        toolbar.addWidget(self.save_button)
+        layout.addLayout(toolbar)
+
+        self.text_edit = QTextEdit(container)
+        self.text_edit.setReadOnly(True)
+        self.text_edit.setMaximumHeight(200)
+        self.text_edit.setPlaceholderText("Application logs will appear here...")
+        layout.addWidget(self.text_edit)
+
+        self.setWidget(container)
+
+    def _current_threshold(self) -> int:
+        return getattr(logging, self.level_combo.currentText())
+
+    def append_record(self, levelno: int, message: str) -> None:
+        """Buffer a log record and render it if it passes the current filter."""
+        self._records.append((levelno, message))
+        if levelno >= self._current_threshold():
+            self._append_line(levelno, message)
+
+    def _append_line(self, levelno: int, message: str) -> None:
+        color = _LEVEL_COLORS.get(levelno)
+        if color:
+            self.text_edit.append(f'<span style="color:{color};">{message}</span>')
+        else:
+            self.text_edit.append(message)
+
+    def _rerender(self) -> None:
+        self.text_edit.clear()
+        threshold = self._current_threshold()
+        for levelno, message in self._records:
+            if levelno >= threshold:
+                self._append_line(levelno, message)
+
+    def _on_save_clicked(self) -> None:
+        path, _ = QFileDialog.getSaveFileName(
+            self, "Save Log", "rheojax-gui.log", "Log Files (*.log);;All Files (*)"
+        )
+        if not path:
+            return
+        with open(path, "w", encoding="utf-8") as fh:
+            fh.write(self.text_edit.toPlainText())

--- a/rheojax/gui/widgets/log_dock.py
+++ b/rheojax/gui/widgets/log_dock.py
@@ -9,6 +9,7 @@ Fed by `rheojax.gui.utils.logging.install_gui_log_handler`.
 
 from __future__ import annotations
 
+import html
 import logging
 from collections import deque
 
@@ -82,10 +83,11 @@ class LogDockWidget(QDockWidget):
 
     def _append_line(self, levelno: int, message: str) -> None:
         color = _LEVEL_COLORS.get(levelno)
+        escaped = html.escape(message)
         if color:
-            self.text_edit.append(f'<span style="color:{color};">{message}</span>')
+            self.text_edit.append(f'<span style="color:{color};">{escaped}</span>')
         else:
-            self.text_edit.append(message)
+            self.text_edit.append(escaped)
 
     def _rerender(self) -> None:
         self.text_edit.clear()
@@ -100,5 +102,7 @@ class LogDockWidget(QDockWidget):
         )
         if not path:
             return
+        # Save the full buffer, not just the currently filtered view -- the
+        # level filter controls what's on screen, not what gets exported.
         with open(path, "w", encoding="utf-8") as fh:
-            fh.write(self.text_edit.toPlainText())
+            fh.write("\n".join(message for _, message in self._records))

--- a/rheojax/gui/workspace/window.py
+++ b/rheojax/gui/workspace/window.py
@@ -1,10 +1,11 @@
 from __future__ import annotations
 
+import logging
 import threading
 from pathlib import Path
 
 from PySide6.QtCore import Qt, Signal
-from PySide6.QtGui import QCloseEvent
+from PySide6.QtGui import QAction, QCloseEvent
 from PySide6.QtWidgets import (
     QLabel,
     QMainWindow,
@@ -17,6 +18,7 @@ from PySide6.QtWidgets import (
 from rheojax.gui.foundation.notifier import DatasetLibraryNotifier
 from rheojax.gui.foundation.state import AppState
 from rheojax.gui.services.pipeline_execution_service import PipelineExecutionService
+from rheojax.gui.widgets.log_dock import LogDockWidget
 from rheojax.gui.workspace.fit.fit_controller import build_fit_controller
 from rheojax.gui.workspace.inspector import InspectorPanel
 from rheojax.gui.workspace.library_rail import LibraryRail
@@ -70,6 +72,11 @@ class WorkspaceWindow(QMainWindow):
         bar.addWidget(self._status_label)
         self._build_file_menu()
 
+        self.log_dock = LogDockWidget(self)
+        self.addDockWidget(Qt.DockWidgetArea.BottomDockWidgetArea, self.log_dock)
+        self.log_dock.setVisible(False)
+        self._build_view_menu()
+
         self._build_workspace(app_state)
 
     def _build_file_menu(self) -> None:
@@ -79,6 +86,20 @@ class WorkspaceWindow(QMainWindow):
         menu.addAction("&Save", self._on_save, "Ctrl+S")
         menu.addAction("Save &As...", self._on_save_as, "Ctrl+Shift+S")
         menu.addAction("&Close", self._on_close)
+
+    def _build_view_menu(self) -> None:
+        menu = self.menuBar().addMenu("&View")
+        action = QAction("&Log Panel", self)
+        action.setCheckable(True)
+        action.setChecked(False)
+        action.setStatusTip("Toggle log panel visibility")
+        action.triggered.connect(lambda: self.log_dock.setVisible(action.isChecked()))
+        menu.addAction(action)
+        self.view_log_dock_action = action
+
+    def log(self, message: str) -> None:
+        """Append message to the log dock at INFO level."""
+        self.log_dock.append_record(logging.INFO, message)
 
     def _build_workspace(self, state: AppState) -> None:
         self._state = state

--- a/tests/gui/test_log_dock.py
+++ b/tests/gui/test_log_dock.py
@@ -49,3 +49,36 @@ def test_buffer_is_bounded(qtbot):
 
     assert len(dock._records) == 2000
     assert dock._records[0][1] == "line 100"
+
+
+def test_message_with_angle_brackets_is_not_corrupted(qtbot):
+    from rheojax.gui.widgets.log_dock import LogDockWidget
+
+    dock = LogDockWidget()
+    qtbot.addWidget(dock)
+
+    dock.append_record(logging.ERROR, "Solver failed: <lambda> at 0x7f0000")
+
+    assert "<lambda>" in dock.text_edit.toPlainText()
+
+
+def test_save_writes_full_buffer_not_filtered_view(qtbot, monkeypatch, tmp_path):
+    from rheojax.gui.compat import QFileDialog
+    from rheojax.gui.widgets.log_dock import LogDockWidget
+
+    dock = LogDockWidget()
+    qtbot.addWidget(dock)
+
+    dock.append_record(logging.DEBUG, "debug message")
+    dock.append_record(logging.ERROR, "error message")
+    dock.level_combo.setCurrentText("ERROR")  # hides the DEBUG line on screen
+
+    out_path = tmp_path / "saved.log"
+    monkeypatch.setattr(
+        QFileDialog, "getSaveFileName", lambda *a, **k: (str(out_path), "")
+    )
+    dock._on_save_clicked()
+
+    saved = out_path.read_text(encoding="utf-8")
+    assert "debug message" in saved
+    assert "error message" in saved

--- a/tests/gui/test_log_dock.py
+++ b/tests/gui/test_log_dock.py
@@ -1,0 +1,51 @@
+"""Tests for the shared GUI log dock widget."""
+
+import logging
+
+import pytest
+
+pytestmark = pytest.mark.gui
+
+
+def test_append_record_buffers_and_renders(qtbot):
+    from rheojax.gui.widgets.log_dock import LogDockWidget
+
+    dock = LogDockWidget()
+    qtbot.addWidget(dock)
+
+    dock.append_record(logging.INFO, "hello world")
+
+    assert "hello world" in dock.text_edit.toPlainText()
+    assert len(dock._records) == 1
+
+
+def test_level_filter_hides_below_threshold(qtbot):
+    from rheojax.gui.widgets.log_dock import LogDockWidget
+
+    dock = LogDockWidget()
+    qtbot.addWidget(dock)
+
+    dock.append_record(logging.DEBUG, "debug message")
+    dock.append_record(logging.ERROR, "error message")
+
+    # Buffer keeps both regardless of filter.
+    assert len(dock._records) == 2
+    # Default filter is INFO, so the DEBUG line should not render.
+    assert "debug message" not in dock.text_edit.toPlainText()
+    assert "error message" in dock.text_edit.toPlainText()
+
+    dock.level_combo.setCurrentText("DEBUG")
+    assert "debug message" in dock.text_edit.toPlainText()
+
+
+def test_buffer_is_bounded(qtbot):
+    from rheojax.gui.widgets.log_dock import LogDockWidget
+
+    dock = LogDockWidget()
+    qtbot.addWidget(dock)
+
+    for i in range(2100):
+        dock.append_record(logging.INFO, f"line {i}")
+
+    assert len(dock._records) == 2000
+    assert dock._records[0][1] == "line 100"

--- a/tests/gui/test_logging_utils.py
+++ b/tests/gui/test_logging_utils.py
@@ -10,9 +10,12 @@ pytestmark = pytest.mark.gui
 
 
 def test_install_gui_log_handler_forwards_records() -> None:
-    """Log records should reach the GUI append callback."""
-    captured: list[str] = []
-    handler = install_gui_log_handler(captured.append, level=logging.DEBUG)
+    """Log records should reach the GUI append callback with their level."""
+    captured: list[tuple[int, str]] = []
+    handler = install_gui_log_handler(
+        lambda levelno, message: captured.append((levelno, message)),
+        level=logging.DEBUG,
+    )
 
     root_logger = logging.getLogger()
     original_level = root_logger.level
@@ -26,4 +29,7 @@ def test_install_gui_log_handler_forwards_records() -> None:
         root_logger.removeHandler(handler)
         root_logger.setLevel(original_level)
 
-    assert any("hello gui logger" in line for line in captured)
+    assert any(
+        levelno == logging.INFO and "hello gui logger" in message
+        for levelno, message in captured
+    )

--- a/tests/gui/test_main_cli_wiring.py
+++ b/tests/gui/test_main_cli_wiring.py
@@ -115,3 +115,69 @@ def test_legacy_flag_constructs_main_window(monkeypatch):
     with pytest.raises(SystemExit):
         main_module.main(["--legacy"])
     assert created.get("legacy") is True
+
+
+class _FakeLogDock:
+    def append_record(self, levelno, message):
+        pass
+
+
+class _FakeDestroyed:
+    def connect(self, fn):
+        # Short-circuits before app.exec() would otherwise block, same as the
+        # existing tests above but one step later (after handler install).
+        raise SystemExit(0)
+
+
+class _FakeWorkspaceWindow:
+    def __init__(self):
+        self.log_dock = _FakeLogDock()
+        self.destroyed = _FakeDestroyed()
+
+
+def test_workspace_branch_installs_gui_log_handler(monkeypatch):
+    import rheojax.gui.main as main_module
+
+    _reuse_qapplication_singleton(monkeypatch)
+    fake_window = _FakeWorkspaceWindow()
+    monkeypatch.setattr(main_module, "_create_workspace_window", lambda: fake_window)
+
+    captured = {}
+
+    def _fake_install(append_fn, **kwargs):
+        captured["append_fn"] = append_fn
+        return object()
+
+    monkeypatch.setattr(main_module, "install_gui_log_handler", _fake_install)
+
+    with pytest.raises(SystemExit):
+        main_module.main([])
+
+    assert captured.get("append_fn") == fake_window.log_dock.append_record
+
+
+def test_uncaught_exception_is_logged_via_global_excepthook(monkeypatch):
+    import sys
+
+    import rheojax.gui.main as main_module
+
+    monkeypatch.setattr(sys, "excepthook", sys.excepthook)  # arm restoration
+
+    monkeypatch.setattr(
+        main_module, "check_dependencies", lambda: (False, ["fake-missing-dep"])
+    )
+
+    result = main_module.main([])
+    assert result == 1
+    assert sys.excepthook is not sys.__excepthook__
+
+    captured = []
+    monkeypatch.setattr(
+        main_module.logger, "critical", lambda *a, **k: captured.append((a, k))
+    )
+    try:
+        raise ValueError("boom")
+    except ValueError:
+        sys.excepthook(*sys.exc_info())
+
+    assert captured

--- a/tests/gui/workspace/test_window_log_dock.py
+++ b/tests/gui/workspace/test_window_log_dock.py
@@ -1,0 +1,32 @@
+import pytest
+
+pytest.importorskip("PySide6")
+
+from rheojax.gui.foundation.state import AppState
+from rheojax.gui.widgets.log_dock import LogDockWidget
+from rheojax.gui.workspace.window import WorkspaceWindow
+
+
+def _win(qtbot):
+    win = WorkspaceWindow(AppState())
+    qtbot.addWidget(win)
+    return win
+
+
+def test_workspace_window_has_log_dock(qtbot):
+    win = _win(qtbot)
+    assert isinstance(win.log_dock, LogDockWidget)
+    assert win.log_dock.isVisible() is False
+
+
+def test_workspace_window_log_appends_to_dock(qtbot):
+    win = _win(qtbot)
+    win.log("hello from workspace")
+    assert "hello from workspace" in win.log_dock.text_edit.toPlainText()
+
+
+def test_view_menu_toggle_shows_log_dock(qtbot):
+    win = _win(qtbot)
+    win.show()
+    win.view_log_dock_action.trigger()
+    assert win.log_dock.isVisible() is True


### PR DESCRIPTION
## Summary
- Default `rheojax-gui` entry point (`WorkspaceWindow`) never installed a GUI log handler and had no log dock — logs were only visible via stdout/rotating file, never in-app. Adds a shared `LogDockWidget` (severity coloring, level filter, save-to-file) and wires it into both `WorkspaceWindow` and the legacy `RheoJAXMainWindow`.
- Installs a global `sys.excepthook` in `main.py` so uncaught exceptions in Qt slots/threads are logged via `logger.critical(exc_info=...)` (and still visible in the log dock) instead of only printing to stderr and being easy to miss.
- `GuiLogHandler`'s append callback now passes the record's `levelno` through, which is what makes severity coloring/filtering possible.
- Worker/job logging coverage (`rheojax/gui/jobs/*.py`) was already adequate — no changes needed there.

## Test plan
- [x] `uv run pytest tests/gui/test_logging_utils.py tests/gui/test_log_dock.py tests/gui/test_main_cli_wiring.py -v` — all pass
- [x] `uv run pytest tests/gui/test_gui_smoke.py tests/gui/test_menu_actions.py -v` — 75 passed (legacy MainWindow regression check)
- [x] `uv run pytest tests/gui/workspace/ -v` — 210 passed, 2 pre-existing failures (confirmed identical on unmodified `main`, unrelated font-rendering/Qt-event-loop env flakes)
- [x] `uv run pytest tests/gui/foundation tests/gui/services -v` — 104 passed
- [x] Additional batches covering crash-prevention, regressions, sidebar/navigation, workflow-switching, import-wizard, batch-panel, transform, and pipeline test files — all pass
- [x] `uv run ruff check rheojax/gui/` — clean
- Note: running `tests/gui/` as one single process segfaults partway through on both this branch and unmodified `main` — a pre-existing native/environment crash unrelated to this change, confirmed by diffing against `main` at the same point.

🤖 Generated with [Claude Code](https://claude.com/claude-code)