### PR TITLE
fix(gui): workspace shell gap-closure — dataset lock, Phase 1 & 2a

### DIFF
--- a/graphify-out/GRAPH_REPORT.md
+++ b/graphify-out/GRAPH_REPORT.md
@@ -1,39 +1,39 @@
-# Graph Report - gui-design-improve  (2026-07-06)
+# Graph Report - fix-commit-dataset-lock  (2026-07-06)
 
 ## Corpus Check
-- 814 files · ~1,761,995 words
+- 817 files · ~1,763,765 words
 - Verdict: corpus is large enough that graph structure adds value.
 
 ## Summary
-- 24828 nodes · 44253 edges · 2742 communities (2575 shown, 167 thin omitted)
-- Extraction: 89% EXTRACTED · 11% INFERRED · 0% AMBIGUOUS · INFERRED: 4724 edges (avg confidence: 0.61)
+- 24800 nodes · 44302 edges · 2707 communities (2504 shown, 203 thin omitted)
+- Extraction: 89% EXTRACTED · 11% INFERRED · 0% AMBIGUOUS · INFERRED: 4733 edges (avg confidence: 0.61)
 - Token cost: 0 input · 0 output
 
 ## Graph Freshness
-- Built from commit: `43905017`
+- Built from commit: `a575beb5`
 - Run `git rev-parse HEAD` and compare to check if the graph is stale.
 - Run `graphify update .` after code changes (no API cost).
 
 ## Community Hubs (Navigation)
-- [[_COMMUNITY_ParameterSet|ParameterSet]]
+- [[_COMMUNITY_test_nlsq_optimization.py|test_nlsq_optimization.py]]
 - [[_COMMUNITY_RheoData|RheoData]]
-- [[_COMMUNITY_test_visual_pipeline_state.py|test_visual_pipeline_state.py]]
-- [[_COMMUNITY_test_bayesian_diagnostics.py|test_bayesian_diagnostics.py]]
+- [[_COMMUNITY_StateStore|StateStore]]
+- [[_COMMUNITY_FitWorker|FitWorker]]
 - [[_COMMUNITY_TransformService|TransformService]]
 - [[_COMMUNITY_Maxwell|Maxwell]]
 - [[_COMMUNITY_Pipeline|Pipeline]]
 - [[_COMMUNITY_ValueError|ValueError]]
 - [[_COMMUNITY_TransformState|TransformState]]
-- [[_COMMUNITY_load_anton_paar|load_anton_paar]]
-- [[_COMMUNITY_ImportWizard|ImportWizard]]
-- [[_COMMUNITY___init__.py|__init__.py]]
+- [[_COMMUNITY_test_vlb.py|test_vlb.py]]
+- [[_COMMUNITY_DataService|DataService]]
+- [[_COMMUNITY_test_initialization.py|test_initialization.py]]
 - [[_COMMUNITY_DataPage|DataPage]]
-- [[_COMMUNITY_FitResult|FitResult]]
+- [[_COMMUNITY_ProcessWorkerAdapter|ProcessWorkerAdapter]]
 - [[_COMMUNITY_BatchPipeline|BatchPipeline]]
 - [[_COMMUNITY_test_fractional_initializers.py|test_fractional_initializers.py]]
 - [[_COMMUNITY_SGRGeneric|SGRGeneric]]
-- [[_COMMUNITY_WorkspaceWindow|WorkspaceWindow]]
-- [[_COMMUNITY_json.py|json.py]]
+- [[_COMMUNITY_AppState|AppState]]
+- [[_COMMUNITY___init__.py|__init__.py]]
 - [[_COMMUNITY_load_csv|load_csv]]
 - [[_COMMUNITY_ITTMCTIsotropic|ITTMCTIsotropic]]
 - [[_COMMUNITY_Zener|Zener]]
@@ -51,14 +51,14 @@
 - [[_COMMUNITY_mittag_leffler_e|mittag_leffler_e]]
 - [[_COMMUNITY_DatasetLibrary|DatasetLibrary]]
 - [[_COMMUNITY__kernels_diffrax.py|_kernels_diffrax.py]]
-- [[_COMMUNITY_BayesianService|BayesianService]]
-- [[_COMMUNITY_test_widgets.py|test_widgets.py]]
-- [[_COMMUNITY_VLBLocal|VLBLocal]]
+- [[_COMMUNITY_arviz_plot_kwargs|arviz_plot_kwargs]]
+- [[_COMMUNITY_PipelineConfigureRunStep|PipelineConfigureRunStep]]
+- [[_COMMUNITY_nlsq_optimize|nlsq_optimize]]
 - [[_COMMUNITY_conftest.py|conftest.py]]
-- [[_COMMUNITY_PipelineExecutionService|PipelineExecutionService]]
+- [[_COMMUNITY_PipelineBatchRunner|PipelineBatchRunner]]
 - [[_COMMUNITY_FluidityNonlocal|FluidityNonlocal]]
-- [[_COMMUNITY_AppState|AppState]]
-- [[_COMMUNITY_test_fikh_caputo.py|test_fikh_caputo.py]]
+- [[_COMMUNITY_state.py|state.py]]
+- [[_COMMUNITY__kernels.py|_kernels.py]]
 - [[_COMMUNITY___init__.py|__init__.py]]
 - [[_COMMUNITY_ExportPage|ExportPage]]
 - [[_COMMUNITY__kernels.py|_kernels.py]]
@@ -68,43 +68,43 @@
 - [[_COMMUNITY_FitPlotter|FitPlotter]]
 - [[_COMMUNITY_mct_kernels.py|mct_kernels.py]]
 - [[_COMMUNITY__kernels.py|_kernels.py]]
-- [[_COMMUNITY__make_mock_spp_results|_make_mock_spp_results]]
-- [[_COMMUNITY_test_transform_plotter.py|test_transform_plotter.py]]
-- [[_COMMUNITY_detect_decay_type|detect_decay_type]]
+- [[_COMMUNITY_to_matlab_dict|to_matlab_dict]]
+- [[_COMMUNITY_TestMastercurvePlot|TestMastercurvePlot]]
+- [[_COMMUNITY_test_arviz_diagnostics.py|test_arviz_diagnostics.py]]
 - [[_COMMUNITY___init__.py|__init__.py]]
 - [[_COMMUNITY__execute_notebook|_execute_notebook]]
 - [[_COMMUNITY_epm_plots.py|epm_plots.py]]
-- [[_COMMUNITY_fit_controller.py|fit_controller.py]]
+- [[_COMMUNITY_ProtocolModelStep|ProtocolModelStep]]
 - [[_COMMUNITY_FMLIKH|FMLIKH]]
 - [[_COMMUNITY_plot_model_fit|plot_model_fit]]
 - [[_COMMUNITY_AnalysisExporter|AnalysisExporter]]
-- [[_COMMUNITY__kernels.py|_kernels.py]]
+- [[_COMMUNITY_test_fikh_thermal.py|test_fikh_thermal.py]]
 - [[_COMMUNITY_TestKernelProperties|TestKernelProperties]]
-- [[_COMMUNITY_VLB Model Equation Verification|VLB Model Equation Verification]]
+- [[_COMMUNITY_ProcessCancellationToken|ProcessCancellationToken]]
 - [[_COMMUNITY_TestMenuBarActionConnections|TestMenuBarActionConnections]]
-- [[_COMMUNITY_TestFractionalZenerSolidSolid|TestFractionalZenerSolidSolid]]
-- [[_COMMUNITY_BaseInitializer|BaseInitializer]]
+- [[_COMMUNITY_test_fractional_zener_family.py|test_fractional_zener_family.py]]
+- [[_COMMUNITY_.clone|.clone]]
 - [[_COMMUNITY_PipelineConfig|PipelineConfig]]
 - [[_COMMUNITY_RheoJaxValidationWarning|RheoJaxValidationWarning]]
-- [[_COMMUNITY_ITT-MCT Literature Review Key Equations|ITT-MCT Literature Review: Key Equations]]
-- [[_COMMUNITY_UnsupportedDataError|UnsupportedDataError]]
+- [[_COMMUNITY_from_yaml|from_yaml]]
+- [[_COMMUNITY_test_project_structure.py|test_project_structure.py]]
 - [[_COMMUNITY_ModelRegistry|ModelRegistry]]
 - [[_COMMUNITY_generate_diagnostic_suite|generate_diagnostic_suite]]
 - [[_COMMUNITY_HVNMBase|HVNMBase]]
 - [[_COMMUNITY_DMTLocal|DMTLocal]]
 - [[_COMMUNITY_GiesekusMultiMode|GiesekusMultiMode]]
 - [[_COMMUNITY_schematic.py|schematic.py]]
-- [[_COMMUNITY_test_schematic.py|test_schematic.py]]
-- [[_COMMUNITY_MultiView|MultiView]]
+- [[_COMMUNITY_.metadata|.metadata]]
+- [[_COMMUNITY_PlotCanvas|PlotCanvas]]
 - [[_COMMUNITY_hebraud_lequeux.py|hebraud_lequeux.py]]
 - [[_COMMUNITY_HVMLocal|HVMLocal]]
-- [[_COMMUNITY_Carreau|Carreau]]
+- [[_COMMUNITY_test_carreau.py|test_carreau.py]]
 - [[_COMMUNITY_test_kernels.py|test_kernels.py]]
 - [[_COMMUNITY_VisualizeStep|VisualizeStep]]
-- [[_COMMUNITY__kernels.py|_kernels.py]]
+- [[_COMMUNITY_FractionalModelMixin|FractionalModelMixin]]
 - [[_COMMUNITY_TransformPlotter|TransformPlotter]]
-- [[_COMMUNITY_ParameterOptimizer|ParameterOptimizer]]
-- [[_COMMUNITY_test_hvm.py|test_hvm.py]]
+- [[_COMMUNITY_ParameterSet|ParameterSet]]
+- [[_COMMUNITY_TestHVMLimitingCases|TestHVMLimitingCases]]
 - [[_COMMUNITY_ndarray|ndarray]]
 - [[_COMMUNITY_prony_conversion.py|prony_conversion.py]]
 - [[_COMMUNITY_TestCoerceBayesianInt|TestCoerceBayesianInt]]
@@ -112,12 +112,12 @@
 - [[_COMMUNITY_test_fikh.py|test_fikh.py]]
 - [[_COMMUNITY_get_template|get_template]]
 - [[_COMMUNITY_FitResult|FitResult]]
-- [[_COMMUNITY_TestModelIntegration|TestModelIntegration]]
+- [[_COMMUNITY_excel.py|excel.py]]
 - [[_COMMUNITY_MIKH|MIKH]]
-- [[_COMMUNITY___init__.py|__init__.py]]
+- [[_COMMUNITY_test_multi_file.py|test_multi_file.py]]
 - [[_COMMUNITY_TestHerschelBulkleyNumericalStability|TestHerschelBulkleyNumericalStability]]
 - [[_COMMUNITY_SPPDecomposer|SPPDecomposer]]
-- [[_COMMUNITY_RheoData|RheoData]]
+- [[_COMMUNITY_MastercurvePipeline|MastercurvePipeline]]
 - [[_COMMUNITY_VLB Model Equation Verification|VLB Model Equation Verification]]
 - [[_COMMUNITY_STZConventional|STZConventional]]
 - [[_COMMUNITY_GiesekusSingleMode|GiesekusSingleMode]]
@@ -140,14 +140,14 @@
 - [[_COMMUNITY_test_dmt.py|test_dmt.py]]
 - [[_COMMUNITY_ndarray|ndarray]]
 - [[_COMMUNITY__make_fit_result|_make_fit_result]]
-- [[_COMMUNITY_TestBootstrapCI|TestBootstrapCI]]
-- [[_COMMUNITY_ModelComparisonPipeline|ModelComparisonPipeline]]
+- [[_COMMUNITY_ndarray|ndarray]]
+- [[_COMMUNITY_.success|.success]]
 - [[_COMMUNITY_HVMBase|HVMBase]]
-- [[_COMMUNITY__yaml_runner.py|_yaml_runner.py]]
+- [[_COMMUNITY_get_console|get_console]]
 - [[_COMMUNITY_Envelope|Envelope]]
 - [[_COMMUNITY_main|main]]
-- [[_COMMUNITY_.fit_bayesian|.fit_bayesian]]
-- [[_COMMUNITY__base.py|_base.py]]
+- [[_COMMUNITY_BayesianMixin|BayesianMixin]]
+- [[_COMMUNITY_TestHVNMInterphase|TestHVNMInterphase]]
 - [[_COMMUNITY_load_npz|load_npz]]
 - [[_COMMUNITY_SmoothDerivative|SmoothDerivative]]
 - [[_COMMUNITY_WorkerPool|WorkerPool]]
@@ -158,8 +158,8 @@
 - [[_COMMUNITY_config_to_builder|config_to_builder]]
 - [[_COMMUNITY_Common Patterns|Common Patterns]]
 - [[_COMMUNITY_Properties|Properties]]
-- [[_COMMUNITY_formatters.py|formatters.py]]
-- [[_COMMUNITY_FluiditySaramitoNonlocal|FluiditySaramitoNonlocal]]
+- [[_COMMUNITY_DetailedFormatter|DetailedFormatter]]
+- [[_COMMUNITY_._setup_parameters|._setup_parameters]]
 - [[_COMMUNITY_Mastercurve|Mastercurve]]
 - [[_COMMUNITY_TestThermodynamicConsistency|TestThermodynamicConsistency]]
 - [[_COMMUNITY_test_phase2_performance.py|test_phase2_performance.py]]
@@ -170,12 +170,12 @@
 - [[_COMMUNITY_test_spp_kernels.py|test_spp_kernels.py]]
 - [[_COMMUNITY_TestFrameworkSmoke|TestFrameworkSmoke]]
 - [[_COMMUNITY_._process_file|._process_file]]
-- [[_COMMUNITY_test_metrics.py|test_metrics.py]]
+- [[_COMMUNITY_run_fit_isolated|run_fit_isolated]]
 - [[_COMMUNITY_test_epm_kernels.py|test_epm_kernels.py]]
-- [[_COMMUNITY_TestInstantiation|TestInstantiation]]
+- [[_COMMUNITY_TNTSingleMode|TNTSingleMode]]
 - [[_COMMUNITY_FFTAnalysis|FFTAnalysis]]
-- [[_COMMUNITY_test_sgr_parity.py|test_sgr_parity.py]]
-- [[_COMMUNITY_TestMultiModeBayesian|TestMultiModeBayesian]]
+- [[_COMMUNITY_set_params|set_params]]
+- [[_COMMUNITY_test_bayesian.py|test_bayesian.py]]
 - [[_COMMUNITY_Registry|Registry]]
 - [[_COMMUNITY_BayesianOptionsDialog|BayesianOptionsDialog]]
 - [[_COMMUNITY_test_single_mode.py|test_single_mode.py]]
@@ -183,14 +183,14 @@
 - [[_COMMUNITY_.connect_signals|.connect_signals]]
 - [[_COMMUNITY_save_excel|save_excel]]
 - [[_COMMUNITY_.globalInstance|.globalInstance]]
-- [[_COMMUNITY_TestOWChirp|TestOWChirp]]
+- [[_COMMUNITY_device.py|device.py]]
 - [[_COMMUNITY_test_priors.py|test_priors.py]]
-- [[_COMMUNITY_SpectrumInversion|SpectrumInversion]]
-- [[_COMMUNITY_.keys|.keys]]
+- [[_COMMUNITY_._transform|._transform]]
+- [[_COMMUNITY_test_physics.py|test_physics.py]]
 - [[_COMMUNITY_RheoJAX GUI Smoke Tests|RheoJAX GUI Smoke Tests]]
 - [[_COMMUNITY_PipelineChips|PipelineChips]]
-- [[_COMMUNITY_TestModeDetection|TestModeDetection]]
-- [[_COMMUNITY_ParameterConstraint|ParameterConstraint]]
+- [[_COMMUNITY_ndarray|ndarray]]
+- [[_COMMUNITY_TRIOSExperiment|TRIOSExperiment]]
 - [[_COMMUNITY_ndarray|ndarray]]
 - [[_COMMUNITY_ndarray|ndarray]]
 - [[_COMMUNITY_GeneralizedMaxwell|GeneralizedMaxwell]]
@@ -200,28 +200,28 @@
 - [[_COMMUNITY_RheoJAX Architecture Overview|RheoJAX Architecture Overview]]
 - [[_COMMUNITY_Hebraud-Lequeux (HL) Model Equations and Physics|Hebraud-Lequeux (HL) Model: Equations and Physics]]
 - [[_COMMUNITY_.navigate_to|.navigate_to]]
-- [[_COMMUNITY_.add_plot|.add_plot]]
-- [[_COMMUNITY_Cross|Cross]]
+- [[_COMMUNITY_ParameterTable|ParameterTable]]
+- [[_COMMUNITY_TestCrossBasics|TestCrossBasics]]
 - [[_COMMUNITY_FractionalMaxwellGel|FractionalMaxwellGel]]
-- [[_COMMUNITY_SPPYieldStress|SPPYieldStress]]
+- [[_COMMUNITY_ModelComparisonPipeline|ModelComparisonPipeline]]
 - [[_COMMUNITY_ndarray|ndarray]]
 - [[_COMMUNITY_.__init__|.__init__]]
 - [[_COMMUNITY_Test Data Fixtures for RheoJAX v0.4.0|Test Data Fixtures for RheoJAX v0.4.0]]
 - [[_COMMUNITY_ArrayLike|ArrayLike]]
 - [[_COMMUNITY_._setup_parameters|._setup_parameters]]
-- [[_COMMUNITY_test_multi_species.py|test_multi_species.py]]
+- [[_COMMUNITY_.create|.create]]
 - [[_COMMUNITY_configure_logging|configure_logging]]
 - [[_COMMUNITY_test_migrated_notebooks.py|test_migrated_notebooks.py]]
 - [[_COMMUNITY_test_dmta_removal.py|test_dmta_removal.py]]
 - [[_COMMUNITY_main|main]]
-- [[_COMMUNITY_anton_paar.py|anton_paar.py]]
-- [[_COMMUNITY__coerce_ndarray|_coerce_ndarray]]
-- [[_COMMUNITY_hvm_solve_laos|hvm_solve_laos]]
+- [[_COMMUNITY_load_anton_paar|load_anton_paar]]
+- [[_COMMUNITY_.shape|.shape]]
+- [[_COMMUNITY_test_basemodel_integration.py|test_basemodel_integration.py]]
 - [[_COMMUNITY_PersistentProcessPool|PersistentProcessPool]]
 - [[_COMMUNITY_sgr_population_balance.py|sgr_population_balance.py]]
-- [[_COMMUNITY_TestBatchVectorization|TestBatchVectorization]]
+- [[_COMMUNITY_test_batch_vectorize.py|test_batch_vectorize.py]]
 - [[_COMMUNITY_EPM (Elasto-Plastic Models) Comprehensive Validation Report|EPM (Elasto-Plastic Models) Comprehensive Validation Report]]
-- [[_COMMUNITY_Parameter|Parameter]]
+- [[_COMMUNITY_TestParameterClass|TestParameterClass]]
 - [[_COMMUNITY_MockBayesianModel|MockBayesianModel]]
 - [[_COMMUNITY_Background Job System - Implementation Summary|Background Job System - Implementation Summary]]
 - [[_COMMUNITY_StatusBar|StatusBar]]
@@ -233,96 +233,96 @@
 - [[_COMMUNITY_FIKH (Fractional Isotropic-Kinematic Hardening) Comprehensive Validation Report|FIKH (Fractional Isotropic-Kinematic Hardening) Comprehensive Validation Report]]
 - [[_COMMUNITY_TestHVMStartup|TestHVMStartup]]
 - [[_COMMUNITY_main|main]]
-- [[_COMMUNITY_TestMaterialTypeDetection|TestMaterialTypeDetection]]
-- [[_COMMUNITY_parse_rheocompass_intervals|parse_rheocompass_intervals]]
-- [[_COMMUNITY_.generate|.generate]]
+- [[_COMMUNITY_.model_function|.model_function]]
+- [[_COMMUNITY_TestFloat64ImportOrder|TestFloat64ImportOrder]]
+- [[_COMMUNITY_.calculate|.calculate]]
 - [[_COMMUNITY_hessian_ci|hessian_ci]]
 - [[_COMMUNITY_run_profiling.py|run_profiling.py]]
 - [[_COMMUNITY_RheoJAX v0.4.0 Task Group 1 - Baseline Test Report|RheoJAX v0.4.0 Task Group 1 - Baseline Test Report]]
 - [[_COMMUNITY_RheoJAX Tech Stack|RheoJAX Tech Stack]]
-- [[_COMMUNITY_TestParameterSetUnpack|TestParameterSetUnpack]]
-- [[_COMMUNITY_test_carreau.py|test_carreau.py]]
-- [[_COMMUNITY_ImportWorker|ImportWorker]]
+- [[_COMMUNITY_make_tensorial_propagator_q|make_tensorial_propagator_q]]
+- [[_COMMUNITY_main.py|main.py]]
+- [[_COMMUNITY_._on_finished|._on_finished]]
 - [[_COMMUNITY_TestFractionalZenerSolidLiquid|TestFractionalZenerSolidLiquid]]
-- [[_COMMUNITY_TestOptimizationResultStatistics|TestOptimizationResultStatistics]]
+- [[_COMMUNITY_LogDockWidget|LogDockWidget]]
 - [[_COMMUNITY_FIKHBase|FIKHBase]]
 - [[_COMMUNITY_FractionalJeffreysModel|FractionalJeffreysModel]]
 - [[_COMMUNITY_ArrayLike|ArrayLike]]
 - [[_COMMUNITY_._get_mode_arrays|._get_mode_arrays]]
-- [[_COMMUNITY_compute_fit_quality|compute_fit_quality]]
-- [[_COMMUNITY_TestY2ColTranslation|TestY2ColTranslation]]
+- [[_COMMUNITY___init__.py|__init__.py]]
+- [[_COMMUNITY__translate_y2_col|_translate_y2_col]]
 - [[_COMMUNITY_solve_linear_creep_compliance|solve_linear_creep_compliance]]
-- [[_COMMUNITY_TestMittagLefflerConvergence|TestMittagLefflerConvergence]]
-- [[_COMMUNITY_spp_kernels.py|spp_kernels.py]]
+- [[_COMMUNITY_test_trios_memory_profiling.py|test_trios_memory_profiling.py]]
+- [[_COMMUNITY_._transform|._transform]]
 - [[_COMMUNITY_TestBayesianNotebooks|TestBayesianNotebooks]]
 - [[_COMMUNITY_handlers.py|handlers.py]]
 - [[_COMMUNITY_RheoJAX GUI Stylesheets|RheoJAX GUI Stylesheets]]
-- [[_COMMUNITY_._predict|._predict]]
-- [[_COMMUNITY_check_wide_frequency_range|check_wide_frequency_range]]
+- [[_COMMUNITY_FractionalBurgersModel|FractionalBurgersModel]]
+- [[_COMMUNITY_detect_data_range_decades|detect_data_range_decades]]
 - [[_COMMUNITY_Hybrid Vitrimer Model (HVM) -- Literature Review & Equations|Hybrid Vitrimer Model (HVM) -- Literature Review & Equations]]
 - [[_COMMUNITY_BayesianPipeline|BayesianPipeline]]
-- [[_COMMUNITY___getattr__|__getattr__]]
+- [[_COMMUNITY_DMTBase|DMTBase]]
 - [[_COMMUNITY_MenuBar|MenuBar]]
-- [[_COMMUNITY_TestHessianCI|TestHessianCI]]
+- [[_COMMUNITY_._fit|._fit]]
 - [[_COMMUNITY_check_model_compatibility|check_model_compatibility]]
 - [[_COMMUNITY_test_epm_kernels_tensorial.py|test_epm_kernels_tensorial.py]]
-- [[_COMMUNITY_MutationNumber|MutationNumber]]
-- [[_COMMUNITY_TestFrequencyDependentModulus|TestFrequencyDependentModulus]]
+- [[_COMMUNITY_TestMutationNumber|TestMutationNumber]]
+- [[_COMMUNITY_Gp|Gp]]
 - [[_COMMUNITY_plot_lissajous|plot_lissajous]]
 - [[_COMMUNITY_TestFIKHPredictions|TestFIKHPredictions]]
-- [[_COMMUNITY_get_logger|get_logger]]
-- [[_COMMUNITY_load_trios|load_trios]]
-- [[_COMMUNITY_compute_diagnostics|compute_diagnostics]]
+- [[_COMMUNITY_ModelService|ModelService]]
+- [[_COMMUNITY_test_trios_auto_chunk.py|test_trios_auto_chunk.py]]
+- [[_COMMUNITY_.create_mastercurve|.create_mastercurve]]
 - [[_COMMUNITY_check_r_hat|check_r_hat]]
 - [[_COMMUNITY_test_unit_conversion.py|test_unit_conversion.py]]
 - [[_COMMUNITY_Capability Matrix|Capability Matrix]]
 - [[_COMMUNITY_Functional Requirements|Functional Requirements]]
 - [[_COMMUNITY_create_global_parser|create_global_parser]]
-- [[_COMMUNITY_cmd_transform.py|cmd_transform.py]]
-- [[_COMMUNITY_parse_args|parse_args]]
-- [[_COMMUNITY__VizTestTransform|_VizTestTransform]]
+- [[_COMMUNITY_main|main]]
+- [[_COMMUNITY_test_main_cli_wiring.py|test_main_cli_wiring.py]]
+- [[_COMMUNITY_._transform|._transform]]
 - [[_COMMUNITY_test_spp_golden_parity.py|test_spp_golden_parity.py]]
 - [[_COMMUNITY_validate_model_doc|validate_model_doc]]
 - [[_COMMUNITY_test_gmm_element_search.py|test_gmm_element_search.py]]
-- [[_COMMUNITY_.export_data|.export_data]]
-- [[_COMMUNITY_animate_tensorial_evolution|animate_tensorial_evolution]]
-- [[_COMMUNITY_PreviewWorker|PreviewWorker]]
+- [[_COMMUNITY_inference_data_from_dict|inference_data_from_dict]]
+- [[_COMMUNITY_TestTensorialAnimation|TestTensorialAnimation]]
+- [[_COMMUNITY_CancellationError|CancellationError]]
 - [[_COMMUNITY_FractionalKelvinVoigtZener|FractionalKelvinVoigtZener]]
 - [[_COMMUNITY_FractionalPoyntingThomson|FractionalPoyntingThomson]]
-- [[_COMMUNITY_SPPAmplitudeSweepPipeline|SPPAmplitudeSweepPipeline]]
-- [[_COMMUNITY_BaseArviZWidget|BaseArviZWidget]]
-- [[_COMMUNITY_auto_p0.py|auto_p0.py]]
+- [[_COMMUNITY_.get_model_result|.get_model_result]]
+- [[_COMMUNITY_spp_kernels.py|spp_kernels.py]]
+- [[_COMMUNITY_TestProcessExitVerification|TestProcessExitVerification]]
 - [[_COMMUNITY_run_single_notebook_96h.py|run_single_notebook_96h.py]]
 - [[_COMMUNITY_PipelineTemplateDialog|PipelineTemplateDialog]]
 - [[_COMMUNITY_TestDynamicX|TestDynamicX]]
 - [[_COMMUNITY_plot_moduli_evolution|plot_moduli_evolution]]
-- [[_COMMUNITY_worker_pool.py|worker_pool.py]]
-- [[_COMMUNITY_.simulate_laos|.simulate_laos]]
-- [[_COMMUNITY_TestHVMSAOS|TestHVMSAOS]]
+- [[_COMMUNITY_TestProjectStructure|TestProjectStructure]]
+- [[_COMMUNITY_ndarray|ndarray]]
+- [[_COMMUNITY_test_import.py|test_import.py]]
 - [[_COMMUNITY_Background Job System|Background Job System]]
 - [[_COMMUNITY_JAXStatusWidget|JAXStatusWidget]]
 - [[_COMMUNITY_VLBNonlocal|VLBNonlocal]]
-- [[_COMMUNITY_TestV032PerformanceIntegration|TestV032PerformanceIntegration]]
+- [[_COMMUNITY_.predict_rheo|.predict_rheo]]
 - [[_COMMUNITY_initialize_equilibrium|initialize_equilibrium]]
 - [[_COMMUNITY_.step|.step]]
-- [[_COMMUNITY_save_intervals_to_excel|save_intervals_to_excel]]
-- [[_COMMUNITY_._handle_transform_result|._handle_transform_result]]
-- [[_COMMUNITY_.create_fit_plot|.create_fit_plot]]
-- [[_COMMUNITY_._fit|._fit]]
+- [[_COMMUNITY_vlb_fene_factor|vlb_fene_factor]]
+- [[_COMMUNITY__make_mock_spp_results|_make_mock_spp_results]]
+- [[_COMMUNITY_.create_arviz_plot|.create_arviz_plot]]
+- [[_COMMUNITY_SPPYieldStress|SPPYieldStress]]
 - [[_COMMUNITY_create_rheo_data_creep|create_rheo_data_creep]]
 - [[_COMMUNITY_TestHebraudLequeux|TestHebraudLequeux]]
 - [[_COMMUNITY_TestVLBMultiNetworkAnalytical|TestVLBMultiNetworkAnalytical]]
-- [[_COMMUNITY_compute_plastic_strain_rate|compute_plastic_strain_rate]]
+- [[_COMMUNITY_TestNLSQOptimizer|TestNLSQOptimizer]]
 - [[_COMMUNITY_ThemeDemo|ThemeDemo]]
-- [[_COMMUNITY_make_grid|make_grid]]
-- [[_COMMUNITY_main|main]]
-- [[_COMMUNITY_.slice|.slice]]
-- [[_COMMUNITY_TestRheoDataCreation|TestRheoDataCreation]]
+- [[_COMMUNITY_json.py|json.py]]
+- [[_COMMUNITY_NumpyJSONEncoder|NumpyJSONEncoder]]
+- [[_COMMUNITY_test_numerical_derivative_second_order_sinusoid|test_numerical_derivative_second_order_sinusoid]]
+- [[_COMMUNITY_test_jobs.py|test_jobs.py]]
 - [[_COMMUNITY_ExportOptionsDialog|ExportOptionsDialog]]
-- [[_COMMUNITY_ndarray|ndarray]]
-- [[_COMMUNITY_TestCoxMerz|TestCoxMerz]]
+- [[_COMMUNITY_._transform|._transform]]
+- [[_COMMUNITY_install_gui_log_handler|install_gui_log_handler]]
 - [[_COMMUNITY_._optimized_wavelet_transform|._optimized_wavelet_transform]]
-- [[_COMMUNITY_FractionalBurgersModel|FractionalBurgersModel]]
+- [[_COMMUNITY_FractionalZenerSolidLiquid|FractionalZenerSolidLiquid]]
 - [[_COMMUNITY_ndarray|ndarray]]
 - [[_COMMUNITY_parallel_load|parallel_load]]
 - [[_COMMUNITY_TestBasicNotebooks|TestBasicNotebooks]]
@@ -333,33 +333,33 @@
 - [[_COMMUNITY_TNTCates|TNTCates]]
 - [[_COMMUNITY_.predict_rheo|.predict_rheo]]
 - [[_COMMUNITY_plot_harmonic_spectrum|plot_harmonic_spectrum]]
-- [[_COMMUNITY_._predict_viscosity|._predict_viscosity]]
+- [[_COMMUNITY_.predict_rheo|.predict_rheo]]
 - [[_COMMUNITY_txt.py|txt.py]]
-- [[_COMMUNITY_TestLatticeEPMModelFunction|TestLatticeEPMModelFunction]]
-- [[_COMMUNITY_._predict|._predict]]
-- [[_COMMUNITY_.shape|.shape]]
+- [[_COMMUNITY_.has_message|.has_message]]
+- [[_COMMUNITY_TestVLBTemperature|TestVLBTemperature]]
+- [[_COMMUNITY_TransformPipeline|TransformPipeline]]
 - [[_COMMUNITY_test_generalized_maxwell_warm_start.py|test_generalized_maxwell_warm_start.py]]
 - [[_COMMUNITY_test_single_mode.py|test_single_mode.py]]
-- [[_COMMUNITY_._arviz_plot|._arviz_plot]]
-- [[_COMMUNITY_EPMBase|EPMBase]]
-- [[_COMMUNITY_TestPipelineExport|TestPipelineExport]]
+- [[_COMMUNITY_verify_float64|verify_float64]]
+- [[_COMMUNITY_._init_state|._init_state]]
+- [[_COMMUNITY_export_spp_txt|export_spp_txt]]
 - [[_COMMUNITY_HerschelBulkley|HerschelBulkley]]
 - [[_COMMUNITY_.result|.result]]
 - [[_COMMUNITY_TestPlotModuliEvolution|TestPlotModuliEvolution]]
 - [[_COMMUNITY_RheoJAX Architecture Review — 2026-04-06|RheoJAX Architecture Review — 2026-04-06]]
-- [[_COMMUNITY_import_dataset|import_dataset]]
+- [[_COMMUNITY_FitState|FitState]]
 - [[_COMMUNITY_TestFluidityLocalModelFunction|TestFluidityLocalModelFunction]]
 - [[_COMMUNITY_TestFluidityNonlocalModelFunction|TestFluidityNonlocalModelFunction]]
 - [[_COMMUNITY_test_sgr_generic_extended.py|test_sgr_generic_extended.py]]
 - [[_COMMUNITY_FitOrchestrator|FitOrchestrator]]
-- [[_COMMUNITY_SRFS|SRFS]]
+- [[_COMMUNITY_export_spp_csv|export_spp_csv]]
 - [[_COMMUNITY_RheoJAX GUI Package|RheoJAX GUI Package]]
 - [[_COMMUNITY_TestFMLIKHPredictions|TestFMLIKHPredictions]]
-- [[_COMMUNITY_TestSTZFlowTransient|TestSTZFlowTransient]]
+- [[_COMMUNITY_._model_function_scalar|._model_function_scalar]]
 - [[_COMMUNITY_.predict_normal_stresses|.predict_normal_stresses]]
 - [[_COMMUNITY_lve_envelope|lve_envelope]]
-- [[_COMMUNITY_TestMaxwellOscillation|TestMaxwellOscillation]]
-- [[_COMMUNITY_TestSpringPotOscillation|TestSpringPotOscillation]]
+- [[_COMMUNITY_._model_function_general|._model_function_general]]
+- [[_COMMUNITY_differentiate_rate_from_strain|differentiate_rate_from_strain]]
 - [[_COMMUNITY_test_transform_page_redesign.py|test_transform_page_redesign.py]]
 - [[_COMMUNITY_test_optimization_validation.py|test_optimization_validation.py]]
 - [[_COMMUNITY_TestLAOSAnalysis|TestLAOSAnalysis]]
@@ -368,208 +368,208 @@
 - [[_COMMUNITY_TestVLBVariantCreation|TestVLBVariantCreation]]
 - [[_COMMUNITY_TestVLBBellPhysics|TestVLBBellPhysics]]
 - [[_COMMUNITY_ResidualsPanel|ResidualsPanel]]
-- [[_COMMUNITY_TestZenerOscillation|TestZenerOscillation]]
+- [[_COMMUNITY_TestFluidityLocalOscillation|TestFluidityLocalOscillation]]
 - [[_COMMUNITY_spp.py|spp.py]]
-- [[_COMMUNITY_TestSAOSModuli|TestSAOSModuli]]
-- [[_COMMUNITY_from_yaml|from_yaml]]
+- [[_COMMUNITY_giesekus_saos_moduli|giesekus_saos_moduli]]
+- [[_COMMUNITY_to_yaml|to_yaml]]
 - [[_COMMUNITY_TestFluidityNonlocalShearBanding|TestFluidityNonlocalShearBanding]]
 - [[_COMMUNITY_FractionalMaxwellLiquid|FractionalMaxwellLiquid]]
-- [[_COMMUNITY_TestSteadyShearAnalytical|TestSteadyShearAnalytical]]
+- [[_COMMUNITY_TestFluidityNonlocalSmoke|TestFluidityNonlocalSmoke]]
 - [[_COMMUNITY_._predict|._predict]]
-- [[_COMMUNITY_ArrayLike|ArrayLike]]
-- [[_COMMUNITY_.predict|.predict]]
-- [[_COMMUNITY_.residuals|.residuals]]
-- [[_COMMUNITY_TestCompatibilityMessageFormatting|TestCompatibilityMessageFormatting]]
-- [[_COMMUNITY_.from_dict|.from_dict]]
+- [[_COMMUNITY_TestInstantiation|TestInstantiation]]
+- [[_COMMUNITY_TestShearBandingDetection|TestShearBandingDetection]]
+- [[_COMMUNITY_TestVLBUtilities|TestVLBUtilities]]
+- [[_COMMUNITY_TestVLBVariantProtocols|TestVLBVariantProtocols]]
+- [[_COMMUNITY_TestParameterSet|TestParameterSet]]
 - [[_COMMUNITY_TestVLBVariantRegression|TestVLBVariantRegression]]
-- [[_COMMUNITY_TestHVNMFlowCurve|TestHVNMFlowCurve]]
+- [[_COMMUNITY_Array|Array]]
 - [[_COMMUNITY_TestLogOperation|TestLogOperation]]
-- [[_COMMUNITY__kernels.py|_kernels.py]]
-- [[_COMMUNITY_TRIOSExperiment|TRIOSExperiment]]
+- [[_COMMUNITY_create_prony_parameter_set|create_prony_parameter_set]]
+- [[_COMMUNITY_TRIOSDataSet|TRIOSDataSet]]
 - [[_COMMUNITY_conftest.py|conftest.py]]
 - [[_COMMUNITY_CarreauYasuda|CarreauYasuda]]
 - [[_COMMUNITY_TestDMTNonlocal|TestDMTNonlocal]]
-- [[_COMMUNITY_.set_parameters|.set_parameters]]
+- [[_COMMUNITY_._on_import|._on_import]]
 - [[_COMMUNITY_parallel_map|parallel_map]]
 - [[_COMMUNITY_TestBaseTransform|TestBaseTransform]]
 - [[_COMMUNITY_G0|G0]]
 - [[_COMMUNITY_TestMLIKHProtocolFitting|TestMLIKHProtocolFitting]]
-- [[_COMMUNITY_.get|.get]]
+- [[_COMMUNITY_test_window_file_menu.py|test_window_file_menu.py]]
 - [[_COMMUNITY_.model_function|.model_function]]
 - [[_COMMUNITY_test_cates.py|test_cates.py]]
-- [[_COMMUNITY_ndarray|ndarray]]
+- [[_COMMUNITY_TestBayesianInterface|TestBayesianInterface]]
 - [[_COMMUNITY_TestComposedVariants|TestComposedVariants]]
 - [[_COMMUNITY_test_multi_mode.py|test_multi_mode.py]]
 - [[_COMMUNITY_Fractional Viscoelastic Models Equation Verification Report|Fractional Viscoelastic Models: Equation Verification Report]]
-- [[_COMMUNITY_FractionalJeffreysInitializer|FractionalJeffreysInitializer]]
+- [[_COMMUNITY_TestLVEEnvelopeTransform|TestLVEEnvelopeTransform]]
 - [[_COMMUNITY_test_trios_chunked_integrity.py|test_trios_chunked_integrity.py]]
 - [[_COMMUNITY_TestMLIKH|TestMLIKH]]
 - [[_COMMUNITY_style_helpers.py|style_helpers.py]]
 - [[_COMMUNITY_TestIdentifiabilityAPI|TestIdentifiabilityAPI]]
 - [[_COMMUNITY_TestFluidityPredictWithoutFit|TestFluidityPredictWithoutFit]]
-- [[_COMMUNITY_._simulate_laos_internal|._simulate_laos_internal]]
+- [[_COMMUNITY_Exception|Exception]]
 - [[_COMMUNITY_TestPlotPipkinDiagram|TestPlotPipkinDiagram]]
 - [[_COMMUNITY_create_spp_report|create_spp_report]]
 - [[_COMMUNITY_TestBaseModel|TestBaseModel]]
-- [[_COMMUNITY_FractionalKelvinVoigtInitializer|FractionalKelvinVoigtInitializer]]
-- [[_COMMUNITY_test_logging_integration.py|test_logging_integration.py]]
+- [[_COMMUNITY_._predict_stress|._predict_stress]]
+- [[_COMMUNITY_LogCapture|LogCapture]]
 - [[_COMMUNITY_TestDMTBayesian|TestDMTBayesian]]
-- [[_COMMUNITY_test_prony.py|test_prony.py]]
+- [[_COMMUNITY__kernels.py|_kernels.py]]
 - [[_COMMUNITY_TestHVNMSAOS|TestHVNMSAOS]]
 - [[_COMMUNITY_TestSTZCoverage|TestSTZCoverage]]
 - [[_COMMUNITY_Notebook Validation Tests - Tiered Testing Strategy|Notebook Validation Tests - Tiered Testing Strategy]]
 - [[_COMMUNITY__mittag_leffler_hybrid|_mittag_leffler_hybrid]]
-- [[_COMMUNITY_FractionalMaxwellModelInitializer|FractionalMaxwellModelInitializer]]
+- [[_COMMUNITY_test_model_config.py|test_model_config.py]]
 - [[_COMMUNITY_When Analytical SAOS Breaks Down for Transient Network Models and Vitrimers|When Analytical SAOS Breaks Down for Transient Network Models and Vitrimers]]
-- [[_COMMUNITY_TestJAXSupport|TestJAXSupport]]
-- [[_COMMUNITY_TestModeEnum|TestModeEnum]]
-- [[_COMMUNITY_TestRheoDataValidation|TestRheoDataValidation]]
+- [[_COMMUNITY_.test_jax_jit_compilation|.test_jax_jit_compilation]]
+- [[_COMMUNITY___init__.py|__init__.py]]
+- [[_COMMUNITY___init__.py|__init__.py]]
 - [[_COMMUNITY_.model_function|.model_function]]
 - [[_COMMUNITY_pool.py|pool.py]]
 - [[_COMMUNITY_.apply_transform|.apply_transform]]
 - [[_COMMUNITY_test_local.py|test_local.py]]
 - [[_COMMUNITY_plot_cole_cole|plot_cole_cole]]
 - [[_COMMUNITY_test_arviz_utils.py|test_arviz_utils.py]]
-- [[_COMMUNITY_TestSpringPotRelaxation|TestSpringPotRelaxation]]
-- [[_COMMUNITY_TestSpringPotEdgeCases|TestSpringPotEdgeCases]]
-- [[_COMMUNITY_TestZenerCreep|TestZenerCreep]]
+- [[_COMMUNITY_test_export_and_project.py|test_export_and_project.py]]
+- [[_COMMUNITY_TestDMTLocalFlowCurve|TestDMTLocalFlowCurve]]
+- [[_COMMUNITY_TestBinghamStability|TestBinghamStability]]
 - [[_COMMUNITY_TestLoggerMethods|TestLoggerMethods]]
 - [[_COMMUNITY_TestDMTLocalCreation|TestDMTLocalCreation]]
 - [[_COMMUNITY_TestDMTLocalCreep|TestDMTLocalCreep]]
-- [[_COMMUNITY_TestFIKHInitialization|TestFIKHInitialization]]
-- [[_COMMUNITY_TestFMLIKHInitialization|TestFMLIKHInitialization]]
+- [[_COMMUNITY_TestCarreauYasudaBasics|TestCarreauYasudaBasics]]
+- [[_COMMUNITY_TestYieldStressEmergence|TestYieldStressEmergence]]
 - [[_COMMUNITY_TestThixotropy|TestThixotropy]]
 - [[_COMMUNITY_TNTLoopBridge|TNTLoopBridge]]
-- [[_COMMUNITY_.test_default_3_species|.test_default_3_species]]
+- [[_COMMUNITY_TestInstantiation|TestInstantiation]]
 - [[_COMMUNITY_test_sticky_rouse.py|test_sticky_rouse.py]]
-- [[_COMMUNITY_TestModelFunctionCompleteness|TestModelFunctionCompleteness]]
+- [[_COMMUNITY_.test_model_function_startup|.test_model_function_startup]]
 - [[_COMMUNITY_TestParameterManagement|TestParameterManagement]]
 - [[_COMMUNITY_TestShearBandingMetrics|TestShearBandingMetrics]]
 - [[_COMMUNITY_TestHVMCreep|TestHVMCreep]]
 - [[_COMMUNITY_TestFractionalKelvinVoigtZener|TestFractionalKelvinVoigtZener]]
 - [[_COMMUNITY_TestHVMFlowCurve|TestHVMFlowCurve]]
-- [[_COMMUNITY_compute_gl_weights|compute_gl_weights]]
+- [[_COMMUNITY_TestShearThinning|TestShearThinning]]
 - [[_COMMUNITY_TestIKHKernels|TestIKHKernels]]
 - [[_COMMUNITY_TestHVMRelaxation|TestHVMRelaxation]]
-- [[_COMMUNITY_TestISMOscillationAnalytic|TestISMOscillationAnalytic]]
+- [[_COMMUNITY_TestStressOvershoot|TestStressOvershoot]]
 - [[_COMMUNITY_TestGetLogger|TestGetLogger]]
 - [[_COMMUNITY_TestPlot3DTrajectory|TestPlot3DTrajectory]]
 - [[_COMMUNITY_micro_benchmarks.py|micro_benchmarks.py]]
 - [[_COMMUNITY_TestRheoJAXLogger|TestRheoJAXLogger]]
 - [[_COMMUNITY_TestHVMLAOS|TestHVMLAOS]]
 - [[_COMMUNITY__simulate_nonlocal_creep|_simulate_nonlocal_creep]]
-- [[_COMMUNITY_TestEdgeCases|TestEdgeCases]]
+- [[_COMMUNITY_TestUserProvidedSk|TestUserProvidedSk]]
 - [[_COMMUNITY_TestHVNMStartup|TestHVNMStartup]]
 - [[_COMMUNITY_TestVLBNonlocalCreation|TestVLBNonlocalCreation]]
 - [[_COMMUNITY_Giesekus Model Mathematical Verification Report|Giesekus Model Mathematical Verification Report]]
 - [[_COMMUNITY_MockBayesianModel|MockBayesianModel]]
 - [[_COMMUNITY_.from_registry|.from_registry]]
 - [[_COMMUNITY_._apply_theme|._apply_theme]]
-- [[_COMMUNITY_._plot_pair|._plot_pair]]
-- [[_COMMUNITY_TestOscillatoryLoading|TestOscillatoryLoading]]
-- [[_COMMUNITY_FluidityBase|FluidityBase]]
-- [[_COMMUNITY_._predict|._predict]]
-- [[_COMMUNITY_TestVLBNonlocalHomogeneous|TestVLBNonlocalHomogeneous]]
-- [[_COMMUNITY_compatibility.py|compatibility.py]]
+- [[_COMMUNITY_TestCombinedFeatures|TestCombinedFeatures]]
+- [[_COMMUNITY_TestSAOS|TestSAOS]]
+- [[_COMMUNITY_._setup_parameters|._setup_parameters]]
+- [[_COMMUNITY_FractionalZenerLiquidLiquid|FractionalZenerLiquidLiquid]]
+- [[_COMMUNITY_laplacian_1d_neumann_vlb|laplacian_1d_neumann_vlb]]
+- [[_COMMUNITY_TestRelaxationSimulation|TestRelaxationSimulation]]
 - [[_COMMUNITY_f12_memory_kernel|f12_memory_kernel]]
-- [[_COMMUNITY_test_cross.py|test_cross.py]]
-- [[_COMMUNITY_BayesianMixin|BayesianMixin]]
+- [[_COMMUNITY_TestBayesianInterface|TestBayesianInterface]]
+- [[_COMMUNITY_test_bayesian.py|test_bayesian.py]]
 - [[_COMMUNITY_TestFractionalBurgersModel|TestFractionalBurgersModel]]
 - [[_COMMUNITY_TestDMTLocalStartup|TestDMTLocalStartup]]
 - [[_COMMUNITY_TestF002KwargsCache|TestF002KwargsCache]]
-- [[_COMMUNITY_PipelineConfigureRunStep|PipelineConfigureRunStep]]
+- [[_COMMUNITY_TestVLBBellFeneCombined|TestVLBBellFeneCombined]]
 - [[_COMMUNITY_TestFractionalPoyntingThomson|TestFractionalPoyntingThomson]]
 - [[_COMMUNITY_TestNormalStresses|TestNormalStresses]]
-- [[_COMMUNITY_.model_function|.model_function]]
+- [[_COMMUNITY_.predict_rheo|.predict_rheo]]
 - [[_COMMUNITY_TestFractionalJeffreysModel|TestFractionalJeffreysModel]]
 - [[_COMMUNITY_._predict_from_params|._predict_from_params]]
 - [[_COMMUNITY_TestInstantiation|TestInstantiation]]
-- [[_COMMUNITY_TestPowerLawPredictions|TestPowerLawPredictions]]
+- [[_COMMUNITY_PowerLaw|PowerLaw]]
 - [[_COMMUNITY_TNTMultiSpecies|TNTMultiSpecies]]
-- [[_COMMUNITY_TestMaxwellLimit|TestMaxwellLimit]]
+- [[_COMMUNITY_.test_saos_moduli_superposition|.test_saos_moduli_superposition]]
 - [[_COMMUNITY_TestStartupSimulation|TestStartupSimulation]]
 - [[_COMMUNITY_TestPhysicalConsistency|TestPhysicalConsistency]]
 - [[_COMMUNITY_TestBellVariant|TestBellVariant]]
 - [[_COMMUNITY_TestFENEVariant|TestFENEVariant]]
-- [[_COMMUNITY_.test_creep_strain_correct_shape|.test_creep_strain_correct_shape]]
+- [[_COMMUNITY_TestCreepSimulation|TestCreepSimulation]]
 - [[_COMMUNITY_Material Classification|Material Classification]]
 - [[_COMMUNITY_NamedTuple|NamedTuple]]
-- [[_COMMUNITY_detect_data_range_decades|detect_data_range_decades]]
+- [[_COMMUNITY_require_dependency|require_dependency]]
 - [[_COMMUNITY_.model_function|.model_function]]
 - [[_COMMUNITY_._transform|._transform]]
-- [[_COMMUNITY_FractionalZenerSSInitializer|FractionalZenerSSInitializer]]
-- [[_COMMUNITY_NaNProducingModel|NaNProducingModel]]
-- [[_COMMUNITY_TestRheoDataNumpyCompatibility|TestRheoDataNumpyCompatibility]]
-- [[_COMMUNITY_.cleanup|.cleanup]]
-- [[_COMMUNITY_TestCreepLoading|TestCreepLoading]]
-- [[_COMMUNITY_ndarray|ndarray]]
-- [[_COMMUNITY_ndarray|ndarray]]
+- [[_COMMUNITY_._model_relaxation_jit|._model_relaxation_jit]]
+- [[_COMMUNITY_._model_startup_jit|._model_startup_jit]]
+- [[_COMMUNITY___init__.py|__init__.py]]
+- [[_COMMUNITY_test_sgr_parity.py|test_sgr_parity.py]]
+- [[_COMMUNITY_TestLogFormat|TestLogFormat]]
+- [[_COMMUNITY_TestFitCreep|TestFitCreep]]
+- [[_COMMUNITY_vlb_stress_fene_xy|vlb_stress_fene_xy]]
 - [[_COMMUNITY_.test_flow_curve_with_components|.test_flow_curve_with_components]]
-- [[_COMMUNITY_TestFluidityLocalFlowCurve|TestFluidityLocalFlowCurve]]
-- [[_COMMUNITY__ExportTestModel|_ExportTestModel]]
+- [[_COMMUNITY_TestBinghamBasics|TestBinghamBasics]]
+- [[_COMMUNITY_TestBinghamFitting|TestBinghamFitting]]
 - [[_COMMUNITY_TestDMTLocalLAOS|TestDMTLocalLAOS]]
-- [[_COMMUNITY_TestMultiInterval|TestMultiInterval]]
-- [[_COMMUNITY_.test_model_function_3_species|.test_model_function_3_species]]
+- [[_COMMUNITY_TestBinghamPhysicalBehavior|TestBinghamPhysicalBehavior]]
+- [[_COMMUNITY_TestCrossStability|TestCrossStability]]
 - [[_COMMUNITY_TestHVNMRelaxation|TestHVNMRelaxation]]
-- [[_COMMUNITY_.test_simulate_startup_runs|.test_simulate_startup_runs]]
-- [[_COMMUNITY_TestMaxwellEdgeCases|TestMaxwellEdgeCases]]
+- [[_COMMUNITY_TestBayesianInference|TestBayesianInference]]
+- [[_COMMUNITY_TestNLSQWarmStart|TestNLSQWarmStart]]
 - [[_COMMUNITY_.test_predict_plateau_modulus_all_modes_limited|.test_predict_plateau_modulus_all_modes_limited]]
 - [[_COMMUNITY_Migration Guide|Migration Guide]]
 - [[_COMMUNITY_Classical Linear Viscoelastic Model Equations -- Verification Reference|Classical Linear Viscoelastic Model Equations -- Verification Reference]]
 - [[_COMMUNITY_RheoJAX Documentation Structure|RheoJAX Documentation Structure]]
-- [[_COMMUNITY_build_numpyro_model|build_numpyro_model]]
-- [[_COMMUNITY_TestFIKHParameters|TestFIKHParameters]]
+- [[_COMMUNITY_TestBayesianSmoke|TestBayesianSmoke]]
+- [[_COMMUNITY_TestUCMLimit|TestUCMLimit]]
 - [[_COMMUNITY_run_all_notebooks.py|run_all_notebooks.py]]
 - [[_COMMUNITY_TestFIKHRelaxation|TestFIKHRelaxation]]
-- [[_COMMUNITY_.test_startup_stress_increases|.test_startup_stress_increases]]
-- [[_COMMUNITY_test_parameter_schema.py|test_parameter_schema.py]]
+- [[_COMMUNITY_TestFluidityNonlocalTransient|TestFluidityNonlocalTransient]]
+- [[_COMMUNITY__extract|_extract]]
 - [[_COMMUNITY_TestPlasticityAlpha|TestPlasticityAlpha]]
-- [[_COMMUNITY_TestDMTLocalRelaxation|TestDMTLocalRelaxation]]
-- [[_COMMUNITY_TestNonlocalShearBanding|TestNonlocalShearBanding]]
-- [[_COMMUNITY_TestFractionalZenerLiquidLiquid|TestFractionalZenerLiquidLiquid]]
-- [[_COMMUNITY_TestHVMDamage|TestHVMDamage]]
-- [[_COMMUNITY_TestNormalStressScaling|TestNormalStressScaling]]
+- [[_COMMUNITY_TestVLBVariantBayesian|TestVLBVariantBayesian]]
 - [[_COMMUNITY_test_physics.py|test_physics.py]]
+- [[_COMMUNITY_TestFluidityLocalNLSQ|TestFluidityLocalNLSQ]]
+- [[_COMMUNITY_TestDiagnosticsValidation|TestDiagnosticsValidation]]
+- [[_COMMUNITY_TestNormalStressScaling|TestNormalStressScaling]]
+- [[_COMMUNITY_TestThixotropicOvershoot|TestThixotropicOvershoot]]
 - [[_COMMUNITY_.update_metadata|.update_metadata]]
 - [[_COMMUNITY_TestHVNMCreep|TestHVNMCreep]]
-- [[_COMMUNITY_TestInstantiation|TestInstantiation]]
-- [[_COMMUNITY_TestPercusYevickSk|TestPercusYevickSk]]
-- [[_COMMUNITY_TestMittagLefflerAccuracy|TestMittagLefflerAccuracy]]
-- [[_COMMUNITY_TestMittagLefflerJAXCompatibility|TestMittagLefflerJAXCompatibility]]
+- [[_COMMUNITY_TestFFTPlot|TestFFTPlot]]
+- [[_COMMUNITY_bayesian_completed|bayesian_completed]]
+- [[_COMMUNITY_.__init__|.__init__]]
+- [[_COMMUNITY_test_parameter_schema.py|test_parameter_schema.py]]
 - [[_COMMUNITY_TestDiffraxCompilation|TestDiffraxCompilation]]
-- [[_COMMUNITY_TestRotationalLoading|TestRotationalLoading]]
+- [[_COMMUNITY__synthetic_laos|_synthetic_laos]]
 - [[_COMMUNITY_TestCatesMaxwellLimit|TestCatesMaxwellLimit]]
 - [[_COMMUNITY_TestFlowCurve|TestFlowCurve]]
-- [[_COMMUNITY_TestStartupSimulation|TestStartupSimulation]]
+- [[_COMMUNITY_.test_startup_approaches_steady_state|.test_startup_approaches_steady_state]]
 - [[_COMMUNITY_TestJAXCompatibility|TestJAXCompatibility]]
-- [[_COMMUNITY_TestLAOSSimulation|TestLAOSSimulation]]
-- [[_COMMUNITY_TestPhysicalConsistency|TestPhysicalConsistency]]
-- [[_COMMUNITY_TestLatticeEPMNLSQ|TestLatticeEPMNLSQ]]
+- [[_COMMUNITY_.test_laos_periodicity|.test_laos_periodicity]]
+- [[_COMMUNITY_.test_stress_positive_under_shear|.test_stress_positive_under_shear]]
+- [[_COMMUNITY_._setup_parameters|._setup_parameters]]
 - [[_COMMUNITY_test_loop_bridge.py|test_loop_bridge.py]]
 - [[_COMMUNITY_TestPlotRheoData|TestPlotRheoData]]
-- [[_COMMUNITY_.from_dict|.from_dict]]
-- [[_COMMUNITY_.test_simulate_laos|.test_simulate_laos]]
-- [[_COMMUNITY_TestBayesianInterface|TestBayesianInterface]]
-- [[_COMMUNITY_._copy_arviz_figure|._copy_arviz_figure]]
-- [[_COMMUNITY_test_plot_service_golden.py|test_plot_service_golden.py]]
+- [[_COMMUNITY_.__init__|.__init__]]
+- [[_COMMUNITY_TestLogTransform|TestLogTransform]]
+- [[_COMMUNITY_.test_model_function_flow_curve|.test_model_function_flow_curve]]
+- [[_COMMUNITY_TestLogIO|TestLogIO]]
+- [[_COMMUNITY_TestLoggingErrorHandling|TestLoggingErrorHandling]]
 - [[_COMMUNITY_TestNonAffineVariant|TestNonAffineVariant]]
 - [[_COMMUNITY_TestMaxwellLimits|TestMaxwellLimits]]
 - [[_COMMUNITY_TestFlowCurve|TestFlowCurve]]
-- [[_COMMUNITY_TestRelaxationLoading|TestRelaxationLoading]]
+- [[_COMMUNITY_TestBinghamModelFunction|TestBinghamModelFunction]]
 - [[_COMMUNITY_TestLAOSSimulation|TestLAOSSimulation]]
-- [[_COMMUNITY_TestFlowCurve|TestFlowCurve]]
-- [[_COMMUNITY_TestErrorHandling|TestErrorHandling]]
+- [[_COMMUNITY_.test_flow_curve_finite|.test_flow_curve_finite]]
+- [[_COMMUNITY_TestGMMBayesianPriorSafetyIntegration|TestGMMBayesianPriorSafetyIntegration]]
 - [[_COMMUNITY_TNTStickyRouse|TNTStickyRouse]]
 - [[_COMMUNITY_.test_model_function_oscillation|.test_model_function_oscillation]]
-- [[_COMMUNITY_TestLazyNumPyroImports|TestLazyNumPyroImports]]
+- [[_COMMUNITY_TestBayesianIntegration|TestBayesianIntegration]]
 - [[_COMMUNITY_TestVLBNonlocalProtocols|TestVLBNonlocalProtocols]]
-- [[_COMMUNITY_test_anton_paar.py|test_anton_paar.py]]
-- [[_COMMUNITY_PowerLaw|PowerLaw]]
-- [[_COMMUNITY_.simulate_steady_shear|.simulate_steady_shear]]
-- [[_COMMUNITY_TestRheoDataDomainSupport|TestRheoDataDomainSupport]]
-- [[_COMMUNITY_TestTemperatureEvolution|TestTemperatureEvolution]]
-- [[_COMMUNITY_TestCompareModels|TestCompareModels]]
-- [[_COMMUNITY_TestFIKHSignSafe|TestFIKHSignSafe]]
+- [[_COMMUNITY_.__init__|.__init__]]
+- [[_COMMUNITY_.__init__|.__init__]]
+- [[_COMMUNITY_.set_bayesian_result|.set_bayesian_result]]
+- [[_COMMUNITY_.set_fit_result|.set_fit_result]]
+- [[_COMMUNITY_.test_jax_grad_support|.test_jax_grad_support]]
+- [[_COMMUNITY_build_fit_result|build_fit_result]]
+- [[_COMMUNITY_.test_jax_vmap_support|.test_jax_vmap_support]]
 - [[_COMMUNITY_TestDMTRegistry|TestDMTRegistry]]
 - [[_COMMUNITY_test_spp_plots.py|test_spp_plots.py]]
 - [[_COMMUNITY_RheoJAX Documentation|RheoJAX Documentation]]
@@ -577,47 +577,47 @@
 - [[_COMMUNITY_ArvizCanvas|ArvizCanvas]]
 - [[_COMMUNITY_TestRheoDataSerialization|TestRheoDataSerialization]]
 - [[_COMMUNITY_TestEquilibriumStructure|TestEquilibriumStructure]]
-- [[_COMMUNITY_TestDialogIntegration|TestDialogIntegration]]
-- [[_COMMUNITY_.test_laos_fluidity_trajectory_stored|.test_laos_fluidity_trajectory_stored]]
+- [[_COMMUNITY_PreferencesDialog|PreferencesDialog]]
+- [[_COMMUNITY_test_bayesian_visual_parity.py|test_bayesian_visual_parity.py]]
 - [[_COMMUNITY_TestNumericalStability|TestNumericalStability]]
 - [[_COMMUNITY_TestIKHProtocols|TestIKHProtocols]]
-- [[_COMMUNITY_TestToRheoDataDoubleCount|TestToRheoDataDoubleCount]]
-- [[_COMMUNITY_TestDetectTestModeFlow|TestDetectTestModeFlow]]
+- [[_COMMUNITY_.__repr__|.__repr__]]
+- [[_COMMUNITY_.__repr__|.__repr__]]
 - [[_COMMUNITY_TestLogFit|TestLogFit]]
-- [[_COMMUNITY_TestDetectTestModeFlowVsRelaxation|TestDetectTestModeFlowVsRelaxation]]
-- [[_COMMUNITY_TestSAOS|TestSAOS]]
-- [[_COMMUNITY_TestRelaxationSimulation|TestRelaxationSimulation]]
-- [[_COMMUNITY_test_hvnm.py|test_hvnm.py]]
-- [[_COMMUNITY_SPP Parity Reference (MATLAB SPPplus v2.1, R oreo, RheoJAX)|SPP Parity Reference (MATLAB SPPplus v2.1, R oreo, RheoJAX)]]
-- [[_COMMUNITY_TestBayesianInterface|TestBayesianInterface]]
-- [[_COMMUNITY_Any|Any]]
-- [[_COMMUNITY_.plot_confidence_band|.plot_confidence_band]]
-- [[_COMMUNITY_TestExportSppHdf5|TestExportSppHdf5]]
+- [[_COMMUNITY_.tau_rep|.tau_rep]]
+- [[_COMMUNITY_.test_predict_saos|.test_predict_saos]]
 - [[_COMMUNITY_.test_simulate_relaxation|.test_simulate_relaxation]]
-- [[_COMMUNITY_is_monotonic_decreasing|is_monotonic_decreasing]]
+- [[_COMMUNITY_.tau_break|.tau_break]]
+- [[_COMMUNITY_SPP Parity Reference (MATLAB SPPplus v2.1, R oreo, RheoJAX)|SPP Parity Reference (MATLAB SPPplus v2.1, R oreo, RheoJAX)]]
+- [[_COMMUNITY_.test_model_function_flow_curve|.test_model_function_flow_curve]]
+- [[_COMMUNITY_Any|Any]]
+- [[_COMMUNITY_.tau_d|.tau_d]]
+- [[_COMMUNITY_test_spp_export.py|test_spp_export.py]]
+- [[_COMMUNITY_.eta_0|.eta_0]]
+- [[_COMMUNITY_TestMonotonicityChecks|TestMonotonicityChecks]]
 - [[_COMMUNITY_.test_rouse_limit_when_tau_s_small|.test_rouse_limit_when_tau_s_small]]
-- [[_COMMUNITY_TestCSVReaderEdgeCases|TestCSVReaderEdgeCases]]
+- [[_COMMUNITY_.nu|.nu]]
 - [[_COMMUNITY_TestDataIntegrity|TestDataIntegrity]]
-- [[_COMMUNITY_.test_laos_returns_expected_structure|.test_laos_returns_expected_structure]]
-- [[_COMMUNITY_.test_simulate_laos|.test_simulate_laos]]
-- [[_COMMUNITY_TNTSingleMode|TNTSingleMode]]
-- [[_COMMUNITY_TestFitOscillation|TestFitOscillation]]
-- [[_COMMUNITY_TestFIKHTestModeValidation|TestFIKHTestModeValidation]]
+- [[_COMMUNITY_.eta_s|.eta_s]]
+- [[_COMMUNITY_.test_shared_parameters_match|.test_shared_parameters_match]]
+- [[_COMMUNITY_TestCreepSimulation|TestCreepSimulation]]
+- [[_COMMUNITY_.test_get_parameter_dict|.test_get_parameter_dict]]
+- [[_COMMUNITY_.test_models_have_fit_method|.test_models_have_fit_method]]
 - [[_COMMUNITY_TestFIKHModelFunction|TestFIKHModelFunction]]
 - [[_COMMUNITY_TestJSONSerialization|TestJSONSerialization]]
-- [[_COMMUNITY_TestFIKHCreep|TestFIKHCreep]]
+- [[_COMMUNITY_.test_flow_curves_differ_by_formulation|.test_flow_curves_differ_by_formulation]]
 - [[_COMMUNITY_TestFIKHPrecompile|TestFIKHPrecompile]]
-- [[_COMMUNITY_TestFIKHOscillation|TestFIKHOscillation]]
+- [[_COMMUNITY_.test_models_have_predict_method|.test_models_have_predict_method]]
 - [[_COMMUNITY_TestNonlocalModelFunction|TestNonlocalModelFunction]]
 - [[_COMMUNITY_TestHerschelBulkleyRheoData|TestHerschelBulkleyRheoData]]
 - [[_COMMUNITY_TestDMTLocalSAOS|TestDMTLocalSAOS]]
-- [[_COMMUNITY_TestPowerLawRheoData|TestPowerLawRheoData]]
-- [[_COMMUNITY_TestPowerLawBasics|TestPowerLawBasics]]
-- [[_COMMUNITY_TestPowerLawNumericalStability|TestPowerLawNumericalStability]]
+- [[_COMMUNITY_.test_saos_magnitude|.test_saos_magnitude]]
+- [[_COMMUNITY_.test_saos_terminal_scaling|.test_saos_terminal_scaling]]
+- [[_COMMUNITY_.test_relaxation_single_exponential|.test_relaxation_single_exponential]]
 - [[_COMMUNITY_generate_synthetic_trios_file|generate_synthetic_trios_file]]
 - [[_COMMUNITY_TestFluidityEvolution|TestFluidityEvolution]]
 - [[_COMMUNITY_TestSteadyStateFlowCurve|TestSteadyStateFlowCurve]]
-- [[_COMMUNITY_TestCreepBifurcation|TestCreepBifurcation]]
+- [[_COMMUNITY_.test_simulate_creep|.test_simulate_creep]]
 - [[_COMMUNITY_TestVonMisesStress|TestVonMisesStress]]
 - [[_COMMUNITY_TestNonlocalCreep|TestNonlocalCreep]]
 - [[_COMMUNITY_TestNonexponentialRelaxation|TestNonexponentialRelaxation]]
@@ -625,13 +625,13 @@
 - [[_COMMUNITY_TestMIKHBayesian|TestMIKHBayesian]]
 - [[_COMMUNITY_TestMLIKHFitting|TestMLIKHFitting]]
 - [[_COMMUNITY_TestGMMBayesianPipelineBugs|TestGMMBayesianPipelineBugs]]
-- [[_COMMUNITY_TestThixotropyKinetics|TestThixotropyKinetics]]
-- [[_COMMUNITY_TestShearBanding|TestShearBanding]]
+- [[_COMMUNITY_.test_creep_strain_increases|.test_creep_strain_increases]]
+- [[_COMMUNITY_.test_model_function_parameter_consistency|.test_model_function_parameter_consistency]]
 - [[_COMMUNITY_.test_simulate_startup|.test_simulate_startup]]
-- [[_COMMUNITY_TestMittagLefflerComplexArguments|TestMittagLefflerComplexArguments]]
-- [[_COMMUNITY_TestMittagLefflerRheologicalApplications|TestMittagLefflerRheologicalApplications]]
+- [[_COMMUNITY_.test_n1_positive|.test_n1_positive]]
+- [[_COMMUNITY_.test_relaxation_positive|.test_relaxation_positive]]
 - [[_COMMUNITY_TestNumericalStability|TestNumericalStability]]
-- [[_COMMUNITY_TestLatticeEPMBayesian|TestLatticeEPMBayesian]]
+- [[_COMMUNITY_.test_model_function_laos_uses_kwargs|.test_model_function_laos_uses_kwargs]]
 - [[_COMMUNITY_TestModeEnum|TestModeEnum]]
 - [[_COMMUNITY_TestLogBayesian|TestLogBayesian]]
 - [[_COMMUNITY_test_vlb_nonlocal.py|test_vlb_nonlocal.py]]
@@ -643,56 +643,56 @@
 - [[_COMMUNITY_TestExportFormats|TestExportFormats]]
 - [[_COMMUNITY_test_fluidity_nlsq_nuts_pipeline.py|test_fluidity_nlsq_nuts_pipeline.py]]
 - [[_COMMUNITY_TestTransformPlotterDispatch|TestTransformPlotterDispatch]]
-- [[_COMMUNITY_.plot_data|.plot_data]]
+- [[_COMMUNITY_.test_predict_flow_curve|.test_predict_flow_curve]]
 - [[_COMMUNITY_🚀 Key Features|🚀 Key Features]]
 - [[_COMMUNITY_._on_state_changed|._on_state_changed]]
-- [[_COMMUNITY_.closeEvent|.closeEvent]]
+- [[_COMMUNITY_.test_saos_magnitude|.test_saos_magnitude]]
 - [[_COMMUNITY_TestUncertaintyBand|TestUncertaintyBand]]
-- [[_COMMUNITY_._predict|._predict]]
-- [[_COMMUNITY_.predict_rheo|.predict_rheo]]
-- [[_COMMUNITY_TestIntrospectionHelpers|TestIntrospectionHelpers]]
+- [[_COMMUNITY_.test_saos_effective_maxwell|.test_saos_effective_maxwell]]
+- [[_COMMUNITY_.test_simulate_startup|.test_simulate_startup]]
+- [[_COMMUNITY_test_registry_consistency.py|test_registry_consistency.py]]
 - [[_COMMUNITY_evolve_thixotropy_lambda|evolve_thixotropy_lambda]]
-- [[_COMMUNITY_TestFitResultSerialization|TestFitResultSerialization]]
+- [[_COMMUNITY_.test_startup_bridge_fraction_decreases|.test_startup_bridge_fraction_decreases]]
 - [[_COMMUNITY_TestVLBLocalRelaxation|TestVLBLocalRelaxation]]
 - [[_COMMUNITY_TestVLBLocalCreep|TestVLBLocalCreep]]
-- [[_COMMUNITY_DecayType|DecayType]]
+- [[_COMMUNITY_.test_simulate_relaxation|.test_simulate_relaxation]]
 - [[_COMMUNITY_SPP Parity Status (MATLAB SPPplus v2.1  R oreo  RheoJAX)|SPP Parity Status (MATLAB SPPplus v2.1 / R oreo / RheoJAX)]]
 - [[_COMMUNITY__LazyModule|_LazyModule]]
-- [[_COMMUNITY_test_transform_flow.py|test_transform_flow.py]]
+- [[_COMMUNITY_.test_relaxation_decay|.test_relaxation_decay]]
 - [[_COMMUNITY_RheoJAX Workspace Shell|RheoJAX Workspace Shell]]
 - [[_COMMUNITY__kernels.py|_kernels.py]]
 - [[_COMMUNITY_.__init__|.__init__]]
 - [[_COMMUNITY_TestNonlocalIdentifiabilityAPI|TestNonlocalIdentifiabilityAPI]]
 - [[_COMMUNITY_SimpleModel|SimpleModel]]
-- [[_COMMUNITY__modulus_labels|_modulus_labels]]
+- [[_COMMUNITY_TestModulusLabels|TestModulusLabels]]
 - [[_COMMUNITY_.__init__|.__init__]]
 - [[_COMMUNITY_.__init__|.__init__]]
-- [[_COMMUNITY_._disconnect_worker_signals|._disconnect_worker_signals]]
-- [[_COMMUNITY_._plot_energy|._plot_energy]]
-- [[_COMMUNITY_.timed_render|.timed_render]]
-- [[_COMMUNITY_.model_function|.model_function]]
+- [[_COMMUNITY_.test_relaxation_with_bridge_fraction|.test_relaxation_with_bridge_fraction]]
+- [[_COMMUNITY_.test_relaxation_bridge_fraction_bounded|.test_relaxation_bridge_fraction_bounded]]
+- [[_COMMUNITY_.test_creep_with_rate|.test_creep_with_rate]]
+- [[_COMMUNITY_.test_laos_periodicity|.test_laos_periodicity]]
 - [[_COMMUNITY_.__init__|.__init__]]
 - [[_COMMUNITY_TestYAMLInjection|TestYAMLInjection]]
 - [[_COMMUNITY_conftest.py|conftest.py]]
-- [[_COMMUNITY_test_spp_integration.py|test_spp_integration.py]]
+- [[_COMMUNITY_.test_laos_harmonics|.test_laos_harmonics]]
 - [[_COMMUNITY_capture_golden_screens.py|capture_golden_screens.py]]
-- [[_COMMUNITY_TestCSVRoundTrip|TestCSVRoundTrip]]
-- [[_COMMUNITY_TestPerformance|TestPerformance]]
-- [[_COMMUNITY_TestAntonPaarReader|TestAntonPaarReader]]
+- [[_COMMUNITY_.test_model_function_parameter_consistency|.test_model_function_parameter_consistency]]
+- [[_COMMUNITY_.test_bridge_fraction_bounded|.test_bridge_fraction_bounded]]
+- [[_COMMUNITY_.test_normal_stress_positive|.test_normal_stress_positive]]
 - [[_COMMUNITY_TestLogPipelineStage|TestLogPipelineStage]]
-- [[_COMMUNITY_TestFitLAOS|TestFitLAOS]]
-- [[_COMMUNITY_TestFIKHLimitingBehavior|TestFIKHLimitingBehavior]]
-- [[_COMMUNITY_TestGENERICThermodynamics|TestGENERICThermodynamics]]
-- [[_COMMUNITY_test_herschel_bulkley.py|test_herschel_bulkley.py]]
+- [[_COMMUNITY_.test_bridge_fraction_vs_rate|.test_bridge_fraction_vs_rate]]
+- [[_COMMUNITY_.test_bridge_fraction_vs_rate_method|.test_bridge_fraction_vs_rate_method]]
+- [[_COMMUNITY_.test_derived_properties|.test_derived_properties]]
+- [[_COMMUNITY_TestHerschelBulkleyModelFunction|TestHerschelBulkleyModelFunction]]
 - [[_COMMUNITY_TestHerschelBulkleyPhysicalBehavior|TestHerschelBulkleyPhysicalBehavior]]
 - [[_COMMUNITY_DatasetTree|DatasetTree]]
-- [[_COMMUNITY_TestPowerLawFitting|TestPowerLawFitting]]
-- [[_COMMUNITY_TestPowerLawPerformance|TestPowerLawPerformance]]
-- [[_COMMUNITY_TestPowerLawModelFunction|TestPowerLawModelFunction]]
+- [[_COMMUNITY_.test_equilibrium_state|.test_equilibrium_state]]
+- [[_COMMUNITY_.test_broader_spectrum_than_single_mode|.test_broader_spectrum_than_single_mode]]
+- [[_COMMUNITY_.test_flow_curve_with_components|.test_flow_curve_with_components]]
 - [[_COMMUNITY_TestVLBNonlocalFene|TestVLBNonlocalFene]]
-- [[_COMMUNITY_.get_posterior_summary|.get_posterior_summary]]
+- [[_COMMUNITY_.test_newtonian_at_low_rates|.test_newtonian_at_low_rates]]
 - [[_COMMUNITY_TestUpperConvected|TestUpperConvected]]
-- [[_COMMUNITY_.__init__|.__init__]]
+- [[_COMMUNITY_.test_saos_terminal_scaling|.test_saos_terminal_scaling]]
 - [[_COMMUNITY_TestYieldStressCoupling|TestYieldStressCoupling]]
 - [[_COMMUNITY_TestPublicAPI|TestPublicAPI]]
 - [[_COMMUNITY_TestHerschelBulkleyViscosity|TestHerschelBulkleyViscosity]]
@@ -705,60 +705,48 @@
 - [[_COMMUNITY_💡 Quick Examples|💡 Quick Examples]]
 - [[_COMMUNITY_📚 Key References|📚 Key References]]
 - [[_COMMUNITY_TestNonlocalFlowCurve|TestNonlocalFlowCurve]]
-- [[_COMMUNITY_TestISMFluidVsGlass|TestISMFluidVsGlass]]
-- [[_COMMUNITY_TestModelFunction|TestModelFunction]]
+- [[_COMMUNITY_.test_relaxation_multi_exponential|.test_relaxation_multi_exponential]]
+- [[_COMMUNITY_.test_laos_periodicity|.test_laos_periodicity]]
 - [[_COMMUNITY_TensorialEPM|TensorialEPM]]
-- [[_COMMUNITY_TestMittagLefflerPerformance|TestMittagLefflerPerformance]]
-- [[_COMMUNITY_.test_parameterset_to_model_function_flow_curve|.test_parameterset_to_model_function_flow_curve]]
-- [[_COMMUNITY_.test_fit_nlsq_with_model_instance|.test_fit_nlsq_with_model_instance]]
+- [[_COMMUNITY_.test_model_function_parameter_order|.test_model_function_parameter_order]]
+- [[_COMMUNITY_.test_stress_positive_under_shear|.test_stress_positive_under_shear]]
+- [[_COMMUNITY_.test_relaxation_spectrum|.test_relaxation_spectrum]]
 - [[_COMMUNITY_TestPronySeries|TestPronySeries]]
-- [[_COMMUNITY_TestSAOS|TestSAOS]]
+- [[_COMMUNITY_.test_predict_saos|.test_predict_saos]]
 - [[_COMMUNITY_🛠️ Building the Documentation Locally|🛠️ Building the Documentation Locally]]
 - [[_COMMUNITY_📊 Documentation Statistics|📊 Documentation Statistics]]
-- [[_COMMUNITY_TestFluidityLocalBayesian|TestFluidityLocalBayesian]]
+- [[_COMMUNITY_.test_repr|.test_repr]]
 - [[_COMMUNITY_clean_notebook|clean_notebook]]
 - [[_COMMUNITY_test_visual_regression_spec_scaffold.py|test_visual_regression_spec_scaffold.py]]
-- [[_COMMUNITY_.test_fit_bayesian_num_chains_parameter|.test_fit_bayesian_num_chains_parameter]]
+- [[_COMMUNITY_TestBayesianPipelineMultiChain|TestBayesianPipelineMultiChain]]
 - [[_COMMUNITY_.test_startup_steady_state_value|.test_startup_steady_state_value]]
-- [[_COMMUNITY_TestFluidityLocalNLSQToNUTS|TestFluidityLocalNLSQToNUTS]]
-- [[_COMMUNITY_test_numerical_derivative_periodic_matches_analytic|test_numerical_derivative_periodic_matches_analytic]]
-- [[_COMMUNITY_TestCreepSimulation|TestCreepSimulation]]
+- [[_COMMUNITY_.test_model_function_laos_uses_kwargs|.test_model_function_laos_uses_kwargs]]
+- [[_COMMUNITY_.test_predict_oscillation_correct_shapes|.test_predict_oscillation_correct_shapes]]
+- [[_COMMUNITY_.test_simulate_creep|.test_simulate_creep]]
 - [[_COMMUNITY_test_spp_numerical_analysis_linear_material|test_spp_numerical_analysis_linear_material]]
 - [[_COMMUNITY_conftest.py|conftest.py]]
-- [[_COMMUNITY_test_numerical_derivative_step_size_smoothing|test_numerical_derivative_step_size_smoothing]]
-- [[_COMMUNITY_test_numerical_derivative_4th_order_second_derivative|test_numerical_derivative_4th_order_second_derivative]]
-- [[_COMMUNITY_test_numerical_derivative_4th_order_third_derivative|test_numerical_derivative_4th_order_third_derivative]]
-- [[_COMMUNITY_test_compute_phase_offset_zero_for_pure_sine|test_compute_phase_offset_zero_for_pure_sine]]
-- [[_COMMUNITY_test_compute_phase_offset_nonzero_for_pure_cosine|test_compute_phase_offset_nonzero_for_pure_cosine]]
-- [[_COMMUNITY_test_spp_fourier_analysis_includes_frenet_serret|test_spp_fourier_analysis_includes_frenet_serret]]
-- [[_COMMUNITY_.test_model_function_laos_uses_kwargs|.test_model_function_laos_uses_kwargs]]
+- [[_COMMUNITY_.test_laos_runs|.test_laos_runs]]
+- [[_COMMUNITY_.test_model_function_laos|.test_model_function_laos]]
+- [[_COMMUNITY_.test_model_function_startup_requires_gamma_dot|.test_model_function_startup_requires_gamma_dot]]
+- [[_COMMUNITY_.test_predict_plateau_modulus_no_sticker_floor|.test_predict_plateau_modulus_no_sticker_floor]]
+- [[_COMMUNITY_.test_predict_zero_shear_viscosity_consistency|.test_predict_zero_shear_viscosity_consistency]]
+- [[_COMMUNITY_test_spp_numerical_analysis_num_mode_toggle|test_spp_numerical_analysis_num_mode_toggle]]
+- [[_COMMUNITY_test_spp_fourier_analysis_linear_material|test_spp_fourier_analysis_linear_material]]
 - [[_COMMUNITY_test_frenet_serret_frame_orthogonality|test_frenet_serret_frame_orthogonality]]
-- [[_COMMUNITY_TestFlowCurve|TestFlowCurve]]
-- [[_COMMUNITY_test_frenet_serret_frame_standalone_function|test_frenet_serret_frame_standalone_function]]
-- [[_COMMUNITY_test_yield_from_displacement_stress_basic|test_yield_from_displacement_stress_basic]]
+- [[_COMMUNITY_.test_predict_flow_curve_method|.test_predict_flow_curve_method]]
+- [[_COMMUNITY_test_numerical_derivative_first_order_sinusoid|test_numerical_derivative_first_order_sinusoid]]
 - [[_COMMUNITY_test_convert_units_strain|test_convert_units_strain]]
 - [[_COMMUNITY_test_fit_subprocess_exits_cleanly|test_fit_subprocess_exits_cleanly]]
 - [[_COMMUNITY_.test_predict_saos|.test_predict_saos]]
 - [[_COMMUNITY___init__.py|__init__.py]]
 - [[_COMMUNITY___init__.py|__init__.py]]
 - [[_COMMUNITY_test_convert_units_stress|test_convert_units_stress]]
-- [[_COMMUNITY_test_convert_units_angle|test_convert_units_angle]]
 - [[_COMMUNITY___init__.py|__init__.py]]
 - [[_COMMUNITY_test_differentiate_rate_from_strain_wrapped_matches_cosine|test_differentiate_rate_from_strain_wrapped_matches_cosine]]
 - [[_COMMUNITY_TestVonMisesPlots|TestVonMisesPlots]]
 - [[_COMMUNITY_TestPlotTimeDomain|TestPlotTimeDomain]]
 - [[_COMMUNITY_TestPlotFrequencyDomain|TestPlotFrequencyDomain]]
-- [[_COMMUNITY_TestPlotFlowCurve|TestPlotFlowCurve]]
-- [[_COMMUNITY_TestPlotResiduals|TestPlotResiduals]]
 - [[_COMMUNITY_TestPublicationQuality|TestPublicationQuality]]
-- [[_COMMUNITY_.test_model_function_laos_kwargs_differ_from_self|.test_model_function_laos_kwargs_differ_from_self]]
-- [[_COMMUNITY_TestModulusFrequencyTemplate|TestModulusFrequencyTemplate]]
-- [[_COMMUNITY_.fit_bayesian|.fit_bayesian]]
-- [[_COMMUNITY_._transform|._transform]]
-- [[_COMMUNITY_._fit|._fit]]
-- [[_COMMUNITY_BatchTestModel|BatchTestModel]]
-- [[_COMMUNITY_._on_mouse_move|._on_mouse_move]]
-- [[_COMMUNITY_.__init__|.__init__]]
 - [[_COMMUNITY_.__init__|.__init__]]
 - [[_COMMUNITY___init__.py|__init__.py]]
 - [[_COMMUNITY___init__.py|__init__.py]]
@@ -786,8 +774,6 @@
 - [[_COMMUNITY___init__.py|__init__.py]]
 - [[_COMMUNITY_._setup_parameters|._setup_parameters]]
 - [[_COMMUNITY_.__init__|.__init__]]
-- [[_COMMUNITY_TestScoreNaNHandling|TestScoreNaNHandling]]
-- [[_COMMUNITY_TestAliases|TestAliases]]
 - [[_COMMUNITY___init__.py|__init__.py]]
 - [[_COMMUNITY_TestFractionalModelsRelaxation|TestFractionalModelsRelaxation]]
 - [[_COMMUNITY__get_simulation_ids|_get_simulation_ids]]
@@ -816,7 +802,6 @@
 - [[_COMMUNITY_IKHBase|IKHBase]]
 - [[_COMMUNITY_ITTMCTBase|ITTMCTBase]]
 - [[_COMMUNITY_Pipeline|Pipeline]]
-- [[_COMMUNITY_._make_error_result|._make_error_result]]
 - [[_COMMUNITY_.get_diagnostics|.get_diagnostics]]
 - [[_COMMUNITY_.test_registry_create|.test_registry_create]]
 - [[_COMMUNITY_.G|.G]]
@@ -847,51 +832,31 @@
 - [[_COMMUNITY_load_trios (Facade)|load_trios (Facade)]]
 - [[_COMMUNITY_VLBBase|VLBBase]]
 - [[_COMMUNITY_Wei, Solomon & Larson (2018)|Wei, Solomon & Larson (2018)]]
-- [[_COMMUNITY_.n_species|.n_species]]
-- [[_COMMUNITY_.weissenberg_number|.weissenberg_number]]
-- [[_COMMUNITY_.k_d_0|.k_d_0]]
 - [[_COMMUNITY_.test_flow_curve_shear_thinning|.test_flow_curve_shear_thinning]]
 - [[_COMMUNITY_.test_startup_with_bridge_fraction|.test_startup_with_bridge_fraction]]
-- [[_COMMUNITY_.test_stress_positive_under_shear|.test_stress_positive_under_shear]]
-- [[_COMMUNITY_.test_parameter_setting|.test_parameter_setting]]
 - [[_COMMUNITY_.test_fit_flow_curve|.test_fit_flow_curve]]
-- [[_COMMUNITY_.test_parameter_count|.test_parameter_count]]
 - [[_COMMUNITY_.test_saos_magnitude|.test_saos_magnitude]]
 - [[_COMMUNITY_.test_startup_approaches_steady_state|.test_startup_approaches_steady_state]]
 - [[_COMMUNITY_.test_startup_full_return|.test_startup_full_return]]
 - [[_COMMUNITY_.test_relaxation_decay|.test_relaxation_decay]]
-- [[_COMMUNITY_.test_parameter_setting|.test_parameter_setting]]
-- [[_COMMUNITY_.test_equilibrium_conformation_multimode|.test_equilibrium_conformation_multimode]]
-- [[_COMMUNITY_.test_relaxation_positive|.test_relaxation_positive]]
-- [[_COMMUNITY_TestGlassTransition|TestGlassTransition]]
 - [[_COMMUNITY_.test_conformation_positive_definite_startup|.test_conformation_positive_definite_startup]]
 - [[_COMMUNITY_.test_fit_flow_curve|.test_fit_flow_curve]]
-- [[_COMMUNITY_.test_derived_properties|.test_derived_properties]]
-- [[_COMMUNITY_.test_default_parameter_distribution|.test_default_parameter_distribution]]
 - [[_COMMUNITY_.test_conventional_generic_oscillation_match|.test_conventional_generic_oscillation_match]]
-- [[_COMMUNITY_.test_startup_stress_finite|.test_startup_stress_finite]]
-- [[_COMMUNITY_.test_stress_decays|.test_stress_decays]]
-- [[_COMMUNITY_.test_strain_increases|.test_strain_increases]]
-- [[_COMMUNITY_.test_creep_needs_eta_s_positive|.test_creep_needs_eta_s_positive]]
+- [[_COMMUNITY_TestRelaxationSimulation|TestRelaxationSimulation]]
 - [[_COMMUNITY_.test_predict_normal_stress_scalar_and_array|.test_predict_normal_stress_scalar_and_array]]
-- [[_COMMUNITY_.test_plot_autocorr_without_bayesian_fit_raises_error|.test_plot_autocorr_without_bayesian_fit_raises_error]]
-- [[_COMMUNITY_.test_fit_bayesian_after_nlsq|.test_fit_bayesian_after_nlsq]]
-- [[_COMMUNITY_.test_fit_bayesian_without_nlsq_raises_error|.test_fit_bayesian_without_nlsq_raises_error]]
-- [[_COMMUNITY_.test_complete_workflow_chaining|.test_complete_workflow_chaining]]
-- [[_COMMUNITY_.test_multichain_improves_rhat|.test_multichain_improves_rhat]]
 - [[_COMMUNITY_TestStartupSimulation|TestStartupSimulation]]
 - [[_COMMUNITY_.test_default_instantiation|.test_default_instantiation]]
 - [[_COMMUNITY_.__init__|.__init__]]
 
 ## God Nodes (most connected - your core abstractions)
-1. `RheoData` - 1182 edges
+1. `RheoData` - 1183 edges
 2. `ModelRegistry` - 554 edges
 3. `ParameterSet` - 398 edges
 4. `safe_import_jax()` - 309 edges
 5. `BaseModel` - 268 edges
 6. `get_logger()` - 246 edges
 7. `StateStore` - 216 edges
-8. `RheoJAXMainWindow` - 184 edges
+8. `RheoJAXMainWindow` - 185 edges
 9. `nlsq_optimize()` - 184 edges
 10. `Maxwell` - 165 edges
 
@@ -914,207 +879,207 @@
 - **IKH Model Family** — docs_source_verification_ikh_literature_verification_ikh_model, docs_source_verification_ikh_literature_verification_dimitriou_2014, docs_source_verification_ikh_literature_verification_wei_2018 [EXTRACTED 0.90]
 - **IKH Model Family** — docs_source_verification_ikh_literature_verification_ikh_model, docs_source_verification_ikh_literature_verification_dimitriou_2014, docs_source_verification_ikh_literature_verification_wei_2018 [EXTRACTED 0.90]
 
-## Communities (2742 total, 167 thin omitted)
+## Communities (2707 total, 203 thin omitted)
 
-### Community 0 - "ParameterSet"
-Cohesion: 0.01
-Nodes (290): Initialize base model., ModelInfo, Structured fit results, model info, and model comparison.  This module provides:, Number of data points used in the fit., Aggregated information about a registered model.      Combines ``PluginInfo`` fr, ParameterSet, Collection of parameters for a model or transform.      A ParameterSet manages m, Initialize empty parameter set. (+282 more)
+### Community 0 - "test_nlsq_optimization.py"
+Cohesion: 0.02
+Nodes (52): nlsq_optimize_global(), Global optimization using NLSQ 0.6.6 workflow='auto_global'.      Convenience fu, Tests for NLSQ optimization integration.  This test suite validates that the nls, Test OptimizationResult dataclass functionality., Test OptimizationResult can be created with required fields., Test error handling in NLSQ optimization., Test that non-callable objective raises ValueError., Test that non-ParameterSet parameters raises ValueError. (+44 more)
 
 ### Community 1 - "RheoData"
 Cohesion: 0.01
-Nodes (155): Convert arrays to JAX arrays.          Returns cached result on subsequent calls, Convert arrays to NumPy arrays.          Uses np.asarray() for zero-copy convers, Create a copy of the RheoData.          Returns:             Copy of the RheoDat, Get storage modulus label. Always returns "G'" (shear)., Get loss modulus label. Always returns 'G"' (shear)., JAX-native container for rheological data with NumPy/JAX array support.      Thi, Support indexing and slicing., Add two RheoData objects or scalar. (+147 more)
+Nodes (265): Convert arrays to JAX arrays.          Returns cached result on subsequent calls, Convert arrays to NumPy arrays.          Uses np.asarray() for zero-copy convers, Create a copy of the RheoData.          Returns:             Copy of the RheoDat, Get storage modulus label. Always returns "G'" (shear)., Get loss modulus label. Always returns 'G"' (shear)., JAX-native container for rheological data with NumPy/JAX array support.      Thi, Support indexing and slicing., Add two RheoData objects or scalar. (+257 more)
 
-### Community 2 - "test_visual_pipeline_state.py"
-Cohesion: 0.02
-Nodes (157): Auto-populate a newly-added pipeline step's config from current UI state., add_pipeline_step(), cache_step_result(), clear_pipeline(), load_pipeline(), Any, Clear the entire visual pipeline (steps, results, selection)., Load a visual pipeline state (e.g., restored from YAML/project file).      Param (+149 more)
+### Community 2 - "StateStore"
+Cohesion: 0.01
+Nodes (252): add_pipeline_step(), add_transform_record(), bayesian_failed(), cache_step_result(), clear_pipeline(), fitting_failed(), load_dataset(), load_pipeline() (+244 more)
 
-### Community 3 - "test_bayesian_diagnostics.py"
+### Community 3 - "FitWorker"
 Cohesion: 0.06
-Nodes (26): Regression tests for Bayesian diagnostics RCA fixes (2026-02-13).  These tests, Result diagnostics should include diagnostics_valid flag., Verify protocol kwargs survive NLSQ→Bayesian without being cleared., _last_fit_kwargs from NLSQ should not be cleared by fit_bayesian., Verify precompiled cache is per-instance, not shared., Two model instances should have independent precompile caches., Verify unknown divergences are reported as -1, not 0., Valid MCMC should report actual divergence count (>= 0). (+18 more)
+Nodes (45): BayesianWorker, Worker for running MCMC sampling in background.      Features:         - NUTS sa, Check if job should be cancelled.          Raises         ------         Cancell, FitWorker, Check if job should be cancelled.          Raises         ------         Cancell, Worker for running NLSQ fitting in background.      Features:         - NLSQ opt, _bayesian_work_entry(), _extract_data() (+37 more)
 
 ### Community 4 - "TransformService"
-Cohesion: 0.03
-Nodes (67): QObject, Signals, _PreviewWorker, Signals for cross-thread preview result delivery., QRunnable that computes a transform preview off the main thread., _WorkerSignals, Transform Service ================  Service for applying rheological transforms, Service for rheological transform operations.      Transforms:         - Masterc (+59 more)
+Cohesion: 0.02
+Nodes (99): QObject, Signals, _PreviewWorker, Signals for cross-thread preview result delivery., QRunnable that computes a transform preview off the main thread., _WorkerSignals, Service for rheological transform operations.      Transforms:         - Masterc, Get list of available transforms.          Returns         -------         list[ (+91 more)
 
 ### Community 5 - "Maxwell"
 Cohesion: 0.01
-Nodes (138): Maxwell, ndarray, Estimate G0 and eta from relaxation data for faster convergence., Predict response based on input data.          Args:             X: RheoData obj, Model function for Bayesian inference.          This method is required by Bayes, Maxwell viscoelastic model (spring and dashpot in series).      The Maxwell mode, Predict relaxation modulus G(t).          Theory: G(t) = G0 * exp(-t/tau) where, Predict creep compliance J(t).          Theory: J(t) = 1/G0 + t/eta          Arg (+130 more)
+Nodes (159): Maxwell, ndarray, Estimate G0 and eta from relaxation data for faster convergence., Predict response based on input data.          Args:             X: RheoData obj, Model function for Bayesian inference.          This method is required by Bayes, Maxwell viscoelastic model (spring and dashpot in series).      The Maxwell mode, Predict relaxation modulus G(t).          Theory: G(t) = G0 * exp(-t/tau) where, Predict creep compliance J(t).          Theory: J(t) = 1/G0 + t/eta          Arg (+151 more)
 
 ### Community 6 - "Pipeline"
 Cohesion: 0.02
-Nodes (48): Pipeline, Any, Get pipeline execution history.          Returns:             List of (operation, Get the last fitted model.          Returns:             Last fitted BaseModel o, Get all fitted models from pipeline.          Returns:             List of all f, Get fitted parameters from the last model as a dictionary.          This is a co, Compare multiple models on the current data.          Fits each model and ranks, Construct a FitResult from the last fitted model.          Returns: (+40 more)
+Nodes (43): Pipeline, RheoData, Get current data state.          Returns:             Current RheoData, Get pipeline execution history.          Returns:             List of (operation, Get the last fitted model.          Returns:             Last fitted BaseModel o, Get all fitted models from pipeline.          Returns:             List of all f, Get fitted parameters from the last model as a dictionary.          This is a co, Create a copy of the pipeline.          Returns:             New Pipeline with c (+35 more)
 
 ### Community 7 - "ValueError"
 Cohesion: 0.01
-Nodes (154): _load_from_file(), Load data from a file using auto_load., create_parser(), main(), ArgumentParser, CLI subcommand for NLSQ model fitting.  Usage:     rheojax fit data.csv --mod, Run NLSQ fit from CLI., Create argument parser for fit subcommand. (+146 more)
+Nodes (175): _load_from_envelope(), _load_from_file(), _parse_params(), CLI subcommand for applying rheological transforms.  Wraps TransformRegistry to, Parse a list of 'key=value' strings into a dict with numeric conversion., Reconstruct a minimal RheoData-like object from a JSON envelope., Load data from a file using auto_load., Any (+167 more)
 
 ### Community 8 - "TransformState"
-Cohesion: 0.04
-Nodes (62): TransformState, SlotSpec, transform_slots(), TransformPickStep, Rebuild slot specs + selector widgets from the current transform_key.          A, SlotsStep, # NOTE: TransformService has no .run() method. The real implementation must:, RunStep (+54 more)
-
-### Community 9 - "load_anton_paar"
-Cohesion: 0.08
-Nodes (21): load_anton_paar(), Load RheoCompass CSV export file and return RheoData object(s).      Handles int, Tests for test type auto-detection (US5: T035-T040)., T035: Test auto-detection identifies creep., T036: Test auto-detection identifies relaxation., T037: Test auto-detection identifies oscillation., T038: Test auto-detection identifies rotation., T039: Test explicit test_mode overrides auto-detection. (+13 more)
-
-### Community 10 - "ImportWizard"
-Cohesion: 0.02
-Nodes (79): ImportWizard, Any, Multi-step data import wizard.      Steps:         1. File selection         2., Handle wizard finished., Get import configuration.          Returns         -------         dict[str, Any, qapp(), Regression check: ImportWizard file I/O runs off the Qt GUI thread., Ensure a QApplication exists. (+71 more)
-
-### Community 11 - "__init__.py"
 Cohesion: 0.03
-Nodes (88): initialize_fractional_burgers(), initialize_fractional_jeffreys(), initialize_fractional_kelvin_voigt(), initialize_fractional_kv_zener(), initialize_fractional_maxwell_gel(), initialize_fractional_maxwell_liquid(), initialize_fractional_maxwell_model(), initialize_fractional_poynting_thomson() (+80 more)
+Nodes (70): PlotDataItem, TransformState, is_pyqtgraph_available(), floating, NDArray, PyQtGraphCanvas, PyQtGraph Canvas Widget for GPU-Accelerated Plotting.  This module provides GPU-, Handle scale selection change. (+62 more)
+
+### Community 9 - "test_vlb.py"
+Cohesion: 0.03
+Nodes (41): Unit tests for VLB (Vernerey-Long-Brighenti) transient network models.  Tests co, Test VLBLocal steady shear predictions., Sigma should be proportional to gamma_dot (Newtonian)., Viscosity should equal G0/k_d., N1 should be proportional to gamma_dot^2., Test predict_flow_curve with return_components., Test VLBLocal startup shear predictions., Compare analytical formula against known values. (+33 more)
+
+### Community 10 - "DataService"
+Cohesion: 0.01
+Nodes (183): ImportWizard, Any, Multi-step data import wizard.      Steps:         1. File selection         2., Handle wizard finished., Get import configuration.          Returns         -------         dict[str, Any, DataService, Get list of supported file formats.          Returns         -------         lis, Service for rheological data operations.      Features:         - Multi-format d (+175 more)
+
+### Community 11 - "test_initialization.py"
+Cohesion: 0.03
+Nodes (91): initialize_fractional_burgers(), initialize_fractional_jeffreys(), initialize_fractional_kelvin_voigt(), initialize_fractional_kv_zener(), initialize_fractional_maxwell_gel(), initialize_fractional_maxwell_liquid(), initialize_fractional_maxwell_model(), initialize_fractional_poynting_thomson() (+83 more)
 
 ### Community 12 - "DataPage"
 Cohesion: 0.01
-Nodes (123): QDragEnterEvent, QDropEvent, QTableWidgetItem, DataPage, DropZone, Any, Path, Handle successful import (called on main thread via signal). (+115 more)
+Nodes (125): QDragEnterEvent, QDropEvent, QTableWidgetItem, ImportWorker, ImportWorkerSignals, Any, Path, QObject (+117 more)
 
-### Community 13 - "FitResult"
-Cohesion: 0.01
-Nodes (257): BaseContext, Exception, Process, Automatically detect or retrieve test mode.          The test mode is detected b, Whether the optimizer converged successfully., BayesianWorker, BayesianWorkerSignals, Any (+249 more)
+### Community 13 - "ProcessWorkerAdapter"
+Cohesion: 0.05
+Nodes (46): Process, bayesian_result_from_dict(), fit_result_from_dict(), ProcessWorkerAdapter, Event, Queue, Run a work function inside a ``multiprocessing.Process``.      The adapter start, Execute the work function in a child process.          Called by QThreadPool.  B (+38 more)
 
 ### Community 14 - "BatchPipeline"
 Cohesion: 0.03
-Nodes (39): BatchPipeline, Apply pipeline to multiple datasets.      This class enables batch processing of, Initialize batch pipeline.          Args:             template_pipeline: Templat, Set template pipeline.          Args:             pipeline: Pipeline to use as t, Clear all results and errors.          Returns:             self for method chai, Get number of processed results., String representation., csv_files() (+31 more)
+Nodes (54): BatchPipeline, Apply pipeline to multiple datasets.      This class enables batch processing of, Initialize batch pipeline.          Args:             template_pipeline: Templat, Set template pipeline.          Args:             pipeline: Pipeline to use as t, Clear all results and errors.          Returns:             self for method chai, Get number of processed results., String representation., BatchTestModel (+46 more)
 
 ### Community 15 - "test_fractional_initializers.py"
-Cohesion: 0.04
-Nodes (47): FractionalBurgersInitializer, Initializer for FractionalBurgers model from oscillation data.  Model equation (, Set FractionalBurgers parameters in ParameterSet.          Parameters         --, Smart initialization for FractionalBurgers from oscillation data., Estimate FractionalBurgers parameters from frequency features.          Paramete, FractionalKVZenerInitializer, Set FractionalKVZener parameters in ParameterSet.          Parameters         --, Smart initialization for FractionalKelvinVoigtZener from oscillation data. (+39 more)
+Cohesion: 0.02
+Nodes (107): BaseInitializer, Base initializer abstract class for fractional model initialization.  This modul, Abstract base class for fractional model parameter initialization.      Implemen, Safely set a parameter if it exists in ParameterSet.          This helper method, FractionalBurgersInitializer, Initializer for FractionalBurgers model from oscillation data.  Model equation (, Set FractionalBurgers parameters in ParameterSet.          Parameters         --, Smart initialization for FractionalBurgers from oscillation data. (+99 more)
 
 ### Community 16 - "SGRGeneric"
-Cohesion: 0.04
-Nodes (30): Full Monte Carlo-based LAOS fitting.          Runs MC simulations within optimiz, Initialize SGR GENERIC Model.          Creates ParameterSet with:         - x (n, Determine material phase regime from noise temperature x.          Returns:, Initialize parameters for dynamic noise temperature evolution.          Adds par, Enable thixotropy modeling with structural parameter lambda(t).          Adds th, Evolve structural parameter lambda(t) for given shear history.          Integrat, Predict stress response with thixotropic modulus.          The effective modulus, Predict stress transient (overshoot/undershoot) for shear step protocol. (+22 more)
+Cohesion: 0.05
+Nodes (27): Initialize SGR GENERIC Model.          Creates ParameterSet with:         - x (n, Initialize parameters for dynamic noise temperature evolution.          Adds par, Enable thixotropy modeling with structural parameter lambda(t).          Adds th, Evolve structural parameter lambda(t) for given shear history.          Integrat, Predict stress response with thixotropic modulus.          The effective modulus, Predict stress transient (overshoot/undershoot) for shear step protocol., Soft Glassy Rheology (SGR) GENERIC Thermodynamic Framework Model.      This mode, SGRGeneric (+19 more)
 
-### Community 17 - "WorkspaceWindow"
-Cohesion: 0.03
-Nodes (67): ColumnMapperDialog, QWidget, Handle dialog accept., Handle dialog reject., Handle dialog show event., Populate combo boxes with column names., Apply current mapping to combo boxes., Auto-detect column mapping based on common patterns. (+59 more)
+### Community 17 - "AppState"
+Cohesion: 0.02
+Nodes (105): ColumnMapperDialog, QWidget, Handle dialog accept., Handle dialog reject., Handle dialog show event., Populate combo boxes with column names., Apply current mapping to combo boxes., Auto-detect column mapping based on common patterns. (+97 more)
 
-### Community 18 - "json.py"
-Cohesion: 0.04
-Nodes (102): File readers for rheological data formats.  This module provides readers for var, ColumnMapping, construct_complex_modulus(), convert_unit(), DataSegment, detect_step_column(), detect_test_type(), map_columns_to_canonical() (+94 more)
+### Community 18 - "__init__.py"
+Cohesion: 0.06
+Nodes (56): ColumnMapping, construct_complex_modulus(), convert_unit(), detect_step_column(), detect_test_type(), map_columns_to_canonical(), DataFrame, ndarray (+48 more)
 
 ### Community 19 - "load_csv"
-Cohesion: 0.03
-Nodes (97): complexfloating, Lightweight validation helpers shared across public boundaries., Reject removed DMTA options without modifying ``options``.      Args:         op, reject_removed_options(), Suggest column mappings based on file headers.          Parameters         -----, detect_csv_delimiter(), _detect_delimiter(), _get_column_data() (+89 more)
+Cohesion: 0.02
+Nodes (118): complexfloating, Index, Lightweight validation helpers shared across public boundaries., Reject removed DMTA options without modifying ``options``.      Args:         op, reject_removed_options(), Data Service ===========  Service for loading, validating, and managing rheologi, Suggest column mappings based on file headers.          Parameters         -----, Unified file I/O for rheological data.  This module provides readers and writers (+110 more)
 
 ### Community 20 - "ITTMCTIsotropic"
 Cohesion: 0.03
-Nodes (51): ITTMCTIsotropic, Any, ndarray, Predict stress relaxation after flow cessation.          Parameters         ----, Predict LAOS stress response.          Parameters         ----------         t :, Extract Fourier harmonics from LAOS response.          Parameters         ------, Static model function for Bayesian inference.          NOTE: Bayesian inference, Return string representation. (+43 more)
+Nodes (55): ITTMCTIsotropic, Any, ndarray, Predict stress relaxation after flow cessation.          Parameters         ----, Predict LAOS stress response.          Parameters         ----------         t :, Extract Fourier harmonics from LAOS response.          Parameters         ------, Static model function for Bayesian inference.          NOTE: Bayesian inference, Return string representation. (+47 more)
 
 ### Community 21 - "Zener"
-Cohesion: 0.05
-Nodes (35): ndarray, Fit Zener model to data.          Args:             X: RheoData object or indepe, Predict response based on input data.          Args:             X: RheoData obj, Model function for Bayesian inference.          This method is required by Bayes, Predict relaxation modulus G(t).          Theory: G(t) = G_e + G_m * exp(-t/tau), Predict creep compliance J(t).          Theory: J(t) = 1/(G_e+G_m) + (G_m/(G_e*(, Predict complex modulus G*(omega).          Theory:             G'(omega) = G_e, Predict steady shear stress sigma(gamma_dot).          Theory: sigma = eta * gam (+27 more)
+Cohesion: 0.03
+Nodes (49): ndarray, Fit Zener model to data.          Args:             X: RheoData object or indepe, Predict response based on input data.          Args:             X: RheoData obj, Model function for Bayesian inference.          This method is required by Bayes, Predict relaxation modulus G(t).          Theory: G(t) = G_e + G_m * exp(-t/tau), Predict creep compliance J(t).          Theory: J(t) = 1/(G_e+G_m) + (G_m/(G_e*(, Predict complex modulus G*(omega).          Theory:             G'(omega) = G_e, Predict steady shear stress sigma(gamma_dot).          Theory: sigma = eta * gam (+41 more)
 
 ### Community 22 - "FIKH"
-Cohesion: 0.07
-Nodes (24): FIKH, ArrayLike, Initialize FIKH model.          Args:             include_thermal: Enable thermo, Fit model parameters using protocol-aware optimization.          Args:, Fit to steady-state flow curve data., Fit using ODE formulation (creep/relaxation)., Fit using return mapping (startup/LAOS)., Fit to oscillatory data (SAOS).          This method fits to frequency-domain SA (+16 more)
+Cohesion: 0.04
+Nodes (47): FIKH, Any, ArrayLike, ndarray, Initialize FIKH model.          Args:             include_thermal: Enable thermo, Fit model parameters using protocol-aware optimization.          Args:, Fit to steady-state flow curve data., Fit using ODE formulation (creep/relaxation). (+39 more)
 
 ### Community 23 - "SGRConventional"
 Cohesion: 0.01
-Nodes (159): Array, ndarray, JIT-compiled relaxation prediction: G(t).          Computes relaxation modulus w, JIT-compiled creep prediction: J(t).          Computes creep compliance as appro, JIT-compiled steady shear prediction: eta(gamma_dot).          Computes viscosit, Predict based on fitted test mode.          Routes to appropriate prediction met, Predict complex modulus in oscillation mode.          Args:             omega: A, Predict relaxation modulus in relaxation mode.          Args:             t: Tim (+151 more)
+Nodes (113): Array, JIT-compiled relaxation prediction: G(t).          Computes relaxation modulus w, JIT-compiled creep prediction: J(t).          Computes creep compliance as appro, JIT-compiled steady shear prediction: eta(gamma_dot).          Computes viscosit, Predict based on fitted test mode.          Routes to appropriate prediction met, Predict complex modulus in oscillation mode.          Args:             omega: A, Predict relaxation modulus in relaxation mode.          Args:             t: Tim, Predict creep compliance in creep mode.          Args:             t: Time array (+105 more)
 
 ### Community 24 - "FitPage"
 Cohesion: 0.03
-Nodes (53): FitPage, Any, Figure, ndarray, Update the Fit page status from a stored FitResult., Replace the plot canvas figure.          Delegates to PlotCanvas.replace_figure(, Forward residuals to the residuals panel., Set up the user interface. (+45 more)
+Nodes (56): FitPage, Any, Figure, ndarray, Update the Fit page status from a stored FitResult., Replace the plot canvas figure.          Delegates to PlotCanvas.replace_figure(, Forward residuals to the residuals panel., Set up the user interface. (+48 more)
 
 ### Community 25 - "SpringPot"
-Cohesion: 0.05
-Nodes (27): Classical rheological models.  Contains fundamental spring-dashpot models: - Max, ndarray, Fit SpringPot model to data.          Args:             X: RheoData object or in, Predict response based on input data.          Args:             X: RheoData obj, Model function for Bayesian inference.          This method is required by Bayes, Predict relaxation modulus G(t).          Theory: G(t) = c_alpha * t^(-alpha) /, Predict creep compliance J(t).          Theory: J(t) = (1/c_alpha) * t^alpha / G, Predict complex modulus G*(omega).          Theory: G*(omega) = c_alpha * (i*ome (+19 more)
+Cohesion: 0.03
+Nodes (51): ndarray, Predict response based on input data.          Args:             X: RheoData obj, Model function for Bayesian inference.          This method is required by Bayes, Predict relaxation modulus G(t).          Theory: G(t) = c_alpha * t^(-alpha) /, Predict creep compliance J(t).          Theory: J(t) = (1/c_alpha) * t^alpha / G, Predict complex modulus G*(omega).          Theory: G*(omega) = c_alpha * (i*ome, Get characteristic time scale for the material.          For SpringPot, there's, String representation of SpringPot model. (+43 more)
 
 ### Community 26 - ".reset"
 Cohesion: 0.06
-Nodes (30): Reset the singleton instance (useful for testing)., setup_function(), setup_function(), Any, QApplication, Reset StateStore singleton before each test., Get or create QApplication instance., Test FitPage can be instantiated and models loaded. (+22 more)
+Nodes (28): Reset the singleton instance (useful for testing)., setup_function(), setup_function(), Any, QApplication, Reset StateStore singleton before each test., Get or create QApplication instance., Test FitPage can be instantiated and models loaded. (+20 more)
 
 ### Community 27 - "ITTMCTSchematic"
-Cohesion: 0.03
-Nodes (55): ITTMCTSchematic, Get the strain decorrelation function form., Get the memory kernel form.          Returns         -------         str, Get the stress computation form.          Returns         -------         str, Initialize F₁₂ Schematic Model.          Parameters         ----------         e, Initialize F₁₂ model parameters., Get critical v₂ value for glass transition.          Parameters         --------, Get separation parameter ε = (v₂ - v₂_c)/v₂_c. (+47 more)
+Cohesion: 0.02
+Nodes (87): ITTMCTSchematic, Get the strain decorrelation function form., Get the memory kernel form.          Returns         -------         str, Get the stress computation form.          Returns         -------         str, Initialize F₁₂ Schematic Model.          Parameters         ----------         e, Initialize F₁₂ model parameters., Get critical v₂ value for glass transition.          Parameters         --------, Get separation parameter ε = (v₂ - v₂_c)/v₂_c. (+79 more)
 
 ### Community 28 - "LatticeEPM"
-Cohesion: 0.03
-Nodes (64): LatticeEPM, Array, RheoData, Perform one scalar EPM time step.          Delegates to the `epm_step` kernel fr, Simulate the model for the given protocol.          Args:             X: Input d, 2D Lattice Elasto-Plastic Model (EPM).      A mesoscopic model for amorphous sol, Initialize the Lattice EPM.          See ``EPMBase.__init__`` for the descriptio, Initialize scalar stress field.          Args:             key: PRNG key (unused (+56 more)
+Cohesion: 0.02
+Nodes (115): get_compatible_test_modes(), TestMode, Enumeration of rheological test modes.      Note: Named TestModeEnum (not TestMo, Validate and convert test mode to TestMode enum.      Args:         test_mode: T, Get compatible test modes for a given model.      Queries the ModelRegistry to d, Suggest appropriate models for a given test mode.      Queries the ModelRegistry, Return string representation., Convert inventory Protocol to TestModeEnum. (+107 more)
 
 ### Community 29 - "PipelineBuilder"
-Cohesion: 0.03
-Nodes (46): PipelineBuilder, Any, Path, Add prediction step.          Args:             store_as: Optional name to store, Add plotting step.          Args:             show: Whether to display plot, Add Bayesian inference step (NUTS sampling).          Args:             num_warm, Add analysis export step.          Args:             output_path: Output directo, Add data saving step.          Args:             file_path: Output file path (+38 more)
+Cohesion: 0.02
+Nodes (63): PipelineBuilder, Any, Path, Pipeline builder for programmatic pipeline construction.  This module provides a, Add prediction step.          Args:             store_as: Optional name to store, Add plotting step.          Args:             show: Whether to display plot, Add Bayesian inference step (NUTS sampling).          Args:             num_warm, Add analysis export step.          Args:             output_path: Output directo (+55 more)
 
 ### Community 30 - "RheoJAXMainWindow"
-Cohesion: 0.04
-Nodes (35): Handle open file action., Handle save as action., Dispatch a failed import on the main thread (via relay)., Handle preferences action., Handle zoom in action., Handle zoom out action., Handle reset zoom action., Clear the current visual pipeline state. (+27 more)
+Cohesion: 0.03
+Nodes (46): FitResult, QCloseEvent, Handle new file action., Handle open file action., Handle save file action.          Returns         -------         bool, Handle save as action., Dispatch a failed import on the main thread (via relay)., Handle zoom in action. (+38 more)
 
 ### Community 31 - "FluidityLocal"
-Cohesion: 0.02
-Nodes (42): FluidityLocal, Local (0D) Fluidity Model for yield-stress fluids.      Implements a homogeneous, Extract Fourier harmonics from LAOS stress response.          Args:, Initialize Local Fluidity Model., Test Local and Nonlocal share common parameters., Test Nonlocal has additional xi parameter., Test both models can export parameter dict., Test parameters.get_values() returns array of values. (+34 more)
+Cohesion: 0.03
+Nodes (53): fluidity_local_steady_state(), Compute steady-state flow curve for Local Fluidity model.      At steady state:, FluidityLocal, Any, ndarray, Fit Fluidity model to data.          Args:             X: Independent variable (, Fit steady-state Herschel-Bulkley flow curve.          At steady state the kerne, Predict steady-state flow curve (compatibility wrapper). (+45 more)
 
 ### Community 32 - "_kernels_diffrax.py"
-Cohesion: 0.05
-Nodes (78): _make_relaxation_vector_field(), Create ODE vector field for stress relaxation.      After step strain, gamma_dot, hvm_ber_rate_stress(), hvm_ber_rate_stretch(), hvm_exchangeable_rhs_shear(), BER rate with von Mises stress coupling (TST).      k_BER = nu_0 * exp(-E_a/(R*T, BER rate with chain stretch coupling (TST).      k_BER = nu_0 * exp(-E_a/(R*T)), ODE RHS for exchangeable network distribution + natural state.      E-network di (+70 more)
+Cohesion: 0.04
+Nodes (94): hvm_ber_rate_stress(), BER rate with von Mises stress coupling (TST).      k_BER = nu_0 * exp(-E_a/(R*T, Base class for HVNM (Hybrid Vitrimer Nanocomposite Model).  Provides shared in, _compute_k_ber_interphase(), _compute_k_ber_matrix(), _default_hvnm_args(), _hvnm_initial_state(), _hvnm_relaxation_initial_state() (+86 more)
 
 ### Community 33 - "mittag_leffler_e"
-Cohesion: 0.08
-Nodes (21): mittag_leffler_e(), ndarray, One-parameter Mittag-Leffler function E_α(z).      E_α(z) = E_{α,1}(z)      Para, Test edge cases and error handling., Test that negative alpha raises error., Test that alpha=0 raises error., Test that alpha > 2 raises error., Test behavior for very small |z|. (+13 more)
+Cohesion: 0.03
+Nodes (61): mittag_leffler_e(), mittag_leffler_e2(), ndarray, One-parameter Mittag-Leffler function E_α(z).      E_α(z) = E_{α,1}(z)      Para, r"""     Two-parameter Mittag-Leffler function E_{α,β}(z).      Uses a hybrid ev, Tests for Mittag-Leffler function implementations.  These tests validate correct, Test accuracy for moderate |z| in rheological range., Test E_α(-z) for negative arguments (relaxation modulus case). (+53 more)
 
 ### Community 34 - "DatasetLibrary"
 Cohesion: 0.04
-Nodes (90): DatasetLibrary, DatasetRef, Any, pipeline_context_from_library(), pipeline_inputs_from_library(), Any, §11 boundary: feed the legacy pipeline from the new Dataset Library.      Resolv, Seed a PipelineExecutionService.execute_single_step context from a     Workspace (+82 more)
+Nodes (99): DatasetLibrary, DatasetRef, Any, pipeline_context_from_library(), pipeline_inputs_from_library(), Any, §11 boundary: feed the legacy pipeline from the new Dataset Library.      Resolv, Seed a PipelineExecutionService.execute_single_step context from a     Workspace (+91 more)
 
 ### Community 35 - "_kernels_diffrax.py"
-Cohesion: 0.07
-Nodes (36): _make_creep_vector_field(), _make_k_ber_fn(), _make_laos_vector_field(), _make_startup_vector_field(), diffrax ODE solvers for HVM (Hybrid Vitrimer Model).  Provides adaptive ODE inte, Create ODE vector field for startup shear.      gamma_dot is constant, passed vi, Create ODE vector field for LAOS.      Oscillatory shear: gamma(t) = gamma_0 * s, Create ODE vector field for creep.      Constant applied stress sigma_0. At each (+28 more)
-
-### Community 36 - "BayesianService"
-Cohesion: 0.02
-Nodes (94): ModuleType, arviz_figure(), _arviz_major_version(), arviz_plot_kwargs(), import_arviz(), inference_data_from_dict(), Any, Utilities for safely importing optional ArviZ dependency. (+86 more)
-
-### Community 37 - "test_widgets.py"
 Cohesion: 0.05
-Nodes (41): FitController, Editing a completed step bumps revision and re-locks everything downstream., Step, TransformController, WorkflowController, InspectorPanel, LibraryRail, build_pipeline_controller() (+33 more)
+Nodes (68): _hvm_initial_state(), hvm_solve_creep(), hvm_solve_laos(), hvm_solve_relaxation(), hvm_solve_startup(), _make_creep_vector_field(), _make_k_ber_fn(), _make_laos_vector_field() (+60 more)
 
-### Community 38 - "VLBLocal"
+### Community 36 - "arviz_plot_kwargs"
+Cohesion: 0.12
+Nodes (19): ModuleType, arviz_figure(), _arviz_major_version(), arviz_plot_kwargs(), import_arviz(), Any, Utilities for safely importing optional ArviZ dependency., Extract the Matplotlib figure from ArviZ 0.x or 1.x plot output. (+11 more)
+
+### Community 37 - "PipelineConfigureRunStep"
+Cohesion: 0.06
+Nodes (36): FitController, Editing a completed step bumps revision and re-locks everything downstream., Step, TransformController, WorkflowController, build_pipeline_controller(), PipelineController, PipelineController: Pipeline mode's WorkflowController plus the sole GUI-thread (+28 more)
+
+### Community 38 - "nlsq_optimize"
 Cohesion: 0.01
-Nodes (132): Compute stretch ratio from distribution tensor.          stretch = sqrt(tr(mu)/3, Compute Weissenberg number Wi = t_R * gamma_dot.          Parameters         ---, Compute Deborah number De = t_R * omega.          Parameters         ----------, Get all parameters as a dictionary.          Returns         -------         dic, Set parameters from a dictionary.          Parameters         ----------, Compute dissociation rate (possibly state-dependent).          Base implementati, Base class for VLB transient network models.      Provides shared infrastructure, Initialize ParameterSet. Must be implemented by subclasses. (+124 more)
+Nodes (194): Standard NLSQ fitting pipeline for models with a stateless model_fn.          Ha, GUI Logging Utilities.  Lightweight logging helpers that bridge the standard lib, log_fit(), Context manager for model fitting operations.      Specialized wrapper around lo, Fit Maxwell model to data.          Args:             X: RheoData object or inde, Fit EPM parameters to data using NLSQ with smooth yielding.          This method, FluidityBase, ndarray (+186 more)
 
 ### Community 39 - "conftest.py"
-Cohesion: 0.03
-Nodes (48): Reset validation state (for testing purposes only).      This function is intend, Verify that JAX is operating in float64 mode.      This function checks that JAX, reset_validation(), verify_float64(), array_pair_numpy_jax(), clean_registries(), complex_array_pair_numpy_jax(), csv_file_data() (+40 more)
+Cohesion: 0.05
+Nodes (43): array_pair_numpy_jax(), clean_registries(), complex_array_pair_numpy_jax(), creep_data_simple(), csv_file_data(), flow_data_bingham(), flow_data_power_law(), json_file_data() (+35 more)
 
-### Community 40 - "PipelineExecutionService"
-Cohesion: 0.06
-Nodes (52): PipelineStepConfig, PipelineExecutionService, Run a ``pipeline_actions.*`` call on this object's own (GUI) thread.          Qt, Execute all pipeline steps sequentially.          This method runs synchronously, Execute a single step with the given context.          Wraps the step in the sam, Run a Pipeline-mode batch (transform/fit/export steps) over one dataset., Run one Pipeline-mode transform step against its sole primary slot.          Nam, Runs `worker` (FitWorker or ProcessWorkerAdapter) synchronously, capturing its (+44 more)
+### Community 40 - "PipelineBatchRunner"
+Cohesion: 0.15
+Nodes (15): Runs `worker` (FitWorker or ProcessWorkerAdapter) synchronously, capturing its, PipelineBatchRunner, QRunnable driving PipelineExecutionService.execute() once per selected dataset,, DatasetArtifact, FileArtifact, FitArtifact, FitStepResult, PhaseResult (+7 more)
 
 ### Community 41 - "FluidityNonlocal"
 Cohesion: 0.03
-Nodes (50): FluidityNonlocal, Any, ndarray, NumPyro/BayesianMixin model function.          Accepts protocol-specific kwargs, Predict based on fitted state., Fit Non-Local Fluidity model to data.          Args:             X: Independent, Get grid-related arguments for PDE solver.          Args:             params: Op, Get initial fluidity field (uniform across gap).          Args:             f_in (+42 more)
+Nodes (45): FluidityNonlocal, Any, ndarray, NumPyro/BayesianMixin model function.          Accepts protocol-specific kwargs, Predict based on fitted state., Fit Non-Local Fluidity model to data.          Args:             X: Independent, Get grid-related arguments for PDE solver.          Args:             params: Op, Get initial fluidity field (uniform across gap).          Args:             f_in (+37 more)
 
-### Community 42 - "AppState"
+### Community 42 - "state.py"
+Cohesion: 0.07
+Nodes (66): File, invalidate_downstream(), _escape_hdf5_key(), _is_allowed_member(), load_project_v2(), Any, Path, Versioned .rheojax v2 project persistence.  write_result_arrays()/read_result_ar (+58 more)
+
+### Community 43 - "_kernels.py"
 Cohesion: 0.04
-Nodes (99): File, invalidate_downstream(), _escape_hdf5_key(), _is_allowed_member(), load_project_v2(), Any, Path, Versioned .rheojax v2 project persistence.  write_result_arrays()/read_result_ar (+91 more)
-
-### Community 43 - "test_fikh_caputo.py"
-Cohesion: 0.06
-Nodes (35): caputo_derivative_l1(), compute_l1_coefficients(), create_history_buffer(), fractional_derivative_with_short_memory(), fractional_structure_derivative(), initialize_history_with_value(), ndarray, Caputo fractional derivative utilities for FIKH models.  This module provides JA (+27 more)
+Nodes (71): caputo_derivative_l1(), compute_gl_weights(), compute_l1_coefficients(), create_history_buffer(), fractional_derivative_with_short_memory(), fractional_structure_derivative(), initialize_history_with_value(), ndarray (+63 more)
 
 ### Community 44 - "__init__.py"
-Cohesion: 0.09
-Nodes (48): Unified fit visualization for NLSQ and Bayesian results.  This module provides t, configure_matplotlib(), Unified plotting and visualization utilities for rheological data.  This module, Configure matplotlib for rheological plotting with proper font handling.      Th, _apply_style(), compute_uncertainty_band(), _filter_positive(), plot_fit_with_uncertainty() (+40 more)
+Cohesion: 0.07
+Nodes (52): Unified fit visualization for NLSQ and Bayesian results.  This module provides t, configure_matplotlib(), Unified plotting and visualization utilities for rheological data.  This module, Configure matplotlib for rheological plotting with proper font handling.      Th, compute_uncertainty_band(), _filter_positive(), plot_fit_with_uncertainty(), plot_flow_curve() (+44 more)
 
 ### Community 45 - "ExportPage"
-Cohesion: 0.05
-Nodes (36): ExportWorker, ExportWorkerSignals, Any, QObject, QRunnable, Export Worker =============  Background worker for export operations (R13-GUI-00, Signals for ExportWorker.      Signals     -------     completed : Signal(list), Worker for performing exports in a background thread.      Parameters     ------ (+28 more)
+Cohesion: 0.06
+Nodes (29): ExportWorker, ExportWorkerSignals, Any, QObject, QRunnable, Export Worker =============  Background worker for export operations (R13-GUI-00, Signals for ExportWorker.      Signals     -------     completed : Signal(list), Worker for performing exports in a background thread.      Parameters     ------ (+21 more)
 
 ### Community 46 - "_kernels.py"
-Cohesion: 0.02
-Nodes (97): build_vlb_creep_ode_rhs(), build_vlb_laos_ode_rhs(), build_vlb_nonlocal_pde_rhs(), build_vlb_ode_rhs(), build_vlb_relaxation_ode_rhs(), build_vlb_stress_fn(), laplacian_1d_neumann_vlb(), ndarray (+89 more)
+Cohesion: 0.04
+Nodes (59): build_vlb_creep_ode_rhs(), build_vlb_laos_ode_rhs(), build_vlb_nonlocal_pde_rhs(), build_vlb_ode_rhs(), build_vlb_relaxation_ode_rhs(), build_vlb_stress_fn(), ndarray, JAX-accelerated physics kernels for VLB transient network models.  This module p (+51 more)
 
 ### Community 47 - "IconProvider"
 Cohesion: 0.01
-Nodes (145): Config, Any, Path, Configuration Management =======================  Application configuration and, Reset to default configuration., Application configuration manager.      Features:         - Persistent settings, Initialize configuration manager.          Parameters         ----------, Get configuration value.          Parameters         ----------         key : st (+137 more)
+Nodes (144): Config, Any, Path, Configuration Management =======================  Application configuration and, Reset to default configuration., Application configuration manager.      Features:         - Persistent settings, Initialize configuration manager.          Parameters         ----------, Get configuration value.          Parameters         ----------         key : st (+136 more)
 
 ### Community 48 - "FluiditySaramitoLocal"
 Cohesion: 0.03
-Nodes (43): FluiditySaramitoLocal, Any, ndarray, Simulate LAOS response using Diffrax.          Parameters         ----------, Simulate LAOS response.          Parameters         ----------         gamma_0 :, Extract Fourier harmonics from LAOS stress response.          Parameters, NumPyro/BayesianMixin model function.          Routes to appropriate prediction, Predict based on fitted state.          Parameters         ----------         X (+35 more)
+Nodes (48): FluiditySaramitoLocal, Any, ndarray, Simulate LAOS response using Diffrax.          Parameters         ----------, Simulate LAOS response.          Parameters         ----------         gamma_0 :, Extract Fourier harmonics from LAOS stress response.          Parameters, NumPyro/BayesianMixin model function.          Routes to appropriate prediction, Predict based on fitted state.          Parameters         ----------         X (+40 more)
 
 ### Community 49 - "HVNMLocal"
-Cohesion: 0.05
-Nodes (23): HVNM (Hybrid Vitrimer Nanocomposite Model) package.  Constitutive models for n, HVNMLocal, ndarray, Create partial vitrimer nanocomposite (G_D=0).          Parameters         -----, Create conventional filled rubber (no E-network, frozen interphase).          Pa, Get parameters as dict with defaults for optional params., Compute derived NP geometry quantities from parameter dict.          Parameters, Build complete ODE args dict with derived quantities. (+15 more)
+Cohesion: 0.03
+Nodes (42): HVNM (Hybrid Vitrimer Nanocomposite Model) package.  Constitutive models for n, HVNMLocal, Create unfilled vitrimer (phi=0, recovers HVM exactly).          Parameters, Create partial vitrimer nanocomposite (G_D=0).          Parameters         -----, Create conventional filled rubber (no E-network, frozen interphase).          Pa, Get parameters as dict with defaults for optional params., Predict steady-state flow curve.          At steady state, mu^E -> mu^E_nat and, Predict steady-state normal stress differences.          At steady state, E and (+34 more)
 
 ### Community 50 - "FitPlotter"
 Cohesion: 0.03
@@ -1126,19 +1091,19 @@ Nodes (60): advected_correlator(), advected_memory_decorrelation(), compute_micr
 
 ### Community 52 - "_kernels.py"
 Cohesion: 0.03
-Nodes (71): banding_ratio(), f_loc_herschel_bulkley(), fluidity_local_creep_ode_rhs(), fluidity_local_ode_rhs(), fluidity_local_steady_state(), fluidity_nonlocal_creep_pde_rhs(), fluidity_nonlocal_pde_rhs(), fluidity_nonlocal_steady_state() (+63 more)
+Nodes (61): banding_ratio(), f_loc_herschel_bulkley(), fluidity_local_creep_ode_rhs(), fluidity_local_ode_rhs(), fluidity_nonlocal_creep_pde_rhs(), fluidity_nonlocal_pde_rhs(), fluidity_nonlocal_steady_state(), laplacian_1d_neumann() (+53 more)
 
-### Community 53 - "_make_mock_spp_results"
-Cohesion: 0.06
-Nodes (44): export_spp_csv(), export_spp_hdf5(), export_spp_txt(), _extract_spp_arrays(), ndarray, Path, SPP (Sequence of Physical Processes) data export module.  This module provides e, Export SPP results to MATLAB-compatible text format.      Creates output files m (+36 more)
+### Community 53 - "to_matlab_dict"
+Cohesion: 0.14
+Nodes (12): Convert SPP results to a dict compatible with scipy.io.savemat.      Returns a s, to_matlab_dict(), Tests for MATLAB-compatible dict export., Test that dict contains out_spp key., Test that out_spp has info, headers, and data., Test that data matrix has 15 columns matching MATLAB., Test that info dict contains frequency., Test that out_fsf is included when Frenet-Serret data available. (+4 more)
 
-### Community 54 - "test_transform_plotter.py"
-Cohesion: 0.04
-Nodes (39): complex_data(), freq_data(), plotter(), Tests for the TransformPlotter class., Tests for mastercurve visualization., Mastercurve plot with shift factors dict., Mastercurve plot without input datasets., Mutation number plot shows bar with value. (+31 more)
+### Community 54 - "TestMastercurvePlot"
+Cohesion: 0.33
+Nodes (4): Tests for mastercurve visualization., Mastercurve plot with shift factors dict., Mastercurve plot without input datasets., TestMastercurvePlot
 
-### Community 55 - "detect_decay_type"
-Cohesion: 0.19
-Nodes (9): detect_decay_type(), Detect the type of relaxation decay from time-domain data.      Analyzes the dec, Tests for decay type detection from relaxation data., Test detection of exponential decay (Maxwell-like)., Test detection of power-law decay (gel-like)., Test that insufficient data returns UNKNOWN., Test handling of invalid data (NaN, inf)., Test detection of multi-mode decay. (+1 more)
+### Community 55 - "test_arviz_diagnostics.py"
+Cohesion: 0.03
+Nodes (40): Tests for ArviZ integration in BayesianPipeline.  This module comprehensively te, Test conversion from BayesianResult to ArviZ InferenceData., Test that to_inference_data() returns valid InferenceData object., Test that InferenceData contains required groups., Test that NUTS-specific diagnostics are preserved in InferenceData., Test plot_pair() method for parameter correlations., Test that plot_pair() returns matplotlib Figure., Test plot_pair() with optional parameters. (+32 more)
 
 ### Community 56 - "__init__.py"
 Cohesion: 0.07
@@ -1149,172 +1114,168 @@ Cohesion: 0.04
 Nodes (37): _execute_notebook(), Validate that WLF parameters (C1, C2) are defined., Validate that shift factors are calculated for all temperatures., Execute a Jupyter notebook and return the executed notebook object.      Paramet, Validate that multi-temperature data is loaded., Validate that Mastercurve transform is applied., Validate that mastercurve quality metrics are computed., Validate that key visualizations are present. (+29 more)
 
 ### Community 58 - "epm_plots.py"
-Cohesion: 0.19
-Nodes (22): animate_stress_evolution(), plot_lattice_fields(), plot_normal_stress_field(), plot_normal_stress_ratio(), _plot_scalar_lattice(), plot_tensorial_fields(), _plot_tensorial_lattice(), plot_von_mises_field() (+14 more)
+Cohesion: 0.17
+Nodes (25): FuncAnimation, animate_stress_evolution(), animate_tensorial_evolution(), plot_lattice_fields(), plot_normal_stress_field(), plot_normal_stress_ratio(), _plot_scalar_lattice(), plot_tensorial_fields() (+17 more)
 
-### Community 59 - "fit_controller.py"
-Cohesion: 0.06
-Nodes (34): _CallableWorker, _CallableWorkerSignals, _fit_fn_body(), _r2_sort_key(), Multi-start restart-selection key: treat missing/NaN r_squared as the     worst, Runs an arbitrary no-arg callable on a QThreadPool thread., Run *fn* on a QThreadPool thread while pumping a local QEventLoop, so     the GU, _run_on_thread() (+26 more)
+### Community 59 - "ProtocolModelStep"
+Cohesion: 0.14
+Nodes (13): _constructor_params(), _make_config_widget(), ProtocolModelStep, Any, Test/programmatic helper: apply a config dict to the widgets, then commit it., Introspect a model class's __init__ for configurable constructor kwargs.      Re, Return (widget, getter) for a supported annotation, or (None, None)., _FakeInfo (+5 more)
 
 ### Community 60 - "FMLIKH"
-Cohesion: 0.05
-Nodes (36): FMLIKH, Any, ArrayLike, ndarray, TestMode, Initialize FMLIKH model.          Args:             n_modes: Number of viscoelas, Setup per-mode parameters, replacing single-mode defaults., Number of viscoelastic modes. (+28 more)
+Cohesion: 0.04
+Nodes (47): FMLIKH, Any, ArrayLike, ndarray, TestMode, Initialize FMLIKH model.          Args:             n_modes: Number of viscoelas, Setup per-mode parameters, replacing single-mode defaults., Number of viscoelastic modes. (+39 more)
 
 ### Community 61 - "plot_model_fit"
-Cohesion: 0.06
-Nodes (36): apply_template_style(), plot_mastercurve(), plot_model_fit(), plot_stress_strain(), Any, Array, Axes, Figure (+28 more)
+Cohesion: 0.05
+Nodes (42): apply_template_style(), plot_mastercurve(), plot_model_fit(), plot_modulus_frequency(), plot_stress_strain(), Any, Array, Axes (+34 more)
 
 ### Community 62 - "AnalysisExporter"
 Cohesion: 0.05
-Nodes (35): AnalysisExporter, Any, Path, Export analysis to a single Excel workbook.          Creates sheets:         - S, Collect all exportable state from a Pipeline., List which sections were populated., Write summary.json and summary.txt., Export pipeline analysis results to structured output.      Supports three expor (+27 more)
+Nodes (42): AnalysisExporter, Any, Path, Export analysis to a single Excel workbook.          Creates sheets:         - S, Collect all exportable state from a Pipeline., List which sections were populated., Write summary.json and summary.txt., Export pipeline analysis results to structured output.      Supports three expor (+34 more)
 
-### Community 63 - "_kernels.py"
-Cohesion: 0.04
-Nodes (64): Update history buffer with new value using ring buffer pattern.      Shifts buff, update_history_buffer(), fikh_return_step_isothermal(), fikh_return_step_thermal(), fractional_structure_rhs(), macaulay(), _make_fikh_creep_ode_rhs(), _make_fikh_maxwell_ode_rhs() (+56 more)
+### Community 63 - "test_fikh_thermal.py"
+Cohesion: 0.05
+Nodes (48): _make_fikh_creep_ode_rhs(), _make_fikh_maxwell_ode_rhs(), Factory for Maxwell ODE RHS for rate-controlled FIKH protocols.      State vecto, Factory for creep ODE RHS for stress-controlled FIKH protocol.      State vector, arrhenius_modulus(), arrhenius_viscosity(), compute_adiabatic_temperature_rise(), ndarray (+40 more)
 
 ### Community 64 - "TestKernelProperties"
 Cohesion: 0.09
 Nodes (12): Trap distribution rho(E) >= 0 for all E >= 0., Trap distribution rho(E) <= 1 for all E >= 0., Trap distribution rho(E) = 0 for E < 0., Equilibrium modulus G0(x) > 0 for all x > 0., Equilibrium modulus G0(x) is finite for all valid x., G0(x) decreases monotonically with increasing x (more fluid-like)., G'(x, omega) >= 0 and G''(x, omega) >= 0 for all valid inputs., G' and G'' are finite for all valid inputs. (+4 more)
 
-### Community 65 - "VLB Model Equation Verification"
+### Community 65 - "ProcessCancellationToken"
 Cohesion: 0.05
-Nodes (40): 10. Creep Compliance, 11. Bell Model Force-Dependent Dissociation, 12. FENE-P Finite Extensibility, 1. Distribution Tensor Evolution Equation, 2. Cauchy Stress, 3. Free Energy, 4. Dissipation, 5. Simple Shear Flow Components (+32 more)
+Nodes (29): BaseContext, ProcessCancellationToken, Event, Wait for cancellation.          Parameters         ----------         timeout :, Cancellation token using multiprocessing.Event for cross-process signaling., The underlying mp.Event -- pass this to child processes., Release the underlying mp.Event and its POSIX semaphores.          After calling, Request cancellation across process boundaries. (+21 more)
 
 ### Community 66 - "TestMenuBarActionConnections"
-Cohesion: 0.08
-Nodes (21): action_has_receivers(), RheoJAX GUI Menu Actions Tests.  Regression tests ensuring all menu bar actions, Verify all Data menu actions have handlers., Verify all Models menu actions have handlers., Check if a QAction has any receivers connected to its triggered signal.      In, Verify all Transforms menu actions have handlers., Verify all Analysis menu actions have handlers., Verify all Pipeline menu actions have handlers. (+13 more)
+Cohesion: 0.10
+Nodes (16): action_has_receivers(), Verify all Data menu actions have handlers., Verify all Models menu actions have handlers., Check if a QAction has any receivers connected to its triggered signal.      In, Verify all Transforms menu actions have handlers., Verify all Analysis menu actions have handlers., Verify all Pipeline menu actions have handlers., Verify all Tools menu actions have handlers. (+8 more)
 
-### Community 67 - "TestFractionalZenerSolidSolid"
-Cohesion: 0.17
-Nodes (6): Test parameter initialization., Test relaxation modulus., Test creep compliance., Test complex modulus., Tests for FZSS model., TestFractionalZenerSolidSolid
+### Community 67 - "test_fractional_zener_family.py"
+Cohesion: 0.07
+Nodes (15): Comprehensive tests for Fractional Zener Family and Advanced Fractional Models (, Test parameter initialization., Test relaxation modulus., Test creep compliance., Test complex modulus., Tests for FZLL model., Test parameter initialization., Test complex modulus (primary mode for FZLL). (+7 more)
 
-### Community 68 - "BaseInitializer"
-Cohesion: 0.06
-Nodes (27): BaseInitializer, Base initializer abstract class for fractional model initialization.  This modul, Abstract base class for fractional model parameter initialization.      Implemen, Common validation logic for extracted features.          Parameters         ----, Estimate all model-specific parameters from frequency features.          Subclas, Set clipped parameters in the ParameterSet.          Subclasses implement this m, Safely set a parameter if it exists in ParameterSet.          This helper method, Initializer for FractionalKelvinVoigtZener model from oscillation data.  Model e (+19 more)
+### Community 68 - ".clone"
+Cohesion: 0.05
+Nodes (26): _notify_subscribers_safe(), Any, Compute which top-level keys changed between two states., Undo the last state change.          Thread-safe: Protected by RLock.          N, Redo the last undone state change.          Thread-safe: Protected by RLock., Apply multiple state updates in a single transaction.          Thread-safe: Prot, Get dataset by ID.          Parameters         ----------         dataset_id : s, Get the currently active dataset.          Returns         -------         Datas (+18 more)
 
 ### Community 69 - "PipelineConfig"
-Cohesion: 0.08
-Nodes (23): Print a human-readable summary of a pipeline config., run_show(), load_config(), PipelineConfig, Path, YAML pipeline config schema definition and validation.  A pipeline config YAML f, Validated representation of a YAML pipeline config file.      Attributes:, Load and validate a YAML pipeline config file.      Args:         path: Filesyst (+15 more)
+Cohesion: 0.07
+Nodes (26): YAML pipeline config execution engine.  Translates a validated :class:`~rheojax., load_config(), PipelineConfig, Path, YAML pipeline config schema definition and validation.  A pipeline config YAML f, Validated representation of a YAML pipeline config file.      Attributes:, Load and validate a YAML pipeline config file.      Args:         path: Filesyst, Validate a :class:`PipelineConfig`, returning error messages.      An empty list (+18 more)
 
 ### Community 70 - "RheoJaxValidationWarning"
-Cohesion: 0.09
-Nodes (51): Custom exceptions and warnings for the RheoJAX package.  This module defines the, Emitted for data quality issues detected during loading or validation.      Subc, Raised for unrecoverable fit failures.      Examples include optimizer divergenc, Emitted when an optimizer converges but with caveats.      Examples: maximum ite, RheoJaxConvergenceWarning, RheoJaxFitError, RheoJaxValidationWarning, _check_creep() (+43 more)
+Cohesion: 0.10
+Nodes (47): Emitted for data quality issues detected during loading or validation.      Subc, Emitted when an optimizer converges but with caveats.      Examples: maximum ite, RheoJaxConvergenceWarning, RheoJaxValidationWarning, _check_creep(), _check_oscillation(), _check_relaxation(), _check_rotation() (+39 more)
 
-### Community 71 - "ITT-MCT Literature Review: Key Equations"
-Cohesion: 0.05
-Nodes (37): 1.1 Density correlator, 1.2 Full MCT equation of motion (underdamped), 1.3 Full MCT memory kernel (microscopic), 1.4 Overdamped (Brownian/colloidal) limit, 1. Equilibrium MCT (No Flow), 2.1 Schematic equation of motion, 2.2 Schematic memory kernel, 2.3 Glass transition criterion (+29 more)
+### Community 71 - "from_yaml"
+Cohesion: 0.06
+Nodes (31): _display_name(), from_pipeline_builder(), from_yaml(), _get_yaml(), _make_step(), Any, PipelineStepConfig, Pipeline serialization for GUI <-> CLI YAML round-trip.  Provides bidirectional (+23 more)
 
-### Community 72 - "UnsupportedDataError"
+### Community 72 - "test_project_structure.py"
 Cohesion: 0.04
-Nodes (69): Index, Raised for unsupported measurement geometry. RheoJAX is shear-only;     tensile/, UnsupportedDataError, check_tensile_guard(), Scan headers and units for tensile/E* and other unsupported deformation modes (b, load_hdf5(), _normalize_hdf5_geometry_marker(), Any (+61 more)
+Nodes (32): Project structure validation tests for rheojax package.  These tests verify that, Test suite for documentation setup., Test that documentation directory exists., Test that Sphinx configuration exists., Test that Sphinx index.rst exists., Test suite for project configuration files., Test that pyproject.toml exists and is valid., Test that pytest configuration exists (in pyproject.toml). (+24 more)
 
 ### Community 73 - "ModelRegistry"
 Cohesion: 0.01
-Nodes (464): ABC, BaseModel, BaseTransform, Base classes for models and transforms with JAX support.  This module provides a, Standard NLSQ fitting pipeline for models with a stateless model_fn.          Ha, Abstract base class for all data transforms.      This class defines the standar, Initialize base transform., Transform multiple datasets sequentially.          Applies the transform to each (+456 more)
+Nodes (404): ABC, CLI subcommand for Bayesian inference with NUTS sampling.  Usage:     rheojax, CLI subcommand for NLSQ model fitting.  Usage:     rheojax fit data.csv --mod, BaseModel, BaseTransform, Base classes for models and transforms with JAX support.  This module provides a, Abstract base class for all data transforms.      This class defines the standar, Initialize base transform. (+396 more)
 
 ### Community 74 - "generate_diagnostic_suite"
 Cohesion: 0.09
 Nodes (26): compute_credible_band(), generate_diagnostic_suite(), Any, Axes, Figure, ndarray, Path, Render a parameter summary table on a matplotlib axes.          Shows parameter (+18 more)
 
 ### Community 75 - "HVNMBase"
-Cohesion: 0.04
-Nodes (31): HVNMBase, Interphase reinforcement ratio G_I/G_E., Interfacial TST attempt frequency (1/s)., Interfacial activation energy (J/mol)., Interfacial activation volume (m^3/mol)., Mobile interphase thickness (m)., Interfacial damage rate (1/s)., Interfacial critical stretch. (+23 more)
+Cohesion: 0.03
+Nodes (36): HVNMBase, ndarray, Interphase reinforcement ratio G_I/G_E., Interfacial TST attempt frequency (1/s)., Interfacial activation energy (J/mol)., Interfacial activation volume (m^3/mol)., Mobile interphase thickness (m)., Interfacial damage rate (1/s). (+28 more)
 
 ### Community 76 - "DMTLocal"
-Cohesion: 0.07
-Nodes (31): DMTLocal, ndarray, Predict creep strain., Fit to SAOS data G*(ω) = G'(ω) + jG''(ω).          Requires include_elasticity=T, Initialize DMTLocal model., Predict complex modulus., Simulate LAOS (Large Amplitude Oscillatory Shear).          Parameters         -, Fit model to data.          Dispatches to protocol-specific fitting method based (+23 more)
+Cohesion: 0.06
+Nodes (36): DMTLocal, ndarray, Predict creep strain., Fit to SAOS data G*(ω) = G'(ω) + jG''(ω).          Requires include_elasticity=T, Initialize DMTLocal model., Predict complex modulus., Simulate LAOS (Large Amplitude Oscillatory Shear).          Parameters         -, Fit model to data.          Dispatches to protocol-specific fitting method based (+28 more)
 
 ### Community 77 - "GiesekusMultiMode"
-Cohesion: 0.06
-Nodes (16): GiesekusMultiMode, Get solvent viscosity η_s (Pa·s)., Get zero-shear viscosity η₀ = η_s + Σ η_p,i (Pa·s)., Get parameters for a specific mode.          Parameters         ----------, Set parameters for a specific mode.          Parameters         ----------, Multi-mode Giesekus nonlinear viscoelastic model.      This model extends the si, Return string representation., Test SAOS prediction. (+8 more)
+Cohesion: 0.03
+Nodes (38): GiesekusMultiMode, ndarray, Initialize multi-mode Giesekus model.          Parameters         ----------, Initialize ParameterSet with multi-mode parameters.          Creates parameters:, Get solvent viscosity η_s (Pa·s)., Get zero-shear viscosity η₀ = η_s + Σ η_p,i (Pa·s)., Get parameters for a specific mode.          Parameters         ----------, Set parameters for a specific mode.          Parameters         ---------- (+30 more)
 
 ### Community 78 - "schematic.py"
-Cohesion: 0.07
-Nodes (52): ITT-MCT (Integration Through Transients Mode-Coupling Theory) models.  This pack, compute_complex_modulus_from_correlator(), clear_solver_cache(), compute_adaptive_t_max(), FlowCurveParams, is_diffrax_available(), _make_batched_solver(), make_flow_curve_vector_field() (+44 more)
-
-### Community 79 - "test_schematic.py"
-Cohesion: 0.04
-Nodes (32): Tests for ITTMCTSchematic (F₁₂) model.  Tests cover: - Parameter initialization, Tests for SAOS (G', G'') predictions., Test that oscillation returns valid moduli., Test that glass shows plateau modulus., Tests for startup flow predictions., Test stress growth in startup flow., Test stress overshoot in startup (characteristic of MCT)., Tests for creep compliance predictions. (+24 more)
-
-### Community 80 - "MultiView"
 Cohesion: 0.06
-Nodes (47): Open MultiView dialog overlaying fit curves for the active dataset., MultiView, Multi-panel plot viewer for comparison and analysis.      Features:         - Co, Prompt for a base path and export all panels (Export All button)., Handle sync button toggle.          Parameters         ----------         checke, Get number of panels.          Returns         -------         int             N, Export all panels to files.          Parameters         ----------         base_, Get current layout.          Returns         -------         str             Cur (+39 more)
+Nodes (54): compute_complex_modulus_from_correlator(), clear_solver_cache(), compute_adaptive_t_max(), FlowCurveParams, is_diffrax_available(), _make_batched_solver(), make_flow_curve_vector_field(), make_flow_curve_with_stress_vector_field() (+46 more)
+
+### Community 79 - ".metadata"
+Cohesion: 0.06
+Nodes (24): Automatically detect or retrieve test mode.          The test mode is detected b, Execute file import in background thread., Convert DatasetState into RheoData for export., Convert DatasetState or RheoData into RheoData for services/workers., Synthesized metadata dict for backward compatibility., _is_jax_array(), Any, Path (+16 more)
+
+### Community 80 - "PlotCanvas"
+Cohesion: 0.04
+Nodes (60): PlotCanvas, Figure, ndarray, Explicitly release matplotlib resources before Qt widget deletion.          Must, Cancel pending matplotlib draws before the widget is closed., Return the primary matplotlib Axes for compatibility., Replace the displayed figure, properly managing the canvas lifecycle.          U, Redraw the canvas (compat helper). (+52 more)
 
 ### Community 81 - "hebraud_lequeux.py"
-Cohesion: 0.12
-Nodes (32): Any, Hébraud–Lequeux (HL) Model implementation.  This module implements the Hébraud–L, Model function for Bayesian inference (NumPyro NUTS).          Args:, Predict response using fitted parameters and stored test_mode., _compute_dt_and_steps_for_rate(), creep_kernel(), flow_curve_kernel(), HLState (+24 more)
+Cohesion: 0.09
+Nodes (41): Hébraud–Lequeux (HL) Model implementation.  This module implements the Hébraud–L, Model function for Bayesian inference (NumPyro NUTS).          Args:, _compute_dt_and_steps_for_rate(), creep_kernel(), flow_curve_kernel(), HLGrid, HLState, laos_kernel() (+33 more)
 
 ### Community 82 - "HVMLocal"
-Cohesion: 0.08
-Nodes (14): HVM (Hybrid Vitrimer Model) package.  Constitutive models for vitrimers with p, HVMLocal, Compute zero-stress BER rate from current parameters., Predict SAOS storage and loss moduli.          Two Maxwell modes (E, D) plus per, Local (0D) Hybrid Vitrimer Model.      A constitutive model for vitrimers combin, Arrhenius temperature dependence., k_BER_0 follows Arrhenius: higher T → faster exchange., arrhenius_plot_data returns correct shapes. (+6 more)
-
-### Community 83 - "Carreau"
 Cohesion: 0.05
-Nodes (31): Carreau, ndarray, RheoData, TestMode, Fit Carreau parameters to data.          Args:             X: Shear rate data (g, Predict viscosity for given shear rates.          Args:             X: Shear rat, Model function for Bayesian inference.          This method is required by Bayes, Compute viscosity using Carreau model.          Args:             gamma_dot: She (+23 more)
+Nodes (23): HVM (Hybrid Vitrimer Model) package.  Constitutive models for vitrimers with p, HVMLocal, Resolve test_mode from kwarg, cached value, or HVM default.          This is HVM, Compute zero-stress BER rate from current parameters., Predict steady-state flow curve.          At steady state, mu^E → mu^E_nat, so s, Predict SAOS storage and loss moduli.          Two Maxwell modes (E, D) plus per, Predict steady-state normal stress differences.          At steady state, E-netw, Extract Fourier harmonics from LAOS simulation.          Parameters         ---- (+15 more)
+
+### Community 83 - "test_carreau.py"
+Cohesion: 0.05
+Nodes (27): Tests for Carreau model.  This module tests the Carreau model for non-Newtonian, Test stress prediction: σ = η(γ̇) * γ̇., Test Newtonian limit when λ → 0., Test Newtonian limit when n = 1., Test basic functionality of Carreau model., Test model initialization., Test parameter fitting for Carreau model., Test fitting with synthetic data. (+19 more)
 
 ### Community 84 - "test_kernels.py"
 Cohesion: 0.09
 Nodes (40): banding_ratio(), detect_shear_bands(), fluidity_evolution_saramito(), herschel_bulkley_viscosity(), laplacian_1d_neumann(), ndarray, JAX-accelerated physics kernels for Fluidity-Saramito EVP models.  This module i, Detect shear banding from fluidity profile.      Args:         f_field: Fluidity (+32 more)
 
 ### Community 85 - "VisualizeStep"
-Cohesion: 0.05
-Nodes (41): _diagnostics_verdict(), NutsStep, Seed the editable PriorsEditor from the NLSQ MAP estimate.          Converts map, Clear a stale skip decision when an upstream NLSQ re-run invalidates         nut, Summarize NUTS convergence diagnostics into a pass/fail verdict.      Per the de, # NOTE: The real implementation must:, Any, ndarray (+33 more)
+Cohesion: 0.04
+Nodes (52): build_fit_controller(), AppState, _diagnostics_verdict(), NutsStep, Seed the editable PriorsEditor from the NLSQ MAP estimate.          Converts map, Clear a stale skip decision when an upstream NLSQ re-run invalidates         nut, Summarize NUTS convergence diagnostics into a pass/fail verdict.      Per the de, # NOTE: The real implementation must: (+44 more)
 
-### Community 86 - "_kernels.py"
-Cohesion: 0.05
-Nodes (53): breakage_bell(), breakage_constant(), breakage_power_law(), build_tnt_creep_ode_rhs(), build_tnt_laos_ode_rhs(), build_tnt_ode_rhs(), build_tnt_relaxation_ode_rhs(), gordon_schowalter_2d() (+45 more)
+### Community 86 - "FractionalModelMixin"
+Cohesion: 0.07
+Nodes (30): FractionalModelMixin, ndarray, TestMode, Convert class name to module name.          Examples:             FractionalZene, Validate fractional model parameters.          Checks:         - Fractional orde, Mixin providing common functionality for fractional viscoelastic models.      Th, Apply smart initialization for oscillation mode.          This method provides c, MockFractionalModel (+22 more)
 
 ### Community 87 - "TransformPlotter"
-Cohesion: 0.11
-Nodes (31): _ensure_numpy(), Ensure data is a NumPy array for plotting.      Args:         data: Input data a, Any, Axes, Figure, ndarray, RheoData, Generic before/after plot for unrecognized transforms. (+23 more)
+Cohesion: 0.10
+Nodes (36): _apply_style(), _ensure_numpy(), _modulus_labels(), Ensure data is a NumPy array for plotting.      Args:         data: Input data a, Return shear storage, loss, and generic modulus labels., Apply plotting style and return style parameters.      Args:         style: Styl, Any, Axes (+28 more)
 
-### Community 88 - "ParameterOptimizer"
+### Community 88 - "ParameterSet"
+Cohesion: 0.01
+Nodes (164): Initialize base model., Parameter, ParameterConstraint, ParameterOptimizer, ParameterSet, Any, Convert to dictionary representation., Create from dictionary representation.          Uses Parameter.from_dict() to pr (+156 more)
+
+### Community 89 - "TestHVMLimitingCases"
 Cohesion: 0.05
-Nodes (31): ParameterOptimizer, Manages parameters shared across multiple models., Initialize shared parameter set., Link a parameter set to a shared parameter.          Args:             param_set, Create a parameter group.          Args:             group_name: Name for the gr, Check if shared parameter exists., Optimizer for parameter fitting., Initialize parameter optimizer.          Args:             parameters: Parameter (+23 more)
-
-### Community 89 - "test_hvm.py"
-Cohesion: 0.07
-Nodes (22): Create Zener/SLS model (G_E=0).          Parameters         ----------         G, Create partial vitrimer (G_D=0, Meng 2019).          Parameters         --------, Create neo-Hookean elastic solid (G_E=0, G_D=0).          Parameters         ---, Create single Maxwell fluid (G_P=0, G_E=0).          Parameters         --------, hvm_default(), hvm_maxwell(), hvm_partial(), hvm_zener() (+14 more)
+Nodes (28): Create Zener/SLS model (G_E=0).          Parameters         ----------         G, Create pure vitrimer (G_P=0, G_D=0).          Parameters         ----------, Create partial vitrimer (G_D=0, Meng 2019).          Parameters         --------, Create neo-Hookean elastic solid (G_E=0, G_D=0).          Parameters         ---, Create single Maxwell fluid (G_P=0, G_E=0).          Parameters         --------, hvm_maxwell(), hvm_partial(), hvm_zener() (+20 more)
 
 ### Community 90 - "ndarray"
-Cohesion: 0.08
-Nodes (19): ndarray, Detect shear banding from constitutive curve.          Computes the steady-state, Compute Helmholtz free energy F(z) = U(z) - T*S(z).          The free energy fun, Extract Fourier harmonics from LAOS stress response.          Performs FFT analy, Compute Chebyshev decomposition of LAOS response.          Decomposes stress int, Compute internal energy U(z) from elastic storage.          The internal energy, Compute 3D Poisson bracket operator L(z) for dynamic x mode.          The 3x3 Po, Compute 3D friction matrix M(z) for dynamic x mode.          Block-diagonal stru (+11 more)
+Cohesion: 0.07
+Nodes (20): ndarray, Detect shear banding from constitutive curve.          Computes the steady-state, Predict flow in shear banding regime with lever rule.          When shear bandin, Compute Helmholtz free energy F(z) = U(z) - T*S(z).          The free energy fun, Extract Fourier harmonics from LAOS stress response.          Performs FFT analy, Compute Chebyshev decomposition of LAOS response.          Decomposes stress int, Compute internal energy U(z) from elastic storage.          The internal energy, Compute 3D Poisson bracket operator L(z) for dynamic x mode.          The 3x3 Po (+12 more)
 
 ### Community 91 - "prony_conversion.py"
-Cohesion: 0.05
-Nodes (47): Initialize transform service., CoxMerz, Cox-Merz rule validation.      Compares |η*(ω)| from oscillation data with η(γ̇), LVEEnvelope, Compute the linear viscoelastic startup stress envelope.      The LVE envelope p, _fit_prony_oscillation(), _fit_prony_relaxation(), _prony_to_frequency() (+39 more)
-
-### Community 92 - "TestCoerceBayesianInt"
-Cohesion: 0.09
-Nodes (10): _coerce_bayesian_int(), Any, Coerce a Bayesian config value to int with range validation.      The per-key li, Execute a load step via DataService.load_file.          Recognised config keys, Execute a transform step via TransformService.apply_transform.          Recognis, Execute a fit step via ModelService.fit.          Recognised config keys, Execute a Bayesian inference step via BayesianService.run_mcmc.          Recogni, Execute an export step via ExportService.          Recognised config keys (+2 more)
+Cohesion: 0.07
+Nodes (34): _fit_prony_oscillation(), _fit_prony_relaxation(), _prony_to_frequency(), _prony_to_frequency_jax(), _prony_to_time(), _prony_to_time_jax(), PronyConversion, PronyResult (+26 more)
 
 ### Community 93 - "ITTMCTBase"
 Cohesion: 0.06
 Nodes (29): ITTMCTBase, Any, ndarray, Initialize ITT-MCT base model.          Parameters         ----------         in, Initialize model parameters.          Subclasses must implement this to add para, Compute equilibrium (quiescent) correlator Φ_eq(t).          Parameters, Compute memory kernel m(Φ) from correlator values.          Parameters         -, Internal fit implementation.          Parameters         ----------         X : (+21 more)
 
 ### Community 94 - "test_fikh.py"
-Cohesion: 0.07
-Nodes (24): Any, ndarray, Predict complex modulus G* from parameter dictionary.          Internal method u, Predict stress using parameter dictionary.          This is the core prediction, Predict based on test_mode.          Args:             X: Input data (shape depe, Predict oscillatory response (SAOS G*, G', G'').          For small amplitudes,, Predict LAOS (Large Amplitude Oscillatory Shear) response.          Integrates o, Model function for NumPyro Bayesian inference.          This method provides a p (+16 more)
+Cohesion: 0.06
+Nodes (22): Unit tests for FIKH model.  Tests cover: - Model initialization with various con, Test FIKH limiting behavior as α → 1., Test that α → 1 gives exponential-like relaxation., Test that small α gives slower structure recovery., Test FIKH creep protocol predictions., Create isothermal FIKH model for creep tests., Test creep prediction produces valid output., Test that creep strain increases monotonically under constant stress. (+14 more)
 
 ### Community 95 - "get_template"
-Cohesion: 0.06
-Nodes (31): Namespace, CLI subcommand for pipeline management (init, validate, show).  Provides utiliti, Write a template YAML pipeline config., Validate a pipeline YAML config against the schema., run_init(), run_validate(), get_template(), list_templates() (+23 more)
+Cohesion: 0.08
+Nodes (21): get_template(), list_templates(), Path, YAML pipeline templates for ``rheojax pipeline init``.  Each template is a compl, Return the YAML string for a named template.      Args:         name: Template i, Return metadata for all available templates.      Returns:         List of dicts, Write a named template YAML to *output_path*.      Args:         name: Template, write_template() (+13 more)
 
 ### Community 96 - "FitResult"
-Cohesion: 0.05
-Nodes (24): FitResult, Any, Root mean squared error, delegated to OptimizationResult., Mean absolute error, delegated to OptimizationResult., Akaike Information Criterion, delegated to OptimizationResult., Bayesian Information Criterion, delegated to OptimizationResult., Alias for :attr:`success` (spec compatibility)., Alias for :attr:`n_data` (spec compatibility). (+16 more)
+Cohesion: 0.04
+Nodes (32): Exception, Build a :class:`FitResult` that records a failed fit attempt., FitResult, Any, ndarray, Root mean squared error, delegated to OptimizationResult., Mean absolute error, delegated to OptimizationResult., Akaike Information Criterion, delegated to OptimizationResult. (+24 more)
 
-### Community 97 - "TestModelIntegration"
-Cohesion: 0.25
-Nodes (5): Integration tests with actual model classes., Test FractionalZenerSolidSolid with smart initialization., Test FractionalKelvinVoigt with smart initialization., Test that smart initialization improves fit quality vs defaults., TestModelIntegration
+### Community 97 - "excel.py"
+Cohesion: 0.11
+Nodes (29): DataSegment, RheoData, Convert DataSegment to RheoData.      Args:         segment: Processed data segm, Processed data segment ready for RheoData conversion.      Represents data after, segment_to_rheodata(), _check_excel_dependencies(), detect_excel_header_row(), extract_units_from_excel() (+21 more)
 
 ### Community 98 - "MIKH"
 Cohesion: 0.06
 Nodes (24): MIKH, r"""Maxwell-Isotropic-Kinematic Hardening (MIKH) Model.      A thixotropic elast, Test NLSQ fitting for MIKH., NLSQ fitting for flow curve should converge., NLSQ fitting for startup should converge., NLSQ should recover parameters within reasonable bounds., Generate synthetic startup shear data., startup_data() (+16 more)
 
-### Community 99 - "__init__.py"
-Cohesion: 0.06
-Nodes (54): Unified analysis exporter for Pipeline results.  Bundles data, model parameters,, Unified file I/O for rheological data.  This module provides readers and writers, NumpyJSONEncoder, Any, Shared JSON encoder for numpy/JAX types.  Used by both analysis_exporter and npz, JSON encoder that handles numpy/JAX scalar and array types.      Handles:     -, _expand_glob(), _flatten_result() (+46 more)
+### Community 99 - "test_multi_file.py"
+Cohesion: 0.08
+Nodes (48): _expand_glob(), _flatten_result(), load_series(), load_srfs(), load_tts(), Any, Path, RheoData (+40 more)
 
 ### Community 100 - "TestHerschelBulkleyNumericalStability"
 Cohesion: 0.20
@@ -1322,11 +1283,11 @@ Nodes (6): Test numerical stability of Herschel-Bulkley model., Test with extrem
 
 ### Community 101 - "SPPDecomposer"
 Cohesion: 0.08
-Nodes (29): ndarray, RheoData, Initialize SPP decomposer transform.          Parameters         ----------, SPP decomposition transform for LAOS stress analysis.      Applies the Sequence, Get computed SPP analysis results.          Returns         -------         dict, Get static and dynamic yield stresses.          Returns         -------, Get nonlinearity quantification metrics.          Returns         -------, String representation of transform. (+21 more)
+Nodes (30): Execute SPP analysis on amplitude sweep data.          Args:             stress_, ndarray, RheoData, Initialize SPP decomposer transform.          Parameters         ----------, SPP decomposition transform for LAOS stress analysis.      Applies the Sequence, Get computed SPP analysis results.          Returns         -------         dict, Get static and dynamic yield stresses.          Returns         -------, Get nonlinearity quantification metrics.          Returns         ------- (+22 more)
 
-### Community 102 - "RheoData"
-Cohesion: 0.08
-Nodes (15): ndarray, RheoData, Execute SPP analysis on amplitude sweep data.          Args:             stress_, Get extracted yield stresses from amplitude sweep.          Returns:, Load datasets sequentially., Load datasets in parallel using threads (I/O-safe)., Merge multiple datasets with temperature metadata.          Args:             da, Apply horizontal shift to create mastercurve.          This implements a simplif (+7 more)
+### Community 102 - "MastercurvePipeline"
+Cohesion: 0.05
+Nodes (25): MastercurvePipeline, ndarray, RheoData, Initialize SPP amplitude sweep pipeline.          Args:             omega: Angul, Get extracted yield stresses from amplitude sweep.          Returns:, Load datasets sequentially., Load datasets in parallel using threads (I/O-safe)., Merge multiple datasets with temperature metadata.          Args:             da (+17 more)
 
 ### Community 103 - "VLB Model Equation Verification"
 Cohesion: 0.05
@@ -1334,35 +1295,35 @@ Nodes (40): 10. Creep Compliance, 11. Bell Model Force-Dependent Dissociation, 1
 
 ### Community 104 - "STZConventional"
 Cohesion: 0.02
-Nodes (96): ndarray, VariantType, Base class for STZ models.  Provides shared infrastructure for: 1. Parameter ini, Get initial state vector based on variant.          Args:             stress_ini, ODE vector field wrapper for Diffrax.          Delegates to the JAX-compiled ker, Base class for Shear Transformation Zone (STZ) models.      Implements the core, Initialize STZ Base Model.          Args:             variant: Complexity varian, Initialize ParameterSet based on selected variant. (+88 more)
+Nodes (95): ndarray, Get initial state vector based on variant.          Args:             stress_ini, ODE vector field wrapper for Diffrax.          Delegates to the JAX-compiled ker, Base class for Shear Transformation Zone (STZ) models.      Implements the core, STZBase, Any, VariantType, STZ Conventional Model Implementation.  This module implements the concrete Shea (+87 more)
 
 ### Community 105 - "GiesekusSingleMode"
-Cohesion: 0.01
-Nodes (122): GiesekusSingleMode, ndarray, Internal LAOS simulation for model_function., Simulate Large-Amplitude Oscillatory Shear (LAOS).          The Giesekus model p, Extract Fourier harmonics from LAOS stress response.          The nonlinear stre, Compute stress overshoot ratio in startup flow.          The overshoot ratio is, Get effective relaxation spectrum G(t).          Note: For single-mode Giesekus,, Initialize single-mode Giesekus model. (+114 more)
+Cohesion: 0.03
+Nodes (35): GiesekusSingleMode, Initialize single-mode Giesekus model., Single-mode Giesekus nonlinear viscoelastic model.      The Giesekus model exten, Test direct predict_flow_curve method., Test flow curve with viscosity and N1., Test viscosity decreases with shear rate., Test SAOS prediction., Test G' = G'' at crossover frequency. (+27 more)
 
 ### Community 106 - "PreprocessingResult"
 Cohesion: 0.08
 Nodes (36): check_kramers_kronig(), estimate_eta0(), fit_gel_point(), _preprocess_creep(), _preprocess_flow_curve(), preprocess_for_protocol(), _preprocess_laos(), _preprocess_oscillation() (+28 more)
 
 ### Community 107 - "percus_yevick_sk"
-Cohesion: 0.06
-Nodes (33): CubicSpline, Interpolator1D, Initialize k-grid and compute/interpolate S(k)., Compute MCT vertex function V(k,q)., create_sk_interpolator(), create_sk_interpolator_jax(), hard_sphere_properties(), interpolate_sk() (+25 more)
+Cohesion: 0.05
+Nodes (41): CubicSpline, Interpolator1D, Initialize k-grid and compute/interpolate S(k)., Compute MCT vertex function V(k,q)., create_sk_interpolator(), create_sk_interpolator_jax(), hard_sphere_properties(), interpolate_sk() (+33 more)
 
 ### Community 108 - "physics_checks.py"
 Cohesion: 0.07
 Nodes (37): Any, Run physics validation and emit warnings for violations.          Args:, Emitted for post-fit physics violations.      Examples: negative moduli, fractio, RheoJaxPhysicsWarning, _build_param_map(), _check_chebyshev_e1(), check_fit_physics(), _check_fractional_orders() (+29 more)
 
 ### Community 109 - "main"
-Cohesion: 0.13
-Nodes (10): create_parser(), main(), ArgumentParser, Dispatch pipeline management subcommands., Create argument parser for pipeline subcommand., Tests for rheojax.cli.cmd_pipeline — pipeline management subcommand., TestCreateParser, TestMainInit (+2 more)
+Cohesion: 0.10
+Nodes (18): create_parser(), main(), ArgumentParser, Namespace, CLI subcommand for pipeline management (init, validate, show).  Provides utiliti, Write a template YAML pipeline config., Validate a pipeline YAML config against the schema., Print a human-readable summary of a pipeline config. (+10 more)
 
 ### Community 110 - "Bingham"
-Cohesion: 0.04
-Nodes (46): Bingham, ndarray, RheoData, TestMode, Predict stress for given shear rates.          Args:             X: Shear rate d, Model function for Bayesian inference.          This method is required by Bayes, Compute shear stress using Bingham model.          Args:             gamma_dot:, Compute apparent viscosity using Bingham model.          Args:             gamma (+38 more)
+Cohesion: 0.15
+Nodes (10): Bingham, Bingham model for linear viscoplastic flow (ROTATION only).      The Bingham mod, Initialize Bingham model., Test that this is Herschel-Bulkley with n=1., Test basic stress prediction: σ = σ_y + η_p γ̇., Test that stress is zero below yield threshold., Test that σ_y = 0 reduces to Newtonian., Test apparent viscosity prediction. (+2 more)
 
 ### Community 111 - "GiesekusBase"
-Cohesion: 0.04
-Nodes (26): GiesekusBase, ndarray, Initialize ParameterSet with Giesekus parameters.          The Giesekus model ha, Get polymer viscosity η_p (Pa·s)., Get relaxation time λ (s)., Get solvent viscosity η_s (Pa·s)., Get zero-shear viscosity η₀ = η_p + η_s (Pa·s)., Get elastic modulus G = η_p/λ (Pa). (+18 more)
+Cohesion: 0.05
+Nodes (25): GiesekusBase, ndarray, Initialize ParameterSet with Giesekus parameters.          The Giesekus model ha, Get polymer viscosity η_p (Pa·s)., Get relaxation time λ (s)., Get solvent viscosity η_s (Pa·s)., Get zero-shear viscosity η₀ = η_p + η_s (Pa·s)., Get elastic modulus G = η_p/λ (Pa). (+17 more)
 
 ### Community 112 - "ITT-MCT Literature Review: Key Equations"
 Cohesion: 0.05
@@ -1370,31 +1331,31 @@ Nodes (37): 1.1 Density correlator, 1.2 Full MCT equation of motion (underdamped
 
 ### Community 113 - "get_default_workers"
 Cohesion: 0.09
-Nodes (26): Public API for parallel execution.  High-level convenience functions that hide p, configure(), get_default_workers(), get_parallel_config(), get_worker_isolation(), is_sequential_mode(), Any, Adaptive parallelism configuration.  Auto-detects optimal worker count based on (+18 more)
+Nodes (24): configure(), get_default_workers(), get_parallel_config(), get_worker_isolation(), is_sequential_mode(), Any, Adaptive parallelism configuration.  Auto-detects optimal worker count based on, Get full parallel configuration as dict.      Takes a snapshot of _overrides und (+16 more)
 
 ### Community 114 - "PipelineSidebar"
-Cohesion: 0.06
-Nodes (25): QPainter, QStyledItemDelegate, PipelineSidebar, Programmatically select a step by ID.          Parameters         ----------, Programmatically select the first step matching a step_type.          List items, Dispatch pipeline name update when editing finishes., Show right-click context menu for step list items.          Parameters         -, Remove a step from the pipeline.          Parameters         ---------- (+17 more)
+Cohesion: 0.03
+Nodes (44): QPainter, QSize, QStyledItemDelegate, QToolBar, get_icon(), MainToolBar, QIcon, QWidget (+36 more)
 
 ### Community 115 - "test_column_mapping.py"
 Cohesion: 0.08
-Nodes (42): CanonicalField, match_column(), match_columns(), Consolidated canonical column field registry for all I/O readers.  Merges patter, Canonical field descriptor for a rheological measurement column., Match a column header string to a CanonicalField.      Uses :func:`~rheojax.io.r, Match a list of column headers to canonical fields.      Parameters     --------, Tests for the consolidated canonical column field registry. (+34 more)
+Nodes (41): CanonicalField, match_column(), match_columns(), Canonical field descriptor for a rheological measurement column., Match a column header string to a CanonicalField.      Uses :func:`~rheojax.io.r, Match a list of column headers to canonical fields.      Parameters     --------, Tests for the consolidated canonical column field registry., test_canonical_field_is_dataclass() (+33 more)
 
 ### Community 116 - "LogConfig"
 Cohesion: 0.07
-Nodes (22): get_config(), LogConfig, Create configuration from environment variables.          Reads the following en, Get the effective log level for a logger.          Args:             logger_name, Get the current logging configuration.      Returns:         Current LogConfig i, RheoJAX logging configuration.      Attributes:         level: Global log level, Test from_env with custom log file., Test from_env with custom format. (+14 more)
+Nodes (20): LogConfig, Create configuration from environment variables.          Reads the following en, Get the effective log level for a logger.          Args:             logger_name, RheoJAX logging configuration.      Attributes:         level: Global log level, Validate configuration after initialization., Test from_env with custom log file., Test from_env with custom format., Test from_env with per-subsystem levels. (+12 more)
 
 ### Community 117 - "FractionalMaxwellModel"
-Cohesion: 0.04
-Nodes (62): Emitted when auto_p0 estimation partially fails.      Some parameters may have b, RheoJaxInitWarning, FractionalMaxwellModel, Fractional Maxwell Model: Two SpringPots in series with independent orders., Initialize Fractional Maxwell Model., FractionalZenerSolidSolid, ndarray, Initialize Fractional Zener Solid-Solid model. (+54 more)
+Cohesion: 0.02
+Nodes (110): Emitted when auto_p0 estimation partially fails.      Some parameters may have b, RheoJaxInitWarning, Cross, ndarray, RheoData, TestMode, Fit Cross parameters to data.          Args:             X: Shear rate data (γ̇), Predict viscosity for given shear rates.          Args:             X: Shear rat (+102 more)
 
 ### Community 118 - "get_stylesheet"
-Cohesion: 0.07
-Nodes (28): available_plot_styles(), load_plot_style(), GUI Resources ============  Loader helpers for stylesheets, plot styles, and ico, Return the list of bundled matplotlib style names., Load a matplotlib style file bundled with the GUI.      Falls back to the defaul, _generate_qss(), get_dark_stylesheet(), get_light_stylesheet() (+20 more)
+Cohesion: 0.11
+Nodes (15): get_dark_stylesheet(), get_light_stylesheet(), get_stylesheet(), Load and return the light theme stylesheet.      Returns     -------     str, Load and return the dark theme stylesheet.      Returns     -------     str, Get stylesheet by theme name.      Loads base.qss and substitutes tokens from th, Test stylesheet utilities import successfully.          Stylesheet functions sho, Test light stylesheet loads and has expected content. (+7 more)
 
 ### Community 119 - "local.py"
-Cohesion: 0.06
-Nodes (50): DMTBase, Base class for de Souza Mendes-Thompson (DMT) models.  Provides shared infrastru, Initialize ParameterSet with model parameters.          Parameters are added con, Get initial structure parameter value (fully structured).          Returns, Get all parameters as a dictionary.          Returns         -------         dic, Build base args dictionary for ODE integration.          Parameters         ----, Get human-readable description of the closure.          Returns         -------, Base class for DMT (de Souza Mendes-Thompson) thixotropic models.      Implement (+42 more)
+Cohesion: 0.09
+Nodes (39): consistency(), elastic_modulus(), equilibrium_structure(), invert_stress_for_gamma_dot_exponential(), invert_stress_for_gamma_dot_hb(), maxwell_stress_evolution(), ndarray, JIT-compiled kernels for DMT (de Souza Mendes-Thompson) models.  This module pro (+31 more)
 
 ### Community 120 - "MLIKH"
 Cohesion: 0.06
@@ -1405,8 +1366,8 @@ Cohesion: 0.07
 Nodes (23): ndarray, Internal relaxation simulation for model_function.          For constant breakag, Internal creep simulation for model_function.          Returns accumulated strai, Internal LAOS simulation for model_function.          Returns (strain, stress) a, Simulate startup flow at constant shear rate.          Parameters         ------, Simulate stress relaxation after cessation of steady shear.          For constan, Simulate creep deformation under constant stress.          Parameters         --, Simulate Large-Amplitude Oscillatory Shear (LAOS).          Parameters         - (+15 more)
 
 ### Community 122 - "test_dmt.py"
-Cohesion: 0.05
-Nodes (27): dmt_exponential(), dmt_herschel_bulkley(), dmt_nonlocal(), dmt_viscous(), Unit tests for DMT (de Souza Mendes-Thompson) models.  Tests cover: - Model crea, Tests for LAOS predict dispatch., model._predict(t, test_mode='laos') should not raise., Test fit() -> predict() through the public BaseModel API. (+19 more)
+Cohesion: 0.04
+Nodes (33): dmt_exponential(), dmt_herschel_bulkley(), dmt_nonlocal(), dmt_viscous(), Unit tests for DMT (de Souza Mendes-Thompson) models.  Tests cover: - Model crea, Viscous variant LAOS fit works., Tests for LAOS predict dispatch., model._predict(t, test_mode='laos') should not raise. (+25 more)
 
 ### Community 123 - "ndarray"
 Cohesion: 0.07
@@ -1416,61 +1377,61 @@ Nodes (20): Any, ndarray, Predict stress relaxation after flow cessation.       
 Cohesion: 0.09
 Nodes (14): _make_fit_result(), _make_optimization_result(), FitResult, Tests for FitResult, ModelInfo, and ModelComparison (Phase 1).  Tests cover: - F, Tests for summary and formatting methods., Tests for save/load round-trips., Smoke tests for plotting., Create a realistic OptimizationResult for testing. (+6 more)
 
-### Community 125 - "TestBootstrapCI"
-Cohesion: 0.06
-Nodes (22): fitted_maxwell(), fitted_maxwell_oscillation(), _maxwell_data(), _maxwell_oscillation_data(), ndarray, hessian_ci raises RuntimeError on an unfitted model., Tests for bootstrap_ci().  Marked slow for full suite runs., bootstrap_ci returns a dict keyed by parameter names. (+14 more)
-
-### Community 126 - "ModelComparisonPipeline"
+### Community 125 - "ndarray"
 Cohesion: 0.07
-Nodes (16): ModelComparisonPipeline, Pipeline for comparing multiple models on the same data.      This pipeline fits, Return name of best-fitting model.          Args:             metric: Metric to, Get comparison table of all models.          Returns:             Dictionary of, Tests for parallel model comparison., With only 1 model, parallel=True should not use pool., TestModelComparisonParallel, Test model comparison pipeline initialization. (+8 more)
+Nodes (17): ndarray, Internal LAOS simulation for model_function., Simulate Large-Amplitude Oscillatory Shear (LAOS).          The Giesekus model p, Extract Fourier harmonics from LAOS stress response.          The nonlinear stre, Compute stress overshoot ratio in startup flow.          The overshoot ratio is, Get effective relaxation spectrum G(t).          Note: For single-mode Giesekus,, Predict response using protocol-aware dispatch.          Parameters         ----, NumPyro/BayesianMixin model function.          Routes to appropriate prediction (+9 more)
+
+### Community 126 - ".success"
+Cohesion: 0.09
+Nodes (20): Whether the optimizer converged successfully., _is_placeholder_model(), Any, FitResult, ndarray, RheoData, Generate model predictions.          Parameters         ----------         model, Return True when the incoming name is a UI placeholder or empty. (+12 more)
 
 ### Community 127 - "HVMBase"
 Cohesion: 0.05
 Nodes (22): HVMBase, ndarray, Whether D-network is present., Permanent network modulus (Pa)., Exchangeable network modulus (Pa)., TST attempt frequency (1/s)., Activation energy for BER (J/mol)., Activation volume (m^3/mol). (+14 more)
 
-### Community 128 - "_yaml_runner.py"
+### Community 128 - "get_console"
 Cohesion: 0.08
-Nodes (28): Console, Progress, create_progress(), get_console(), print_error(), print_result(), print_success(), print_table() (+20 more)
+Nodes (27): Console, Progress, create_progress(), get_console(), print_error(), print_result(), print_success(), print_table() (+19 more)
 
 ### Community 129 - "Envelope"
 Cohesion: 0.08
 Nodes (19): create_data_envelope(), create_fit_envelope(), Envelope, _get_version(), Any, JSON envelope dataclass for stdin/stdout piping between CLI commands.  RheoJAX C, Read an envelope from stdin if stdin is not a terminal.          Returns:, Write the envelope as JSON to stdout.          The newline ensures downstream pr (+11 more)
 
 ### Community 130 - "main"
-Cohesion: 0.09
-Nodes (22): main(), Run Bayesian inference from CLI., cli_entry(), create_main_parser(), main(), ArgumentParser, RheoJAX CLI main entry point.  This module provides the main CLI dispatcher for, Display package information. (+14 more)
+Cohesion: 0.06
+Nodes (30): create_parser(), main(), ArgumentParser, Run Bayesian inference from CLI., Create argument parser for bayesian subcommand., main(), Run NLSQ fit from CLI., cli_entry() (+22 more)
 
-### Community 131 - ".fit_bayesian"
-Cohesion: 0.08
-Nodes (22): Any, Array, BayesianResult, MCMC, ndarray, RheoData, TestMode, Perform Bayesian inference using NumPyro NUTS sampler.          Runs NUTS (No-U- (+14 more)
+### Community 131 - "BayesianMixin"
+Cohesion: 0.03
+Nodes (81): BayesianMixin, compute_diagnostics(), compute_per_param_diagnostic(), _import_numpyro_diagnostics(), MCMC, ndarray, Bayesian convergence diagnostics: R-hat, ESS, divergence counting.  This module, Compute convergence diagnostics from MCMC samples.      Args:         mcmc: NumP (+73 more)
 
-### Community 132 - "_base.py"
-Cohesion: 0.05
-Nodes (28): ndarray, Base class for HVNM (Hybrid Vitrimer Nanocomposite Model).  Provides shared in, Interphase volume fraction (from NP geometry)., Effective NP volume fraction (with glassy layer)., Guth-Gold strain amplification X(phi) for P-network., Strain amplification for I-network X(phi_eff)., Effective interphase modulus G_I = beta_I * G_E * phi_I (Pa)., Generate dual Arrhenius plot data for both BER rates.          Parameters (+20 more)
+### Community 132 - "TestHVNMInterphase"
+Cohesion: 0.15
+Nodes (5): Test interphase physics and NP geometry., Verify Guth-Gold formula at known values., Matrix and interphase BER rates should differ (different E_a)., T_v^int > T_v^mat when E_a^int > E_a^mat., TestHVNMInterphase
 
 ### Community 133 - "load_npz"
 Cohesion: 0.10
 Nodes (38): _decode_str(), _encode_str(), load_npz(), Any, ndarray, Path, RheoData, NumPy .npz writer/reader for RheoData objects. (+30 more)
 
 ### Community 134 - "SmoothDerivative"
-Cohesion: 0.05
-Nodes (35): DerivativeMethod, JaxArray, RheoData, Initialize Smooth Derivative transform.          Parameters         ----------, Apply moving average smoothing.          Parameters         ----------         y, Compute derivative using Savitzky-Golay filter.          Parameters         ----, Compute derivative using finite differences.          Parameters         -------, Compute derivative using JIT-safe cubic splines via interpax.          Parameter (+27 more)
+Cohesion: 0.07
+Nodes (23): Smooth noise-robust numerical differentiation.      This transform computes deri, SmoothDerivative, Tests for batch transform vectorization., TestBatchSmoothDerivative, Test derivative on noisy data., Test different differentiation methods., Test suite for Smooth Derivative transform., Test inverse transform (integration). (+15 more)
 
 ### Community 135 - "WorkerPool"
-Cohesion: 0.08
-Nodes (22): Any, Create or return singleton instance., Get the singleton WorkerPool instance.          Parameters         ----------, Reset the singleton instance (useful for testing)., Request cancellation of a job.          Parameters         ----------         jo, Perform the (possibly blocking) cancel call for an already-resolved worker/token, Cancel all active jobs.          Requests cancellation for every currently runni, Check if any jobs are running.          Returns         -------         bool (+14 more)
+Cohesion: 0.05
+Nodes (30): Any, QObject, QRunnable, Qt, QThreadPool, Worker Pool ==========  Thread pool for executing background jobs with progress, Create or return singleton instance., Get the singleton WorkerPool instance.          Parameters         ---------- (+22 more)
 
 ### Community 136 - "._predict"
-Cohesion: 0.08
-Nodes (16): Array, JIT-compiled creep prediction: J(t).          Theory: J(t) ~ t^(x-1) for x > 1 (, JIT-compiled steady shear prediction: sigma(gamma_dot).          Theory:, JIT-compiled startup flow prediction: eta_plus(t).          Computes stress grow, JIT-compiled oscillation prediction: G'(omega), G''(omega).          Uses same k, JIT-compiled relaxation prediction: G(t).          Uses power-law form consisten, JIT-compiled viscosity prediction: eta(gamma_dot).          Computes viscosity a, Predict based on fitted test mode.          Routes to appropriate prediction met (+8 more)
+Cohesion: 0.12
+Nodes (9): JIT-compiled startup flow prediction: eta_plus(t).          Computes stress grow, JIT-compiled oscillation prediction: G'(omega), G''(omega).          Uses same k, Predict based on fitted test mode.          Routes to appropriate prediction met, Predict complex modulus in oscillation mode.          Args:             omega: A, Predict relaxation modulus in relaxation mode.          Args:             t: Tim, Predict creep compliance J(t)., Predict startup stress growth coefficient eta_plus(t)., Simulate LAOS response for given strain amplitude and frequency.          Genera (+1 more)
 
 ### Community 137 - "__init__.py"
-Cohesion: 0.08
-Nodes (40): RheoJAX Logging Configuration.  Centralized configuration management for the Rhe, Reset logging configuration to defaults.      Primarily useful for testing., reset_config(), log_bayesian(), log_gui_action(), log_io(), log_operation(), log_pipeline_stage() (+32 more)
+Cohesion: 0.07
+Nodes (44): Reset logging configuration to defaults.      Primarily useful for testing., reset_config(), log_bayesian(), log_gui_action(), log_operation(), log_pipeline_stage(), log_transform(), Any (+36 more)
 
 ### Community 138 - "extract_frequency_features"
-Cohesion: 0.07
-Nodes (32): extract_frequency_features(), ndarray, Template method defining initialization algorithm.          This method enforces, Extract features from frequency-domain complex modulus data.      Analyzes frequ, create_mock_param_set(), MockInitializer, Unit tests for BaseInitializer template method pattern.  Tests verify: - Templat, Test feature extraction with complex modulus data. (+24 more)
+Cohesion: 0.05
+Nodes (36): extract_frequency_features(), ndarray, Template method defining initialization algorithm.          This method enforces, Common validation logic for extracted features.          Parameters         ----, Estimate all model-specific parameters from frequency features.          Subclas, Clip estimated parameters to their defined bounds.          Common logic to ensu, Extract features from frequency-domain complex modulus data.      Analyzes frequ, Set clipped parameters in the ParameterSet.          Subclasses implement this m (+28 more)
 
 ### Community 139 - "ColumnMappingPage"
 Cohesion: 0.03
@@ -1488,17 +1449,13 @@ Nodes (41): 1. Initialize Store and Signals, 2. Connect Signal Handlers, 3. Load
 Cohesion: 0.05
 Nodes (40): type, description, type, properties, required, type, type, type (+32 more)
 
-### Community 143 - "formatters.py"
-Cohesion: 0.08
-Nodes (26): Colors, DetailedFormatter, get_formatter(), JSONFormatter, Any, Formatter, LogRecord, RheoJAX Log Formatters.  Custom formatters for human-readable, detailed, JSON, a (+18 more)
-
-### Community 144 - "FluiditySaramitoNonlocal"
-Cohesion: 0.05
-Nodes (35): Fluidity Models for yield-stress fluids.  This package provides fluidity-based c, FluiditySaramitoBase, Get initial fluidity value based on waiting time.          For aged samples (t_w, Get effective yield stress based on coupling mode.          Parameters         -, Base class for Fluidity-Saramito EVP models.      Implements shared parameter ma, Get characteristic relaxation time λ = 1/(G*f_age).          This is the relaxat, Get Deborah number De = λ * ω (for oscillatory tests).          Returns, Get Weissenberg number Wi = λ * γ̇ (for steady/startup tests).          Returns (+27 more)
+### Community 143 - "DetailedFormatter"
+Cohesion: 0.10
+Nodes (16): DetailedFormatter, JSONFormatter, Any, LogRecord, Format a value for log output.          Args:             value: Value to format, Detailed format with file/line info for debugging.      Format: YYYY-MM-DD HH:MM, Initialize the formatter.          Args:             colorize: Enable ANSI color, Format timestamp with true microsecond precision.          Args:             rec (+8 more)
 
 ### Community 145 - "Mastercurve"
 Cohesion: 0.02
-Nodes (78): Mastercurve, ndarray, RheoData, Optimize WLF parameters to minimize overlap error.          Parameters         -, Initialize Mastercurve transform.          Parameters         ----------, Calculate WLF shift factor.          Parameters         ----------         T : f, Calculate Arrhenius shift factor.          Parameters         ----------, Detect and remove outliers (first point) if it improves fit.          Following (+70 more)
+Nodes (79): Mastercurve, ndarray, Initialize Mastercurve transform.          Parameters         ----------, Detect and remove outliers (first point) if it improves fit.          Following, Compute shift factor between two adjacent curves via intersection.          Uses, Compute automatic shift factors via sequential pairwise power-law intersection., Time-Temperature Superposition (TTS) mastercurve generation.      This transform, Get automatic shift factors as arrays for plotting.          Returns         --- (+71 more)
 
 ### Community 146 - "TestThermodynamicConsistency"
 Cohesion: 0.14
@@ -1510,23 +1467,23 @@ Nodes (21): Phase 2 Performance Benchmarking (Task 16.4)  Benchmarks for JAX-pow
 
 ### Community 148 - "QWidget"
 Cohesion: 0.02
-Nodes (117): FigureCanvasQTAgg, QFrame, QGroupBox, QLayout, QPushButton, QSplitter, QStackedWidget, QTableWidget (+109 more)
+Nodes (115): FigureCanvasQTAgg, QFrame, QGroupBox, QLayout, QPushButton, QSplitter, QStackedWidget, QTableWidget (+107 more)
 
 ### Community 149 - "ModelComparison"
-Cohesion: 0.11
-Nodes (11): ModelComparison, Plot the fit result (2-panel: fit + residuals).          Args:             ax: O, Comparison of multiple model fit results.      Ranks models by an information cr, Compute rankings and Akaike weights from results., Return model names sorted by rank (best first)., Human-readable summary table.          Returns:             Formatted string wit, Bar plot of Akaike weights.          Args:             ax: Optional matplotlib a, Test ModelComparison rankings. (+3 more)
+Cohesion: 0.08
+Nodes (14): ModelComparison, Plot the fit result (2-panel: fit + residuals).          Args:             ax: O, Comparison of multiple model fit results.      Ranks models by an information cr, Compute rankings and Akaike weights from results., Return model names sorted by rank (best first)., Human-readable summary table.          Returns:             Formatted string wit, Bar plot of Akaike weights.          Args:             ax: Optional matplotlib a, Tests for FitResult, ModelInfo, and ModelComparison. (+6 more)
 
 ### Community 150 - "TestFractionalZenerSolidLiquid"
 Cohesion: 0.05
-Nodes (21): Test limit case: alpha → 0 (purely elastic)., Test limit case: alpha → 1 (classical viscoelastic)., Test that G' and G'' satisfy physical constraints., Test that model works across wide range of time scales., Test that model is sensitive to parameter changes., Test that prediction functions can be JIT compiled., Test suite for FZSL model., Test vectorization with vmap. (+13 more)
+Nodes (20): Test limit case: alpha → 0 (purely elastic)., Test limit case: alpha → 1 (classical viscoelastic)., Test that G' and G'' satisfy physical constraints., Test that model works across wide range of time scales., Test that model is sensitive to parameter changes., Test that prediction functions can be JIT compiled., Test suite for FZSL model., Test vectorization with vmap. (+12 more)
 
 ### Community 151 - "ndarray"
-Cohesion: 0.14
-Nodes (12): ndarray, Predict SAOS moduli (Maxwell, analytical).          In the linear regime, Bell r, Predict steady-state first normal stress difference N1.          For Bell breaka, Simulate startup shear.          Parameters         ----------         t : np.nd, Simulate stress relaxation after cessation of flow.          Parameters, Simulate creep (stress-controlled).          Parameters         ----------, Simulate Large Amplitude Oscillatory Shear (LAOS).          Parameters         -, Predict steady-state extensional stress.          For FENE-P, extensional stress (+4 more)
+Cohesion: 0.10
+Nodes (19): ndarray, Predict SAOS moduli (Maxwell, analytical).          In the linear regime, Bell r, Predict steady-state first normal stress difference N1.          For Bell breaka, Simulate startup shear.          Parameters         ----------         t : np.nd, Simulate stress relaxation after cessation of flow.          Parameters, Simulate creep (stress-controlled).          Parameters         ----------, Simulate Large Amplitude Oscillatory Shear (LAOS).          Parameters         -, Predict steady-state extensional stress.          For FENE-P, extensional stress (+11 more)
 
 ### Community 152 - "test_spp_kernels.py"
-Cohesion: 0.14
-Nodes (14): Unit tests for SPP JAX kernels.  These tests exercise the lightweight analytical, Generate a simple LAOS waveform with optional 3rd harmonic., num_mode=2 (periodic) should smooth boundary artifacts compared to mode 1., Phase-aligned reconstruction should preserve signal phase., Numerical analysis should include Gp_t_dot, Gpp_t_dot, G_speed, delta_t_dot., Numerical analysis should accept per-sample omega and keep shapes stable., _synthetic_laos(), test_apparent_cage_modulus_matches_modulus_in_linear_regime() (+6 more)
+Cohesion: 0.05
+Nodes (35): Unit tests for SPP JAX kernels.  These tests exercise the lightweight analytical, Test periodic differentiation on a complete period., Larger step sizes should provide smoother derivatives., Test 4th-order derivative of sin(t) matches cos(t)., Test 4th-order second derivative of sin(t) matches -sin(t)., Test 4th-order third derivative of sin(t) matches -cos(t)., Phase offset should be near zero for pure sine wave., Phase offset should be nonzero for pure cosine wave. (+27 more)
 
 ### Community 153 - "TestFrameworkSmoke"
 Cohesion: 0.05
@@ -1536,41 +1493,41 @@ Nodes (27): ndarray, Smoke tests validating the test framework itself., Verify a
 Cohesion: 0.10
 Nodes (16): Any, DataFrame, Exception, Path, RheoData, Process all files in directory matching pattern.          Args:             dire, Pre-load files in parallel using threads (I/O only, thread-safe).          Retur, Process single file with pipeline.          Args:             file_path: Path to (+8 more)
 
-### Community 155 - "test_metrics.py"
-Cohesion: 0.16
-Nodes (19): bfmi(), param_uncertainties(), Result Metrics ==============  Pure numerical functions for post-fit quality met, Reduced chi-squared goodness-of-fit statistic.      Parameters     ----------, Parameter 1-sigma uncertainties from a covariance matrix.      Parameters     --, Energy Bayesian Fraction of Missing Information (E-BFMI).      Computed as ``mea, reduced_chi_squared(), Subprocess Fit =============  Pure function for NLSQ fitting in a child process. (+11 more)
+### Community 155 - "run_fit_isolated"
+Cohesion: 0.08
+Nodes (34): bfmi(), param_uncertainties(), Result Metrics ==============  Pure numerical functions for post-fit quality met, Reduced chi-squared goodness-of-fit statistic.      Parameters     ----------, Parameter 1-sigma uncertainties from a covariance matrix.      Parameters     --, Energy Bayesian Fraction of Missing Information (E-BFMI).      Computed as ``mea, reduced_chi_squared(), Subprocess Bayesian ==================  Pure function for NUTS Bayesian sampling (+26 more)
 
 ### Community 156 - "test_epm_kernels.py"
-Cohesion: 0.12
-Nodes (29): compute_plastic_strain_rate(), epm_step(), make_propagator_q(), Array, Kernels for Elasto-Plastic Models (EPM).  This module implements the core physic, Renew yield thresholds for active sites.      Args:         key: PRNG Key., Perform one full EPM time step.      Dynamics:     sigma_dot = mu * gamma_dot -, Create the quadrupolar Eshelby propagator in Fourier space.      G(q) = -2 * mu (+21 more)
-
-### Community 157 - "TestInstantiation"
 Cohesion: 0.09
-Nodes (12): Test stretch_creation breakage variant adds kappa., Test Bell + FENE combined variant has correct parameters., Tests for model instantiation and parameters., Test model instantiates with default parameters., Test parameters can be set., Test derived properties are computed correctly., Test Weissenberg and Deborah number computations., Test constant breakage model has exactly 3 parameters. (+4 more)
+Nodes (33): Array, Perform one scalar EPM time step.          Delegates to the `epm_step` kernel fr, Initialize the Lattice EPM.          See ``EPMBase.__init__`` for the descriptio, Initialize scalar stress field.          Args:             key: PRNG key (unused, compute_plastic_strain_rate(), epm_step(), make_propagator_q(), Array (+25 more)
+
+### Community 157 - "TNTSingleMode"
+Cohesion: 0.07
+Nodes (20): Single-mode Transient Network Theory model.      Implements the Green-Tobolsky /, Get network modulus G (Pa)., Get bond lifetime τ_b (s)., Get solvent viscosity η_s (Pa·s)., Get zero-shear viscosity η₀ = G·τ_b + η_s (Pa·s)., Get slip parameter ξ., Whether this is the basic (constant/linear/UC) variant., TNTSingleMode (+12 more)
 
 ### Community 158 - "FFTAnalysis"
-Cohesion: 0.06
-Nodes (28): FFTAnalysis, JaxArray, RheoData, Get window function of length n.          Parameters         ----------, Remove linear trend from data.          Parameters         ----------         y, Apply FFT transform to time-domain data.          Parameters         ----------, Apply inverse FFT to return to time domain.          Parameters         --------, Transform time-domain rheological data to frequency domain using FFT.      This (+20 more)
+Cohesion: 0.08
+Nodes (20): FFTAnalysis, Transform time-domain rheological data to frequency domain using FFT.      This, Initialize FFT Analysis transform.          Parameters         ----------, TestBatchFFT, Test round-trip FFT → inverse FFT., Test detrending functionality., Test suite for FFT Analysis transform., Test peak finding in FFT spectrum. (+12 more)
 
-### Community 159 - "test_sgr_parity.py"
+### Community 159 - "set_params"
+Cohesion: 0.08
+Nodes (19): Test banded flow prediction matches between models., Parity tests for LAOS analysis., Test I3/I1 harmonic ratio matches within 2% tolerance., Test fundamental amplitude I1 matches between models., Test Chebyshev coefficients match between models., Parity tests for thixotropic stress transients., Test stress transient matches within 5% tolerance., Test lambda evolution matches between models. (+11 more)
+
+### Community 160 - "test_bayesian.py"
 Cohesion: 0.07
-Nodes (28): laos_params(), Parity tests: SGRGeneric vs SGRConventional feature comparison.  This module v, Test banded flow prediction matches between models., Parity tests for LAOS analysis., Test I3/I1 harmonic ratio matches within 2% tolerance., Test fundamental amplitude I1 matches between models., Test Chebyshev coefficients match between models., Parity tests for thixotropic stress transients. (+20 more)
-
-### Community 160 - "TestMultiModeBayesian"
-Cohesion: 0.50
-Nodes (3): Tests for multi-mode Bayesian fitting., Test multi-mode Bayesian on SAOS data., TestMultiModeBayesian
+Nodes (19): Tests for Giesekus Bayesian inference pipeline.  Tests cover: - NLSQ fitting, Tests for credible interval extraction., Test 95% credible interval extraction., Test that 95% CI contains true value (statistical test)., Tests for mode-aware Bayesian inference (v0.4.0 fix)., Test that test_mode is correctly captured for Bayesian., Tests for multi-mode Bayesian fitting., Test multi-mode Bayesian on SAOS data. (+11 more)
 
 ### Community 161 - "Registry"
 Cohesion: 0.01
-Nodes (275): PluginInfo, PluginType, Any, Unregister a transform.          Args:             name: Name of the transform t, Register a plugin in the registry.          Args:             name: Unique name, Validate that a plugin implements the required interface.          Args:, Retrieve a registered plugin class.          Args:             name: Name of the, Get full information about a registered plugin.          Args:             name: (+267 more)
+Nodes (135): PluginInfo, PluginType, Any, Register a plugin in the registry.          Args:             name: Unique name, Validate that a plugin implements the required interface.          Args:, Retrieve a registered plugin class.          Args:             name: Name of the, Get full information about a registered plugin.          Args:             name:, Get list of all registered transform names.          Returns:             List o (+127 more)
 
 ### Community 162 - "BayesianOptionsDialog"
-Cohesion: 0.03
-Nodes (45): QDialog, AboutDialog, QWidget, Handle dialog show event., Handle link clicks.          Parameters         ----------         url : QUrl, About dialog with version info.      Content:         - RheoJAX version and logo, Initialize about dialog.          Parameters         ----------         parent :, Set up user interface. (+37 more)
+Cohesion: 0.05
+Nodes (32): BayesianOptionsDialog, Any, QWidget, Bayesian Options Dialog ======================  Configure NUTS sampling paramete, Load current options into UI., Handle sampler combo box change., Handle option change., Handle target accept rate slider change. (+24 more)
 
 ### Community 163 - "test_single_mode.py"
-Cohesion: 0.06
-Nodes (30): Tests for GiesekusSingleMode model.  Tests cover: - Instantiation and paramet, Tests for SAOS predictions., Tests for normal stress predictions., Tests for model instantiation and parameters., Tests for startup flow simulation., Tests for stress relaxation simulation., Tests for creep simulation., Tests for LAOS simulation. (+22 more)
+Cohesion: 0.07
+Nodes (26): Tests for GiesekusSingleMode model.  Tests cover: - Instantiation and paramet, Tests for SAOS predictions., Tests for normal stress predictions., Tests for startup flow simulation., Tests for stress relaxation simulation., Tests for creep simulation., Tests for LAOS simulation., Tests for model registry integration. (+18 more)
 
 ### Community 164 - "PriorsEditor"
 Cohesion: 0.08
@@ -1581,28 +1538,28 @@ Cohesion: 0.08
 Nodes (13): Update the selected pipeline step's config when transform selection changes., Handle set test mode action., Handle model selection., Connect state signals to UI updates., Connect File menu actions., Connect Edit menu actions., Connect Data menu actions., Connect Models menu actions. (+5 more)
 
 ### Community 166 - "save_excel"
-Cohesion: 0.08
-Nodes (29): _create_parameters_dataframe(), _create_predictions_dataframe(), _create_quality_dataframe(), _create_residuals_dataframe(), _embed_plots(), Any, ndarray, Path (+21 more)
+Cohesion: 0.05
+Nodes (42): Any, Figure, Path, RheoData, Export figure to file.          Parameters         ----------         fig : Figu, Convert metadata values to JSON-serializable types., Export posterior samples.          Parameters         ----------         result, Save project as .rheojax file (ZIP with JSON + HDF5).          Parameters (+34 more)
 
 ### Community 167 - ".globalInstance"
-Cohesion: 0.08
-Nodes (12): Any, Handle import data action., Load the file on a background thread (R8-NEW-003).          The previous ``QTime, Execute all pipeline steps in sequence on a background thread.          Pipeline, Execute a single pipeline step with accumulated context.          Builds context, Route DatasetTree context menu actions to the appropriate handler.          R13-, Handle new dataset action., Handle delete dataset action. (+4 more)
+Cohesion: 0.10
+Nodes (12): Any, Execute all pipeline steps in sequence on a background thread.          Pipeline, Execute a single pipeline step with accumulated context.          Builds context, Handle auto-detect test mode action., Run test-mode statistical detection on a background thread.          R6-GUI-006, Handle batch fit action — opens the BatchPanel dialog., Execute the current pipeline for each file in the batch.          For each file,, qapp() (+4 more)
 
-### Community 168 - "TestOWChirp"
-Cohesion: 0.08
-Nodes (14): Test OWChirp on LAOS-like signal with multiple harmonics., Test full time-frequency map extraction., Test automatic detection of fundamental frequency., Test suite for OWChirp transform., Test that wavelet transform is consistent., Test that OWChirp raises error for frequency-domain input., Test handling of complex input data., Test basic OWChirp initialization. (+6 more)
+### Community 168 - "device.py"
+Cohesion: 0.12
+Nodes (23): check_gpu_availability(), check_plugin_conflicts(), get_device_info(), get_gpu_info(), get_gpu_memory_info(), get_recommended_package(), get_system_cuda_version(), print_device_summary() (+15 more)
 
 ### Community 169 - "test_priors.py"
 Cohesion: 0.08
 Nodes (34): adapt_prior(), map_centered_priors(), Prior format conversion utilities.  Converts between PriorsEditor's ``{"distribu, Convert one PriorsEditor entry to the ``prior_dict_to_dist`` format.      Parame, Build LogNormal priors centered on MAP values plus a HalfNormal sigma prior., Tests for rheojax.gui.foundation.priors., Negative MAP value uses abs() so loc = log(|val|)., Empty MAP estimate → only sigma key. (+26 more)
 
-### Community 170 - "SpectrumInversion"
-Cohesion: 0.07
-Nodes (33): _assemble_target(), _build_kernel(), _max_entropy_inversion(), Any, ndarray, RheoData, Relaxation spectrum inversion transform.  Recovers the continuous relaxation spe, Build the kernel matrix A for the linear inverse problem A @ H ≈ b.      The tar (+25 more)
+### Community 170 - "._transform"
+Cohesion: 0.19
+Nodes (14): _assemble_target(), _build_kernel(), _max_entropy_inversion(), Any, ndarray, RheoData, Build the kernel matrix A for the linear inverse problem A @ H ≈ b.      The tar, Assemble the target vector b from measurement data. (+6 more)
 
-### Community 171 - ".keys"
-Cohesion: 0.09
-Nodes (12): Add a shared parameter.          Args:             name: Parameter name, Set shared parameter value.          Args:             name: Parameter name, Validate value against all constraints.          Args:             value: Value, Add a parameter to the set.          Args:             name: Parameter name, Set parameter value.          Args:             name: Parameter name, Set bounds for a parameter.          Args:             name: Parameter name, Get all parameter values as array.          Returns:             Array of parame, Get bounds for all parameters.          Returns:             List of (min, max) (+4 more)
+### Community 171 - "test_physics.py"
+Cohesion: 0.07
+Nodes (19): Physical validation tests for Giesekus model.  Tests verify that the implement, Tests for physical diagnostic relationships., Test N₂/N₁ → -α/2 at low Wi (zero-shear limit).          In the zero-shear lim, Tests for stress relaxation physics., Test stress decays to zero during relaxation., Test Giesekus relaxes faster than pure exponential.          The quadratic τ·τ, Tests for normal stress physics., Test N₁ increases with shear rate (roughly quadratically at low Wi). (+11 more)
 
 ### Community 172 - "RheoJAX GUI Smoke Tests"
 Cohesion: 0.06
@@ -1612,25 +1569,25 @@ Nodes (35): Adding New Tests, All GUI smoke tests, Architecture, CI/CD Integrati
 Cohesion: 0.11
 Nodes (14): PipelineChips, QLabel, Create a chip button for a pipeline step.          Parameters         ----------, Handle chip click.          Parameters         ----------         step : Pipelin, Create an arrow connector between chips.          Returns         -------, Set the status of a pipeline step.          Parameters         ----------, Reset all chips to pending status., Reset all chips to pending status.          Convenience alias for ``reset_all()` (+6 more)
 
-### Community 174 - "TestModeDetection"
+### Community 174 - "ndarray"
 Cohesion: 0.08
-Nodes (13): Test ambiguous case returns unknown., Test detection with complex modulus data., Test that RheoData.test_mode property works correctly., Test automatic test mode detection., Test that detection works with JAX arrays., Test relaxation detection with monotonic decreasing stress., Test creep detection with monotonic increasing strain., Test oscillation detection with frequency-domain data. (+5 more)
+Nodes (15): Vectorized SAOS moduli over frequency array.      Parameters     ----------, vlb_saos_moduli_vec(), ndarray, Predict response using protocol-aware dispatch.          Parameters         ----, NumPyro/BayesianMixin model function.          Routes to appropriate prediction, Internal LAOS simulation for model_function.          Returns (strain, stress) a, Predict steady shear stress (and optionally viscosity, N1).          Newtonian:, Predict SAOS storage and loss moduli.          Parameters         ---------- (+7 more)
 
-### Community 175 - "ParameterConstraint"
-Cohesion: 0.12
-Nodes (13): ParameterConstraint, Validate parameter after initialization., Constraint on a parameter value., Check if value satisfies the constraint.          Args:             value: Value, Test applying multiple constraints., Test parameter constraint system., Test bounds constraints on parameters., Test positive value constraint. (+5 more)
+### Community 175 - "TRIOSExperiment"
+Cohesion: 0.09
+Nodes (14): DataFrame, Root container for TRIOS JSON experiment data.      Represents the complete expe, Extract DataFrame from specified result set.          Args:             result_i, Split result DataFrame by step column.          Args:             result_index:, Get units mapping from specified result.          Args:             result_index, Get DataFrames from all results.          Returns:             List of DataFrame, Get experiment name from properties., Get experiment date from properties. (+6 more)
 
 ### Community 176 - "ndarray"
-Cohesion: 0.07
-Nodes (22): _loop_bridge_creep_ode_rhs(), _loop_bridge_laos_ode_rhs(), _loop_bridge_ode_rhs(), _loop_bridge_relaxation_ode_rhs(), ndarray, ODE right-hand side for loop-bridge dynamics.      State: [f_B, S_xx, S_yy, S_zz, Compute steady-state [f_B, S] via ODE.          Returns array of shape (N, 5) wi, Predict steady shear stress and viscosity.          Parameters         --------- (+14 more)
+Cohesion: 0.08
+Nodes (15): ndarray, Compute steady-state [f_B, S] via ODE.          Returns array of shape (N, 5) wi, Internal relaxation simulation for model_function.          Returns relaxing str, Predict steady shear stress and viscosity.          Parameters         ---------, Predict SAOS storage and loss moduli.          In the linear regime, loop-bridge, Predict first and second normal stress differences.          N₁ = f_B·G·(S_xx -, Simulate startup flow at constant shear rate.          Parameters         ------, Simulate stress relaxation after cessation of steady shear.          Parameters (+7 more)
 
 ### Community 177 - "ndarray"
 Cohesion: 0.08
 Nodes (18): ndarray, Simulate startup flow at constant shear rate.          Parameters         ------, Simulate stress relaxation after cessation of steady shear.          Analytical, Simulate creep deformation under constant stress.          Parameters         --, Simulate Large-Amplitude Oscillatory Shear (LAOS).          Parameters         -, Get relaxation modulus G(t).          For multi-species TNT: G(t) = Σ G_i·exp(-t, Extract Fourier harmonics from LAOS stress response.          Parameters, Return string representation. (+10 more)
 
 ### Community 178 - "GeneralizedMaxwell"
-Cohesion: 0.02
-Nodes (105): GeneralizedMaxwell, ndarray, Fit GMM to creep compliance data.          Args:             t: Time array, Initialize Generalized Maxwell Model.          Args:             n_modes: Number, Internal creep prediction for optimization.          Args:             t: Time a, Predict based on fitted test mode.          Args:             X: Independent var, JIT-compiled relaxation prediction.          Args:             t: Time array, Predict relaxation modulus E(t).          Args:             t: Time array (+97 more)
+Cohesion: 0.01
+Nodes (187): Number of data points used in the fit., GeneralizedMaxwell, ndarray, Fit GMM to creep compliance data.          Args:             t: Time array, Internal creep prediction for optimization.          Args:             t: Time a, Predict based on fitted test mode.          Args:             X: Independent var, JIT-compiled relaxation prediction.          Args:             t: Time array, Predict relaxation modulus E(t).          Args:             t: Time array (+179 more)
 
 ### Community 179 - "test_notebook_execution_consistency.py"
 Cohesion: 0.12
@@ -1654,31 +1611,31 @@ Nodes (32): 10. Benchmark Results for Numerical Verification, 10a. Flow curve sh
 
 ### Community 184 - ".navigate_to"
 Cohesion: 0.09
-Nodes (12): Path, Handle opening a recent project from the home page., Dispatch a successful import on the main thread (via relay)., Handle export action., Navigate to the workspace page matching the sidebar step selection.          The, Open a pipeline from a YAML file., Save the current pipeline to a YAML file., Simple command palette to trigger common actions. (+4 more)
+Nodes (13): Path, Handle opening a recent project from the home page., Dispatch a successful import on the main thread (via relay)., Handle export action., Navigate to the workspace page matching the sidebar step selection.          The, Open a pipeline from a YAML file., Save the current pipeline to a YAML file., Register application-wide shortcuts and command palette. (+5 more)
 
-### Community 185 - ".add_plot"
-Cohesion: 0.11
-Nodes (10): Any, Figure, Get matplotlib figure.          Returns         -------         Figure, Add or replace figure in a panel.          Parameters         ----------, Set title for a panel.          Parameters         ----------         index : in, Get panel by index.          Parameters         ----------         index : int, Get figure from panel.          Parameters         ----------         index : in, Refresh all panel canvases. (+2 more)
+### Community 185 - "ParameterTable"
+Cohesion: 0.03
+Nodes (52): Fit Page.  Fit model controls + visualization (fit plot + residuals)., Update state when the user edits parameter bounds., Open MultiView dialog overlaying fit curves for the active dataset., Update bounds for a model parameter.      Parameters     ----------     name : s, update_parameter_bounds(), Batch Processing Panel Widget ==============================  Workspace panel fo, EmptyStateWidget, Reusable empty state widget for placeholder content.  Styling is handled entirel (+44 more)
 
-### Community 186 - "Cross"
-Cohesion: 0.05
-Nodes (30): Cross, ndarray, RheoData, TestMode, Fit Cross parameters to data.          Args:             X: Shear rate data (γ̇), Predict viscosity for given shear rates.          Args:             X: Shear rat, Model function for Bayesian inference.          This method is required by Bayes, Compute viscosity using Cross model.          Args:             gamma_dot: Shear (+22 more)
+### Community 186 - "TestCrossBasics"
+Cohesion: 0.33
+Nodes (4): Test basic functionality., Test model initialization., Test parameter bounds., TestCrossBasics
 
 ### Community 187 - "FractionalMaxwellGel"
 Cohesion: 0.09
 Nodes (18): FractionalMaxwellGel, ndarray, RheoData, Prefer conservative NUTS settings for the stiff Mittag-Leffler kernel., Compute characteristic relaxation time.          Args:             c_alpha: Spri, Predict relaxation modulus G(t) using JAX.          G(t) = c_α t^(-α) E_{1-α,1-α, Predict creep compliance J(t) using JAX.          J(t) = (1/c_α) t^α E_{1+α,1+α}, Predict complex modulus G*(ω) using JAX.          G*(ω) = c_α (iω)^α / (1 + (iωτ (+10 more)
 
-### Community 188 - "SPPYieldStress"
-Cohesion: 0.04
-Nodes (50): Distribution, Sequence of Physical Processes (SPP) models.  Contains models for LAOS (Large Am, Initialize SPP yield stress model., Create NumPyro-friendly priors for model parameters.          Uses physically-mo, SPP-based yield stress model for LAOS analysis.      This model extracts yield s, String representation., SPPYieldStress, Pipeline API for rheological analysis workflows.  This module provides a fluent (+42 more)
+### Community 188 - "ModelComparisonPipeline"
+Cohesion: 0.03
+Nodes (68): Pipeline API for rheological analysis workflows.  This module provides a fluent, CreepToRelaxationPipeline, FrequencyToTimePipeline, ModelComparisonPipeline, Specialized pipeline classes for common rheological workflows.  This module prov, Get full SPP results for a specific amplitude.          Args:             gamma_, Get nonlinearity metrics (I3/I1, S, T) for each amplitude.          Returns:, Pipeline for comparing multiple models on the same data.      This pipeline fits (+60 more)
 
 ### Community 189 - "ndarray"
 Cohesion: 0.09
 Nodes (12): ndarray, Simulate stress relaxation after cessation of steady shear.          Analytical, Simulate creep deformation under constant stress.          Parameters         --, Simulate Large-Amplitude Oscillatory Shear (LAOS).          Parameters         -, Get relaxation modulus G(t).          For Cates model: G(t) = G₀·exp(-t/τ_d), Extract Fourier harmonics from LAOS stress response.          Parameters, Map data-scale estimates to Cates-specific parameter names.          Cates uses, Predict steady shear stress and viscosity.          For Cates model with constan (+4 more)
 
 ### Community 190 - ".__init__"
-Cohesion: 0.09
-Nodes (12): QToolBar, QWidget, Initialize main window with pages and services.          Parameters         ----, Create all UI elements., Create dock widgets for log panel.          The left DatasetTree dock has been r, Hook ``QStyleHints.colorSchemeChanged`` (Qt 6.5+) to re-apply auto theme., Create sidebar + workspace splitter as central widget.          The WorkspaceCon, Register application-wide shortcuts and command palette. (+4 more)
+Cohesion: 0.12
+Nodes (9): QToolBar, QWidget, Initialize main window with pages and services.          Parameters         ----, Create dock widgets for log panel.          The left DatasetTree dock has been r, Hook ``QStyleHints.colorSchemeChanged`` (Qt 6.5+) to re-apply auto theme., Create sidebar + workspace splitter as central widget.          The WorkspaceCon, Place an arbitrary widget inside a non-movable toolbar., Connect store signals to UI updates (theme, pipeline, datasets). (+1 more)
 
 ### Community 191 - "Test Data Fixtures for RheoJAX v0.4.0"
 Cohesion: 0.06
@@ -1688,13 +1645,13 @@ Nodes (32): Adding New Fixtures, Bayesian Mode-Aware Tests, Data Characteristics
 Cohesion: 0.09
 Nodes (17): ArrayLike, ndarray, Fit model parameters to data using protocol-aware optimization.          Args:, Fit to steady-state flow curve data., Fit using ODE formulation (for creep/relaxation)., Fit using return mapping formulation (for startup/LAOS)., Fit to oscillatory data (SAOS).          Supports two modes:         1. Frequenc, Fit to frequency-domain SAOS data using Maxwell analytical expressions. (+9 more)
 
-### Community 194 - "test_multi_species.py"
-Cohesion: 0.06
-Nodes (29): Tests for TNTMultiSpecies model.  Tests cover: - Instantiation and parameter, Tests for model instantiation and parameters., Tests for SAOS predictions., Tests for startup flow simulation., Tests for stress relaxation simulation., Tests for creep simulation., Tests for LAOS simulation., Tests for BayesianMixin compatibility. (+21 more)
+### Community 194 - ".create"
+Cohesion: 0.02
+Nodes (105): Get list of all registered model names.          Returns:             List of mo, Create a model instance by name (factory method).          Args:             nam, List all registered model names (discovery).          Returns:             List, Get information about a registered model.          Args:             name: Name, Test ModelRegistry.create(name) factory method., Test factory method with constructor arguments., Test that creating non-existent model raises KeyError., Test listing models when none registered. (+97 more)
 
 ### Community 195 - "configure_logging"
 Cohesion: 0.08
-Nodes (24): Configure application logging.      Parameters     ----------     verbose : bool, setup_logging(), _apply_config(), configure_logging(), is_configured(), LogFormat, Configure the RheoJAX logging system.      This function should be called once a, Available log output formats. (+16 more)
+Nodes (31): _apply_config(), configure_logging(), get_config(), is_configured(), LogFormat, RheoJAX Logging Configuration.  Centralized configuration management for the Rhe, Get the current logging configuration.      Returns:         Current LogConfig i, Configure the RheoJAX logging system.      This function should be called once a (+23 more)
 
 ### Community 196 - "test_migrated_notebooks.py"
 Cohesion: 0.09
@@ -1702,71 +1659,71 @@ Nodes (26): NotebookNode, convergence_thresholds(), _enable_custom_models_fast_m
 
 ### Community 197 - "test_dmta_removal.py"
 Cohesion: 0.10
-Nodes (17): _hits(), The shear-only fit remains numerically identical to the pre-strip fit., Only the central removed-option rejection boundary may name old keys., test_analysis_exporter_does_not_copy_retired_metadata(), test_base_signatures_clean(), test_csv_reader_does_not_create_retired_metadata(), test_maxwell_shear_relaxation_fit_matches_pre_strip_baseline(), test_model_registry_create_rejects_removed_option() (+9 more)
+Nodes (17): _hits(), The shear-only fit remains numerically identical to the pre-strip fit., Only the central removed-option rejection boundary may name old keys., test_analysis_exporter_does_not_copy_retired_metadata(), test_base_signatures_clean(), test_csv_reader_does_not_create_retired_metadata(), test_excel_reader_does_not_create_retired_metadata(), test_maxwell_shear_relaxation_fit_matches_pre_strip_baseline() (+9 more)
 
 ### Community 198 - "main"
 Cohesion: 0.12
 Nodes (15): create_parser(), _fit_single(), main(), _print_summary_table(), ArgumentParser, Path, CLI subcommand for batch processing multiple rheological data files.  Globs file, Load, fit, and return a result dict for a single file.      Returns a dict with (+7 more)
 
-### Community 199 - "anton_paar.py"
-Cohesion: 0.09
-Nodes (44): _compute_complex_modulus(), _compute_compliance(), _compute_relaxation_modulus(), _convert_unit(), _detect_test_type(), _extract_auxiliary_columns(), _extract_geometry_metadata(), _extract_global_metadata() (+36 more)
+### Community 199 - "load_anton_paar"
+Cohesion: 0.02
+Nodes (160): _compute_complex_modulus(), _compute_compliance(), _compute_relaxation_modulus(), _convert_unit(), _create_interval_dataframe(), _create_metadata_sheet(), _detect_decimal_separator(), _detect_encoding() (+152 more)
 
-### Community 200 - "_coerce_ndarray"
-Cohesion: 0.07
-Nodes (18): _coerce_ndarray(), ArrayLike, ndarray, Ensure data is a proper array., Validate data for common issues., Convert any array-like input to a NumPy array for scalar ops., Number of dimensions of y data., Check if y data is complex. (+10 more)
+### Community 200 - ".shape"
+Cohesion: 0.05
+Nodes (24): BayesianResult, Fit the transform to data (learn parameters if needed).          Args:, Perform Bayesian inference using NumPyro NUTS sampler.          This method dele, Make predictions.          Args:             X: Input features             test_, Internal predict implementation to be overridden by subclasses.          Args:, Get stored Bayesian inference result.          Returns:             BayesianResu, _coerce_ndarray(), ArrayLike (+16 more)
 
-### Community 201 - "hvm_solve_laos"
-Cohesion: 0.15
-Nodes (19): _hvm_initial_state(), hvm_solve_creep(), hvm_solve_laos(), hvm_solve_relaxation(), hvm_solve_startup(), _mask_failed_solution_ys(), ndarray, Solution (+11 more)
+### Community 201 - "test_basemodel_integration.py"
+Cohesion: 0.08
+Nodes (21): Tests for BaseModel integration with NLSQ + NumPyro workflow.  This module tests, Test that all models automatically gain fit_bayesian() method., Test complete NLSQ → NUTS workflow on Maxwell model.      Uses tau=1.0 s so the, Test that BaseModel.fit() uses NLSQ optimizer by default., Test that BaseModel stores NLSQ and Bayesian results for later access., Test that BaseModel.fit() maintains backward compatibility with existing API., Tests for BaseModel.precompile() JIT precompilation., precompile() should return compilation time as a float. (+13 more)
 
 ### Community 202 - "PersistentProcessPool"
-Cohesion: 0.11
-Nodes (16): __getattr__(), Lazy import for PersistentProcessPool (avoids multiprocessing import at package, PersistentProcessPool, Process pool with long-lived workers for JAX-safe parallel execution.      Each, Run model fits in parallel subprocesses., _add_one(), _raise_error(), Tests for PersistentProcessPool. (+8 more)
+Cohesion: 0.15
+Nodes (10): PersistentProcessPool, Process pool with long-lived workers for JAX-safe parallel execution.      Each, _add_one(), _raise_error(), Tests for PersistentProcessPool., Futures submitted but not completed before shutdown get an error., Test persistent process pool lifecycle and task execution., _slow_add() (+2 more)
 
 ### Community 203 - "sgr_population_balance.py"
 Cohesion: 0.12
 Nodes (25): advection_operator(), create_grid(), initialize_equilibrium(), Array, SGR Population Balance Solver (Eulerian Approach).  This module provides an Eule, Initialize P(E, ell) at equilibrium (ell=0, E from prior).      The equilibrium, Advection step: ell -> ell + gamma_dot * dt.      Uses adaptive sub-stepping to, Yielding step: remove mass from traps according to yield rate.      Parameters (+17 more)
 
-### Community 204 - "TestBatchVectorization"
-Cohesion: 0.08
-Nodes (14): Test handling of variable-length datasets with padding/masking., Benchmark multi-dataset processing with 3-4x speedup target., Test that parallel I/O produces correct results (structural check)., Test that error handling preserves file-level granularity., Test backward compatibility with batch_vectorize=False (default)., Test _stack_datasets helper with padding for variable lengths., Test that model fitting can be vmapped over datasets., Simple model that supports vectorization. (+6 more)
+### Community 204 - "test_batch_vectorize.py"
+Cohesion: 0.06
+Nodes (23): Tests for batch pipeline vectorization.  This module tests the vectorized batch, Test handling of variable-length datasets with padding/masking., Benchmark multi-dataset processing with 3-4x speedup target., Test that parallel I/O produces correct results (structural check)., Test that error handling preserves file-level granularity., Test backward compatibility with batch_vectorize=False (default)., Test _stack_datasets helper with padding for variable lengths., Test that model fitting can be vmapped over datasets. (+15 more)
 
 ### Community 205 - "EPM (Elasto-Plastic Models) Comprehensive Validation Report"
 Cohesion: 0.07
 Nodes (29): 1. Automated Checks, 2.1 Eshelby Propagator — CORRECT, 2.2 Von Mises Yield Criterion — CORRECT, 2.3 Hill Anisotropic Criterion — CORRECT, 2.4 Prandtl-Reuss Plastic Flow Rule — CORRECT, 2.5 FFT-Based Stress Redistribution — CORRECT, 2.6 Hébraud-Lequeux as Mean-Field Limit — CORRECT, 2.7 Smooth Yielding Approximation — CORRECT (with caveat) (+21 more)
 
-### Community 206 - "Parameter"
-Cohesion: 0.07
-Nodes (22): Parameter, Single parameter with value, bounds, and metadata.      A Parameter represents a, Get parameter bounds., Set parameter bounds and sync any bounds constraint., Return True if the last assignment clamped the value., Make Parameter hashable for use as dict keys.          Returns:             Hash, Check equality with another Parameter.          Matches __hash__: identity-based, Test Parameter class for parameter management. (+14 more)
+### Community 206 - "TestParameterClass"
+Cohesion: 0.11
+Nodes (13): Test Parameter class for parameter management., Test creating a parameter., Test parameter value validation., Test parameter without bounds., Test Parameter class for parameter management., Test creating a parameter., Test parameter value validation., Test parameter serialization to dict. (+5 more)
 
 ### Community 207 - "MockBayesianModel"
-Cohesion: 0.11
-Nodes (10): MockBayesianModel, Test that fit_nlsq stores NLSQ result., Test get_diagnostics returns correct structure., Test complete workflow: load → fit_nlsq → fit_bayesian → diagnostics., Simple mock model for testing Bayesian pipeline., Test that warm-start from NLSQ helps convergence., Test that state is properly managed across method calls., Test error handling when methods called out of order. (+2 more)
+Cohesion: 0.09
+Nodes (12): MockBayesianModel, Test fit_nlsq with model instance., Test that fit_nlsq stores NLSQ result., Test fit_bayesian with warm-start from NLSQ., Test get_diagnostics returns correct structure., Test complete workflow with method chaining., Test complete workflow: load → fit_nlsq → fit_bayesian → diagnostics., Simple mock model for testing Bayesian pipeline. (+4 more)
 
 ### Community 208 - "Background Job System - Implementation Summary"
 Cohesion: 0.07
 Nodes (29): 1. `cancellation.py` (139 lines), 1. Thread Safety, 2. JAX Integration, 2. `worker_pool.py` (284 lines), 3. Error Handling, 3. `fit_worker.py` (294 lines), 4. `bayesian_worker.py` (360 lines), 4. Progress Tracking (+21 more)
 
 ### Community 209 - "StatusBar"
-Cohesion: 0.10
-Nodes (12): QStatusBar, QWidget, Clear message_label if it still shows the message that timed out., Update and show progress bar.          Parameters         ----------         val, Update JAX device and memory status.          Parameters         ----------, Update memory usage indicator.          Parameters         ----------         us, Update JAX device indicator.          Parameters         ----------         devi, Update float64 status indicator.          Parameters         ---------- (+4 more)
+Cohesion: 0.09
+Nodes (14): QStatusBar, __getattr__(), Lazy import for application components., QWidget, Clear message_label if it still shows the message that timed out., Update and show progress bar.          Parameters         ----------         val, Update JAX device and memory status.          Parameters         ----------, Update memory usage indicator.          Parameters         ----------         us (+6 more)
 
 ### Community 210 - "_SpyModel"
-Cohesion: 0.17
-Nodes (14): model_function is JAX-traceable with temperature kwarg., Behavioral guards for removed DMTA kwargs at pipeline boundaries., Permissive duck-typed model that records every received kwarg., shear_data(), _SpyModel, test_batch_fit_replay_rejects_removed_kwargs_before_model(), test_batch_replay_preserves_fit_bayesian_and_export_fields(), test_model_comparison_preserves_supported_kwargs() (+6 more)
+Cohesion: 0.20
+Nodes (13): Behavioral guards for removed DMTA kwargs at pipeline boundaries., Permissive duck-typed model that records every received kwarg., shear_data(), _SpyModel, test_batch_fit_replay_rejects_removed_kwargs_before_model(), test_batch_replay_preserves_fit_bayesian_and_export_fields(), test_model_comparison_preserves_supported_kwargs(), test_model_comparison_rejects_removed_kwargs_before_model() (+5 more)
 
 ### Community 211 - "DMTNonlocal"
 Cohesion: 0.09
 Nodes (16): de Souza Mendes-Thompson (DMT) thixotropic models.  This module provides DMT mod, DMTNonlocal, ndarray, Initialize DMTNonlocal model., Add parameters specific to nonlocal model., Compute cooperativity length scale.          ξ = √(D_λ · t_eq)          Returns, Predict model response., Compute 1D Laplacian with Neumann BCs (∂field/∂y = 0 at walls).          Uses se (+8 more)
 
 ### Community 212 - "FractionalKelvinVoigt"
-Cohesion: 0.11
-Nodes (15): FractionalKelvinVoigt, ndarray, RheoData, Compute characteristic retardation time.          Args:             Ge: Equilibr, Predict relaxation modulus G(t) using JAX.          G(t) = G_e + c_α t^(-α) / Γ(, Predict creep compliance J(t) using JAX.          J(t) = (1/G_e) (1 - E_α(-(t/τ_, Predict complex modulus G*(ω) using JAX.          G*(ω) = G_e + c_α (iω)^α, Internal predict implementation.          Args:             X: RheoData object o (+7 more)
+Cohesion: 0.10
+Nodes (16): FractionalKelvinVoigt, ndarray, RheoData, Compute characteristic retardation time.          Args:             Ge: Equilibr, Predict relaxation modulus G(t) using JAX.          G(t) = G_e + c_α t^(-α) / Γ(, Predict creep compliance J(t) using JAX.          J(t) = (1/G_e) (1 - E_α(-(t/τ_, Predict complex modulus G*(ω) using JAX.          G*(ω) = G_e + c_α (iω)^α, Internal predict implementation.          Args:             X: RheoData object o (+8 more)
 
 ### Community 213 - "HebraudLequeux"
-Cohesion: 0.14
-Nodes (14): HebraudLequeux, ndarray, Return the phase state based on alpha., Get grid parameters based on current or provided sigma_c., Compute adaptive dt and n_steps to cap scan length.          The CFL sub-steppin, Fit HL model parameters to data.          Args:             X: Independent varia, Fit flow curve using derivative-free optimization.          The HL PDE solver ha, Fit creep compliance. (+6 more)
+Cohesion: 0.12
+Nodes (16): HebraudLequeux, Any, ndarray, Return the phase state based on alpha., Get grid parameters based on current or provided sigma_c., Compute adaptive dt and n_steps to cap scan length.          The CFL sub-steppin, Fit HL model parameters to data.          Args:             X: Independent varia, Fit flow curve using derivative-free optimization.          The HL PDE solver ha (+8 more)
 
 ### Community 214 - "test_protocols.py"
 Cohesion: 0.07
@@ -1784,21 +1741,21 @@ Nodes (8): Transient startup shear., Short-time slope = G_tot * gamma_dot., No N
 Cohesion: 0.11
 Nodes (14): create_parser(), main(), ArgumentParser, ndarray, CLI subcommand for loading rheological data files.  Wraps auto_load() to load da, Validate loaded arrays for NaN/Inf. Returns error message or None., Load data from file and print summary or JSON envelope., Create argument parser for load subcommand. (+6 more)
 
-### Community 218 - "TestMaterialTypeDetection"
-Cohesion: 0.14
-Nodes (8): Test detection of gel-like material from relaxation., Test detection of solid from oscillation data., Test detection of liquid from oscillation data., Test that no data returns UNKNOWN., Tests for material type detection., Test detection of solid-like material from relaxation., Test detection of liquid-like material from relaxation., TestMaterialTypeDetection
+### Community 218 - ".model_function"
+Cohesion: 0.10
+Nodes (14): Vectorized multi-network SAOS moduli.      Parameters     ----------     omega_a, vlb_multi_saos_vec(), ndarray, Total modulus: sum G_i + G_e., Zero-shear viscosity: sum G_i/k_d_i + eta_s., Get mode arrays as numpy arrays.          Returns         -------         tuple, Unpack mode parameters from a flat JAX array.          Parameters         ------, Predict response using protocol-aware dispatch.          Parameters         ---- (+6 more)
 
-### Community 219 - "parse_rheocompass_intervals"
-Cohesion: 0.11
-Nodes (19): _detect_decimal_separator(), _detect_encoding(), _detect_encoding_cached(), _detect_encoding_impl(), _find_interval_boundaries(), parse_rheocompass_intervals(), Path, Detect file encoding using cascade approach.      RheoCompass exports are typica (+11 more)
-
-### Community 220 - ".generate"
+### Community 219 - "TestFloat64ImportOrder"
 Cohesion: 0.09
-Nodes (19): Any, ndarray, Generate minimal test data for a given protocol.          Args:             p, Try to predict, handling different test_mode dispatch patterns.      Some mode, Validate that all models can execute predict() for their declared protocols., Test that model.predict() executes successfully for the given protocol., Verify test parametrization found model/protocol pairs., Validate the test data factory itself. (+11 more)
+Nodes (15): Reset validation state (for testing purposes only).      This function is intend, reset_validation(), Reset JAX configuration and free memory after each test.      Without periodic c, reset_jax_config(), Tests for float64 precision enforcement in JAX.  This test suite validates that, Test that import order violation error messages are clear and actionable., Test that calling safe_import_jax() multiple times is safe., Test import order enforcement for float64 precision. (+7 more)
+
+### Community 220 - ".calculate"
+Cohesion: 0.10
+Nodes (13): Array, RheoData, Perform numerical integration.          Parameters         ----------         x, Extrapolate tail contribution to infinite time.          Parameters         ----, Estimate equilibrium modulus from tail of data.          Parameters         ----, Check if extrapolation should be applied.          Parameters         ----------, Extrapolate the ∫t×G_relax(t)dt integral contribution.          Parameters, Apply tail extrapolation to integrals.          Parameters         ---------- (+5 more)
 
 ### Community 221 - "hessian_ci"
-Cohesion: 0.09
-Nodes (31): PostFitValidator, ArrayLike, Runs post-fit physics checks and uncertainty quantification., Compute post-fit uncertainty estimates.          Args:             model: Fitted, _assert_fitted(), bootstrap_ci(), hessian_ci(), _jacobian_fallback_pcov() (+23 more)
+Cohesion: 0.04
+Nodes (63): PostFitValidator, ArrayLike, Runs post-fit physics checks and uncertainty quantification., Compute post-fit uncertainty estimates.          Args:             model: Fitted, _assert_fitted(), bootstrap_ci(), hessian_ci(), _jacobian_fallback_pcov() (+55 more)
 
 ### Community 222 - "run_profiling.py"
 Cohesion: 0.11
@@ -1812,33 +1769,33 @@ Nodes (28): 10. Version and Dates, 1. Feature Branch Creation, 2.1 Smoke Tier (1
 Cohesion: 0.07
 Nodes (27): Build & Quality Commands, CI/CD, Code Quality, Core Dependencies, Development Dependencies, Documentation, Documentation Structure, File I/O (+19 more)
 
-### Community 225 - "TestParameterSetUnpack"
-Cohesion: 0.10
-Nodes (11): Test ParameterSet.unpack() method for multi-value extraction.      This test cla, Create a ParameterSet with test parameters., T003: unpack() returns values in the same order as requested names., T004: unpack() works with a single parameter name., T005: unpack() with no arguments returns empty tuple., T006: unpack() raises KeyError for non-existent parameter names., T007: KeyError message lists available parameter names., T007a: unpack() with duplicate names returns the same value multiple times. (+3 more)
+### Community 225 - "make_tensorial_propagator_q"
+Cohesion: 0.08
+Nodes (24): make_tensorial_propagator_q(), Create the tensorial Eshelby propagator in Fourier space for plane strain., Test that the tensorial propagator has correct shape (3, 3, L, L//2+1)., Test that tensorial propagator application preserves zero mean., Test tensorial EPM step with pure elastic loading (no yielding)., Test tensorial EPM step with active plastic sites., Test that smooth yielding approximates hard yielding away from threshold., Test that propagator enforces total stress conservation (zero net stress change) (+16 more)
 
-### Community 226 - "test_carreau.py"
-Cohesion: 0.10
-Nodes (14): Tests for Carreau model.  This module tests the Carreau model for non-Newtonian, Test Carreau with RheoData., Test prediction with RheoData (viscosity output)., Test that wrong test mode raises error., Test parameter fitting for Carreau model., Test fitting with synthetic data., Test Carreau model against known analytical solutions., Test against Carreau formula directly. (+6 more)
+### Community 226 - "main.py"
+Cohesion: 0.11
+Nodes (19): main(), RheoJAX GUI Package ==================  Qt-based graphical user interface for Rh, Launch the RheoJAX GUI application.      This is a convenience wrapper that impo, check_dependencies(), _create_workspace_window(), main(), RheoJAX GUI Application Entry Point.  This module provides the main entry point, Main entry point for RheoJAX GUI.      Parameters     ----------     argv : list (+11 more)
 
-### Community 227 - "ImportWorker"
+### Community 227 - "._on_finished"
 Cohesion: 0.06
-Nodes (25): ImportWorker, ImportWorkerSignals, Any, Path, QObject, QRunnable, Import Worker =============  Background worker for data file import.  Offloads f, Execute file import in background thread. (+17 more)
+Nodes (20): Any, BayesianResult, ndarray, Handle Bayesian inference completion.          Parameters         ----------, Update convergence diagnostics display.          Parameters         ----------, Update credible intervals table.          Parameters         ----------, Replace the Fit Plot canvas figure.          Delegates to PlotCanvas.replace_fig, Compute a representative parameter set from posterior samples. (+12 more)
 
 ### Community 228 - "TestFractionalZenerSolidLiquid"
 Cohesion: 0.17
 Nodes (6): Tests for FZSL model., Test parameter initialization., Test relaxation modulus., Test complex modulus., Test alpha limit cases., TestFractionalZenerSolidLiquid
 
-### Community 229 - "TestOptimizationResultStatistics"
-Cohesion: 0.08
-Nodes (13): Test OptimizationResult statistical properties (NLSQ 0.6.0 compatibility)., Create an OptimizationResult with residuals and y_data for testing., Test R² computation from residuals and y_data., Test adjusted R² computation., Test RMSE computation., Test MAE computation., Test AIC computation., Test BIC computation. (+5 more)
+### Community 229 - "LogDockWidget"
+Cohesion: 0.16
+Nodes (14): QDockWidget, LogDockWidget, Bottom dock: buffered, filterable, severity-colored log viewer., Buffer a log record and render it if it passes the current filter., Tests for the shared GUI log dock widget., test_append_record_buffers_and_renders(), test_buffer_is_bounded(), test_level_filter_hides_below_threshold() (+6 more)
 
 ### Community 230 - "FIKHBase"
 Cohesion: 0.10
 Nodes (17): FIKHBase, Any, ArrayLike, ndarray, TestMode, Setup base FIKH parameters (mechanical + fractional)., Setup thermal coupling parameters., Setup isotropic hardening parameters. (+9 more)
 
 ### Community 231 - "FractionalJeffreysModel"
-Cohesion: 0.14
-Nodes (11): FractionalJeffreysModel, ndarray, Predict relaxation modulus G(t).          G(t) = (η_1/τ_1) * t^(-α) * E_{1-α,1-α, Predict creep compliance J(t).          For Jeffreys model, creep shows unbounde, Predict complex modulus G*(ω).          G*(ω) = η_1(iω) * [1 + (iωτ_2)^α] / [1 +, Predict steady shear viscosity η(γ̇).          For Jeffreys model at steady stat, Predict response for given input.          Parameters         ----------, Model function for Bayesian inference.          This method is required by Bayes (+3 more)
+Cohesion: 0.13
+Nodes (12): FractionalJeffreysModel, ndarray, Initialize Fractional Jeffreys model., Predict relaxation modulus G(t).          G(t) = (η_1/τ_1) * t^(-α) * E_{1-α,1-α, Predict creep compliance J(t).          For Jeffreys model, creep shows unbounde, Predict complex modulus G*(ω).          G*(ω) = η_1(iω) * [1 + (iωτ_2)^α] / [1 +, Predict steady shear viscosity η(γ̇).          For Jeffreys model at steady stat, Predict response for given input.          Parameters         ---------- (+4 more)
 
 ### Community 232 - "ArrayLike"
 Cohesion: 0.10
@@ -1848,25 +1805,25 @@ Nodes (15): ArrayLike, ndarray, Predict steady-state flow curve.          Args: 
 Cohesion: 0.12
 Nodes (8): Predict SAOS storage and loss moduli.          Analytical superposition for mult, Return longest effective relaxation time (terminal mode).          Returns, Predict first normal stress difference N₁(γ̇).          N₁ = Σ 2·G_k·τ_eff_k²·γ̇, Return string representation., Extract mode parameters as JAX arrays.          Returns         -------, Get effective relaxation times for all modes.          Returns         -------, Compute plateau modulus G_N = Σ G_k for modes with τ_R_k < τ_s.          The pla, Compute zero-shear viscosity η₀ = Σ G_k·τ_eff_k + η_s.          Returns
 
-### Community 234 - "compute_fit_quality"
-Cohesion: 0.12
-Nodes (15): compute_fit_quality(), ArrayLike, r2_complex(), r2_complex_components(), Fit quality metrics for rheological model evaluation.  This module provides func, Compute R² for complex data using separate real and imaginary components.      R, Compute R² and RMSE fit quality metrics.      Parameters     ----------     y_tr, Compute R² for complex-valued data using magnitudes.      Parameters     ------- (+7 more)
-
-### Community 235 - "TestY2ColTranslation"
+### Community 234 - "__init__.py"
 Cohesion: 0.11
-Nodes (10): F-IO-R2-001: y2_col must be translated to y_cols for generic readers., y2_col + y_col should become y_cols=[y_col, y2_col]., y2_col without y_col should not create y_cols., Pre-existing y_cols should not be overwritten by y2_col., No y2_col → kwargs unchanged., _translate_y2_col must not mutate the original dict., y2_col must NOT be in _CSV_KWARGS (would pass through unhandled)., y2_col must NOT be in _EXCEL_KWARGS. (+2 more)
+Nodes (16): Utility functions for the rheojax package.  This module provides: - Mittag-Leffl, compute_fit_quality(), ArrayLike, r2_complex(), r2_complex_components(), Fit quality metrics for rheological model evaluation.  This module provides func, Compute R² for complex data using separate real and imaginary components.      R, Compute R² and RMSE fit quality metrics.      Parameters     ----------     y_tr (+8 more)
+
+### Community 235 - "_translate_y2_col"
+Cohesion: 0.08
+Nodes (16): Translate GUI-layer ``y2_col`` to reader-layer ``y_cols``.      The GUI passes `, _translate_y2_col(), auto_load must translate y2_col → y_cols before format dispatch., Double-translation of y2_col must be idempotent., y2_col + y_col should become y_cols=[y_col, y2_col]., y2_col without y_col should not create y_cols., Pre-existing y_cols should not be overwritten by y2_col., No y2_col → kwargs unchanged. (+8 more)
 
 ### Community 236 - "solve_linear_creep_compliance"
 Cohesion: 0.13
 Nodes (26): creep_compliance_from_prony(), _prony_fit_modulus(), ndarray, Linear-viscoelastic creep compliance via the Volterra history integral.  In line, Non-negative least-squares Prony fit ``G(t) ≈ G_∞ + Σ gᵢ e^{-t/τᵢ}``.      Relax, Creep compliance ``J(t)`` from a sampled relaxation modulus ``G(t)``.      Fits, Creep compliance ``J(t)`` for a Prony-series relaxation modulus.      Solves the, solve_linear_creep_compliance() (+18 more)
 
-### Community 237 - "TestMittagLefflerConvergence"
-Cohesion: 0.11
-Nodes (10): Test 7: Benchmark Mittag-Leffler performance on arrays., Test 8: Verify alpha != beta case (Pade approximation)., Test suite for Mittag-Leffler convergence optimization., Test 1: Verify convergence criterion produces correct results., Test 2: Verify Kahan summation preserves numerical stability., Test 3: Benchmark performance for typical rheological alpha values., Test 4: Verify convergence for common cases., Test 5: Verify asymptotic approximation logic for large |z|. (+2 more)
+### Community 237 - "test_trios_memory_profiling.py"
+Cohesion: 0.19
+Nodes (19): cleanup_temp_files(), measure_peak_memory(), Memory profiling tests for TRIOS auto-chunking feature.  This test module valida, Cleanup temporary files after each test., Measure peak memory usage of a function.      Args:         func: Function to me, Test memory reduction for 5 MB file (at threshold)., Test memory reduction for 10 MB file., Test memory reduction for 50 MB file (large file). (+11 more)
 
-### Community 238 - "spp_kernels.py"
-Cohesion: 0.05
-Nodes (47): Array, Compute mask for selected cycles from time series data.          Parameters, Apply SPP decomposition to LAOS stress data.          Parameters         -------, apparent_cage_modulus(), build_spp_exports(), calculate_loop_energy(), compute_phase_offset(), convert_units() (+39 more)
+### Community 238 - "._transform"
+Cohesion: 0.10
+Nodes (18): Array, Compute mask for selected cycles from time series data.          Parameters, Apply SPP decomposition to LAOS stress data.          Parameters         -------, build_spp_exports(), dynamic_yield_stress(), harmonic_reconstruction(), lissajous_metrics(), power_law_fit() (+10 more)
 
 ### Community 239 - "TestBayesianNotebooks"
 Cohesion: 0.07
@@ -1880,49 +1837,49 @@ Nodes (21): Handler, MemoryHandler, create_handlers(), NullHandler, LogRecord, P
 Cohesion: 0.07
 Nodes (26): Basic Usage, Border Radius, Color Schemes, Container Widgets, Custom Button Variants, Custom Progress Bar Variants, Dark Theme, Dialogs (+18 more)
 
-### Community 242 - "._predict"
-Cohesion: 0.27
-Nodes (6): ndarray, Predict creep compliance J(t).          J(t) = J_g + t^α/(η_1 * Γ(1+α)) + J_k *, Predict relaxation modulus G(t).          Note: Analytical relaxation modulus re, Predict complex modulus G*(ω).          Computed from complex compliance:, Predict response for given input.          Parameters         ----------, Model function for Bayesian inference.          This method is required by Bayes
+### Community 242 - "FractionalBurgersModel"
+Cohesion: 0.13
+Nodes (11): FractionalBurgersModel, ndarray, Initialize Fractional Burgers model., Predict creep compliance J(t).          J(t) = J_g + t^α/(η_1 * Γ(1+α)) + J_k *, Predict relaxation modulus G(t).          Note: Analytical relaxation modulus re, Predict complex modulus G*(ω).          Computed from complex compliance:, Predict response for given input.          Parameters         ----------, Model function for Bayesian inference.          This method is required by Bayes (+3 more)
 
-### Community 243 - "check_wide_frequency_range"
-Cohesion: 0.16
-Nodes (13): check_monotonicity(), check_nan_inf(), check_wide_frequency_range(), ndarray, Data quality and range detection utilities.  This module provides utilities for, Suggest optimization strategy based on data characteristics.      Analyzes data, Check for NaN/Inf values and return a diagnostic dictionary.      Args:, Check whether an array is approximately monotonic.      An array is considered m (+5 more)
+### Community 243 - "detect_data_range_decades"
+Cohesion: 0.12
+Nodes (17): check_monotonicity(), check_nan_inf(), check_wide_frequency_range(), detect_data_range_decades(), ndarray, Data quality and range detection utilities.  This module provides utilities for, Suggest optimization strategy based on data characteristics.      Analyzes data, Detect the range of data in decades (log10 scale).      Args:         x: Data ar (+9 more)
 
 ### Community 244 - "Hybrid Vitrimer Model (HVM) -- Literature Review & Equations"
 Cohesion: 0.08
 Nodes (25): 1. Key References, 2. Physical Model: Three-Subnetwork Architecture, 3.1 Stress Decomposition (General Tensorial Form), 3.2 Simple Shear Stress Components, 3.3 Evolution ODEs (Simple Shear), 3.4 Factor-of-2 in Relaxation, 3. Constitutive Equations, 4.1 Storage and Loss Moduli (SAOS) (+17 more)
 
 ### Community 245 - "BayesianPipeline"
-Cohesion: 0.08
-Nodes (13): BayesianPipeline, Reset pipeline to initial state.          Clears all data, models, and results i, String representation of Bayesian pipeline., Perform Bayesian inference using NumPyro NUTS sampler.          This method runs, Specialized pipeline for Bayesian rheological analysis workflows.      This clas, Plot posterior distributions.          Generates histogram plots of posterior di, Plot MCMC trace plots.          Generates trace plots showing parameter values a, Initialize Bayesian pipeline.          Args:             data: Optional initial (+5 more)
+Cohesion: 0.07
+Nodes (20): BayesianPipeline, DataFrame, Reset pipeline to initial state.          Clears all data, models, and results i, String representation of Bayesian pipeline., Specialized pipeline for Bayesian rheological analysis workflows.      This clas, Get formatted posterior summary statistics.          Returns a pandas DataFrame, Plot posterior distributions.          Generates histogram plots of posterior di, Plot MCMC trace plots.          Generates trace plots showing parameter values a (+12 more)
 
-### Community 246 - "__getattr__"
-Cohesion: 0.14
-Nodes (12): QSize, QToolBar, __getattr__(), Lazy import for application components., get_icon(), MainToolBar, QIcon, QWidget (+4 more)
+### Community 246 - "DMTBase"
+Cohesion: 0.12
+Nodes (10): DMTBase, Initialize ParameterSet with model parameters.          Parameters are added con, Get initial structure parameter value (fully structured).          Returns, Get all parameters as a dictionary.          Returns         -------         dic, Build base args dictionary for ODE integration.          Parameters         ----, Get human-readable description of the closure.          Returns         -------, Base class for DMT (de Souza Mendes-Thompson) thixotropic models.      Implement, Get human-readable description of elasticity setting.          Returns         - (+2 more)
 
 ### Community 247 - "MenuBar"
-Cohesion: 0.14
-Nodes (10): QMenuBar, MenuBar, QWidget, Create Transforms menu., Create Analysis menu., Create Pipeline menu for visual pipeline management., Populate recent files menu (placeholder)., Application menu bar for RheoJAX GUI.      Menu Structure:         - File: New, (+2 more)
-
-### Community 248 - "TestHessianCI"
 Cohesion: 0.11
-Nodes (10): The optimal parameter value must lie within its CI., Tighter alpha should produce wider intervals (more conservative)., hessian_ci works on models fitted to complex G* data., All CI bounds must be finite floats., When _nlsq_result.pcov exists, hessian_ci must reuse it (no Hessian)., Explicit test_mode kwarg is accepted without error., Tests for hessian_ci()., hessian_ci returns a dict keyed by parameter names. (+2 more)
+Nodes (12): QMenuBar, Create all UI elements., Update JAX device and memory status in status bar., MenuBar, QWidget, Create Transforms menu., Create Analysis menu., Create Pipeline menu for visual pipeline management. (+4 more)
+
+### Community 248 - "._fit"
+Cohesion: 0.12
+Nodes (9): Full Monte Carlo-based LAOS fitting.          Runs MC simulations within optimiz, Determine material phase regime from noise temperature x.          Returns:, Fit SGR GENERIC model to data using NLSQ optimization.          Routes to approp, Fit SGR GENERIC to complex modulus data (oscillation mode).          Uses NLSQ-a, Fit SGR GENERIC to relaxation modulus data (relaxation mode).          Uses NLSQ, Fit SGR GENERIC to creep compliance data (creep mode).          Uses NLSQ-accele, Fit SGR GENERIC to steady shear flow curve data.          Uses NLSQ-accelerated, Fit SGR GENERIC to startup flow data (stress growth coefficient).          Uses (+1 more)
 
 ### Community 249 - "check_model_compatibility"
-Cohesion: 0.15
-Nodes (11): check_model_compatibility(), Any, Check if a model is compatible with the given data.      This function analyzes, Tests for model-data compatibility checking., Test that FZSS is detected as incompatible with exponential decay., Test that Maxwell is compatible with exponential decay., Test that Maxwell is incompatible with power-law decay., Test that FractionalMaxwellGel is compatible with power-law. (+3 more)
+Cohesion: 0.03
+Nodes (78): Any, ArrayLike, RuntimeError, Serialize model to dictionary.          Returns:             Dictionary represen, Create model from dictionary.          Args:             data: Dictionary repres, String representation of model., Fit to data and transform it.          Args:             data: Input data (RheoD, Fit all transforms in the pipeline.          Args:             data: Training da (+70 more)
 
 ### Community 250 - "test_epm_kernels_tensorial.py"
 Cohesion: 0.07
-Nodes (51): apply_tensorial_propagator(), compute_hill_stress(), compute_von_mises_stress(), get_yield_criterion(), make_tensorial_propagator_q(), Array, Tensorial kernels for Elasto-Plastic Models (EPM).  This module implements the f, Compute von Mises effective stress for plane strain.      For plane strain: σ_zz (+43 more)
+Nodes (49): apply_tensorial_propagator(), compute_hill_stress(), compute_plastic_strain_rate(), compute_von_mises_stress(), get_yield_criterion(), Array, Tensorial kernels for Elasto-Plastic Models (EPM).  This module implements the f, Compute von Mises effective stress for plane strain.      For plane strain: σ_zz (+41 more)
 
-### Community 251 - "MutationNumber"
-Cohesion: 0.05
-Nodes (34): IntegrationMethod, MutationNumber, Array, RheoData, Perform numerical integration.          Parameters         ----------         x, Extrapolate tail contribution to infinite time.          Parameters         ----, Validate relaxation data and prepare arrays.          Parameters         -------, Estimate equilibrium modulus from tail of data.          Parameters         ---- (+26 more)
+### Community 251 - "TestMutationNumber"
+Cohesion: 0.07
+Nodes (16): Test transform method returns RheoData., Test average relaxation time calculation., Test equilibrium modulus estimation., Test suite for Mutation Number transform., Test extrapolation to infinite time (exponential)., Test error for non-relaxation data., Test basic mutation number initialization., Test handling of complex data. (+8 more)
 
-### Community 252 - "TestFrequencyDependentModulus"
-Cohesion: 0.14
-Nodes (8): Test Gp(x, z) frequency-dependent complex modulus., Test SGR Gp physical behavior for 1 < x < 2.          With the corrected Sollich, Test power-law scaling for different x values., Test G''(omega) > G'(omega) at low frequencies (viscous dominance)., Test G'(omega) approaches G0(x) at high frequencies (elastic plateau)., Test vectorized evaluation over frequency array., Test that G' >= 0 and G'' >= 0 for all frequencies., TestFrequencyDependentModulus
+### Community 252 - "Gp"
+Cohesion: 0.04
+Nodes (47): _G0_compute(), _G0_integrand(), Gp(), _Gp_integrand_imag(), _Gp_integrand_real(), _Gp_quadrature(), power_law_exponent(), JAX-compatible SGR (Soft Glassy Rheology) kernel functions.  This module provide (+39 more)
 
 ### Community 253 - "plot_lissajous"
 Cohesion: 0.10
@@ -1932,17 +1889,17 @@ Nodes (16): plot_lissajous(), Create Lissajous-Bowditch plots (stress vs strain 
 Cohesion: 0.10
 Nodes (11): Test FIKH model predictions., Create isothermal FIKH model., Create thermal FIKH model., Test startup prediction produces valid output., Test startup shows stress overshoot characteristic of EVP., Test steady-state flow curve prediction., Test flow curve shows yield stress behavior., Test LAOS prediction. (+3 more)
 
-### Community 255 - "get_logger"
+### Community 255 - "ModelService"
 Cohesion: 0.01
-Nodes (416): Enum, Application Core Components ===========================  Main window, menu bar,, Main Application Window =======================  Central window coordinating pag, # TODO: Implement project serialization (state → JSON/HDF5)., # NOTE: This guard assumes single-threaded (GUI main thread) access., Menu Bar ========  Application menu bar with File, Edit, View, Data, Models, Tra, Status Bar ==========  Application status bar with progress indicators, JAX devi, Toolbars ========  Main toolbar and related utilities. (+408 more)
+Nodes (260): Enum, Application Core Components ===========================  Main window, menu bar,, Main Application Window =======================  Central window coordinating pag, # TODO: Implement project serialization (state → JSON/HDF5)., # NOTE: This guard assumes single-threaded (GUI main thread) access., Menu Bar ========  Application menu bar with File, Edit, View, Data, Models, Tra, Status Bar ==========  Application status bar with progress indicators, JAX devi, Toolbars ========  Main toolbar and related utilities. (+252 more)
 
-### Community 256 - "load_trios"
-Cohesion: 0.04
-Nodes (70): detect_trios_format(), load_trios(), _log_parse_result(), Any, Path, RheoData, Load TRIOS file with automatic format detection.      Detects format from file e, Log parse completion with record count. (+62 more)
-
-### Community 257 - "compute_diagnostics"
+### Community 256 - "test_trios_auto_chunk.py"
 Cohesion: 0.17
-Nodes (13): compute_diagnostics(), compute_per_param_diagnostic(), _import_numpyro_diagnostics(), MCMC, ndarray, Bayesian convergence diagnostics: R-hat, ESS, divergence counting.  This module, Compute convergence diagnostics from MCMC samples.      Args:         mcmc: NumP, Lazy-import NumPyro diagnostics functions. (+5 more)
+Nodes (19): cleanup_temp_files(), Unit tests for TRIOS auto-chunking detection and behavior.  This test module val, Cleanup temporary files after each test., Test that files < 5 MB do NOT trigger auto-chunking., Test that files > 5 MB automatically trigger chunked loading., Test that files at exactly 5 MB threshold trigger chunked loading., Test that auto_chunk=False disables auto-detection for large files., Test that progress callback works when auto-chunking is triggered. (+11 more)
+
+### Community 257 - ".create_mastercurve"
+Cohesion: 0.14
+Nodes (10): RheoData, Optimize WLF parameters to minimize overlap error.          Parameters         -, Calculate WLF shift factor.          Parameters         ----------         T : f, Calculate Arrhenius shift factor.          Parameters         ----------, Get shift factor for a given temperature.          Parameters         ----------, Apply horizontal shift to single-temperature data.          Parameters         -, Apply horizontal shift to single-temperature data or create mastercurve., Create mastercurve from multiple temperature datasets.          Parameters (+2 more)
 
 ### Community 258 - "check_r_hat"
 Cohesion: 0.08
@@ -1962,19 +1919,19 @@ Nodes (24): Critical Invariants, Deliverables, Execution Order, Existing archite
 
 ### Community 262 - "create_global_parser"
 Cohesion: 0.10
-Nodes (17): create_parser(), ArgumentParser, CLI subcommand for Bayesian inference with NUTS sampling.  Usage:     rheojax, Create argument parser for bayesian subcommand., apply_globals(), create_global_parser(), ArgumentParser, Namespace (+9 more)
+Nodes (16): create_parser(), ArgumentParser, Create argument parser for fit subcommand., apply_globals(), create_global_parser(), ArgumentParser, Namespace, Shared argparse parent parser and global flag handling for the RheoJAX CLI.  All (+8 more)
 
-### Community 263 - "cmd_transform.py"
-Cohesion: 0.13
-Nodes (14): create_parser(), _load_from_envelope(), main(), _parse_params(), ArgumentParser, CLI subcommand for applying rheological transforms.  Wraps TransformRegistry to, Parse a list of 'key=value' strings into a dict with numeric conversion., Reconstruct a minimal RheoData-like object from a JSON envelope. (+6 more)
+### Community 263 - "main"
+Cohesion: 0.16
+Nodes (9): create_parser(), main(), ArgumentParser, Apply a transform to data and print results or a JSON envelope., Create argument parser for transform subcommand., Tests for rheojax.cli.cmd_transform — transform subcommand., TestCreateParser, TestMainErrors (+1 more)
 
-### Community 264 - "parse_args"
-Cohesion: 0.09
-Nodes (26): parse_args(), Namespace, Parse command line arguments.      Parameters     ----------     argv : list[str, GuiLogHandler, install_gui_log_handler(), _LogEmitter, Formatter, LogRecord (+18 more)
+### Community 264 - "test_main_cli_wiring.py"
+Cohesion: 0.12
+Nodes (21): parse_args(), Namespace, Parse command line arguments.      Parameters     ----------     argv : list[str, The --workspace flag exists and defaults to False., _FakeDestroyed, _FakeLogDock, _FakeWorkspaceWindow, Qt allows only one QApplication per process; main() unconditionally     construc (+13 more)
 
-### Community 265 - "_VizTestTransform"
-Cohesion: 0.09
-Nodes (12): fitted_pipeline(), Pipeline that has been fitted with a model., plot_transform() after transform() creates a figure., Transform results are cached for later plotting., plot_transform() can reference a specific transform by name., plot_transform() with show_intermediate=False skips input panel., reset() clears cached transform results., Complete workflow: transform → plot_transform → fit → plot_fit. (+4 more)
+### Community 265 - "._transform"
+Cohesion: 0.16
+Nodes (10): JaxArray, RheoData, Apply moving average smoothing.          Parameters         ----------         y, Compute derivative using Savitzky-Golay filter.          Parameters         ----, Compute derivative using finite differences.          Parameters         -------, Compute derivative using JIT-safe cubic splines via interpax.          Parameter, Compute derivative with total variation regularization.          This minimizes:, Compute smooth derivative of data.          Parameters         ---------- (+2 more)
 
 ### Community 266 - "test_spp_golden_parity.py"
 Cohesion: 0.15
@@ -1988,17 +1945,17 @@ Nodes (22): check_code_blocks(), check_internal_links(), check_math_blocks(), ch
 Cohesion: 0.09
 Nodes (24): ndarray, Benchmark tests for Generalized Maxwell Model element search optimization.  Test, Generate synthetic creep compliance data.      Returns:         (t, J_t): Time a, Benchmark element search for N=5 in relaxation mode.      Baseline (v0.3.1): ~10, Benchmark element search for N=10 in relaxation mode.      Baseline (v0.3.1): ~2, Benchmark element search for N=20 in relaxation mode.      Baseline (v0.3.1): ~4, Benchmark element search for N=10 in oscillation mode.      Baseline (v0.3.1): ~, Benchmark element search for N=10 in creep mode.      Baseline (v0.3.1): ~30-40s (+16 more)
 
-### Community 269 - ".export_data"
-Cohesion: 0.13
-Nodes (13): Any, Figure, Path, RheoData, Export figure to file.          Parameters         ----------         fig : Figu, Convert metadata values to JSON-serializable types., Export posterior samples.          Parameters         ----------         result, Write NUTS posterior samples to NetCDF via ArviZ InferenceData.          `result (+5 more)
-
-### Community 270 - "animate_tensorial_evolution"
+### Community 269 - "inference_data_from_dict"
 Cohesion: 0.14
-Nodes (11): FuncAnimation, Apply a batch of name→value updates with optional failure tolerance.          Re, animate_tensorial_evolution(), Create animation of tensorial stress field evolution.      Args:         history, Test animation of tensorial stress evolution., Test animation with all components., Test animation with single component (e.g., 'xx')., Test animation of von Mises effective stress. (+3 more)
+Nodes (11): inference_data_from_dict(), Build inference data across the ArviZ 0.x and 1.x dictionary APIs.      ``groups, Any, BayesianResult dataclass and related types for Bayesian inference output.  This, Convert to ArviZ InferenceData format for advanced visualization.          Conve, Write NUTS posterior samples to NetCDF via ArviZ InferenceData.          `result, Strict Bayesian parity test for GMM-like flow.  Uses bundled multi-technique fix, # NOTE: this hash differs from main because adding 'flow_quantity: str' as a (+3 more)
 
-### Community 271 - "PreviewWorker"
-Cohesion: 0.14
-Nodes (13): PreviewWorker, PreviewWorkerSignals, Any, Path, QObject, QRunnable, Preview Worker =============  Background worker for data file preview loading, Execute file preview in background thread. (+5 more)
+### Community 270 - "TestTensorialAnimation"
+Cohesion: 0.17
+Nodes (7): Test animation of tensorial stress evolution., Test animation with all components., Test animation with single component (e.g., 'xx')., Test animation of von Mises effective stress., Test animate_stress_evolution with scalar stress history., Test that an unrecognised component name raises ValueError., TestTensorialAnimation
+
+### Community 271 - "CancellationError"
+Cohesion: 0.06
+Nodes (47): BayesianWorkerSignals, Any, QObject, QRunnable, Bayesian Worker ==============  Background worker for Bayesian inference with NU, Initialize Bayesian worker.          Parameters         ----------         model, Signals for BayesianWorker.      Signals     -------     progress : Signal(int,, Slot: relay staged elapsed-time message on the GUI thread.          Called exclu (+39 more)
 
 ### Community 272 - "FractionalKelvinVoigtZener"
 Cohesion: 0.13
@@ -2008,17 +1965,17 @@ Nodes (11): FractionalKelvinVoigtZener, ndarray, Predict creep compliance J(t). 
 Cohesion: 0.13
 Nodes (11): FractionalPoyntingThomson, ndarray, Initialize Fractional Poynting-Thomson model., Predict creep compliance J(t).          J(t) = 1/G_e + (1/G_k) * (1 - E_α(-(t/τ), Predict relaxation modulus G(t).          G(t) exhibits stress relaxation from i, Predict complex modulus G*(ω).          Convert from complex compliance:, Predict response for given input.          Parameters         ----------, Model function for Bayesian inference.          This method is required by Bayes (+3 more)
 
-### Community 274 - "SPPAmplitudeSweepPipeline"
-Cohesion: 0.08
-Nodes (20): Any, Initialize SPP amplitude sweep pipeline.          Args:             omega: Angul, Fit SPPYieldStress model to extracted yield stresses.          Args:, Get full SPP results for a specific amplitude.          Args:             gamma_, Get fitted SPPYieldStress model.          Returns:             Fitted model or N, Get nonlinearity metrics (I3/I1, S, T) for each amplitude.          Returns:, Initialize model comparison pipeline.          Args:             models: List of, Initialize mastercurve pipeline.          Args:             reference_temp: Refe (+12 more)
+### Community 274 - ".get_model_result"
+Cohesion: 0.40
+Nodes (3): Any, Get fitted SPPYieldStress model.          Returns:             Fitted model or N, Get detailed results for a specific model.          Args:             model_name
 
-### Community 275 - "BaseArviZWidget"
-Cohesion: 0.16
-Nodes (9): BaseArviZWidget, Figure, Base class for widgets that embed ArviZ figures.      Provides a standardized pr, Initialize base widget.          Parameters         ----------         parent :, Release matplotlib resources before Qt widget deletion.          Prevents segfau, Cancel pending matplotlib draws before the widget is closed., Thread-safe figure replacement with proper cleanup.          This method handles, Clean up an old figure.          Parameters         ----------         fig : Fig (+1 more)
+### Community 275 - "spp_kernels.py"
+Cohesion: 0.11
+Nodes (17): apparent_cage_modulus(), calculate_loop_energy(), compute_phase_offset(), convert_units(), frenet_serret_frame(), harmonic_truncation_robustness(), JAX-compatible SPP (Sequence of Physical Processes) kernel functions.  This modu, Find indices of zero-crossings in a signal (robust implementation).      Uses li (+9 more)
 
-### Community 276 - "auto_p0.py"
-Cohesion: 0.10
-Nodes (37): _bounds_midpoint(), _clamp_to_bounds(), _compute_data_features(), _est_eta_0(), _est_modulus(), _est_prony_modulus(), _est_prony_tau(), _est_tau() (+29 more)
+### Community 276 - "TestProcessExitVerification"
+Cohesion: 0.12
+Nodes (14): _assert_process_dead(), Work function that completes immediately with a dict result., Assert a multiprocessing.Process is dead or already closed.      After ``_ensure, Work function that loops until cancel event is set., Verify no orphaned processes remain after worker lifecycle., Start worker -> let it complete -> verify no child process remains., Start long worker -> cancel -> verify child process is terminated., Start unresponsive worker -> cancel -> verify SIGKILL after timeout. (+6 more)
 
 ### Community 277 - "run_single_notebook_96h.py"
 Cohesion: 0.17
@@ -2036,17 +1993,17 @@ Nodes (13): Tests for dynamic noise temperature x(t) evolution., Test SGRGeneric
 Cohesion: 0.27
 Nodes (12): _ensure_matplotlib(), plot_3d_trajectory(), plot_moduli_evolution(), plot_pipkin_diagram(), Axes, Figure, ndarray, SPP (Sequence of Physical Processes) visualization module.  This module provides (+4 more)
 
-### Community 281 - "worker_pool.py"
-Cohesion: 0.15
-Nodes (8): QObject, QRunnable, Qt, QThreadPool, Worker Pool ==========  Thread pool for executing background jobs with progress, Initialize worker pool.          Parameters         ----------         max_threa, Submit a worker to the pool.          Parameters         ----------         work, Signal
+### Community 281 - "TestProjectStructure"
+Cohesion: 0.11
+Nodes (10): Test that JAX is installed and accessible., Test that py.typed marker file exists for type checking support., Test suite for validating project structure and setup., Test that the main rheojax package can be imported., Test that all core submodules can be imported., Test that all expected package directories exist., Test that version information is accessible and valid., Test that JAX version information is accessible. (+2 more)
 
-### Community 282 - ".simulate_laos"
-Cohesion: 0.14
-Nodes (9): ndarray, Get parameters as dict with defaults for optional params., Predict steady-state flow curve.          At steady state, mu^E → mu^E_nat, so s, Simulate startup shear flow.          Uses analytical solution for constant-rate, Simulate stress relaxation after step strain.          Parameters         ------, Simulate creep under constant stress.          Parameters         ----------, Simulate LAOS (Large Amplitude Oscillatory Shear).          Parameters         -, Predict steady-state normal stress differences.          At steady state, E-netw (+1 more)
+### Community 282 - "ndarray"
+Cohesion: 0.18
+Nodes (9): ndarray, Predict relaxation modulus G(t) using JAX.          G(t) = G_e + G_m * E_α(-(t/τ, Predict relaxation modulus G(t).          Wrapper for JIT-compiled implementatio, Predict creep compliance J(t) using JAX.          For FZSS, creep compliance is:, Predict creep compliance J(t).          Wrapper for JIT-compiled implementation., Predict complex modulus G*(ω) using JAX.          G*(ω) = G_e + G_m / (1 + (iωτ_, Predict complex modulus G*(ω).          Wrapper for JIT-compiled implementation., Predict response for given input.          Parameters         ---------- (+1 more)
 
-### Community 283 - "TestHVMSAOS"
+### Community 283 - "test_import.py"
 Cohesion: 0.12
-Nodes (9): Create pure vitrimer (G_P=0, G_D=0).          Parameters         ----------, G_P=0, G_D=0 → single vitrimer mode with factor-of-2., Small Amplitude Oscillatory Shear., G'(omega → inf) → G_P + G_E + G_D., G'' has two peaks from E and D networks., tau_E_eff = 1/(2*k_BER_0), not 1/k_BER_0., return_components=False returns |G*|., Higher T → lower tau_E → shifted crossover. (+1 more)
+Nodes (13): RheoJAX: Unified Rheological Analysis Framework.  A comprehensive rheological an, __getattr__(), Rheological models package.  This package contains 53 rheological models organiz, Lazy-load model classes on first access.      Model registration decorators (@Mo, Basic import test for the rheojax package., Test that rheojax package can be imported., Test that all submodules can be imported., Test version information structure. (+5 more)
 
 ### Community 284 - "Background Job System"
 Cohesion: 0.09
@@ -2057,12 +2014,12 @@ Cohesion: 0.12
 Nodes (13): JAXStatusWidget, QLabel, Apply themed badge styling to a QLabel.          Parameters         ----------, Apply themed styling to the memory progress bar.          Parameters         ---, Update the list of available devices.          Parameters         ----------, Set the currently active device.          Parameters         ----------, Update memory usage display.          Parameters         ----------         used, Compact widget for JAX runtime information and device control.      Features: (+5 more)
 
 ### Community 286 - "VLBNonlocal"
-Cohesion: 0.12
-Nodes (8): Cooperativity length xi = sqrt(D_mu / k_d_0).          This sets the shear band, Simulate stress-controlled creep with spatial resolution.          In creep, the, Detect shear banding from steady-state profiles.          Parameters         ---, Nonlocal VLB with tensor diffusion for shear banding.      Solves a 1D PDE acros, Plot spatial profiles (shear rate and mu_xy).          Parameters         ------, Fit is not supported for nonlocal models (use simulate methods)., Predict is not directly supported for nonlocal models., VLBNonlocal
+Cohesion: 0.09
+Nodes (11): Cooperativity length xi = sqrt(D_mu / k_d_0).          This sets the shear band, Build PDE RHS function for diffrax integration.          State: [Sigma, mu_xx[0:, Simulate approach to steady state under imposed average shear rate.          Par, Simulate startup from rest with banding evolution.          Parameters         -, Simulate stress-controlled creep with spatial resolution.          In creep, the, Detect shear banding from steady-state profiles.          Parameters         ---, Nonlocal VLB with tensor diffusion for shear banding.      Solves a 1D PDE acros, Plot spatial profiles (shear rate and mu_xy).          Parameters         ------ (+3 more)
 
-### Community 287 - "TestV032PerformanceIntegration"
+### Community 287 - ".predict_rheo"
 Cohesion: 0.15
-Nodes (10): _fast_perf_mode(), Test fractional model speedup from Mittag-Leffler optimization.          Target:, Test Mastercurve transform on multiple datasets.          Target: 2-5x speedup f, Test batch pipeline processing multiple datasets.          Target: 3-4x speedup, Test that data remains on device throughout pipeline.          Checks that JAX a, Test backward compatibility of all modified APIs.          Verifies that:, Integration tests for v0.3.2 performance optimizations., Validate cumulative performance improvement vs v0.3.1 baseline.          This is (+2 more)
+Nodes (10): ndarray, RheoData, TestMode, Fit Carreau parameters to data.          Args:             X: Shear rate data (g, Predict viscosity for given shear rates.          Args:             X: Shear rat, Model function for Bayesian inference.          This method is required by Bayes, Compute viscosity using Carreau model.          Args:             gamma_dot: She, Compute shear stress using Carreau model.          Args:             gamma_dot: (+2 more)
 
 ### Community 288 - "initialize_equilibrium"
 Cohesion: 0.16
@@ -2072,21 +2029,21 @@ Nodes (17): initialize_equilibrium(), Array, SGR Monte Carlo Simulator (Lagrangi
 Cohesion: 0.18
 Nodes (10): _coerce_array(), ArrayLike, ndarray, Get current parameter values., Evaluate objective at given values.          Args:             values: Parameter, Compute gradient of objective.          Args:             values: Parameter valu, Check if constraints are satisfied.          Args:             values: Parameter, Perform one optimization step.          Args:             values: Current parame (+2 more)
 
-### Community 290 - "save_intervals_to_excel"
-Cohesion: 0.09
-Nodes (22): _create_interval_dataframe(), _create_metadata_sheet(), _format_aux_column_name(), _get_x_column_name(), _get_y_column_name(), RheoData, Export multi-interval RheoData to Excel with one sheet per interval.      Create, Create metadata DataFrame summarizing all intervals.      Args:         rheo_dat (+14 more)
-
-### Community 291 - "._handle_transform_result"
+### Community 290 - "vlb_fene_factor"
 Cohesion: 0.12
-Nodes (8): FitResult, Render fit plot and residuals on fit page using PlotService., Handle transform application via background worker (T-009)., Synchronous fallback when WorkerPool is unavailable., Process transform output into state store (shared by async and sync paths)., Handle transform requests originating from TransformPage.          Uses Transfor, Auto-save project if a path is set and auto-save is enabled.          Defers the, Connect Transforms menu actions.
+Nodes (11): FENE-P Peterlin spring factor.      f = L²/(L² - tr(mu) + 3)      Note: We use (, FENE-P first normal stress difference: N1 = G0·f·(mu_xx - mu_yy).      Parameter, vlb_fene_factor(), vlb_stress_fene_n1(), Test FENE-P finite extensibility physics., FENE-P prevents divergence in extensional stress., FENE-P gives strain hardening relative to linear at moderate rates., Large L_max makes FENE-P approach linear stress. (+3 more)
 
-### Community 292 - ".create_fit_plot"
+### Community 291 - "_make_mock_spp_results"
+Cohesion: 0.17
+Nodes (10): _make_mock_spp_results(), Test that header row matches MATLAB SPPplus format., Test that analysis parameters are written to file., Test Fourier analysis type creates correct filename., Create mock SPP results dict for testing., Tests for MATLAB-compatible text export., Test that main SPP data file is created., Test that Frenet-Serret frame file is created when requested. (+2 more)
+
+### Community 292 - ".create_arviz_plot"
 Cohesion: 0.13
-Nodes (12): Any, Figure, RheoData, Apply matplotlib style to figure.          Parameters         ----------, Apply publication style (IEEE, Nature, etc.)., Apply presentation style (larger fonts, bold)., Apply dark-theme adjustments after RC params., Create publication-quality fit plot with optional uncertainty bands.          Pa (+4 more)
+Nodes (13): Any, Figure, RheoData, Apply matplotlib style to figure.          Parameters         ----------, Apply publication style (IEEE, Nature, etc.)., Apply presentation style (larger fonts, bold)., Apply dark-theme adjustments after RC params., Create publication-quality fit plot with optional uncertainty bands.          Pa (+5 more)
 
-### Community 293 - "._fit"
-Cohesion: 0.10
-Nodes (15): Array, ndarray, RheoData, TestMode, Fit SPP yield stress model to data.          The fitting strategy depends on the, Fit to amplitude sweep data (oscillation mode).          Uses power-law scaling:, Fit to steady shear flow curve (rotation mode).          Uses Herschel-Bulkley-l, Predict stress using fitted parameters.          Parameters         ---------- (+7 more)
+### Community 293 - "SPPYieldStress"
+Cohesion: 0.07
+Nodes (23): Distribution, Sequence of Physical Processes (SPP) models.  Contains models for LAOS (Large Am, Array, RheoData, TestMode, Initialize SPP yield stress model., Predict stress using fitted parameters.          Parameters         ----------, Model function for predictions and Bayesian inference.          This is the NumP (+15 more)
 
 ### Community 294 - "create_rheo_data_creep"
 Cohesion: 0.16
@@ -2100,57 +2057,53 @@ Nodes (11): Test that grid adapts to large sigma_c., Create a standard HL model 
 Cohesion: 0.09
 Nodes (12): Test multi-network analytical predictions., G' and G'' should be sum of Maxwell contributions., G(t) should be a multi-exponential Prony series., Startup stress is sum of individual mode transients., Flow curve should be Newtonian: sigma = eta_0 * gdot., 1 mode + permanent should give SLS creep (bounded)., G(inf) should equal G_e for network with permanent component., Creep compliance for mode + permanent network reaches bounded plateau. (+4 more)
 
-### Community 297 - "compute_plastic_strain_rate"
-Cohesion: 0.09
-Nodes (22): compute_plastic_strain_rate(), r"""Compute component-wise plastic strain rate using Prandtl-Reuss flow rule., Test that plastic strain rate aligns with stress deviator direction., Test that plastic strain rate is zero when not yielding., Test that plastic strain rate magnitude is bounded by physical limits., Test plastic flow rule with extreme relaxation times (numerical stability)., Test that plastic flow is incompressible (ε̇ᵖ_xx + ε̇ᵖ_yy ≈ 0)., Overstress form produces zero plastic rate when sigma_eff <= sigma_c_mean. (+14 more)
+### Community 297 - "TestNLSQOptimizer"
+Cohesion: 0.12
+Nodes (9): Test that float64 precision is maintained throughout optimization., Test convergence for simple optimization problem., Test that nlsq_optimize() updates ParameterSet with optimal values., Test NLSQ optimizer implementation., Test NLSQ optimizer handles tight bounds correctly., Test nlsq_optimize() function signature and parameter handling., Test that bounds are correctly extracted from ParameterSet., Test OptimizationResult dataclass structure and fields. (+1 more)
 
 ### Community 298 - "ThemeDemo"
-Cohesion: 0.14
-Nodes (13): QMainWindow, main(), QWidget, Example usage of RheoJAX GUI stylesheets.  This demonstrates how to apply themes, Create inputs demonstration tab., Create progress and feedback tab., Apply the current theme to the application., Toggle between light and dark themes. (+5 more)
-
-### Community 299 - "make_grid"
-Cohesion: 0.18
-Nodes (11): HLGrid, make_grid(), _physics_step(), Single explicit Euler step for HL model physics., Advance HL model by one time step with adaptive sub-stepping.      Implements th, Grid specification for HL solver.      Attributes:         sigma: Stress grid po, Create discretization grid for stress P(sigma).      Args:         sigma_max: Ma, step_hl() (+3 more)
-
-### Community 300 - "main"
 Cohesion: 0.15
-Nodes (11): _build_pipeline_from_envelope(), create_parser(), main(), ArgumentParser, CLI subcommand for exporting pipeline analysis results.  Wraps AnalysisExporter, Construct a minimal Pipeline populated with envelope data for export., Export pipeline results to the chosen format., Create argument parser for export subcommand. (+3 more)
+Nodes (12): QMainWindow, main(), QWidget, Example usage of RheoJAX GUI stylesheets.  This demonstrates how to apply themes, Create inputs demonstration tab., Create progress and feedback tab., Apply the current theme to the application., Toggle between light and dark themes. (+4 more)
 
-### Community 301 - ".slice"
-Cohesion: 0.12
-Nodes (15): Slice data between x values.          Args:             start: Start x value, Test second derivative of sin(t) should be -sin(t)., Test 4th-order derivative of sin(t) matches cos(t)., Test Fourier SPP analysis recovers linear moduli., For linear material, moduli should be constant so rates ~0., T, N, B vectors should be unit vectors., Test strain rate differentiation from strain., Test first derivative of sin(t) should be cos(t). (+7 more)
+### Community 299 - "json.py"
+Cohesion: 0.21
+Nodes (14): _load_schema(), load_trios_json(), parse_trios_json(), Any, Path, RheoData, TA Instruments TRIOS JSON file reader.  This module provides a reader for TRIOS, Low-level JSON parser returning TRIOSExperiment and metadata.      Args: (+6 more)
 
-### Community 302 - "TestRheoDataCreation"
-Cohesion: 0.12
-Nodes (9): Test RheoData creation and initialization., Test creating RheoData from numpy arrays., Test creating RheoData from JAX arrays., Test creating RheoData with units., Test that RheoData storage/loss modulus labels are always shear (G'/G\")., Test creating RheoData with domain specification., Test that creating empty RheoData raises appropriate error., Test that mismatched array sizes raise error. (+1 more)
+### Community 300 - "NumpyJSONEncoder"
+Cohesion: 0.10
+Nodes (16): _build_pipeline_from_envelope(), create_parser(), main(), ArgumentParser, CLI subcommand for exporting pipeline analysis results.  Wraps AnalysisExporter, Construct a minimal Pipeline populated with envelope data for export., Export pipeline results to the chosen format., Create argument parser for export subcommand. (+8 more)
+
+### Community 302 - "test_jobs.py"
+Cohesion: 0.14
+Nodes (13): Test script for background job system.  This demonstrates the functionality with, Test FitResult dataclass., Test CancellationToken functionality., Test BayesianResult dataclass., Test cancellation in a simulated workflow., Test error storage and retrieval., Test wait with timeout., test_bayesian_result_structure() (+5 more)
 
 ### Community 303 - "ExportOptionsDialog"
-Cohesion: 0.11
-Nodes (12): ExportOptionsDialog, Any, QWidget, Load current options into UI., Handle data format radio button change., Handle figure format radio button change., Handle option change., Handle dialog accepted. (+4 more)
+Cohesion: 0.10
+Nodes (13): QDialog, ExportOptionsDialog, Any, QWidget, Load current options into UI., Handle data format radio button change., Handle figure format radio button change., Handle option change. (+5 more)
 
-### Community 304 - "ndarray"
+### Community 304 - "._transform"
+Cohesion: 0.18
+Nodes (8): JaxArray, RheoData, Get window function of length n.          Parameters         ----------, Remove linear trend from data.          Parameters         ----------         y, Apply FFT transform to time-domain data.          Parameters         ----------, Apply inverse FFT to return to time domain.          Parameters         --------, Find characteristic frequency peaks in FFT spectrum.          Parameters, Extract characteristic time from FFT peak frequency.          Parameters
+
+### Community 305 - "install_gui_log_handler"
 Cohesion: 0.17
-Nodes (9): ndarray, Get all mode parameters as JAX arrays.          Uses vectorized extraction via g, Internal SAOS prediction., Predict SAOS storage and loss moduli.          Parameters         ----------, Internal flow curve prediction (steady shear).          For multi-mode Giesekus,, Predict steady shear stress.          Parameters         ----------         gamm, Simulate startup flow at constant shear rate.          Parameters         ------, Get discrete relaxation spectrum.          Returns         -------         tuple (+1 more)
-
-### Community 305 - "TestCoxMerz"
-Cohesion: 0.15
-Nodes (9): Zero viscosity values should not produce NaN/inf in log interpolation., Tests for the Cox-Merz rule validation transform., Create oscillation + flow data that satisfy Cox-Merz exactly., Cox-Merz should pass for data that satisfies the rule., Cox-Merz should fail when data diverges significantly., Should raise ValueError for wrong number of inputs., Should raise ValueError when frequency ranges don't overlap., When flow data is stress, it should be auto-converted to viscosity. (+1 more)
+Nodes (10): GuiLogHandler, install_gui_log_handler(), _LogEmitter, Formatter, LogRecord, Route log records into the GUI log panel safely., Attach GUI handler to root logger and return it., Logging utilities tests for RheoJAX GUI. (+2 more)
 
 ### Community 306 - "._optimized_wavelet_transform"
 Cohesion: 0.13
 Nodes (10): Array, ndarray, RheoData, Generate chirp wavelet at given frequency.          The chirp wavelet is a Morle, Compute wavelet transform of signal.          Uses vectorized JAX operations (vm, Optimized wavelet transform using FFT convolution.          This is much faster, Apply OWChirp transform to LAOS data.          Parameters         ----------, Get full time-frequency map (spectrogram).          Parameters         --------- (+2 more)
 
-### Community 307 - "FractionalBurgersModel"
-Cohesion: 0.04
-Nodes (42): __getattr__(), RheoJAX: Unified Rheological Analysis Framework.  A comprehensive rheological an, Lazy-load top-level subpackages on first access.      This avoids the 270ms star, FractionalBurgersModel, Initialize Fractional Burgers model., Fractional Burgers model.      A four-parameter fractional viscoelastic model co, FractionalZenerLiquidLiquid, Derive heuristic starting values from relaxation data.          For FZLL, estima (+34 more)
+### Community 307 - "FractionalZenerSolidLiquid"
+Cohesion: 0.10
+Nodes (17): __getattr__(), Lazy-load top-level subpackages on first access.      This avoids the 270ms star, FractionalZenerSolidLiquid, ndarray, Initialize Fractional Zener Solid-Liquid model., Predict relaxation modulus G(t).          G(t) = G_e + c_α * t^(-α) * E_{1-α,1}(, Predict creep compliance J(t).          Note: Analytical creep compliance for FZ, Predict complex modulus G*(ω).          G*(ω) = G_e + c_α * (iω)^α / (1 + (iωτ)^ (+9 more)
 
 ### Community 308 - "ndarray"
 Cohesion: 0.15
 Nodes (11): ndarray, Get stored ODE trajectory from last prediction.          Returns         -------, Initialize parameters from SAOS data.          Uses crossover frequency to estim, Compute model prediction for given parameters.          Parameters         -----, Predict complex modulus G*(ω) for SAOS (vectorized).          Parameters, Predict stress relaxation σ(t) (vectorized).          Parameters         -------, Predict steady shear stress σ(γ̇) (vectorized).          For UCM conformation te, Predict response for given input.          Parameters         ---------- (+3 more)
 
 ### Community 309 - "parallel_load"
-Cohesion: 0.12
-Nodes (11): parallel_load(), Any, Path, Load multiple data files in parallel using threads.      Uses ThreadPoolExecutor, Test parallel_load() for multi-file I/O., TestParallelLoad, TestParallelImports, Test parallel file loading end-to-end. (+3 more)
+Cohesion: 0.13
+Nodes (9): parallel_load(), Any, Path, Load multiple data files in parallel using threads.      Uses ThreadPoolExecutor, Test parallel_load() for multi-file I/O., TestParallelLoad, TestParallelImports, Load multiple CSV files in parallel threads. (+1 more)
 
 ### Community 310 - "TestBasicNotebooks"
 Cohesion: 0.09
@@ -2173,8 +2126,8 @@ Cohesion: 0.11
 Nodes (8): Create filled elastomer (no exchange networks).          Parameters         ----, Create model with frozen interphase (k_BER^int=0).          The interphase acts, Test limiting case recovery — highest priority tests., PRIMARY VALIDATION: phi=0 must match HVM exactly., phi=0 relaxation must match HVM., phi=0 startup must match HVM., G_E=0, G_D=0, phi>0 → only amplified permanent network., TestHVNMLimitingCases
 
 ### Community 315 - "TNTCates"
-Cohesion: 0.07
-Nodes (16): Return string representation., Get plateau modulus G₀ (Pa)., Get reptation time τ_rep (s)., Get breaking time τ_break (s)., Get solvent viscosity η_s (Pa·s)., Get effective relaxation time τ_d = √(τ_rep · τ_break) (s)., Get zero-shear viscosity η₀ = G₀·τ_d + η_s (Pa·s)., Cates living polymer (wormlike micelle) model.      Implements the Cates theory (+8 more)
+Cohesion: 0.06
+Nodes (18): Return string representation., Get plateau modulus G₀ (Pa)., Get solvent viscosity η_s (Pa·s)., Cates living polymer (wormlike micelle) model.      Implements the Cates theory, TNTCates, Test startup simulation runs., Cates model should have monotonic startup (no overshoot)., Test full conformation tensor return. (+10 more)
 
 ### Community 316 - ".predict_rheo"
 Cohesion: 0.14
@@ -2184,49 +2137,49 @@ Nodes (10): ndarray, RheoData, TestMode, Predict stress for given shear rates.  
 Cohesion: 0.14
 Nodes (12): plot_harmonic_spectrum(), Plot harmonic spectrum bar chart (I_n/I_1 vs harmonic number).      Parameters, Tests for plot_harmonic_spectrum., Bar chart creates figure with odd-harmonic labels., Normalized amplitudes: I_n/I_1 ylabel., Unnormalized: I_n ylabel., n_harmonics limits displayed bars., Empty amplitudes returns figure with 'empty' title. (+4 more)
 
-### Community 318 - "._predict_viscosity"
-Cohesion: 0.25
-Nodes (5): ndarray, Predict viscosity for given shear rates.          Args:             X: Shear rat, Model function for Bayesian inference.          This method is required by Bayes, Compute viscosity: η(γ̇) = K |γ̇|^(n-1).          Args:             gamma_dot: S, Fit Power Law parameters to data.          Args:             X: Shear rate data
+### Community 318 - ".predict_rheo"
+Cohesion: 0.14
+Nodes (10): ndarray, RheoData, TestMode, Predict viscosity for given shear rates.          Args:             X: Shear rat, Model function for Bayesian inference.          This method is required by Bayes, Compute viscosity: η(γ̇) = K |γ̇|^(n-1).          Args:             gamma_dot: S, Compute shear stress: σ(γ̇) = K |γ̇|^n.          Args:             gamma_dot: Sh, Predict shear stress for given shear rates.          Args:             gamma_dot (+2 more)
 
 ### Community 319 - "txt.py"
 Cohesion: 0.03
 Nodes (87): _add_sample_to_buffers(), _build_segment_metadata(), convert_units(), _create_rheodata_chunk(), _detect_txt_encoding(), _determine_xy_columns(), _extract_metadata(), _extract_step_temperature() (+79 more)
 
-### Community 320 - "TestLatticeEPMModelFunction"
-Cohesion: 0.12
-Nodes (9): Test model_function() for LatticeEPM., Create a small LatticeEPM for fast testing., model_function for flow_curve should return array with correct shape., model_function for flow_curve should return positive stresses., model_function for startup should return array with correct shape., model_function for relaxation should return array with correct shape., model_function for creep should return array with correct shape., model_function for oscillation should return array with correct shape. (+1 more)
-
-### Community 321 - "._predict"
+### Community 320 - ".has_message"
 Cohesion: 0.15
-Nodes (8): Any, Predict steady-state flow curve (compatibility wrapper)., Predict transient response.          Protocol inputs (``gamma_dot`` for startup,, SAOS prediction using linear viscoelastic approximation.          In the linear, Simulate LAOS response using Diffrax.          Args:             t: Time array, Simulate LAOS response.          Args:             gamma_0: Strain amplitude, NumPyro/BayesianMixin model function.          Routes to appropriate prediction, Predict based on fitted state.
+Nodes (6): Test that pipeline stages are properly logged., Test log_operation with JAX computation., Test log_transform context manager., Test that log_fit properly logs exceptions., Test log_fit context manager with actual Maxwell model., Test logging with FractionalMaxwellModel.
 
-### Community 322 - ".shape"
-Cohesion: 0.16
-Nodes (7): Internal inverse transform implementation.          Args:             data: Tran, Apply inverse transformation.          Args:             data: Transformed data, Fit the transform to data (learn parameters if needed).          Args:, Fit to data and transform it.          Args:             data: Input data (RheoD, Apply inverse transforms in reverse order.          Args:             data: Tran, Fit all transforms in the pipeline.          Args:             data: Training da, Fit model and return predictions.          Args:             X: Input features
+### Community 321 - "TestVLBTemperature"
+Cohesion: 0.15
+Nodes (7): Test Arrhenius temperature dependence., Higher T increases k_d (more thermal energy)., G0 scales linearly with T (rubber elasticity)., At T=T_ref, temperature model matches non-temp model., Time-temperature superposition: a_T = k_d(T)/k_d(T_ref)., model_function is JAX-traceable with temperature kwarg., TestVLBTemperature
+
+### Community 322 - "TransformPipeline"
+Cohesion: 0.11
+Nodes (11): Internal transform implementation to be overridden by subclasses.          Args:, Internal inverse transform implementation.          Args:             data: Tran, Transform the data.          Args:             data: Input data (RheoData or lis, Apply inverse transformation.          Args:             data: Transformed data, Compose transforms using + operator.          Args:             other: Another t, Pipeline of multiple transforms applied sequentially., Initialize transform pipeline.          Args:             transforms: List of tr, Apply all transforms in sequence.          Args:             data: Input data (R (+3 more)
 
 ### Community 323 - "test_generalized_maxwell_warm_start.py"
 Cohesion: 0.25
 Nodes (7): creep_multi_decade_data(), multi_decade_relaxation_data(), oscillation_multi_decade_data(), GMM element search warm-start correctness validation tests.  This module validat, Multi-decade creep compliance data.      Time-dependent creep response over 6 de, Multi-decade relaxation data (10⁻³ to 10⁵ s).      Typical for polymer melt visc, Multi-decade oscillatory shear data.      Frequency sweep from 0.01 to 1000 rad/
 
 ### Community 324 - "test_single_mode.py"
-Cohesion: 0.10
-Nodes (17): Tests for TNTSingleMode model.  Tests cover: - Instantiation and parameter ma, Tests for SAOS predictions., Tests for stress relaxation simulation., Tests for creep simulation., Tests for model registry integration., Test model creation via registry., Test alias creation via registry., Tests for BayesianMixin compatibility. (+9 more)
+Cohesion: 0.11
+Nodes (12): Tests for TNTSingleMode model.  Tests cover: - Instantiation and parameter ma, Tests for model registry integration., Test model creation via registry., Test alias creation via registry., Tests for model fitting., Test fitting to flow curve data., Tests for analysis helper methods., For UCM (constant breakage), overshoot ratio should be ~1. (+4 more)
 
-### Community 325 - "._arviz_plot"
-Cohesion: 0.19
-Nodes (6): Close only figures created since *pre_fignums* was captured., Run an ArviZ plot function, copy its figure, and clean up only new figures., Generate forest plot., Generate posterior plot., Generate autocorrelation plot., Display fallback message when plotting fails.          Parameters         ------
+### Community 325 - "verify_float64"
+Cohesion: 0.18
+Nodes (6): Verify that JAX is operating in float64 mode.      This function checks that JAX, verify_float64(), Tests for safe_import_jax() and float64 configuration., Calling safe_import_jax() multiple times returns same modules., Tests for safe_import_jax()., TestSafeImportJax
 
-### Community 326 - "EPMBase"
-Cohesion: 0.05
-Nodes (46): EPMBase, _jit_creep_kernel(), _jit_flow_curve_batch(), _jit_flow_curve_single(), _jit_oscillation_kernel(), _jit_relaxation_kernel(), _jit_startup_kernel(), Array (+38 more)
-
-### Community 327 - "TestPipelineExport"
+### Community 326 - "._init_state"
 Cohesion: 0.12
-Nodes (9): Tests for Pipeline.export() method., Pipeline.export() creates directory export., Pipeline.export() with .xlsx creates Excel., Auto format detection for directory path., Auto format detection for .xlsx path., Export records operation in pipeline history., Export supports fluent chaining., Invalid format raises ValueError. (+1 more)
+Nodes (10): RheoData, Stress relaxation: G(t) after step strain.          Args:             data: Rheo, Creep: Strain(t) at constant stress using Adaptive P-Controller.          The co, SAOS/LAOS: Stress(t) for sinusoidal strain.          Args:             data: Rhe, JAX-pure creep simulation with P-controller., Initialize yield thresholds from Gaussian distribution.          Args:, Initialize stress field (subclass-specific shape).          Args:             ke, Initialize full simulation state.          Args:             key: PRNG key for r (+2 more)
+
+### Community 327 - "export_spp_txt"
+Cohesion: 0.27
+Nodes (11): export_spp_txt(), _extract_spp_arrays(), ndarray, Path, SPP (Sequence of Physical Processes) data export module.  This module provides e, Export SPP results to MATLAB-compatible text format.      Creates output files m, Write main SPP data file in MATLAB format., Write Frenet-Serret frame data file in MATLAB format. (+3 more)
 
 ### Community 328 - "HerschelBulkley"
 Cohesion: 0.13
-Nodes (12): HerschelBulkley, Herschel-Bulkley model for viscoplastic flow (ROTATION only).      The Herschel-, String representation., Test apparent viscosity prediction., Test shear-thinning behavior (n < 1)., Test shear-thickening behavior (n > 1)., Test predictions for Herschel-Bulkley model., Test basic stress prediction: σ = σ_y + K γ̇^n. (+4 more)
+Nodes (12): HerschelBulkley, Herschel-Bulkley model for viscoplastic flow (ROTATION only).      The Herschel-, Initialize Herschel-Bulkley model., Test apparent viscosity prediction., Test shear-thinning behavior (n < 1)., Test shear-thickening behavior (n > 1)., Test predictions for Herschel-Bulkley model., Test basic stress prediction: σ = σ_y + K γ̇^n. (+4 more)
 
 ### Community 329 - ".result"
 Cohesion: 0.14
@@ -2240,9 +2193,9 @@ Nodes (6): Tests for plot_moduli_evolution., Minimal call creates 2 subplots (G'
 Cohesion: 0.07
 Nodes (29): Additional Observations, ADR-001: BaseModel God Class (1,610 lines, 44cc fit()), ADR-002: _fit() Boilerplate Duplication Across 41 Model Files, ADR-003: BayesianMixin at 2,163 Lines — Mixed Abstraction Levels, ADR-004: predict() Defensive kwargs Stripping (Lines 984-1021), ADR-005: GUI Complexity Hotspots, Consequences, Consequences (+21 more)
 
-### Community 332 - "import_dataset"
-Cohesion: 0.11
-Nodes (21): ColumnSpec, input_contract(), InputContract, import_dataset(), Path, RheoData, CLI/non-interactive dataset import, backing `rheojax-gui --import FILE --protoco, Shape/NaN/monotonicity checks against a loaded RheoData. Empty = valid. (+13 more)
+### Community 332 - "FitState"
+Cohesion: 0.04
+Nodes (74): FittingOptionsDialog, Any, QWidget, Load current options into UI., Fitting configuration dialog.      Options:         - Optimization algorithm, Handle algorithm combo box change., Handle option change., Handle multi-start checkbox change. (+66 more)
 
 ### Community 333 - "TestFluidityLocalModelFunction"
 Cohesion: 0.12
@@ -2253,16 +2206,16 @@ Cohesion: 0.12
 Nodes (9): Tests for Bayesian model_function interface., Test model_function works for flow curve mode., Test model_function works for oscillation mode., TC-002: Test model_function for startup protocol., TC-002: Test model_function for relaxation protocol., TC-002: Test model_function for creep protocol., TC-002: Test model_function for LAOS protocol., TC-004: LAOS without gamma_0/omega should raise. (+1 more)
 
 ### Community 335 - "test_sgr_generic_extended.py"
-Cohesion: 0.07
-Nodes (21): dynamic_x_model(), fluid_model(), glass_model(), model(), Extended tests for SGRGeneric model with advanced features.  This module conta, Tests for shear banding detection in glass regime., Test detect_shear_banding() returns correct types., Test shear banding detection in glass regime (x < 1). (+13 more)
+Cohesion: 0.12
+Nodes (14): dynamic_x_model(), fluid_model(), glass_model(), model(), Extended tests for SGRGeneric model with advanced features.  This module conta, Create a basic SGRGeneric model with default parameters., Create SGRGeneric model in glass regime (x < 1)., Create SGRGeneric model in power-law fluid regime (x > 1). (+6 more)
 
 ### Community 336 - "FitOrchestrator"
 Cohesion: 0.23
 Nodes (10): FitOrchestrator, Any, ArrayLike, Extract arrays and test_mode from RheoData., Ensure model.X_data / y_data are raw arrays, not RheoData., Remove optimization-only kwargs so they don't leak to model_function., Compute R-squared (DEBUG only) and log fit completion., Construct a FitResult, attaching uncertainty if available. (+2 more)
 
-### Community 337 - "SRFS"
-Cohesion: 0.16
-Nodes (9): Initialize SRFS transform.          Parameters         ----------         refere, Get shift factors as arrays for plotting.          Parameters         ----------, Strain-Rate Frequency Superposition (SRFS) transform.      SRFS collapses flow c, SRFS, Test suite for SRFS shift factor computation., Test SRFS shift factor a_gamma_dot from SGR theory., Test SRFS integrates with existing Mastercurve transform pattern., Test SRFS mastercurve collapse of flow curves. (+1 more)
+### Community 337 - "export_spp_csv"
+Cohesion: 0.21
+Nodes (8): export_spp_csv(), Export SPP results to CSV format.      Parameters     ----------     filepath :, Tests for CSV export., Test that CSV file is created., Test that CSV has proper header row., Test that CSV includes Frenet-Serret columns when requested., Test that CSV has correct number of data rows., TestExportSppCsv
 
 ### Community 338 - "RheoJAX GUI Package"
 Cohesion: 0.11
@@ -2272,9 +2225,9 @@ Nodes (18): Architecture, Architecture Overview, Background Workers, Contributin
 Cohesion: 0.12
 Nodes (9): Test FMLIKH model predictions., Create 2-mode isothermal FMLIKH., Test startup prediction with multiple modes., Test flow curve prediction with multiple modes., FMLIKH startup fit must reach R^2 > 0.9 when warm-started.          Regression f, FMLIKH flow-curve fit must reach R^2 > 0.9 when warm-started.          Regressio, Test that more modes changes the response., Test single-mode FMLIKH is similar to FIKH. (+1 more)
 
-### Community 340 - "TestSTZFlowTransient"
-Cohesion: 0.12
-Nodes (9): Test stress relaxation (gamma_dot = 0 after initial loading)., Test creep response (constant stress, measure strain)., Test that different variants produce different dynamics., Test suite for STZ Flow and Transient protocols., Test that Diffrax ODE integration converges properly., Test steady-state flow curve prediction., Test that stress saturates near sigma_y at high shear rates., Test stress overshoot in startup flow (strain-controlled). (+1 more)
+### Community 340 - "._model_function_scalar"
+Cohesion: 0.17
+Nodes (7): _jit_creep_kernel(), Check if this is a scalar (not tensorial) EPM.          Returns True for Lattice, Compute EPM predictions for BayesianMixin integration.          This method prov, Model function using JIT-compiled scalar kernels (for LatticeEPM)., JIT-friendly creep simulation with controller substep.          The creep P-cont, Dispatch to JIT-compiled creep kernel (substepped controller)., JIT-compiled creep simulation with a substepped P-controller.      The controlle
 
 ### Community 341 - ".predict_normal_stresses"
 Cohesion: 0.22
@@ -2284,17 +2237,17 @@ Nodes (5): ndarray, Get all parameters as a dictionary.          Returns        
 Cohesion: 0.12
 Nodes (14): lve_envelope(), _lve_envelope_jax(), Any, ndarray, RheoData, JIT-compiled LVE envelope computation., Compute LVE startup stress envelope.      σ_LVE⁺(t) = γ̇₀ [G_e * t + Σ Gᵢτᵢ (1 −, Compute LVE envelope.          Args:             data: Optional RheoData. If G_i (+6 more)
 
-### Community 343 - "TestMaxwellOscillation"
-Cohesion: 0.14
-Nodes (8): Test Maxwell oscillatory response (SAOS)., Test oscillation prediction returns correct shape., Test complex modulus matches analytical solution., Test storage modulus G' is positive., Test loss modulus G'' is positive., Test low frequency limit (viscous behavior)., Test high frequency limit (elastic behavior)., TestMaxwellOscillation
+### Community 343 - "._model_function_general"
+Cohesion: 0.20
+Nodes (6): Model function using general (non-JIT) methods (for TensorialEPM)., JAX-pure flow curve simulation (no RheoData, no numpy)., Extract the mean shear stress from a stress field.          For scalar EPM (shap, JAX-pure startup simulation., JAX-pure relaxation simulation., JAX-pure oscillation simulation.
 
-### Community 344 - "TestSpringPotOscillation"
-Cohesion: 0.14
-Nodes (8): Test SpringPot oscillatory response (SAOS)., Test oscillation prediction returns correct shape., Test complex modulus matches analytical solution., Test storage modulus G' is positive., Test loss modulus G'' is positive., Test complex modulus follows power-law in frequency., Test loss tangent tan(delta) = G''/G' is constant., TestSpringPotOscillation
+### Community 344 - "differentiate_rate_from_strain"
+Cohesion: 0.18
+Nodes (12): differentiate_rate_from_strain(), harmonic_reconstruction_full(), numerical_derivative_4th_order(), numerical_derivative_periodic(), Compute numerical derivatives using 4th-order finite differences (MATLAB SPPplus, Compute 1st, 2nd, and 3rd derivatives assuming periodic signal (MATLAB "looped", Perform full SPP analysis using numerical differentiation (MATLAB-compatible)., Compute strain rate from strain via numerical differentiation.      Provides a w (+4 more)
 
 ### Community 345 - "test_transform_page_redesign.py"
-Cohesion: 0.11
-Nodes (16): mock_store(), page(), Tests for the redesigned TransformPage., Selecting Mastercurve shows dataset checklist., Selecting FFT does NOT show dataset checklist., Empty state widget is visible before any transform is selected., Mock StateStore for testing., Clicking a sidebar item populates the parameter form. (+8 more)
+Cohesion: 0.09
+Nodes (22): _ensure_all_registered(), No-op — all transforms are eagerly imported above.      This function exists so, mock_store(), page(), Tests for the redesigned TransformPage., Selecting Mastercurve shows dataset checklist., Selecting FFT does NOT show dataset checklist., Empty state widget is visible before any transform is selected. (+14 more)
 
 ### Community 346 - "test_optimization_validation.py"
 Cohesion: 0.11
@@ -2324,21 +2277,21 @@ Nodes (10): Test Bell breakage physics: force-dependent k_d., Bell gives shear-t
 Cohesion: 0.06
 Nodes (24): Figure, ndarray, Connect internal signals., Prompt for a file path and export the current figure (Export button)., Handle plot type change.          Parameters         ----------         index :, Set data and plot residuals.          Parameters         ----------         y_tr, Set residuals directly.          Parameters         ----------         residuals, Split residuals into labeled, real-valued parts.          Returns ``[("", residu (+16 more)
 
-### Community 353 - "TestZenerOscillation"
-Cohesion: 0.14
-Nodes (8): Test Zener oscillatory response (SAOS)., Test oscillation prediction returns correct shape., Test complex modulus matches analytical solution., Test storage modulus G' is positive., Test loss modulus G'' is positive., Test low frequency limit approaches Ge., Test high frequency limit approaches Ge+Gm., TestZenerOscillation
+### Community 353 - "TestFluidityLocalOscillation"
+Cohesion: 0.17
+Nodes (7): Tests for FluidityLocal oscillation protocols., Test SAOS prediction returns [G', G''] shape., Test SAOS shows Maxwell-like behavior., Test LAOS simulation returns valid output., TC-014: At small amplitude, I_3/I_1 should be very small., Test harmonic extraction from LAOS., TestFluidityLocalOscillation
 
 ### Community 354 - "spp.py"
 Cohesion: 0.16
 Nodes (18): _add_analyze_args(), _add_batch_args(), create_parser(), main(), ArgumentParser, Namespace, Path, SPP (Sequence of Physical Processes) CLI commands.  This module provides command (+10 more)
 
-### Community 355 - "TestSAOSModuli"
-Cohesion: 0.20
-Nodes (6): Tests for small-amplitude oscillatory shear predictions., Test G' → 0 and G'' → η₀ω as ω → 0., Test G' → G and G'' → 0 as ω → ∞., Test crossover occurs at ω = 1/λ., Test vectorized SAOS computation., TestSAOSModuli
+### Community 355 - "giesekus_saos_moduli"
+Cohesion: 0.16
+Nodes (10): giesekus_complex_viscosity(), giesekus_saos_moduli(), Compute storage and loss moduli G'(ω) and G''(ω).      Uses the Cole-Cole gene, Compute complex viscosity magnitude and phase.      The complex viscosity is::, Tests for small-amplitude oscillatory shear predictions., Test G' → 0 and G'' → η₀ω as ω → 0., Test G' → G and G'' → 0 as ω → ∞., Test crossover occurs at ω = 1/λ. (+2 more)
 
-### Community 356 - "from_yaml"
-Cohesion: 0.04
-Nodes (69): _display_name(), from_pipeline_builder(), from_yaml(), _get_yaml(), _make_step(), Any, PipelineStepConfig, Pipeline serialization for GUI <-> CLI YAML round-trip.  Provides bidirectional (+61 more)
+### Community 356 - "to_yaml"
+Cohesion: 0.07
+Nodes (38): Convert GUI pipeline steps to a YAML string.      The resulting string is compat, Convert GUI pipeline steps to a PipelineBuilder.      Uses the same field mappin, to_pipeline_builder(), to_yaml(), _basic_steps(), _make_bayesian_step(), _make_export_step(), _make_fit_step() (+30 more)
 
 ### Community 357 - "TestFluidityNonlocalShearBanding"
 Cohesion: 0.14
@@ -2346,71 +2299,71 @@ Nodes (8): Tests for shear banding analysis functionality., Test fluidity profil
 
 ### Community 358 - "FractionalMaxwellLiquid"
 Cohesion: 0.04
-Nodes (37): FractionalMaxwellLiquid, ndarray, RheoData, Provide custom priors that stay near realistic data-informed scales., Tighten tau bounds based on data scale to avoid pathological samples., Prefer conservative NUTS settings for the stiff Mittag-Leffler kernel., Predict relaxation modulus G(t) using JAX.          G(t) = G_m E_{α,1}(-(t/τ)^α), Predict creep compliance J(t) using JAX.          J(t) = (1/G_m) + (t^α)/(G_m τ^ (+29 more)
+Nodes (33): FractionalMaxwellLiquid, ndarray, RheoData, Provide custom priors that stay near realistic data-informed scales., Tighten tau bounds based on data scale to avoid pathological samples., Prefer conservative NUTS settings for the stiff Mittag-Leffler kernel., Predict relaxation modulus G(t) using JAX.          G(t) = G_m E_{α,1}(-(t/τ)^α), Predict creep compliance J(t) using JAX.          J(t) = (1/G_m) + (t^α)/(G_m τ^ (+25 more)
 
-### Community 359 - "TestSteadyShearAnalytical"
-Cohesion: 0.20
-Nodes (6): Tests for steady-state analytical solutions., Test viscosity approaches η₀ at low Wi.          Note: The quartic solver has, Test viscosity decreases with shear rate., Test α=0 gives constant viscosity (UCM limit)., Test vectorized stress prediction., TestSteadyShearAnalytical
+### Community 359 - "TestFluidityNonlocalSmoke"
+Cohesion: 0.17
+Nodes (7): Smoke tests for basic FluidityNonlocal functionality., Test FluidityNonlocal can be instantiated., Test FluidityNonlocal with custom grid parameters., Test FluidityNonlocal is registered correctly., Test expected parameters are present including xi., Test cooperativity length parameter has valid bounds., TestFluidityNonlocalSmoke
 
 ### Community 360 - "._predict"
 Cohesion: 0.18
 Nodes (10): ndarray, RheoData, Predict relaxation modulus G(t) using JAX.          Derived from the inverse Lap, Predict creep compliance J(t) using JAX.          Derived from J̃(s) = 1/(s·G*(s, Predict complex modulus G*(ω) using JAX.          G*(ω) = c_1 (iω)^α / (1 + (iωτ, Internal predict implementation.          Args:             X: RheoData object o, Model function for Bayesian inference.          This method is required by Bayes, Predict response for RheoData.          Args:             rheo_data: Input RheoD (+2 more)
 
-### Community 361 - "ArrayLike"
-Cohesion: 0.14
-Nodes (10): ArrayLike, RuntimeError, Check model-data compatibility and return result.          Args:             X:, Enhance optimization error with compatibility information.          Args:, Fit the model to data using NLSQ optimization.          This method uses NLSQ (G, Precompile NLSQ residual functions to eliminate JIT cold-start.          Trigger, Internal fit implementation to be overridden by subclasses.          Args:, Make predictions.          Args:             X: Input features             test_ (+2 more)
+### Community 361 - "TestInstantiation"
+Cohesion: 0.17
+Nodes (7): Tests for model instantiation and parameters., Test model instantiates with default parameters., Test parameters can be set., Test derived properties are computed correctly., Test Weissenberg and Deborah number computations., Test theoretical N₂/N₁ ratio., TestInstantiation
 
-### Community 362 - ".predict"
-Cohesion: 0.14
-Nodes (8): ndarray, RheoData, Plot the result of a previously applied transform.          Uses TransformPlotte, Get current data state.          Returns:             Current RheoData, Attach explicit test mode information to loaded data., Generate predictions from fitted model.          Args:             model: Model, Plot current data state.          Args:             show: Whether to call plt.sh, Initialize pipeline.          Args:             data: Optional initial RheoData.
+### Community 362 - "TestShearBandingDetection"
+Cohesion: 0.17
+Nodes (7): Tests for shear banding detection in glass regime., Test detect_shear_banding() returns correct types., Test shear banding detection in glass regime (x < 1)., Test no shear banding in fluid regime (x > 1)., Test predict_banded_flow() returns correct types., Test lever rule conservation in banded flow., TestShearBandingDetection
 
-### Community 363 - ".residuals"
-Cohesion: 0.15
-Nodes (7): ndarray, Residual vector from the fit., Parameter covariance matrix from the Jacobian., Parameter confidence intervals (95%) as {name: (lower, upper)}., Parameter confidence intervals from the covariance matrix.          Args:, Prediction intervals for new x values.          Args:             x_new: New inp, Human-readable summary of the fit result.          Returns:             Multi-li
+### Community 363 - "TestVLBUtilities"
+Cohesion: 0.17
+Nodes (7): Test utility methods., Test relaxation spectrum for single mode., Test relaxation spectrum for multi-mode., Test dimensionless number calculations., Test equilibrium distribution tensor., Test parameter dict round-trip., TestVLBUtilities
 
-### Community 364 - "TestCompatibilityMessageFormatting"
-Cohesion: 0.25
-Nodes (5): Tests for compatibility message formatting., Test formatting of compatible message., Test formatting of incompatible message., Test formatting when decay/material types are unknown., TestCompatibilityMessageFormatting
+### Community 364 - "TestVLBVariantProtocols"
+Cohesion: 0.17
+Nodes (7): Test NLSQ fitting for various protocols., NLSQ fits shear-thinning flow curve., SAOS fitting (analytical Maxwell)., predict() works after fit., Startup fitting recovers Bell parameters., Relaxation fitting for constant k_d., TestVLBVariantProtocols
 
-### Community 365 - ".from_dict"
-Cohesion: 0.09
-Nodes (13): Any, Convert to dictionary representation., Create from dictionary representation.          Uses Parameter.from_dict() to pr, Link a model to a shared parameter.          Args:             model: Model to l, Get optimization history.          Returns:             List of history dictiona, Convert to dictionary representation., Create from dictionary representation., Serialize constraint to a dictionary. (+5 more)
+### Community 365 - "TestParameterSet"
+Cohesion: 0.07
+Nodes (21): Test adding parameters to set., Test retrieving parameters., Test setting parameter values., Test getting parameter values as array., Test setting parameter values from array., Test getting parameter bounds., Test serializing parameter set., Test creating parameter set from dict. (+13 more)
 
 ### Community 366 - "TestVLBVariantRegression"
 Cohesion: 0.21
 Nodes (9): VLBVariant(constant, linear) must match VLBLocal for all 6 protocols., Return (local_params, variant_params)., Flow curve matches VLBLocal to rtol < 1e-4., SAOS matches VLBLocal exactly (both analytical)., Startup matches VLBLocal to rtol < 1e-6., Relaxation matches VLBLocal exactly (both analytical for constant)., Creep matches VLBLocal to rtol < 1e-6., LAOS matches VLBLocal exactly (same ODE approach). (+1 more)
 
-### Community 367 - "TestHVNMFlowCurve"
-Cohesion: 0.18
-Nodes (5): Test steady-state flow curve predictions., E and I networks relax to zero at steady state., D-network viscous stress dominates at steady state., Steady-state flow curve is independent of phi (only D-network)., TestHVNMFlowCurve
+### Community 367 - "Array"
+Cohesion: 0.22
+Nodes (8): _jit_flow_curve_single(), _jit_oscillation_kernel(), Array, JIT-friendly oscillation simulation., Dispatch to JIT-compiled oscillation kernel., JIT-compiled flow curve for a single shear rate.      Args:         gdot: Shear, JIT-compiled oscillatory shear simulation.      ``fluidity_form`` selects the pl, Perform one EPM time step (subclass-specific kernel).          Args:
 
 ### Community 368 - "TestLogOperation"
 Cohesion: 0.14
 Nodes (8): Tests for log_operation context manager., Test that start and end are logged., Test that elapsed time is logged., Test that exceptions are logged., Test that context dict can be updated., Test that custom log level is used., Test that additional context is included., TestLogOperation
 
-### Community 369 - "_kernels.py"
-Cohesion: 0.06
-Nodes (42): evolution_lambda(), ikh_creep_ode_rhs(), ikh_maxwell_ode_rhs(), ikh_scan_kernel(), macaulay(), make_ml_ikh_creep_ode_rhs_per_mode(), make_ml_ikh_creep_ode_rhs_weighted_sum(), make_ml_ikh_maxwell_ode_rhs_per_mode() (+34 more)
+### Community 369 - "create_prony_parameter_set"
+Cohesion: 0.20
+Nodes (8): Initialize Generalized Maxwell Model.          Args:             n_modes: Number, create_prony_parameter_set(), Create ParameterSet for N-mode Prony series.      Dynamically generates paramete, test_no_tensile_modulus_type(), Test create_prony_parameter_set() for N modes., Create shear modulus parameters (G_inf, G_i, tau_i)., n_modes < 1 should raise ValueError., TestParameterSetCreation
 
-### Community 370 - "TRIOSExperiment"
-Cohesion: 0.04
-Nodes (36): Any, DataFrame, TRIOS JSON DataSet dataclass.  This module provides the TRIOSDataSet dataclass f, Extract units mapping from column definitions.          Returns:             Dic, Get list of column names., Get number of data rows., Get number of columns., Dataset containing column definitions and values.      Represents a single datas (+28 more)
+### Community 370 - "TRIOSDataSet"
+Cohesion: 0.07
+Nodes (22): Any, DataFrame, TRIOS JSON DataSet dataclass.  This module provides the TRIOSDataSet dataclass f, Extract units mapping from column definitions.          Returns:             Dic, Get list of column names., Get number of data rows., Get number of columns., Dataset containing column definitions and values.      Represents a single datas (+14 more)
 
 ### Community 371 - "conftest.py"
-Cohesion: 0.06
-Nodes (33): PlotMetrics, Clear all collected metrics., Track plot rendering performance metrics.      This class collects timing data f, Get statistics for a plot type.          Parameters         ----------         p, Get statistics for all plot types.          Returns         -------         dict, app_state_instance(), contains_emoji(), emoji_checker() (+25 more)
+Cohesion: 0.04
+Nodes (45): BaseArviZWidget, PlotMetrics, Any, Figure, Base ArviZ Widget ================  Base class for widgets that embed ArviZ/matp, Clear all collected metrics., Base class for widgets that embed ArviZ figures.      Provides a standardized pr, Release matplotlib resources before Qt widget deletion.          Prevents segfau (+37 more)
 
 ### Community 372 - "CarreauYasuda"
-Cohesion: 0.05
-Nodes (31): CarreauYasuda, ndarray, RheoData, TestMode, Fit Carreau-Yasuda parameters to data.          Args:             X: Shear rate, Predict viscosity for given shear rates.          Args:             X: Shear rat, Model function for Bayesian inference.          This method is required by Bayes, Compute viscosity using Carreau-Yasuda model.          Args:             gamma_d (+23 more)
+Cohesion: 0.14
+Nodes (13): CarreauYasuda, ndarray, RheoData, TestMode, Fit Carreau-Yasuda parameters to data.          Args:             X: Shear rate, Predict viscosity for given shear rates.          Args:             X: Shear rat, Model function for Bayesian inference.          This method is required by Bayes, Compute viscosity using Carreau-Yasuda model.          Args:             gamma_d (+5 more)
 
 ### Community 373 - "TestDMTNonlocal"
 Cohesion: 0.20
 Nodes (6): Test nonlocal (1D) DMT model., Test nonlocal model instantiation., Test cooperativity length calculation., Test steady shear simulation runs., Test shear banding detection., TestDMTNonlocal
 
-### Community 374 - ".set_parameters"
-Cohesion: 0.17
-Nodes (7): QWidget, Update displayed parameters.          Parameters         ----------         para, Reset all parameters to their original values., Create centered checkbox widget for Fixed column.          Parameters         --, Handle fixed checkbox toggle.          Parameters         ----------         par, Update row styling based on parameter state.          Parameters         -------, Initialize parameter table.          Parameters         ----------         paren
+### Community 374 - "._on_import"
+Cohesion: 0.20
+Nodes (5): Handle import data action., Load the file on a background thread (R8-NEW-003).          The previous ``QTime, Route DatasetTree context menu actions to the appropriate handler.          R13-, Handle new dataset action., Handle delete dataset action.
 
 ### Community 375 - "parallel_map"
 Cohesion: 0.16
@@ -2421,44 +2374,44 @@ Cohesion: 0.08
 Nodes (17): Test BaseTransform abstract class., Test that BaseTransform defines required interface., Test transform with numpy arrays., Test transform with JAX arrays., Test fit_transform method., Test transform with parameters., Test transform input validation., Test chaining multiple transforms. (+9 more)
 
 ### Community 377 - "G0"
-Cohesion: 0.11
-Nodes (14): G0(), Equilibrium modulus for SGR model.      Computes the dimensionless equilibrium m, Property-based tests for JAX transformation correctness., JIT compilation preserves G0 values., JIT compilation preserves Gp values., TestJAXInvariance, Test G0(x) asymptotic limits., Test that G0(x) >= 0 for all x > 0. (+6 more)
+Cohesion: 0.07
+Nodes (21): Array, JIT-compiled creep prediction: J(t).          Theory: J(t) ~ t^(x-1) for x > 1 (, JIT-compiled steady shear prediction: sigma(gamma_dot).          Theory:, JIT-compiled relaxation prediction: G(t).          Uses power-law form consisten, JIT-compiled viscosity prediction: eta(gamma_dot).          Computes viscosity a, Predict stress in steady shear mode.          Args:             gamma_dot: Shear, Model function for Bayesian inference with NumPyro NUTS.          Required by Ba, G0() (+13 more)
 
 ### Community 378 - "TestMLIKHProtocolFitting"
 Cohesion: 0.12
 Nodes (9): Tests for ML-IKH protocol-specific fitting., Generate synthetic flow curve data., Test fitting flow curve data., Test startup fitting uses return mapping (not ODE)., Test fitting relaxation data., Test fitting creep data., Test Bayesian inference on flow curve data., Verify _fit dispatches to correct sub-method based on test_mode. (+1 more)
 
-### Community 379 - ".get"
-Cohesion: 0.17
-Nodes (6): Get shared parameter value.          Args:             name: Parameter name, Get models linked to a parameter.          Args:             param_name: Paramet, Get parameters in a group.          Args:             group_name: Group name, Get a parameter by name.          Args:             name: Parameter name, Get value of a specific parameter.          Args:             name: Parameter na, Extract multiple parameter values in a single call.          This method provide
+### Community 379 - "test_window_file_menu.py"
+Cohesion: 0.38
+Nodes (9): test_maybe_confirm_unsaved_clean_state_proceeds_without_dialog(), test_maybe_confirm_unsaved_discard_still_proceeds(), test_maybe_confirm_unsaved_save_blocked_by_active_jobs_warns_and_aborts(), test_maybe_confirm_unsaved_save_cancelled_does_not_proceed(), test_maybe_confirm_unsaved_save_success_proceeds(), test_on_open_shows_critical_dialog_on_value_error(), test_on_save_as_shows_critical_dialog_on_os_error(), test_on_save_shows_critical_dialog_on_value_error() (+1 more)
 
 ### Community 380 - ".model_function"
 Cohesion: 0.17
 Nodes (6): Predict response using protocol-aware dispatch.          Parameters         ----, NumPyro/BayesianMixin model function.          Routes to appropriate prediction, Analytical steady shear stress for multi-species TNT.          σ = Σ G_i·τ_b_i·γ, Predict steady shear stress and viscosity.          Analytical superposition: σ, Internal relaxation simulation for model_function.          Analytical multi-mod, Internal creep simulation for model_function.          State: [S_xx_0, S_yy_0, S
 
 ### Community 381 - "test_cates.py"
-Cohesion: 0.17
-Nodes (10): Tests for TNTCates model (Cates living polymer / wormlike micelle).  Tests cov, Tests for creep simulation., Tests for analysis helper methods., Tests for model registry integration., Test model creation via registry., Regression tests for F-TNT-001: LAOS branch must use kwargs, not self._., TestAnalysisMethods, TestCreepSimulation (+2 more)
+Cohesion: 0.08
+Nodes (22): Tests for TNTCates model (Cates living polymer / wormlike micelle).  Tests cov, Tests for SAOS predictions., Tests for startup flow simulation., Tests for stress relaxation simulation., Tests for creep simulation., Tests for LAOS simulation., Tests for BayesianMixin compatibility., Tests for physical correctness and consistency. (+14 more)
 
-### Community 382 - "ndarray"
-Cohesion: 0.15
-Nodes (7): ndarray, Initialize parameters from SAOS data.          Uses the crossover frequency and, Initialize parameters from flow curve data.          Parameters         --------, Initialize parameters from stress relaxation data G(t) = G₀ exp(-k_d·t)., Initialize parameters from startup shear data.          Uses the steady-state st, Initialize parameters from creep data γ(t) = σ₀·(1 + k_d·t)/G₀.          Paramet, Return equilibrium distribution tensor mu_eq = I.          In the absence of flo
+### Community 382 - "TestBayesianInterface"
+Cohesion: 0.20
+Nodes (6): Tests for BayesianMixin compatibility., Test model_function for BayesianMixin., Test model_function for SAOS., Test model_function output matches predict for flow_curve.          Divergence, Test model_function output matches predict_saos for oscillation., TestBayesianInterface
 
 ### Community 383 - "TestComposedVariants"
 Cohesion: 0.12
 Nodes (9): Tests for combining multiple variant flags., Bell+FENE should have both nu and L_max parameters., Bell+FENE composition should run all 6 protocols., Bell+NonAffine should run without errors., Full composition: Bell+FENE+NonAffine should run all protocols., model_function should work for fully composed variant., Power-law breakage variant should run all protocols., Stretch-creation variant should run all protocols. (+1 more)
 
 ### Community 384 - "test_multi_mode.py"
-Cohesion: 0.14
-Nodes (12): Tests for GiesekusMultiMode model.  Tests cover: - Instantiation with differe, Tests for multi-mode SAOS predictions., Tests for multi-mode flow curve predictions., Tests for relaxation spectrum analysis., Tests for model registry integration., Test model creation via registry., Tests for ParameterSet→model_function roundtrip (the actual NUTS path).      D, TestFlowCurvePredictions (+4 more)
+Cohesion: 0.11
+Nodes (16): Tests for GiesekusMultiMode model.  Tests cover: - Instantiation with differe, Tests for multi-mode SAOS predictions., Tests for multi-mode flow curve predictions., Tests for multi-mode instantiation., Tests for relaxation spectrum analysis., Tests for model registry integration., Test model creation via registry., Tests for model_function (Bayesian interface). (+8 more)
 
 ### Community 385 - "Fractional Viscoelastic Models: Equation Verification Report"
 Cohesion: 0.08
 Nodes (24): 1. Springpot (Scott Blair Element), 2. Fractional Maxwell Model (FMM) -- Two Springpots in Series, 3. Fractional Kelvin-Voigt (FKV) -- Two Springpots in Parallel, 4. Fractional Zener (Standard Linear Solid), 5. Relaxation Modulus for FMM, 6. Mittag-Leffler Function, 7. Creep Compliance for FMM, Fractional Viscoelastic Models: Equation Verification Report (+16 more)
 
-### Community 386 - "FractionalJeffreysInitializer"
-Cohesion: 0.17
-Nodes (9): FractionalJeffreysInitializer, Initializer for FractionalJeffreys model from oscillation data.  Model equation:, Set FractionalJeffreys parameters in ParameterSet.          Parameters         -, Smart initialization for FractionalJeffreys from oscillation data., Estimate FractionalJeffreys parameters from frequency features.          Paramet, Test FractionalJeffreys initializer produces valid parameter estimates., Test FractionalJeffreys maintains eta2 < eta1., test_fj_initializer_eta_ratio() (+1 more)
+### Community 386 - "TestLVEEnvelopeTransform"
+Cohesion: 0.20
+Nodes (6): Test LVEEnvelope as a BaseTransform., Basic transform with explicit Prony parameters., Read Prony params from data metadata., Should raise ValueError when no Prony params available., G_i and tau_i must have same length., TestLVEEnvelopeTransform
 
 ### Community 387 - "test_trios_chunked_integrity.py"
 Cohesion: 0.06
@@ -2480,9 +2433,9 @@ Nodes (7): Locked-in behaviour for identifiability_check()., Relaxation: theta i
 Cohesion: 0.24
 Nodes (5): ndarray, Small (101-point) log-linear time grid covering early + late transient., Direct regression tests for the four fluidity models.      Each test constructs, _t_grid(), TestFluidityPredictWithoutFit
 
-### Community 392 - "._simulate_laos_internal"
-Cohesion: 0.20
-Nodes (6): Compute total shear stress from distribution tensor components., Return standard diffrax solver and controller., Internal startup simulation. Returns total shear stress sigma_xy(t)., Internal relaxation simulation.          Computes steady-state pre-shear conform, Internal creep simulation. Returns accumulated strain gamma(t)., Internal LAOS simulation. Returns (strain, stress) arrays.
+### Community 392 - "Exception"
+Cohesion: 0.22
+Nodes (5): Exception, Store an error that occurred during execution.          Parameters         -----, Get any error that occurred.          Returns         -------         Exception, Store an error that occurred during execution.          Parameters         -----, Get any error that occurred.          Returns         -------         Exception
 
 ### Community 393 - "TestPlotPipkinDiagram"
 Cohesion: 0.25
@@ -2496,21 +2449,21 @@ Nodes (10): create_spp_report(), Create comprehensive SPP analysis report figure
 Cohesion: 0.08
 Nodes (17): Test BaseModel abstract class., Test that BaseModel defines required interface., Test model fitting with numpy arrays., Test model fitting with JAX arrays., Test model prediction., Test model parameter management., Test model serialization., Test scikit-learn style interface. (+9 more)
 
-### Community 396 - "FractionalKelvinVoigtInitializer"
-Cohesion: 0.17
-Nodes (9): FractionalKelvinVoigtInitializer, Initializer for FractionalKelvinVoigt model from oscillation data.  Model equati, Smart initialization for FractionalKelvinVoigt from oscillation data., Estimate FractionalKelvinVoigt parameters from frequency features.          Para, Set FractionalKelvinVoigt parameters in ParameterSet.          Parameters, Test FractionalKelvinVoigt initializer produces valid parameter estimates., Test FractionalKelvinVoigt handles small datasets., test_fkv_initializer_handles_small_dataset() (+1 more)
+### Community 396 - "._predict_stress"
+Cohesion: 0.25
+Nodes (5): ndarray, Predict stress for given shear rates.          Args:             X: Shear rate d, Model function for Bayesian inference.          This method is required by Bayes, Compute shear stress using Bingham model.          Args:             gamma_dot:, Fit Bingham parameters to data.          Args:             X: Shear rate data (g
 
-### Community 397 - "test_logging_integration.py"
-Cohesion: 0.05
-Nodes (31): log_capture(), LogCapture, LogRecord, Integration tests for RheoJAX logging with actual model fitting.  Tests the logg, Test logging with RheoJAX pipeline workflows., Test that pipeline stages are properly logged., Test JAX-specific logging utilities with real JAX operations., Test log_operation with JAX computation. (+23 more)
+### Community 397 - "LogCapture"
+Cohesion: 0.15
+Nodes (9): log_capture(), LogCapture, LogRecord, Test logging configuration with actual usage., Test that configure_logging configures the logging system., Test per-subsystem log level configuration., Helper to capture log records for verification., Fixture to capture log records. (+1 more)
 
 ### Community 398 - "TestDMTBayesian"
 Cohesion: 0.12
 Nodes (9): Test model_function and Bayesian inference for DMT models., Test model_function returns correct flow curve (exponential)., Test model_function returns correct flow curve (HB)., Test model_function returns correct startup stress., Test model_function returns correct relaxation stress., Test model_function returns complex modulus for SAOS., Test model_function returns LAOS stress waveform., Smoke test: fit_bayesian works end-to-end for flow curve. (+1 more)
 
-### Community 399 - "test_prony.py"
-Cohesion: 0.04
-Nodes (52): compute_r_squared(), create_prony_parameter_set(), iterative_n_reduction(), log_tau_to_tau(), ArrayLike, Prony series utilities for Generalized Maxwell Model parameter identification., Create ParameterSet for N-mode Prony series.      Dynamically generates paramete, Transform relaxation times to log-space.      Useful for optimization over wide (+44 more)
+### Community 399 - "_kernels.py"
+Cohesion: 0.01
+Nodes (196): lazy_import(), Return a lazy proxy for *module_name*.      The real ``import`` is deferred unti, IKHBase, ArrayLike, Helper to extract time and strain from inputs.          Args:             X:, Fit model parameters to data.          Args:             X: Time/Strain input, Base class for Isotropic-Kinematic Hardening models.      These models describ, evolution_lambda() (+188 more)
 
 ### Community 400 - "TestHVNMSAOS"
 Cohesion: 0.13
@@ -2528,33 +2481,29 @@ Nodes (14): Adding New Tests, CI Configuration Examples, Future Optimizations, G
 Cohesion: 0.17
 Nodes (12): _mittag_leffler_hybrid(), _ml_asymptotic_neg(), _ml_asymptotic_pos(), _ml_taylor(), _ml_taylor_complex(), r"""Taylor series: E_{a,b}(z) = \sum_{k=0}^{N} z^k / \Gamma(a k + b).      For r, Iterative Taylor series for complex z (Kahan summation + overflow clamp)., Asymptotic expansion for large positive z (Creep mode).     E_{a,b}(z) ~ (1/a) * (+4 more)
 
-### Community 404 - "FractionalMaxwellModelInitializer"
-Cohesion: 0.17
-Nodes (9): FractionalMaxwellModelInitializer, Initializer for FractionalMaxwellModel from oscillation data.  Model equation:, Set FractionalMaxwellModel parameters in ParameterSet.          Parameters, Smart initialization for FractionalMaxwellModel from oscillation data., Estimate FractionalMaxwellModel parameters from frequency features.          Par, Test FractionalMaxwellModel initializer produces valid parameter estimates., Test FractionalMaxwellModel defaults beta to 0.5., test_fmm_initializer_defaults_beta() (+1 more)
+### Community 404 - "test_model_config.py"
+Cohesion: 0.28
+Nodes (8): ndarray, RheoData, Test model_config passthrough: service -> worker -> registry.create., n_modes=2 via model_config must expose tau_1, tau_2 but not tau_3., Omitting model_config must give the same result as model_config=None., _relaxation_rheodata(), test_model_config_changes_param_set(), test_model_config_none_is_backward_compat()
 
 ### Community 405 - "When Analytical SAOS Breaks Down for Transient Network Models and Vitrimers"
 Cohesion: 0.14
 Nodes (13): 1. VLB Multi-Network SAOS: Exact or Approximate?, 2. Vitrimer TST Stress-Coupled Bond Exchange: SAOS Validity, 3. MAOS Corrections at O(γ²) for Transient Networks, 4. The Factor-of-2 in τ_eff = 1/(2k_BER): Exact or Linear-Limit Only?, 5. Literature on SAOS Breakdown for Vitrimers, 6. Implications for RheoJAX Implementation, Critical strain amplitude γ_c, Is the analytical SAOS exact below γ_c? (+5 more)
 
-### Community 406 - "TestJAXSupport"
-Cohesion: 0.17
-Nodes (9): Test JAX-specific functionality in base classes., Test that methods can be JIT compiled., Test that methods support automatic differentiation., Test that methods support vectorization., Test JAX-specific functionality in base classes., Test that methods can be JIT compiled., Test that methods support automatic differentiation., Test that methods support vectorization. (+1 more)
+### Community 407 - "__init__.py"
+Cohesion: 0.29
+Nodes (6): available_plot_styles(), load_plot_style(), GUI Resources ============  Loader helpers for stylesheets, plot styles, and ico, Return the list of bundled matplotlib style names., Load a matplotlib style file bundled with the GUI.      Falls back to the defaul, Initialize plot service.
 
-### Community 407 - "TestModeEnum"
-Cohesion: 0.04
-Nodes (35): Enumeration of rheological test modes.      Note: Named TestModeEnum (not TestMo, Return string representation., Convert inventory Protocol to TestModeEnum., Convert TestModeEnum to inventory Protocol (best effort)., TestModeEnum, epm_flow_curve_data(), epm_oscillation_data(), epm_relaxation_data() (+27 more)
-
-### Community 408 - "TestRheoDataValidation"
-Cohesion: 0.17
-Nodes (7): Test data validation., Test validation of finite values., Test validation of NaN values., Test validation of monotonic x-axis., Test validation for positive values when required., Test that validation can be skipped., TestRheoDataValidation
+### Community 408 - "__init__.py"
+Cohesion: 0.29
+Nodes (7): _generate_qss(), _parse_tokens(), RheoJAX GUI Stylesheets.  Provides light and dark themes for the application, al, Generate a complete QSS stylesheet by substituting Python token dicts.      This, Parse @token = value definitions from a theme token file.      Parameters     --, Replace @token placeholders in base QSS with actual values.      Parameters, _substitute_tokens()
 
 ### Community 409 - ".model_function"
-Cohesion: 0.14
-Nodes (7): Internal startup simulation for model_function.          Returns total shear str, Internal relaxation simulation for model_function.          Returns relaxing str, Internal creep simulation for model_function.          Returns accumulated strai, Internal LAOS simulation for model_function.          Returns (strain, stress) a, Simulate Large-Amplitude Oscillatory Shear (LAOS).          Parameters         -, Predict response using protocol-aware dispatch.          Parameters         ----, NumPyro/BayesianMixin model function.          Routes to appropriate prediction
+Cohesion: 0.17
+Nodes (6): Internal startup simulation for model_function.          Returns total shear str, Internal creep simulation for model_function.          Returns accumulated strai, Internal LAOS simulation for model_function.          Returns (strain, stress) a, Simulate Large-Amplitude Oscillatory Shear (LAOS).          Parameters         -, Predict response using protocol-aware dispatch.          Parameters         ----, NumPyro/BayesianMixin model function.          Routes to appropriate prediction
 
 ### Community 410 - "pool.py"
-Cohesion: 0.16
-Nodes (9): _atexit_kill_pools(), Queue, Persistent process pool for JAX-safe parallel execution.  Long-lived subprocesse, Check if any worker processes are still running., Kill all remaining pool worker processes at interpreter exit., Safety net: kill worker processes if pool is garbage-collected without shutdown., Force-kill all worker processes without waiting., Worker main loop — runs in a subprocess.      Receives (task_id, fn, args, kwarg (+1 more)
+Cohesion: 0.15
+Nodes (11): _atexit_kill_pools(), Queue, Persistent process pool for JAX-safe parallel execution.  Long-lived subprocesse, Check if any worker processes are still running., Kill all remaining pool worker processes at interpreter exit., Safety net: kill worker processes if pool is garbage-collected without shutdown., Force-kill all worker processes without waiting., Pre-import JAX and register models in a worker process.      This triggers JIT c (+3 more)
 
 ### Community 411 - ".apply_transform"
 Cohesion: 0.21
@@ -2568,17 +2517,17 @@ Nodes (43): Unit tests for FluiditySaramitoLocal model.  Tests cover: - Model in
 Cohesion: 0.17
 Nodes (10): plot_cole_cole(), Create Cole-Cole diagram (G'' vs G') with optional time coloring.      Parameter, Tests for plot_cole_cole., Cole-Cole diagram creates single-axis figure., Trajectory mode with time coloring., Scatter mode (show_trajectory=False)., Mismatched G'/G'' lengths raise ValueError., Empty arrays produce a 'No data' text instead of crash. (+2 more)
 
-### Community 415 - "TestSpringPotRelaxation"
-Cohesion: 0.17
-Nodes (7): Test SpringPot relaxation modulus predictions., Test relaxation prediction returns correct shape., Test relaxation modulus matches analytical solution., Test relaxation modulus follows power-law decay., Test alpha=0 limit (pure fluid/constant)., Test alpha=1 limit (pure elastic)., TestSpringPotRelaxation
+### Community 415 - "test_export_and_project.py"
+Cohesion: 0.36
+Nodes (7): _fit_simple_relaxation(), Any, Path, RheoData, Integration smokes for export and project save/load flows., test_export_parameters_and_data(), test_project_save_load_round_trip()
 
-### Community 416 - "TestSpringPotEdgeCases"
-Cohesion: 0.17
-Nodes (7): Test SpringPot model edge cases and robustness., Test handling of very small times., Test handling of very large times., Test prediction with single data point., Test characteristic time calculation., Test alpha very close to zero., TestSpringPotEdgeCases
+### Community 416 - "TestDMTLocalFlowCurve"
+Cohesion: 0.25
+Nodes (5): Test steady-state flow curve predictions., Flow curve should show shear-thinning behavior., HB flow curve should show yield stress plateau., Test viscosity limits at extreme shear rates., TestDMTLocalFlowCurve
 
-### Community 417 - "TestZenerCreep"
-Cohesion: 0.17
-Nodes (7): Test Zener creep compliance predictions., Test creep prediction returns correct shape., Test creep compliance matches analytical solution., Test creep compliance increases monotonically., Test creep compliance at t=0 equals 1/(Ge+Gm)., Test creep compliance approaches equilibrium at long times., TestZenerCreep
+### Community 417 - "TestBinghamStability"
+Cohesion: 0.25
+Nodes (5): Test numerical stability., Test with extreme shear rates., Test at zero shear rate., Test with negative shear rates., TestBinghamStability
 
 ### Community 418 - "TestLoggerMethods"
 Cohesion: 0.14
@@ -2592,29 +2541,29 @@ Nodes (8): Test parameter bounds are physically reasonable., Test string represe
 Cohesion: 0.14
 Nodes (8): Test creep simulations., Test creep simulation runs., Strain should accumulate during creep., Creep below yield stress should be very slow., Maxwell creep should have initial elastic strain γ_e(0) = σ₀/G., As structure breaks down (λ decreases), elastic modulus decreases,         so el, Compare viscous and Maxwell creep initial behavior., TestDMTLocalCreep
 
-### Community 421 - "TestFIKHInitialization"
-Cohesion: 0.17
-Nodes (7): Test FIKH model initialization., Test default FIKH initialization., Test isothermal FIKH initialization., Test FIKH with custom fractional order., Test that alpha_structure has correct bounds., Test string representation., TestFIKHInitialization
+### Community 421 - "TestCarreauYasudaBasics"
+Cohesion: 0.25
+Nodes (5): Test basic functionality., Test model initialization., Test that a=2 reduces to Carreau model., Test that parameter 'a' affects transition width., TestCarreauYasudaBasics
 
-### Community 422 - "TestFMLIKHInitialization"
-Cohesion: 0.17
-Nodes (7): Test FMLIKH model initialization., Test default FMLIKH initialization., Test FMLIKH with custom number of modes., Test FMLIKH rejects invalid n_modes., Test isothermal FMLIKH., Test string representation., TestFMLIKHInitialization
+### Community 422 - "TestYieldStressEmergence"
+Cohesion: 0.25
+Nodes (5): Test yield stress behavior in flow curves., Create model with known yield stress., Test stress approaches τ_y at low shear rates., Test HB power-law scaling at high rates., TestYieldStressEmergence
 
 ### Community 423 - "TestThixotropy"
 Cohesion: 0.14
 Nodes (8): Tests for thixotropic stress transients., Test enable_thixotropy() activates parameters correctly., Test evolve_lambda() with build/break kinetics., Test lambda recovery at rest (zero shear)., Test predict_thixotropic_stress() returns reasonable values., Test stress overshoot behavior for step-up shear., Test W >= 0 during thixotropic evolution (1000 random states)., TestThixotropy
 
 ### Community 424 - "TNTLoopBridge"
-Cohesion: 0.05
-Nodes (23): Loop-bridge kinetics model for telechelic polymer networks.      Implements reve, Get Bell force sensitivity ν (dimensionless)., TNTLoopBridge, Test flow curve prediction via predict()., Test direct predict_flow_curve method., Test startup simulation runs., Test bridge fraction decreases during startup flow., Test relaxation simulation runs. (+15 more)
+Cohesion: 0.06
+Nodes (17): Loop-bridge kinetics model for telechelic polymer networks.      Implements reve, TNTLoopBridge, Test direct predict_flow_curve method., Test terminal regime scaling: G' ~ ω², G'' ~ ω., Test strain increases during creep., Test creep requires eta_s > 0 for stability., Test LAOS simulation runs., Test bridge fraction oscillates during LAOS. (+9 more)
+
+### Community 425 - "TestInstantiation"
+Cohesion: 0.14
+Nodes (8): Tests for model instantiation and parameters., Test default instantiation creates 2-species model with 5 parameters., Test 3-species model has 7 parameters., Test parameters can be set., Test n_species >= 1 is enforced., Test derived properties (G_total, eta_0)., Test default parameters have logarithmic spacing for tau_b., TestInstantiation
 
 ### Community 426 - "test_sticky_rouse.py"
 Cohesion: 0.08
-Nodes (23): Tests for TNTStickyRouse model.  Tests cover: - Instantiation and parameter m, Tests for sticker floor constraint: tau_eff_k = max(tau_R_k, tau_s)., Tests for SAOS predictions., Tests for startup flow simulation., Tests for stress relaxation simulation., Tests for creep simulation., Tests for LAOS simulation., Tests for BayesianMixin compatibility. (+15 more)
-
-### Community 427 - "TestModelFunctionCompleteness"
-Cohesion: 0.14
-Nodes (8): Regression tests for F-TNT-002: model_function must handle all protocols., Test model_function handles startup protocol., Test model_function handles creep protocol., Test model_function handles LAOS protocol., Test that kwargs gamma_0/omega override self._ attributes., Test startup raises ValueError without gamma_dot., Test that _fit() caches protocol kwargs for model_function fallback., TestModelFunctionCompleteness
+Nodes (23): Tests for TNTStickyRouse model.  Tests cover: - Instantiation and parameter m, Tests for sticker floor constraint: tau_eff_k = max(tau_R_k, tau_s)., Tests for flow curve (steady shear) predictions., Tests for SAOS predictions., Tests for startup flow simulation., Tests for LAOS simulation., Tests for BayesianMixin compatibility., Regression tests for F-TNT-002: model_function must handle all protocols. (+15 more)
 
 ### Community 428 - "TestParameterManagement"
 Cohesion: 0.17
@@ -2636,9 +2585,9 @@ Nodes (6): Tests for FKVZ model., Test parameter initialization., Test creep com
 Cohesion: 0.17
 Nodes (7): Steady-state flow curve behavior., E-network stress → 0 at steady state (vitrimer signature)., D-network viscous stress dominates flow curve., Stress increases monotonically with shear rate., Low shear rate: Newtonian behavior sigma = eta*gamma_dot., Components dict has expected keys., TestHVMFlowCurve
 
-### Community 433 - "compute_gl_weights"
-Cohesion: 0.21
-Nodes (8): compute_gl_weights(), Compute Grünwald-Letnikov weights for fractional derivative.      The GL weights, Test Grünwald-Letnikov weights computation., Test w_0 = 1 for all alpha., Test weights generally decrease in magnitude., Test weights have expected sign pattern for 0 < α < 1., Test GL weights sum converges to 0 as n → ∞., TestGLWeights
+### Community 433 - "TestShearThinning"
+Cohesion: 0.25
+Nodes (5): Tests for shear-thinning behavior., Test η(γ̇) is monotonically decreasing for α > 0., Test η approaches η₀ = η_p + η_s at low shear rates.          Note: Numerical, Test power-law thinning at high Wi.          At high Wi, η ~ γ̇^(n-1) where n, TestShearThinning
 
 ### Community 434 - "TestIKHKernels"
 Cohesion: 0.20
@@ -2648,9 +2597,9 @@ Nodes (6): Tests for IKH kernels directly., Test lambda evolution reaches equili
 Cohesion: 0.17
 Nodes (7): Stress relaxation after step strain., G(0+) ≈ G_P + G_E + G_D., G(t → inf) → G_P (permanent network plateau)., G(t) decreases monotonically., No NaN in relaxation modulus., return_full dict has expected keys., TestHVMRelaxation
 
-### Community 436 - "TestISMOscillationAnalytic"
-Cohesion: 0.17
-Nodes (7): SAOS limits and consistency with the creep Volterra solver., Glass: G'(omega -> 0) -> G_inf, G''(omega -> 0) -> 0., G'(omega -> inf) -> G(0) = G_inf + sum(g_i)., Fluid: G''(omega)/omega -> eta_0 = sum(g_i * tau_i) at low omega., Across many decades the analytic G*(omega) has no spurious zeros., Same Prony modes drive both J(t) and G*(omega): J(inf)*G_inf == 1., TestISMOscillationAnalytic
+### Community 436 - "TestStressOvershoot"
+Cohesion: 0.25
+Nodes (5): Tests for stress overshoot in startup flow., Test stress overshoot occurs in startup., Test overshoot ratio increases with Weissenberg number., Test overshoot occurs at strain ~ O(1).          The characteristic strain for, TestStressOvershoot
 
 ### Community 437 - "TestGetLogger"
 Cohesion: 0.17
@@ -2676,9 +2625,9 @@ Nodes (7): Large Amplitude Oscillatory Shear., No NaN in LAOS stress., LAOS retu
 Cohesion: 0.25
 Nodes (7): ndarray, Integrate FluidityNonlocal creep and return strain(t).      Uses a small grid (N, Numerical proof that G, f_inf, a, n_rejuv, xi are inert for the     nonlocal cre, Perturbing an inert parameter must leave creep strain(t) unchanged         to ~1, Sanity check: tau_y and theta (both in the identifiable set)         MUST shift, _simulate_nonlocal_creep(), TestNonlocalCreepInertParams
 
-### Community 443 - "TestEdgeCases"
-Cohesion: 0.17
-Nodes (7): Tests for edge cases in compatibility checking., Test handling of empty arrays., Test handling of single data point., Test handling of negative times., Test handling of zero modulus values., Test handling of negative modulus values., TestEdgeCases
+### Community 443 - "TestUserProvidedSk"
+Cohesion: 0.25
+Nodes (5): Test initialization with user-provided S(k)., Test that missing S(k) data raises error., Test updating S(k) after initialization., Tests for user-provided S(k) interface., TestUserProvidedSk
 
 ### Community 444 - "TestHVNMStartup"
 Cohesion: 0.15
@@ -2704,41 +2653,37 @@ Nodes (6): Construct ModelInfo by inspecting a registered model.          Tempor
 Cohesion: 0.18
 Nodes (5): Apply QSS theme to the QApplication.          When *theme* is ``"auto"``, the re, Map UI theme to default plot style., Detect the current OS color scheme.          Tries ``QStyleHints.colorScheme()``, Handle OS color scheme change.          Re-applies the theme only when the user, Connect View menu actions.
 
-### Community 450 - "._plot_pair"
-Cohesion: 0.27
-Nodes (7): _filter_degenerate_vars(), Any, Set ArviZ InferenceData object.          Parameters         ----------         i, Filter out degenerate parameters (range < 1e-10) to prevent ArviZ KDE crashes., Set current plot type.          Parameters         ----------         plot_type, Generate trace plot (convenience method).          Parameters         ----------, Generate pair plot (convenience method).          Parameters         ----------
+### Community 450 - "TestCombinedFeatures"
+Cohesion: 0.25
+Nodes (5): Tests for combining memory_form and stress_form., Test combining full memory with microscopic stress., Test combining all new options with existing options., Test that __repr__ shows all form options., TestCombinedFeatures
 
-### Community 451 - "TestOscillatoryLoading"
-Cohesion: 0.20
-Nodes (6): Tests for oscillatory test loading (US3: T028-T030)., T028: Test oscillatory loading returns complex G*., Test complex modulus G* = G' + i*G'' is computed., T030: Test G'/G'' accessible via properties., T029: Test Hz to rad/s conversion., TestOscillatoryLoading
+### Community 451 - "TestSAOS"
+Cohesion: 0.25
+Nodes (5): Tests for SAOS predictions., Test SAOS prediction., Test |G*| prediction via test_mode='oscillation'., Test terminal regime scaling: G' ~ ω², G'' ~ ω., TestSAOS
 
-### Community 452 - "FluidityBase"
-Cohesion: 0.15
-Nodes (9): FluidityBase, ndarray, Seed HB parameters (tau_y, K, n_flow) from flow-curve data.          Estimates a, Base class for Fluidity models for yield-stress fluids.      Implements shared p, Get initial fluidity value (equilibrium).          Returns:             Initial, Get all parameters as a dictionary.          Returns:             Dictionary of, Build base args dictionary for ODE integration.          Args:             param, Initialize Fluidity Base Model. (+1 more)
+### Community 453 - "FractionalZenerLiquidLiquid"
+Cohesion: 0.12
+Nodes (12): FractionalZenerLiquidLiquid, ndarray, Predict complex modulus G*(ω).          G*(ω) = c_1 * (iω)^α / (1 + (iωτ)^β) + c, Predict relaxation modulus G(t).          Approximate form (no exact closed-form, Predict creep compliance J(t).          Note: Analytical creep compliance is com, Derive heuristic starting values from relaxation data.          For FZLL, estima, Predict response for given input.          Parameters         ----------, Model function for Bayesian inference.          This method is required by Bayes (+4 more)
 
-### Community 453 - "._predict"
-Cohesion: 0.27
-Nodes (6): ndarray, Predict complex modulus G*(ω).          G*(ω) = c_1 * (iω)^α / (1 + (iωτ)^β) + c, Predict relaxation modulus G(t).          Approximate form (no exact closed-form, Predict creep compliance J(t).          Note: Analytical creep compliance is com, Predict response for given input.          Parameters         ----------, Model function for Bayesian inference.          This method is required by Bayes
+### Community 454 - "laplacian_1d_neumann_vlb"
+Cohesion: 0.17
+Nodes (8): laplacian_1d_neumann_vlb(), 1D Laplacian with Neumann (zero-flux) boundary conditions.      ∂²f/∂y² using se, Uniform initial conditions should give uniform profiles., Constant k_d with uniform IC gives uniform mu_xy profile., Startup with uniform IC stays uniform., D_mu > 0 damps spatial perturbations over time., Neumann BC: gradient at boundaries is approximately zero., TestVLBNonlocalHomogeneous
 
-### Community 454 - "TestVLBNonlocalHomogeneous"
-Cohesion: 0.20
-Nodes (6): Uniform initial conditions should give uniform profiles., Constant k_d with uniform IC gives uniform mu_xy profile., Startup with uniform IC stays uniform., D_mu > 0 damps spatial perturbations over time., Neumann BC: gradient at boundaries is approximately zero., TestVLBNonlocalHomogeneous
-
-### Community 455 - "compatibility.py"
-Cohesion: 0.31
-Nodes (10): _detect_from_oscillation(), _detect_from_relaxation(), detect_material_type(), MaterialType, ndarray, Model-data compatibility checking for rheological models.  This module provides, Detect the material type from relaxation or oscillation data.      Parameters, Detect material type from relaxation modulus. (+2 more)
+### Community 455 - "TestRelaxationSimulation"
+Cohesion: 0.25
+Nodes (5): Tests for stress relaxation simulation., Test relaxation simulation runs., Verify single-exponential relaxation for constant breakage., Test stress decays during relaxation., TestRelaxationSimulation
 
 ### Community 456 - "f12_memory_kernel"
 Cohesion: 0.23
 Nodes (7): f12_memory_kernel(), Compute F₁₂ schematic model memory kernel.      The memory kernel for the F₁₂ mo, Tests for the F12 schematic model memory kernel., m(0) = 0 for any v1, v2., m(Phi) = v1*Phi + v2*Phi^2., At v2=4, phi=1: m(1) = v2 = 4., TestF12MemoryKernel
 
-### Community 457 - "test_cross.py"
-Cohesion: 0.18
-Nodes (8): Tests for Cross model.  This module tests the Cross model for non-Newtonian flow, Test prediction with RheoData., Test error for wrong test mode., Test parameter fitting., Test model_function for Bayesian inference compatibility., TestCrossFitting, TestCrossModelFunction, TestCrossRheoData
+### Community 457 - "TestBayesianInterface"
+Cohesion: 0.25
+Nodes (5): Tests for BayesianMixin compatibility., Test model_function for flow curve., Test model_function for SAOS., Test model_function params match ParameterSet order., TestBayesianInterface
 
-### Community 458 - "BayesianMixin"
-Cohesion: 0.02
-Nodes (90): Compose transforms using + operator.          Args:             other: Another t, Pipeline of multiple transforms applied sequentially., Initialize transform pipeline.          Args:             transforms: List of tr, String representation of pipeline., TransformPipeline, BayesianMixin, Compute default midpoint for parameter initialization., Mixin class providing Bayesian inference capabilities via NumPyro NUTS.      Thi (+82 more)
+### Community 458 - "test_bayesian.py"
+Cohesion: 0.05
+Nodes (55): Tests for Bayesian inference infrastructure.  This module tests the BayesianMixi, Test that BayesianResult dataclass has required fields., Test basic fit_bayesian() workflow on simple problem., Simple model for testing BayesianMixin functionality., Test that NUTS sampling maintains float64 precision., Test that warm-starting from NLSQ initial values works., Initialize simple model., Test that warm-starting with initial values works correctly for multi-chain MCMC (+47 more)
 
 ### Community 459 - "TestFractionalBurgersModel"
 Cohesion: 0.18
@@ -2752,9 +2697,9 @@ Nodes (7): Test startup of steady shear simulations., Test that startup simulati
 Cohesion: 0.17
 Nodes (7): Regression tests for F-002: model_function must use cached protocol kwargs., After _fit_transient(gamma_dot=10), model_function must use 10, not 1., After _fit_relaxation(sigma_init=200), model_function must use 200., After _fit_creep(sigma_0=50), model_function must use 50., After _fit_oscillation(lam_0=0.8), model_function must use 0.8., After _fit_laos, model_function must use cached gamma_0/omega., TestF002KwargsCache
 
-### Community 462 - "PipelineConfigureRunStep"
-Cohesion: 0.13
-Nodes (14): PipelineConfigureRunStep, PipelineStepConfig, Pipeline mode's single step body: assemble a step sequence, select datasets, Run, Rebuild the dataset list from the library (call on library changes)., A step's config must actually satisfy what execute() requires for that step_type, _step_config_is_complete(), _ref(), test_add_step_appends_to_state() (+6 more)
+### Community 462 - "TestVLBBellFeneCombined"
+Cohesion: 0.25
+Nodes (5): Test combined Bell + FENE-P behavior., Bell+FENE: shear thinning (viscosity) but stress hardening., Bell+FENE: extensional stress is bounded., Bell+FENE LAOS produces higher harmonics., TestVLBBellFeneCombined
 
 ### Community 463 - "TestFractionalPoyntingThomson"
 Cohesion: 0.18
@@ -2764,9 +2709,9 @@ Nodes (5): Test parameter initialization., Test creep compliance., Test relaxati
 Cohesion: 0.17
 Nodes (7): Tests for normal stress differences., Test N₂/N₁ → -α/2 at low Wi (zero-shear limit)., Test that exact N₂/N₁ deviates from -α/2 at high Wi., Test N₁ > 0 (first normal stress is always positive)., Test N₂ < 0 (second normal stress is always negative)., Test N₂ → 0 as α → 0 (UCM limit)., TestNormalStresses
 
-### Community 465 - ".model_function"
-Cohesion: 0.20
-Nodes (5): NumPyro/BayesianMixin model function for DMT.          Routes to appropriate JAX, Startup shear prediction: σ(t) at constant γ̇., Stress relaxation prediction: σ(t) after cessation of shear., Creep prediction: γ(t) at constant σ₀., LAOS prediction: σ(t) under oscillatory strain.
+### Community 465 - ".predict_rheo"
+Cohesion: 0.29
+Nodes (5): RheoData, TestMode, Compute apparent viscosity using Bingham model.          Args:             gamma, Predict apparent viscosity for given shear rates.          Args:             gam, Predict rheological response for RheoData.          Args:             rheo_data:
 
 ### Community 466 - "TestFractionalJeffreysModel"
 Cohesion: 0.18
@@ -2780,17 +2725,13 @@ Nodes (5): Stack per-mode parameters in a single pass.          Reduces repeated
 Cohesion: 0.17
 Nodes (7): Tests for model instantiation and parameters., Test model instantiates with default parameters., Test derived τ_d = √(τ_rep · τ_break)., Test parameters can be set., Test derived η₀ = G₀·τ_d + η_s., Test Cates model has exactly 4 parameters., TestInstantiation
 
-### Community 469 - "TestPowerLawPredictions"
-Cohesion: 0.20
-Nodes (6): Test stress prediction: σ = K * γ̇^n., Test Newtonian limit (n = 1)., Test predictions for Power Law model., Test viscosity prediction for shear-thinning (n < 1)., Test viscosity prediction for shear-thickening (n > 1)., TestPowerLawPredictions
+### Community 469 - "PowerLaw"
+Cohesion: 0.05
+Nodes (32): PowerLaw, String representation., Power Law model for non-Newtonian flow (ROTATION only).      The Power Law (Ostw, Tests for Power Law model.  This module tests the Power Law (Ostwald-de Waele) m, Test stress prediction: σ = K * γ̇^n., Test Newtonian limit (n = 1)., Test basic functionality of Power Law model., Test model initialization. (+24 more)
 
 ### Community 470 - "TNTMultiSpecies"
 Cohesion: 0.05
-Nodes (22): Get solvent viscosity η_s (Pa·s)., Multi-species Transient Network Theory model.      Implements a network with N i, TNTMultiSpecies, Test terminal regime scaling: G' ~ ω², G'' ~ ω., Test default instantiation creates 2-species model with 5 parameters., Verify multi-exponential relaxation for 2 species., Test creep simulation runs and returns correct shape, finite., Test strain increases during creep. (+14 more)
-
-### Community 471 - "TestMaxwellLimit"
-Cohesion: 0.20
-Nodes (6): Verify TNTMultiSpecies recovers multi-mode Maxwell (generalized UCM).      For, Single species (N=1) should behave identically to single Maxwell mode., Verify σ = Σ(G_i·τ_b_i)·γ̇ + η_s·γ̇ for 2 species., Verify G'(ω) and G''(ω) match multi-mode Maxwell formulas., 2-species should show broader relaxation spectrum than 1-species., TestMaxwellLimit
+Nodes (21): Get number of bond species N., Multi-species Transient Network Theory model.      Implements a network with N i, TNTMultiSpecies, Single species (N=1) should behave identically to single Maxwell mode., Verify σ = Σ(G_i·τ_b_i)·γ̇ + η_s·γ̇ for 2 species., Test flow curve prediction returns correct shape, positive, finite., Test relaxation simulation runs and returns correct shape, finite., Test creep simulation runs and returns correct shape, finite. (+13 more)
 
 ### Community 472 - "TestStartupSimulation"
 Cohesion: 0.17
@@ -2808,6 +2749,10 @@ Nodes (7): Tests for Bell force-dependent breakage: β = (1/τ_b)·exp(ν·(stre
 Cohesion: 0.17
 Nodes (7): Tests for FENE-P finite extensibility: σ = G·f(trS)·(S-I)., FENE variant should have L_max parameter., FENE stress should saturate at high stretch (bounded by L_max).          Unlik, FENE should show strain stiffening in startup (higher transient stress)., Test model_function for FENE variant., Verify FENE variant can execute all 6 protocols., TestFENEVariant
 
+### Community 476 - "TestCreepSimulation"
+Cohesion: 0.17
+Nodes (7): Tests for creep simulation., Test creep simulation runs without error., Test creep returns correct shape., Test creep strain is finite., Test strain increases during creep., Test creep with eta_s > 0 works properly., TestCreepSimulation
+
 ### Community 477 - "Material Classification"
 Cohesion: 0.18
 Nodes (11): **Critical Gels**, **Fractional Order α (0 < α < 1)**, Material Classification, Model Selection Flowchart, Parameter Interpretation, 🔬 Rheological Fundamentals, **Shear-Thinning/Thickening**, Test Mode Guide (+3 more)
@@ -2816,69 +2761,77 @@ Nodes (11): **Critical Gels**, **Fractional Order α (0 < α < 1)**, Material Cl
 Cohesion: 0.24
 Nodes (10): NamedTuple, DefaultParameters, FeatureExtractionConfig, InitializationConstants, ParameterBounds, Constants for fractional model initialization.  This module centralizes all magi, Configuration constants for parameter initialization., Configuration for frequency-domain feature extraction. (+2 more)
 
-### Community 479 - "detect_data_range_decades"
-Cohesion: 0.27
-Nodes (5): Auto-detect optimization strategy based on data range.          Args:, detect_data_range_decades(), Detect the range of data in decades (log10 scale).      Args:         x: Data ar, Tests for detect_data_range_decades., TestDetectDataRangeDecades
+### Community 479 - "require_dependency"
+Cohesion: 0.33
+Nodes (4): Compare models using information criteria.          Parameters         ---------, Optional-dependency import guards for the GUI layer., Raise ImportError with a helpful message if *module* is not installed.      Pa, require_dependency()
 
 ### Community 480 - ".model_function"
 Cohesion: 0.20
 Nodes (5): Predict response using protocol-aware dispatch.          Parameters         ----, NumPyro/BayesianMixin model function.          Routes to appropriate prediction, Internal startup simulation for model_function.          Returns total shear str, Internal relaxation simulation for model_function.          Analytical: σ(t) = G, Internal creep simulation for model_function.          Returns accumulated strai
 
 ### Community 481 - "._transform"
-Cohesion: 0.29
-Nodes (6): RheoData, Compute SRFS shift factor from SGR theory.          For SGR materials, the shift, Apply SRFS shift to a single dataset.          Parameters         ----------, Apply SRFS transformation.          Parameters         ----------         data :, Apply SRFS transformation (public interface).          Parameters         ------, Create SRFS master curve from multiple flow curve datasets.          Parameters
+Cohesion: 0.23
+Nodes (7): RheoData, Compute SRFS shift factor from SGR theory.          For SGR materials, the shift, Apply SRFS shift to a single dataset.          Parameters         ----------, Apply SRFS transformation.          Parameters         ----------         data :, Apply SRFS transformation (public interface).          Parameters         ------, Create SRFS master curve from multiple flow curve datasets.          Parameters, Get shift factors as arrays for plotting.          Parameters         ----------
 
-### Community 482 - "FractionalZenerSSInitializer"
-Cohesion: 0.20
-Nodes (8): FractionalZenerSSInitializer, Set FZSS parameters in ParameterSet.          Parameters         ----------, Smart initialization for FractionalZenerSolidSolid from oscillation data., Estimate FZSS parameters from frequency features.          Parameters         --, Test FZSS initializer produces valid parameter estimates., Test FZSS initializer respects parameter bounds., test_fzss_initializer_produces_valid_parameters(), test_fzss_initializer_respects_bounds()
+### Community 482 - "._model_relaxation_jit"
+Cohesion: 0.33
+Nodes (4): _jit_relaxation_kernel(), JIT-friendly relaxation simulation.          Threads ``self.fluidity_form`` thro, Dispatch to JIT-compiled relaxation kernel., JIT-compiled stress relaxation simulation.      ``fluidity_form`` selects the pl
 
-### Community 483 - "NaNProducingModel"
-Cohesion: 0.22
-Nodes (6): NaNProducingModel, Verify NaN predictions are penalized, not silently zeroed., Model that can produce NaN should complete Bayesian inference., num_nonfinite deterministic should be tracked in posterior., Model that produces NaN for certain parameter regions., TestNaNGuard
+### Community 483 - "._model_startup_jit"
+Cohesion: 0.33
+Nodes (4): _jit_startup_kernel(), JIT-friendly startup simulation., Dispatch to JIT-compiled startup kernel., JIT-compiled startup shear simulation.      ``fluidity_form`` selects the plasti
 
-### Community 484 - "TestRheoDataNumpyCompatibility"
-Cohesion: 0.20
-Nodes (6): Test NumPy array operation compatibility., Test that RheoData supports numpy array operations., Test arithmetic operations on RheoData., Test indexing and slicing operations., Test that numpy functions work with RheoData., TestRheoDataNumpyCompatibility
+### Community 484 - "__init__.py"
+Cohesion: 0.33
+Nodes (4): Public API for parallel execution.  High-level convenience functions that hide p, __getattr__(), Parallel execution layer for RheoJAX.  Provides process-based parallelism for mo, Lazy import for PersistentProcessPool (avoids multiprocessing import at package
 
-### Community 485 - ".cleanup"
-Cohesion: 0.22
-Nodes (5): Figure, Explicitly release matplotlib resources before Qt widget deletion.          Must, Cancel pending matplotlib draws before the widget is closed., Replace the displayed figure, properly managing the canvas lifecycle.          U, Clear all plot content.
+### Community 485 - "test_sgr_parity.py"
+Cohesion: 0.33
+Nodes (5): laos_params(), Parity tests: SGRGeneric vs SGRConventional feature comparison.  This module v, Common parameters for both models., Common parameters for LAOS tests., shared_params()
 
-### Community 486 - "TestCreepLoading"
-Cohesion: 0.20
-Nodes (6): Test time values are correctly extracted., Test compliance values are correctly extracted., T019: Test compliance calculated when J(t) column missing., Tests for creep test loading (US1: T018-T019)., T018: Test creep loading returns correct structure., TestCreepLoading
+### Community 486 - "TestLogFormat"
+Cohesion: 0.33
+Nodes (4): Tests for LogFormat enum., Test that all expected formats exist., Test creating LogFormat from string., TestLogFormat
 
-### Community 487 - "ndarray"
+### Community 487 - "TestFitCreep"
+Cohesion: 0.33
+Nodes (4): Tests for _fit_creep implementation., _fit_creep returns self for fluent API., Viscous variant creep fit works., TestFitCreep
+
+### Community 488 - "vlb_stress_fene_xy"
 Cohesion: 0.18
-Nodes (6): ndarray, Initialize parameters from SAOS data.          Uses the crossover frequency an, Initialize parameters from flow curve data.          Parameters         -----, Initialize parameters from stress-relaxation data.          Sets G ≈ G(t=0) an, Generic warm-start for startup/creep/LAOS time-domain protocols.          Sets, Return equilibrium conformation tensor S_eq = I.          In the absence of fl
+Nodes (7): FENE-P shear stress: sigma_xy = G0 · f(tr(mu)) · mu_xy.      Parameters     ----, vlb_stress_fene_xy(), ndarray, Build initial state with small perturbation for symmetry breaking.          Para, Unpack state vector into named fields., Compute local shear rate profile from state., Compute velocity profile from final shear rate profile.          v(y) = integral
 
-### Community 488 - "ndarray"
-Cohesion: 0.29
-Nodes (4): ndarray, Unpack state vector into named fields., Compute local shear rate profile from state., Compute velocity profile from final shear rate profile.          v(y) = integral
+### Community 490 - "TestBinghamBasics"
+Cohesion: 0.33
+Nodes (4): Test basic functionality., Test model initialization., Test parameter bounds., TestBinghamBasics
 
-### Community 490 - "TestFluidityLocalFlowCurve"
-Cohesion: 0.20
-Nodes (6): Tests for FluidityLocal flow curve (steady-state) protocol., Test flow curve prediction returns correct shape., Test flow curve stress increases with shear rate., Test flow curve shows yield stress at low rates., Test flow curve at high rates approaches power-law., TestFluidityLocalFlowCurve
-
-### Community 491 - "_ExportTestModel"
-Cohesion: 0.17
-Nodes (7): _ExportTestModel, fitted_pipeline(), full_pipeline(), Pipeline with fitted model., Pipeline with transform + fit + plot., Simple model for export testing., Full pipeline with export at the end.
+### Community 491 - "TestBinghamFitting"
+Cohesion: 0.33
+Nodes (4): Test parameter fitting., Test fitting with synthetic data., Test fitting with noisy data., TestBinghamFitting
 
 ### Community 492 - "TestDMTLocalLAOS"
 Cohesion: 0.20
 Nodes (6): Test large amplitude oscillatory shear simulations., Test LAOS simulation runs., Input strain should be sinusoidal., Test Fourier harmonic extraction., Higher harmonics should increase with strain amplitude., TestDMTLocalLAOS
 
-### Community 493 - "TestMultiInterval"
-Cohesion: 0.20
-Nodes (6): Tests for multi-interval handling (T061-T064)., T061: Single-interval file returns RheoData (not list)., T062: Multi-interval file returns list when return_all=True., T063: Test interval parameter selects specific interval., T064: Test progress_callback invoked., TestMultiInterval
+### Community 493 - "TestBinghamPhysicalBehavior"
+Cohesion: 0.33
+Nodes (4): Test physical behavior., Test yield stress consistency., Test that plastic viscosity is constant above yield., TestBinghamPhysicalBehavior
+
+### Community 494 - "TestCrossStability"
+Cohesion: 0.33
+Nodes (4): Test numerical stability., Test with extreme shear rates., Test at zero shear rate., TestCrossStability
 
 ### Community 495 - "TestHVNMRelaxation"
 Cohesion: 0.18
 Nodes (5): Test stress relaxation predictions., G(t) has 4 modes: permanent plateau + E + D + I decay., G(inf) → G_P * X(phi) (amplified permanent modulus)., G(0+) ≈ sum of all network moduli., TestHVNMRelaxation
 
-### Community 497 - "TestMaxwellEdgeCases"
-Cohesion: 0.20
-Nodes (6): Test Maxwell model edge cases and robustness., Test handling of t=0 in relaxation., Test prediction with single data point., Test model with extreme parameter values., Test model with small parameter values., TestMaxwellEdgeCases
+### Community 496 - "TestBayesianInference"
+Cohesion: 0.33
+Nodes (4): Test Bayesian fitting on SAOS data., Tests for Bayesian inference with NumPyro., Test Bayesian fitting on flow curve data., TestBayesianInference
+
+### Community 497 - "TestNLSQWarmStart"
+Cohesion: 0.33
+Nodes (4): Tests for NLSQ fitting as Bayesian warm-start., Test NLSQ fitting on flow curve data., Test NLSQ fitting on SAOS data.          Uses complex G* (not magnitude) to av, TestNLSQWarmStart
 
 ### Community 499 - "Migration Guide"
 Cohesion: 0.20
@@ -2892,13 +2845,13 @@ Nodes (9): 1. Maxwell Model (Spring + Dashpot in Series), 2. Kelvin-Voigt Model 
 Cohesion: 0.20
 Nodes (9): Archive Files, Building Documentation, Documentation Tiers, Key Features, Production Documentation, RheoJAX Documentation Structure, Tier 1: User Guide (Conceptual Learning), Tier 2: Model Handbook (Technical Reference) (+1 more)
 
-### Community 502 - "build_numpyro_model"
-Cohesion: 0.20
-Nodes (9): Convert a prior specification dict to a NumPyro distribution.          Delegates, build_numpyro_model(), _import_numpyro(), prior_dict_to_dist(), Any, TestMode, Lazy-import NumPyro and its submodules., Convert a prior specification dict to a NumPyro distribution.      Supports prio (+1 more)
+### Community 502 - "TestBayesianSmoke"
+Cohesion: 0.33
+Nodes (4): Fast smoke tests for Bayesian pipeline (FAST_MODE compatible)., Verify Bayesian pipeline completes with minimal samples.          Uses 10 warm, Verify Bayesian SAOS pipeline completes with minimal samples., TestBayesianSmoke
 
-### Community 503 - "TestFIKHParameters"
-Cohesion: 0.20
-Nodes (6): Test _get_params_dict returns correct dictionary., Test FIKH parameter handling., Test all base parameters exist., Test thermal parameters exist when enabled., Test all parameters have valid bounds., TestFIKHParameters
+### Community 503 - "TestUCMLimit"
+Cohesion: 0.33
+Nodes (4): Tests for Upper-Convected Maxwell (α = 0) limit., Test α=0 gives N₂ = 0.          UCM predicts N₁ > 0 but N₂ = 0., Test α=0 SAOS matches Maxwell model exactly.          SAOS is independent of α, TestUCMLimit
 
 ### Community 504 - "run_all_notebooks.py"
 Cohesion: 0.29
@@ -2908,37 +2861,41 @@ Nodes (9): discover_notebooks(), _is_setup_cell(), main(), _print_result(), Chec
 Cohesion: 0.20
 Nodes (6): Test FIKH relaxation protocol predictions., Create isothermal FIKH model for relaxation tests., Test relaxation prediction produces valid output., Test that relaxation shows stress decay (Mittag-Leffler behavior)., Test that smaller alpha gives slower (power-law) relaxation., TestFIKHRelaxation
 
-### Community 507 - "test_parameter_schema.py"
+### Community 506 - "TestFluidityNonlocalTransient"
 Cohesion: 0.20
-Nodes (7): _extract(), Parameter-schema regression tests for the Fluidity family.  Freezes the exact pa, Explicitly assert that the old pre-April-2026 names no longer exist.      If any, Return [(name, bounds), ...] in registration order., Lock the current parameter schema for every fluidity model.      Changes to thes, TestLegacyNamesRejected, TestParameterSchema
+Nodes (6): Tests for FluidityNonlocal transient protocols., Test startup shows stress increase from zero., Test fluidity field trajectory is stored after simulation., Test relaxation shows stress decay., TC-012: Test creep strain increases under applied stress., TestFluidityNonlocalTransient
+
+### Community 507 - "_extract"
+Cohesion: 0.33
+Nodes (4): _extract(), Return [(name, bounds), ...] in registration order., Lock the current parameter schema for every fluidity model.      Changes to thes, TestParameterSchema
 
 ### Community 508 - "TestPlasticityAlpha"
 Cohesion: 0.20
 Nodes (6): Test α is bounded [0, 1]., Tests for Saramito plasticity function., Test α = 0 below yield stress., Test α > 0 above yield stress., Test α → 1 far above yield., TestPlasticityAlpha
 
-### Community 509 - "TestDMTLocalRelaxation"
-Cohesion: 0.20
-Nodes (6): Test stress relaxation simulations., Relaxation should raise error without elasticity., Test relaxation simulation runs., Stress should decay during relaxation., Structure should recover toward λ=1 during relaxation., TestDMTLocalRelaxation
+### Community 509 - "TestVLBVariantBayesian"
+Cohesion: 0.33
+Nodes (4): Test JAX traceability for Bayesian inference., model_function compiles under jax.jit for all modes., Bell model_function compiles under jax.jit., TestVLBVariantBayesian
 
-### Community 510 - "TestNonlocalShearBanding"
-Cohesion: 0.20
-Nodes (6): Test shear banding in nonlocal model., Create nonlocal model., Test nonlocal startup simulation runs., Test shear banding detection method., Test banding metrics calculation., TestNonlocalShearBanding
+### Community 510 - "test_physics.py"
+Cohesion: 0.08
+Nodes (16): Physics validation tests for Fluidity-Saramito EVP models.  Tests verify key phy, Test creep bifurcation behavior., Create model for creep tests., Test continuous flow above yield stress., Test arrested flow below yield stress., Test shear banding in nonlocal model., Create nonlocal model., Test nonlocal startup simulation runs. (+8 more)
 
-### Community 511 - "TestFractionalZenerLiquidLiquid"
-Cohesion: 0.20
-Nodes (5): Tests for FZLL model., Test parameter initialization., Test complex modulus (primary mode for FZLL)., Test model with three different fractional orders., TestFractionalZenerLiquidLiquid
+### Community 511 - "TestFluidityLocalNLSQ"
+Cohesion: 0.33
+Nodes (4): Test NLSQ fitting for FluidityLocal., NLSQ fitting for flow curve should converge., NLSQ fitting for SAOS should converge., TestFluidityLocalNLSQ
 
-### Community 512 - "TestHVMDamage"
-Cohesion: 0.20
-Nodes (6): Cooperative damage shielding., Damage is off by default., Damage parameters present when enabled., Damage model with Gamma_0=0 matches no-damage model., Damage variable D increases monotonically under load., TestHVMDamage
+### Community 512 - "TestDiagnosticsValidation"
+Cohesion: 0.33
+Nodes (4): Validate convergence diagnostics are computed correctly., R-hat should be computed correctly with multiple chains., ESS should be computed correctly., TestDiagnosticsValidation
 
 ### Community 513 - "TestNormalStressScaling"
 Cohesion: 0.20
 Nodes (6): Test normal stress difference scaling., Create model for normal stress tests., Test N₁ > 0 (Weissenberg effect)., Test N₁ increases with shear rate., Test N₂ = 0 for upper-convected Maxwell., TestNormalStressScaling
 
-### Community 514 - "test_physics.py"
-Cohesion: 0.08
-Nodes (15): Physics validation tests for Fluidity-Saramito EVP models.  Tests verify key phy, Test overshoot increases with waiting time (TC-019).          The simulate_start, Test yield stress behavior in flow curves., Create model with known yield stress., Test stress approaches τ_y at low shear rates., Compare minimal vs full coupling behavior., Test full coupling gives higher effective yield when aged., Test full coupling approaches minimal at high fluidity. (+7 more)
+### Community 514 - "TestThixotropicOvershoot"
+Cohesion: 0.25
+Nodes (5): Test overshoot increases with waiting time (TC-019).          The simulate_start, Test thixotropic stress overshoot behavior., Create thixotropic model with parameters that show overshoot.          Key insig, Test stress overshoot is present in startup., TestThixotropicOvershoot
 
 ### Community 515 - ".update_metadata"
 Cohesion: 0.22
@@ -2948,29 +2905,29 @@ Nodes (5): Any, Invalidate JAX cache when x or y data is reassigned., Update met
 Cohesion: 0.20
 Nodes (5): Test creep predictions., Strain should increase monotonically under constant stress., NP filling should reduce creep compliance., Creep strain increases with time as networks relax., TestHVNMCreep
 
-### Community 517 - "TestInstantiation"
-Cohesion: 0.20
-Nodes (6): Tests for multi-mode instantiation., Test model instantiates with default 3 modes., Test instantiation with custom number of modes., Test error for invalid n_modes., Test parameters are created for each mode., TestInstantiation
+### Community 517 - "TestFFTPlot"
+Cohesion: 0.33
+Nodes (4): Tests for FFT analysis visualization., FFT plot with input data shows 2 panels., FFT plot without input shows single panel., TestFFTPlot
 
-### Community 518 - "TestPercusYevickSk"
-Cohesion: 0.20
-Nodes (6): Tests for Percus-Yevick S(k) computation., Test S(k) is always positive., Test S(k) has characteristic peak., Test S(k) peak increases with volume fraction., Test hard_sphere_properties utility., TestPercusYevickSk
+### Community 518 - "bayesian_completed"
+Cohesion: 0.40
+Nodes (5): bayesian_completed(), BayesianResult, Store a completed Bayesian result.      Routes through dispatch() to ensure pipe, Mark Bayesian inference as completed (dispatches internally).      Parameters, store_bayesian_result()
 
-### Community 519 - "TestMittagLefflerAccuracy"
-Cohesion: 0.20
-Nodes (6): Test accuracy for moderate |z| in rheological range., Test E_α(-z) for negative arguments (relaxation modulus case)., Test E_{α,β}(z) accuracy for various parameter combinations., Test numerical accuracy for rheological range |z| < 10., Test accuracy for small |z| using hybrid Taylor/asymptotic., TestMittagLefflerAccuracy
+### Community 519 - ".__init__"
+Cohesion: 0.40
+Nodes (3): VariantType, Initialize STZ Base Model.          Args:             variant: Complexity varian, Initialize ParameterSet based on selected variant.
 
-### Community 520 - "TestMittagLefflerJAXCompatibility"
-Cohesion: 0.20
-Nodes (6): Test JAX-specific features., Test mittag_leffler_e is already JIT compiled., Test mittag_leffler_e2 is already JIT compiled., Test that mittag_leffler_e works with vmap., Test that gradient can be computed through mittag_leffler_e., TestMittagLefflerJAXCompatibility
+### Community 520 - "test_parameter_schema.py"
+Cohesion: 0.40
+Nodes (3): Parameter-schema regression tests for the Fluidity family.  Freezes the exact pa, Explicitly assert that the old pre-April-2026 names no longer exist.      If any, TestLegacyNamesRejected
 
 ### Community 521 - "TestDiffraxCompilation"
 Cohesion: 0.20
 Nodes (6): Tests for diffrax JIT compilation performance., Create ITTMCTSchematic model for testing., Test that JIT compilation happens on first call., Test that precompile() method triggers compilation., Test that precompile() reduces the effective first-call time., TestDiffraxCompilation
 
-### Community 522 - "TestRotationalLoading"
-Cohesion: 0.25
-Nodes (5): Tests for rotational/flow test loading (US4: T055-T057)., T055: Test rotational loading returns correct structure., T056: Test shear rate ordering preserved., T057: Test y_col allows selecting alternative column., TestRotationalLoading
+### Community 522 - "_synthetic_laos"
+Cohesion: 0.40
+Nodes (5): Generate a simple LAOS waveform with optional 3rd harmonic., _synthetic_laos(), test_apparent_cage_modulus_matches_modulus_in_linear_regime(), test_lissajous_metrics_positive_area(), test_static_and_dynamic_yield_stress_linear_material()
 
 ### Community 523 - "TestCatesMaxwellLimit"
 Cohesion: 0.20
@@ -2980,49 +2937,29 @@ Nodes (6): Verify Cates model reduces to Maxwell behavior with effective τ_d.  
 Cohesion: 0.20
 Nodes (6): Tests for flow curve (steady shear) predictions., Test flow curve prediction via predict()., Test direct predict_flow_curve method., Test flow curve with viscosity and N₁., Cates with constant breakage gives Newtonian viscosity., TestFlowCurve
 
-### Community 525 - "TestStartupSimulation"
-Cohesion: 0.20
-Nodes (6): Tests for startup flow simulation., Test startup simulation runs., Cates model should have monotonic startup (no overshoot)., Startup should approach steady-state stress σ_ss = η₀·γ̇., Test full conformation tensor return., TestStartupSimulation
-
 ### Community 526 - "TestJAXCompatibility"
 Cohesion: 0.20
 Nodes (6): Test JAX transformations (jit, vmap, grad)., Test that G0 JIT compiles successfully., Test that Gp JIT compiles successfully., Test G0 vectorization with vmap., Test Gp vectorization over frequency array., TestJAXCompatibility
 
-### Community 527 - "TestLAOSSimulation"
-Cohesion: 0.20
-Nodes (6): Tests for LAOS simulation., Test LAOS simulation runs., Test LAOS response is periodic after transient., Small-amplitude LAOS should match SAOS (linear limit)., Test LAOS harmonic extraction., TestLAOSSimulation
-
-### Community 528 - "TestPhysicalConsistency"
-Cohesion: 0.20
-Nodes (6): Tests for physical correctness and consistency., Test stress is positive for positive shear rate., Test first normal stress difference N₁ >= 0., Test conformation tensor stays positive definite during startup., Test relaxation stress stays positive., TestPhysicalConsistency
-
-### Community 529 - "TestLatticeEPMNLSQ"
-Cohesion: 0.20
-Nodes (6): Test NLSQ fitting for LatticeEPM., Create a small LatticeEPM for fast testing., NLSQ fitting for flow curve should converge., NLSQ fitting for startup should converge., NLSQ fitting for relaxation should converge., TestLatticeEPMNLSQ
-
 ### Community 530 - "test_loop_bridge.py"
-Cohesion: 0.08
-Nodes (24): _cleanup_jit_caches(), Tests for TNTLoopBridge model.  Tests cover: - Instantiation and parameter ma, Tests for flow curve (steady shear) predictions., Free JIT caches after each test to prevent xdist worker OOM.      TNT loop_bri, Tests for startup flow simulation., Tests for stress relaxation simulation., Tests for model instantiation and parameters., Tests for LAOS simulation. (+16 more)
+Cohesion: 0.06
+Nodes (30): _cleanup_jit_caches(), Tests for TNTLoopBridge model.  Tests cover: - Instantiation and parameter ma, Tests for flow curve (steady shear) predictions., Tests for SAOS predictions., Free JIT caches after each test to prevent xdist worker OOM.      TNT loop_bri, Tests for startup flow simulation., Tests for stress relaxation simulation., Tests for creep simulation. (+22 more)
 
 ### Community 531 - "TestPlotRheoData"
 Cohesion: 0.20
 Nodes (6): Test plot_rheo_data automatic plot type selection., Test plotting time-domain data., Test plotting frequency-domain data., Test plotting with custom matplotlib kwargs., Test plotting rotation (flow curve) data., TestPlotRheoData
 
-### Community 532 - ".from_dict"
-Cohesion: 0.22
-Nodes (5): Any, Serialize model to dictionary.          Returns:             Dictionary represen, Create model from dictionary.          Args:             data: Dictionary repres, String representation of model., Get model parameters.          Args:             deep: If True, return parameter
+### Community 533 - "TestLogTransform"
+Cohesion: 0.50
+Nodes (3): Tests for log_transform context manager., Test that transform-specific context is logged., TestLogTransform
 
-### Community 534 - "TestBayesianInterface"
-Cohesion: 0.20
-Nodes (6): Tests for BayesianMixin compatibility., Test model_function for flow curve., Test model_function for SAOS., Test model_function params match ParameterSet order., Verify parameter order for Bayesian inference., TestBayesianInterface
+### Community 535 - "TestLogIO"
+Cohesion: 0.50
+Nodes (3): Tests for log_io context manager., Test that I/O-specific context is logged., TestLogIO
 
-### Community 535 - "._copy_arviz_figure"
-Cohesion: 0.25
-Nodes (5): Figure, Scale the figure to the viewport width, preserving aspect ratio.          Instea, Swap ArviZ-generated figure into our Qt canvas.          ArviZ plotting function, Replace tab characters with spaces in all figure text.          ArviZ sometimes, Get matplotlib figure.          Returns         -------         Figure
-
-### Community 536 - "test_plot_service_golden.py"
-Cohesion: 0.31
-Nodes (8): _generate_fit_plot(), _images_similar(), Path, Generate and compare PlotService goldens using sample data.  On first run, golde, Test PlotService fit plot against golden image., Compare two images with perceptual tolerance.      Returns     -------     tuple, Generate a fit plot for testing., test_plot_service_fit_golden()
+### Community 536 - "TestLoggingErrorHandling"
+Cohesion: 0.50
+Nodes (3): Test logging during error conditions., Test that exceptions are logged with type information., TestLoggingErrorHandling
 
 ### Community 537 - "TestNonAffineVariant"
 Cohesion: 0.20
@@ -3036,61 +2973,33 @@ Nodes (6): Verify TNT basic model recovers exact Maxwell behavior.      The cons
 Cohesion: 0.20
 Nodes (6): Tests for flow curve (steady shear) predictions., Test flow curve prediction via predict()., Test direct predict_flow_curve method., Test flow curve with viscosity and N1., Constant breakage gives Newtonian viscosity (no shear thinning)., TestFlowCurve
 
-### Community 540 - "TestRelaxationLoading"
-Cohesion: 0.25
-Nodes (5): Tests for relaxation test loading (US2: T020-T021)., T020: Test relaxation loading returns correct structure., Test relaxation modulus values are correctly extracted., T021: Test G(t) calculated when column missing., TestRelaxationLoading
+### Community 540 - "TestBinghamModelFunction"
+Cohesion: 0.50
+Nodes (3): Test model_function for Bayesian inference compatibility., Test that model_function output matches predict., TestBinghamModelFunction
 
 ### Community 541 - "TestLAOSSimulation"
 Cohesion: 0.20
 Nodes (6): Tests for LAOS simulation., Test LAOS simulation runs., Test LAOS response is periodic after transient., Small-amplitude LAOS should match SAOS (linear limit)., Test LAOS harmonic extraction., TestLAOSSimulation
 
-### Community 542 - "TestFlowCurve"
-Cohesion: 0.20
-Nodes (6): Tests for flow curve (steady shear) predictions., Test flow curve prediction returns correct shape., Test flow curve stress is positive., Test flow curve stress is finite., Test flow curve approaches Newtonian behavior at low shear rates.          At, TestFlowCurve
-
-### Community 543 - "TestErrorHandling"
-Cohesion: 0.25
-Nodes (5): Tests for error handling (T075-T078)., T075: Test FileNotFoundError for missing file., T076: Test ValueError for no interval blocks., T078: Test error for interval index out of range., TestErrorHandling
+### Community 543 - "TestGMMBayesianPriorSafetyIntegration"
+Cohesion: 0.50
+Nodes (3): Test integration of prior safety with Bayesian inference., Test that fit_bayesian uses NLSQ estimates when convergence is good., TestGMMBayesianPriorSafetyIntegration
 
 ### Community 544 - "TNTStickyRouse"
 Cohesion: 0.04
-Nodes (26): Sticky Rouse model for associative polymers.      Multi-mode Maxwell model where, Number of Rouse modes., Sticker lifetime (s)., Solvent viscosity (Pa·s)., TNTStickyRouse, Test effective times are τ_R_k + τ_s (Leibler-Rubinstein-Colby 1991)., When tau_s > tau_R_k, sticker contribution dominates., Test SAOS prediction returns correct shapes. (+18 more)
+Nodes (26): Sticky Rouse model for associative polymers.      Multi-mode Maxwell model where, Number of Rouse modes., Sticker lifetime (s)., Solvent viscosity (Pa·s)., TNTStickyRouse, Test effective times are τ_R_k + τ_s (Leibler-Rubinstein-Colby 1991)., When tau_s > tau_R_k, sticker contribution dominates., Test flow curve prediction returns correct shape. (+18 more)
 
-### Community 546 - "TestLazyNumPyroImports"
-Cohesion: 0.29
-Nodes (6): _import_numpyro(), Lazy-import NumPyro and its submodules.      Returns all NumPyro symbols needed, Verify that _import_numpyro() provides all necessary symbols., _import_numpyro() should return numpyro, dist, transforms, MCMC, NUTS, init_to_*, Calling _import_numpyro() twice returns same objects., TestLazyNumPyroImports
+### Community 546 - "TestBayesianIntegration"
+Cohesion: 0.50
+Nodes (3): Test integration of prior safety with fit_bayesian() workflow., Test that fit_bayesian() runs end-to-end with prior safety., TestBayesianIntegration
 
 ### Community 547 - "TestVLBNonlocalProtocols"
 Cohesion: 0.20
 Nodes (6): Test simulation protocols., simulate_steady_shear returns correct keys., simulate_startup returns correct structure., simulate_creep returns correct structure., Nonlocal model cannot be fitted directly., TestVLBNonlocalProtocols
 
-### Community 548 - "test_anton_paar.py"
-Cohesion: 0.10
-Nodes (13): Tests for RheoCompass CSV parser (Anton Paar).  This module tests the full RheoC, Tests for edge cases (T070-T074)., T071: Test bracket [unit] notation., T071: Test parentheses (unit) notation., T072: Test Unicode characters in headers., Tests for European locale decimal separator handling (T074)., Test parsing with comma as decimal separator (European format)., Test parsing relaxation data with European comma decimal format. (+5 more)
-
-### Community 549 - "PowerLaw"
-Cohesion: 0.25
-Nodes (6): PowerLaw, String representation., Power Law model for non-Newtonian flow (ROTATION only).      The Power Law (Ostw, Initialize Power Law model., Test float64 precision for a flow model.      Flow models have different physics, test_flow_model_float64_precision()
-
-### Community 550 - ".simulate_steady_shear"
-Cohesion: 0.25
-Nodes (4): Build PDE RHS function for diffrax integration.          State: [Sigma, mu_xx[0:, Build initial state with small perturbation for symmetry breaking.          Para, Simulate approach to steady state under imposed average shear rate.          Par, Simulate startup from rest with banding evolution.          Parameters         -
-
-### Community 551 - "TestRheoDataDomainSupport"
-Cohesion: 0.25
-Nodes (5): Test time/frequency domain support., Test frequency domain data., Test time domain data., Test that domain conversion methods exist., TestRheoDataDomainSupport
-
-### Community 552 - "TestTemperatureEvolution"
-Cohesion: 0.25
-Nodes (5): Test temperature evolution rate calculation., Test dT/dt = 0 when γ̇ᵖ = 0 and T = T_env., Test viscous heating increases temperature., Test convective cooling decreases temperature., TestTemperatureEvolution
-
-### Community 553 - "TestCompareModels"
-Cohesion: 0.20
-Nodes (6): Tests for compare_models function., Compare 2 classical models on relaxation data., Akaike weights should sum to 1., Invalid criterion should raise ValueError., Nonexistent models should be skipped, not crash., TestCompareModels
-
-### Community 554 - "TestFIKHSignSafe"
-Cohesion: 0.25
-Nodes (5): Test sign_safe fix (F-001)., Test sign_safe returns +1 for positive values., Test sign_safe returns -1 for negative values., Test sign_safe returns 0 for zero., TestFIKHSignSafe
+### Community 553 - "build_fit_result"
+Cohesion: 0.11
+Nodes (16): build_fit_result(), compare_models(), Any, FitResult, Fit multiple models to the same data and rank them by an information criterion., Build a :class:`~rheojax.core.fit_result.FitResult` from a fitted model.      Re, Tests for compare_models function., Compare 2 classical models on relaxation data. (+8 more)
 
 ### Community 555 - "TestDMTRegistry"
 Cohesion: 0.25
@@ -3109,8 +3018,8 @@ Cohesion: 0.22
 Nodes (9): **1. Models Handbook** (53 Models Documented), **2. Transforms** (7 Transforms Documented), **3. User Guides**, **4. API Reference**, **5. Examples** (100+ Jupyter Notebooks), **Classical Models** (3 models), 📖 Documentation Structure, **Flow & Viscoplastic Models** (6 models) (+1 more)
 
 ### Community 559 - "ArvizCanvas"
-Cohesion: 0.15
-Nodes (9): ArvizCanvas, Connect internal signals., Handle plot type change.          Parameters         ----------         index :, Refresh the current plot with performance tracking., Set HDI probability for credible intervals.          Parameters         --------, Get current plot type.          Returns         -------         str, ArviZ diagnostic canvas for Bayesian visualization.      Inherits from BaseArviZ, Export figure to file.          Parameters         ----------         filepath : (+1 more)
+Cohesion: 0.06
+Nodes (30): ArvizCanvas, _filter_degenerate_vars(), Any, Figure, Connect internal signals., Scale the figure to the viewport width, preserving aspect ratio.          Instea, Handle plot type change.          Parameters         ----------         index :, Refresh the current plot with performance tracking. (+22 more)
 
 ### Community 560 - "TestRheoDataSerialization"
 Cohesion: 0.25
@@ -3120,9 +3029,9 @@ Nodes (5): Test serialization/deserialization., Test conversion to dictionary., 
 Cohesion: 0.25
 Nodes (5): Test equilibrium structure calculations., λ_eq should approach 0 at high shear rates., λ_eq should approach 1 at low shear rates., λ_eq should decrease monotonically with γ̇., TestEquilibriumStructure
 
-### Community 562 - "TestDialogIntegration"
-Cohesion: 0.25
-Nodes (5): Test that dialogs are properly integrated with menu actions., Verify PreferencesDialog can be imported and instantiated., Verify AboutDialog can be imported and instantiated., Verify ImportWizard can be imported and instantiated., TestDialogIntegration
+### Community 562 - "PreferencesDialog"
+Cohesion: 0.05
+Nodes (30): Handle preferences action., AboutDialog, QWidget, Handle dialog show event., Handle link clicks.          Parameters         ----------         url : QUrl, About dialog with version info.      Content:         - RheoJAX version and logo, Initialize about dialog.          Parameters         ----------         parent :, Set up user interface. (+22 more)
 
 ### Community 564 - "TestNumericalStability"
 Cohesion: 0.25
@@ -3132,77 +3041,33 @@ Nodes (5): Property-based tests for numerical stability near edge cases., G0 and
 Cohesion: 0.25
 Nodes (5): Test different experimental protocols., Flow curve fitting should work., Startup fitting should work., Test convenience predict methods., TestIKHProtocols
 
-### Community 566 - "TestToRheoDataDoubleCount"
-Cohesion: 0.25
-Nodes (5): F-IO-R3-001: DataService.to_rheo_data must not double-count G''., to_rheo_data with complex y_data + real y2_data must not double G''., to_rheo_data with real y_data + real y2_data must combine correctly., to_rheo_data with real y_data + no y2_data stays real., TestToRheoDataDoubleCount
-
-### Community 567 - "TestDetectTestModeFlow"
-Cohesion: 0.25
-Nodes (5): F-IO-R3-006: detect_test_mode flow detection edge cases., Shear-thinning power-law data must be detected as flow., Exponential relaxation must NOT be misclassified as flow., Creep compliance (monotonic increase) must be detected as creep., TestDetectTestModeFlow
-
 ### Community 568 - "TestLogFit"
 Cohesion: 0.33
 Nodes (4): Tests for log_fit context manager., Test that fit-specific context is logged., Test that completion context is included., TestLogFit
-
-### Community 569 - "TestDetectTestModeFlowVsRelaxation"
-Cohesion: 0.25
-Nodes (5): F-IO-R2-009: Flow must be detected before relaxation., Power-law shear-thinning flow curve must NOT be classified as relaxation., Exponential relaxation must NOT be classified as flow., Data spanning <1 decade should not trigger flow classification., TestDetectTestModeFlowVsRelaxation
-
-### Community 570 - "TestSAOS"
-Cohesion: 0.25
-Nodes (5): Tests for SAOS predictions., Test SAOS prediction., Test |G*| prediction via test_mode='oscillation'., Test terminal regime scaling: G' ~ ω², G'' ~ ω., TestSAOS
-
-### Community 571 - "TestRelaxationSimulation"
-Cohesion: 0.25
-Nodes (5): Tests for stress relaxation simulation., Test relaxation simulation runs., Test stress decays during relaxation., Verify single-exponential relaxation: σ(t) = G₀·τ_d·γ̇·exp(-t/τ_d)., TestRelaxationSimulation
-
-### Community 572 - "test_hvnm.py"
-Cohesion: 0.07
-Nodes (18): Create unfilled vitrimer (phi=0, recovers HVM exactly).          Parameters, default_model(), filled_model(), full_model(), Tests for HVNM (Hybrid Vitrimer Nanocomposite Model).  Tests are organized int, Default HVNM model with all flags off., HVNM with all features enabled., HVNM with phi=0 (should recover HVM). (+10 more)
 
 ### Community 573 - "SPP Parity Reference (MATLAB SPPplus v2.1, R oreo, RheoJAX)"
 Cohesion: 0.25
 Nodes (7): Gap Matrix (parity notes), Golden-Data Harness (actionable plan), How to generate goldens, Immediate use, MATLAB SPPplus v2.1 (key points), Scope, SPP Parity Reference (MATLAB SPPplus v2.1, R oreo, RheoJAX)
 
-### Community 574 - "TestBayesianInterface"
-Cohesion: 0.25
-Nodes (5): Tests for BayesianMixin compatibility., Test model_function for flow curve., Test model_function for SAOS., Test model_function params match ParameterSet order., TestBayesianInterface
-
 ### Community 575 - "Any"
 Cohesion: 0.29
 Nodes (4): Any, Emit a signal by name with logging.          Parameters         ----------, Connect a handler to a signal by name with logging.          Parameters, Disconnect a handler from a signal by name with logging.          Parameters
 
-### Community 576 - ".plot_confidence_band"
-Cohesion: 0.29
-Nodes (4): ndarray, Plot data points.          Parameters         ----------         x : np.ndarray, Plot fitted curve.          Parameters         ----------         x : np.ndarray, Plot confidence band.          Parameters         ----------         x : np.ndar
+### Community 577 - "test_spp_export.py"
+Cohesion: 0.21
+Nodes (8): export_spp_hdf5(), Export SPP results to HDF5 format.      Creates a hierarchical structure with:, Tests for SPP export functionality., Tests for HDF5 export., Test that HDF5 file is created., Test that HDF5 file contains expected data groups., Test that HDF5 metadata contains expected attributes., TestExportSppHdf5
 
-### Community 577 - "TestExportSppHdf5"
+### Community 579 - "TestMonotonicityChecks"
 Cohesion: 0.25
-Nodes (5): Tests for HDF5 export., Test that HDF5 file is created., Test that HDF5 file contains expected data groups., Test that HDF5 metadata contains expected attributes., TestExportSppHdf5
-
-### Community 579 - "is_monotonic_decreasing"
-Cohesion: 0.18
-Nodes (10): is_monotonic_decreasing(), is_monotonic_increasing(), ndarray, Check if data is mostly monotonically increasing.      Args:         data: Array, Check if data is mostly monotonically decreasing.      Args:         data: Array, Test monotonicity checking utilities., Test detection of monotonic increasing., Test detection of monotonic decreasing. (+2 more)
-
-### Community 581 - "TestCSVReaderEdgeCases"
-Cohesion: 0.25
-Nodes (5): Test edge cases in the CSV reader., CSV with all NaN values raises ValueError., Explicit encoding parameter is respected., European decimal comma format is handled., TestCSVReaderEdgeCases
+Nodes (5): Test monotonicity checking utilities., Test detection of monotonic increasing., Test detection of monotonic decreasing., Test monotonicity with small noise (tolerance)., TestMonotonicityChecks
 
 ### Community 582 - "TestDataIntegrity"
 Cohesion: 0.25
 Nodes (5): Test data integrity through I/O operations., Test numeric precision in CSV round-trip., Test that data shapes are preserved in workflows., Test that dtypes are handled correctly., TestDataIntegrity
 
-### Community 585 - "TNTSingleMode"
-Cohesion: 0.04
-Nodes (24): Single-mode Transient Network Theory model.      Implements the Green-Tobolsky /, Get network modulus G (Pa)., Get bond lifetime τ_b (s)., Get solvent viscosity η_s (Pa·s)., Get zero-shear viscosity η₀ = G·τ_b + η_s (Pa·s)., Get slip parameter ξ., Whether this is the basic (constant/linear/UC) variant., TNTSingleMode (+16 more)
-
-### Community 586 - "TestFitOscillation"
-Cohesion: 0.25
-Nodes (5): Tests for _fit_oscillation implementation., _fit_oscillation returns self for fluent API., _fit_oscillation accepts (N,2) input [G', G'']., Fitted model should reproduce SAOS moduli., TestFitOscillation
-
-### Community 587 - "TestFIKHTestModeValidation"
-Cohesion: 0.25
-Nodes (5): Test test_mode validation and handling., Test all valid test modes are accepted., Test invalid test mode raises error., Test LAOS mode maps to STARTUP (return mapping) internally., TestFIKHTestModeValidation
+### Community 585 - "TestCreepSimulation"
+Cohesion: 0.20
+Nodes (6): Tests for creep simulation., Test creep simulation runs., Test strain increases during creep., Test creep with rate return., Test creep reaches steady shear rate.          At long times: γ̇ → σ/(G·τ_b +, TestCreepSimulation
 
 ### Community 588 - "TestFIKHModelFunction"
 Cohesion: 0.25
@@ -3212,17 +3077,9 @@ Nodes (5): Test model_function for Bayesian inference., Test model_function acce
 Cohesion: 0.33
 Nodes (4): Test JSON serialization of parameters., Test JSON serialization for data and parameters., Test converting RheoData to JSON., TestJSONSerialization
 
-### Community 590 - "TestFIKHCreep"
-Cohesion: 0.25
-Nodes (5): Test FIKH creep protocol predictions., Create isothermal FIKH model for creep tests., Test creep prediction produces valid output., Test that creep strain increases monotonically under constant stress., TestFIKHCreep
-
 ### Community 591 - "TestFIKHPrecompile"
 Cohesion: 0.25
 Nodes (5): Test FIKH precompile method., Test precompile works for isothermal model., Test precompile works for thermal model., Test that precompile reduces prediction time., TestFIKHPrecompile
-
-### Community 592 - "TestFIKHOscillation"
-Cohesion: 0.25
-Nodes (5): Test FIKH oscillation (SAOS) predictions (F-026)., Test that oscillation prediction returns complex G*., Test oscillation via _predict method with test_mode., Test G* is finite and positive across frequencies., TestFIKHOscillation
 
 ### Community 593 - "TestNonlocalModelFunction"
 Cohesion: 0.25
@@ -3236,18 +3093,6 @@ Nodes (5): Test Herschel-Bulkley with RheoData., Test prediction with RheoData (
 Cohesion: 0.25
 Nodes (5): Test small amplitude oscillatory shear predictions., SAOS should raise error without elasticity., SAOS should return G' and G''., SAOS should show Maxwell-like frequency dependence., TestDMTLocalSAOS
 
-### Community 596 - "TestPowerLawRheoData"
-Cohesion: 0.25
-Nodes (5): Test Power Law with RheoData., Test prediction with RheoData (viscosity output)., Test prediction with RheoData (stress output)., Test that wrong test mode raises error., TestPowerLawRheoData
-
-### Community 597 - "TestPowerLawBasics"
-Cohesion: 0.25
-Nodes (5): Test basic functionality of Power Law model., Test model initialization., Test parameter bounds., Test setting parameters., TestPowerLawBasics
-
-### Community 598 - "TestPowerLawNumericalStability"
-Cohesion: 0.25
-Nodes (5): Test numerical stability of Power Law model., Test with extreme shear rates., Test behavior at zero shear rate., Test with negative shear rates (should use absolute value)., TestPowerLawNumericalStability
-
 ### Community 599 - "generate_synthetic_trios_file"
 Cohesion: 0.33
 Nodes (7): generate_synthetic_trios_file(), generate_trios_files_batch(), get_fixture_path(), Path, Generate batch of TRIOS files for testing at multiple sizes.      Args:, Get or create path to fixture file.      Args:         filename: Name of fixture, Generate synthetic TRIOS file of specified size.      Creates a valid TRIOS form
@@ -3259,10 +3104,6 @@ Nodes (5): Tests for fluidity evolution kernel., Test fluidity decreases (ages) 
 ### Community 601 - "TestSteadyStateFlowCurve"
 Cohesion: 0.25
 Nodes (5): Tests for steady-state flow curve prediction., Test yield stress appears at low rates.          Note: FS-015 removed the dead G, Test stress increases monotonically with rate., Test full coupling increases low-rate stress., TestSteadyStateFlowCurve
-
-### Community 602 - "TestCreepBifurcation"
-Cohesion: 0.25
-Nodes (5): Test creep bifurcation behavior., Create model for creep tests., Test continuous flow above yield stress., Test arrested flow below yield stress., TestCreepBifurcation
 
 ### Community 603 - "TestVonMisesStress"
 Cohesion: 0.25
@@ -3292,29 +3133,9 @@ Nodes (5): Tests for ML-IKH fitting., ML-IKH per_mode should fit startup data., 
 Cohesion: 0.25
 Nodes (5): Regression tests for F-GMM-001/002/003 GUI Bayesian pipeline bugs., F-GMM-001: infer_model_kwargs detects n_modes from G_i names., F-GMM-002: model_function uses _laos_omega/_laos_gamma_0 from self attrs., F-GMM-001: fit_bayesian works after element minimization reduces n_modes., TestGMMBayesianPipelineBugs
 
-### Community 610 - "TestThixotropyKinetics"
-Cohesion: 0.25
-Nodes (5): Test suite for thixotropy kinetics with structural parameter lambda(t)., Test structural parameter lambda(t) evolution kinetics., Test thixotropy step-up protocol produces stress overshoot., Test thixotropy step-down protocol produces stress undershoot., TestThixotropyKinetics
-
-### Community 611 - "TestShearBanding"
-Cohesion: 0.25
-Nodes (5): Test suite for shear banding detection and coexistence calculations., Test shear banding detection: d(sigma)/d(gamma_dot) < 0., Test shear banding warning is generated for non-monotonic curves., Test lever rule for computing shear band fractions., TestShearBanding
-
-### Community 613 - "TestMittagLefflerComplexArguments"
-Cohesion: 0.25
-Nodes (5): Test complex argument support., Test E_α(z) with complex z., Test E_{α,β}(z) with complex z., Test E_α(iω) for frequency-domain applications., TestMittagLefflerComplexArguments
-
-### Community 614 - "TestMittagLefflerRheologicalApplications"
-Cohesion: 0.25
-Nodes (5): Test Mittag-Leffler in typical rheological scenarios., Test E_α(-t^α) for fractional relaxation modulus., Test E_{α,2}(z) for fractional Kelvin-Voigt model., Test E_α((iω)^α) for frequency-domain applications., TestMittagLefflerRheologicalApplications
-
 ### Community 615 - "TestNumericalStability"
 Cohesion: 0.25
 Nodes (5): Test numerical stability near glass transition and edge cases., Test G0(x) stability near x=1 (glass transition)., Test Gp(x, z) stability near x=1., Test Gp at very low and very high frequencies., TestNumericalStability
-
-### Community 616 - "TestLatticeEPMBayesian"
-Cohesion: 0.25
-Nodes (5): Test Bayesian inference for LatticeEPM., Create a small LatticeEPM for fast testing., Bayesian inference for flow curve should produce valid result., Bayesian inference should have acceptable diagnostics., TestLatticeEPMBayesian
 
 ### Community 617 - "TestModeEnum"
 Cohesion: 0.33
@@ -3345,8 +3166,8 @@ Cohesion: 0.25
 Nodes (5): Test auto-detection of scalar vs tensorial stress fields., Test that plot_lattice_fields auto-detects scalar (L, L) stress., Test that plot_lattice_fields auto-detects tensorial (3, L, L) stress., Test that invalid stress shape raises ValueError., TestTensorialAutoDetection
 
 ### Community 624 - "VLBVariant"
-Cohesion: 0.04
-Nodes (28): VLB with Bell breakage, FENE-P stress, and/or temperature dependence.      This, Extract Fourier harmonics from LAOS data.          Parameters         ----------, Compute Deborah number De = t_R * omega., Network modulus (Pa)., Force sensitivity parameter (Bell only)., Maximum extensibility (FENE only)., Equilibrium relaxation time t_R = 1/k_d_0 (s)., Zero-shear viscosity eta_0 = G0/k_d_0 (Pa·s). (+20 more)
+Cohesion: 0.06
+Nodes (23): VLB with Bell breakage, FENE-P stress, and/or temperature dependence.      This, Extract Fourier harmonics from LAOS data.          Parameters         ----------, Compute Weissenberg number Wi = t_R * gamma_dot., Compute Deborah number De = t_R * omega., Network modulus (Pa)., Unstressed dissociation rate (1/s)., Force sensitivity parameter (Bell only)., Maximum extensibility (FENE only). (+15 more)
 
 ### Community 625 - "TestExportFormats"
 Cohesion: 0.25
@@ -3354,15 +3175,11 @@ Nodes (5): Test export to different file formats., Test export to PNG format., T
 
 ### Community 626 - "test_fluidity_nlsq_nuts_pipeline.py"
 Cohesion: 0.05
-Nodes (28): flow_curve_data(), oscillation_data(), Validation tests for NLSQ → NUTS pipeline for Fluidity models.  This module vali, Generate synthetic SAOS data (G', G'')., Test NLSQ fitting for FluidityLocal., NLSQ fitting for flow curve should converge., NLSQ fitting for SAOS should converge., Test NLSQ fitting for FluidityNonlocal. (+20 more)
+Nodes (28): flow_curve_data(), oscillation_data(), Validation tests for NLSQ → NUTS pipeline for Fluidity models.  This module vali, Generate synthetic SAOS data (G', G'')., Test Bayesian inference for FluidityLocal., Bayesian inference for flow curve should converge with good diagnostics., Bayesian inference for SAOS should converge., Test complete NLSQ → NUTS pipeline for FluidityLocal. (+20 more)
 
 ### Community 627 - "TestTransformPlotterDispatch"
 Cohesion: 0.25
 Nodes (5): Tests for auto-dispatch based on transform name., Unknown transform falls back to generic plot., Known transform name dispatches to correct method., Transform names are normalized (case, hyphens, spaces)., TestTransformPlotterDispatch
-
-### Community 628 - ".plot_data"
-Cohesion: 0.38
-Nodes (5): PlotDataItem, floating, NDArray, Plot data points.          Parameters         ----------         x : NDArray, Plot a line (typically for fits/predictions).          Parameters         ------
 
 ### Community 629 - "🚀 Key Features"
 Cohesion: 0.29
@@ -3372,25 +3189,13 @@ Nodes (7): **Bayesian Inference** (NEW in v0.2.0), **Data I/O**, 🚀 Key Featur
 Cohesion: 0.29
 Nodes (4): AppState, Handle state changes from store.          Parameters         ----------, Sync chip statuses from the current pipeline state., Update visible page on mode change.          In the new splitter layout the side
 
-### Community 631 - ".closeEvent"
-Cohesion: 0.29
-Nodes (4): QCloseEvent, Handle new file action., Handle save file action.          Returns         -------         bool, Handle window close event with cleanup.          Parameters         ----------
-
 ### Community 632 - "TestUncertaintyBand"
 Cohesion: 0.33
 Nodes (4): Tests for compute_uncertainty_band and plot_fit_with_uncertainty., Test uncertainty band for a simple linear model., Test that complex model output returns None for bands., TestUncertaintyBand
 
-### Community 633 - "._predict"
-Cohesion: 0.11
-Nodes (14): Array, RheoData, Initialize tensorial stress field.          Args:             key: PRNG key (unu, Extract parameters as dictionary for kernel calls.          Extends base class m, Perform one tensorial EPM time step.          Delegates to tensorial_epm_step ke, Extract shear stress component from stress tensor.          Args:             st, Compute normal stress differences from stress tensor.          For plane strain:, Convenience method to predict normal stress differences.          Runs the simul (+6 more)
-
-### Community 634 - ".predict_rheo"
-Cohesion: 0.29
-Nodes (5): RheoData, TestMode, Compute shear stress: σ(γ̇) = K |γ̇|^n.          Args:             gamma_dot: Sh, Predict shear stress for given shear rates.          Args:             gamma_dot, Predict rheological response for RheoData.          Args:             rheo_data:
-
-### Community 635 - "TestIntrospectionHelpers"
-Cohesion: 0.12
-Nodes (15): find_test_mode_patterns(), get_implementation_evidence(), get_predict_source(), has_predict_method(), Check for evidence that a protocol is implemented.      Args:         model_c, Test the introspection helper functions themselves., Test detection of == patterns., Test detection of 'in [...]' patterns. (+7 more)
+### Community 635 - "test_registry_consistency.py"
+Cohesion: 0.13
+Nodes (16): find_test_mode_patterns(), get_implementation_evidence(), get_predict_source(), has_predict_method(), Registry consistency tests using static analysis.  This module uses introspect, Check for evidence that a protocol is implemented.      Args:         model_c, Test the introspection helper functions themselves., Test detection of == patterns. (+8 more)
 
 ### Community 636 - "evolve_thixotropy_lambda"
 Cohesion: 0.29
@@ -3404,17 +3209,9 @@ Nodes (4): Test VLBLocal stress relaxation., G(t) should be a single exponential
 Cohesion: 0.29
 Nodes (4): Test VLBLocal creep compliance., J(t) = (1 + k_d*t) / G0 for Maxwell., dJ/dt = k_d/G0 = 1/eta., TestVLBLocalCreep
 
-### Community 640 - "DecayType"
-Cohesion: 0.22
-Nodes (7): DecayType, Types of relaxation decay behavior., Tests for model-data compatibility checking., Tests for enhanced error messaging in model fitting., Test that FZSS with exponential data provides enhanced error., Test that check_compatibility parameter works., TestEnhancedErrorMessaging
-
 ### Community 641 - "SPP Parity Status (MATLAB SPPplus v2.1 / R oreo / RheoJAX)"
 Cohesion: 0.33
 Nodes (5): Current status, Open risks / follow-ups, Remaining actions (require MATLAB/R availability), SPP Parity Status (MATLAB SPPplus v2.1 / R oreo / RheoJAX), What's done
-
-### Community 643 - "test_transform_flow.py"
-Cohesion: 0.43
-Nodes (6): _make_freq_dataset(), _make_time_dataset(), RheoData, Integration smokes for transform -> fit and multi-dataset flows (Task 9.3.3/9.3., test_transform_mastercurve_multi_dataset(), test_transform_mastercurve_then_fit_single_dataset()
 
 ### Community 644 - "RheoJAX Workspace Shell"
 Cohesion: 0.33
@@ -3422,7 +3219,7 @@ Nodes (5): File Menu / Project Model, Package Structure, Relationship to `founda
 
 ### Community 645 - "_kernels.py"
 Cohesion: 0.05
-Nodes (51): _compute_steady_dimensionless_stresses(), giesekus_complex_viscosity(), giesekus_creep_ode_rhs(), giesekus_multimode_ode_rhs(), giesekus_multimode_saos_moduli(), giesekus_ode_rhs(), giesekus_ode_rhs_laos(), giesekus_relaxation_ode_rhs() (+43 more)
+Nodes (53): _compute_steady_dimensionless_stresses(), giesekus_creep_ode_rhs(), giesekus_multimode_ode_rhs(), giesekus_multimode_saos_moduli(), giesekus_ode_rhs(), giesekus_ode_rhs_laos(), giesekus_relaxation_ode_rhs(), giesekus_steady_normal_stresses() (+45 more)
 
 ### Community 646 - ".__init__"
 Cohesion: 0.33
@@ -3432,9 +3229,9 @@ Nodes (4): Any, Logger, Initialize the logger adapter.          Args:           
 Cohesion: 0.29
 Nodes (3): FluidityNonlocal overrides _IDENTIFIABILITY because its PDE kernels     use HB-a, a, n_rejuv, f_inf never enter the nonlocal PDE RHS — assert         they appear, TestNonlocalIdentifiabilityAPI
 
-### Community 649 - "_modulus_labels"
-Cohesion: 0.25
-Nodes (7): _modulus_labels(), RheoData, Return shear storage, loss, and generic modulus labels., Gap-6: _modulus_labels returns shear modulus labels., No deformation mode → G'/G'' labels., y_units kwarg reflected in label., TestModulusLabels
+### Community 649 - "TestModulusLabels"
+Cohesion: 0.33
+Nodes (4): Gap-6: _modulus_labels returns shear modulus labels., No deformation mode → G'/G'' labels., y_units kwarg reflected in label., TestModulusLabels
 
 ### Community 650 - ".__init__"
 Cohesion: 0.33
@@ -3443,22 +3240,6 @@ Nodes (4): BreakageType, StressType, Initialize single-mode TNT model.          
 ### Community 651 - ".__init__"
 Cohesion: 0.33
 Nodes (4): BreakageType, StressType, Initialize VLBNonlocal model., Initialize ParameterSet for nonlocal model.
-
-### Community 652 - "._disconnect_worker_signals"
-Cohesion: 0.33
-Nodes (3): Handle error during inference.          Parameters         ----------         er, Disconnect this page's slots from the current worker's signals.          Disconn, Prepare this page for parent window close.          Called by MainWindow.closeEv
-
-### Community 653 - "._plot_energy"
-Cohesion: 0.33
-Nodes (3): Enable/disable plot types based on available data., Generate energy plot.          Requires sample_stats group with energy diagnosti, Check if InferenceData has sample_stats with energy.          Returns         --
-
-### Community 654 - ".timed_render"
-Cohesion: 0.40
-Nodes (3): Any, Execute a render function with timing.          Parameters         ----------, Record a plot rendering duration.          Parameters         ----------
-
-### Community 655 - ".model_function"
-Cohesion: 0.33
-Nodes (3): Predict response.          Parameters         ----------         x : array-like, NumPyro/BayesianMixin model function.          Parameters         ----------, Internal startup simulation.
 
 ### Community 656 - ".__init__"
 Cohesion: 0.33
@@ -3472,45 +3253,17 @@ Nodes (4): Verify yaml.safe_load rejects Python object tags.      These are regr
 Cohesion: 0.33
 Nodes (5): _io_test_gc(), Shared fixtures for tests/io/., Skip tests if rheocompass fixtures are not available., Free memory after each io test to prevent xdist worker OOM.      Several io te, rheocompass_fixtures()
 
-### Community 659 - "test_spp_integration.py"
-Cohesion: 0.60
-Nodes (4): Integration smoke tests for SPP pipeline workflow., _spp_dataset(), test_pipeline_bayesian_warm_start(), test_pipeline_nlsq_only()
-
 ### Community 660 - "capture_golden_screens.py"
 Cohesion: 0.53
 Nodes (5): _capture(), _ensure_offscreen(), main(), Path, Helper script to capture GUI golden screenshots locally.  Usage (run locally wit
-
-### Community 661 - "TestCSVRoundTrip"
-Cohesion: 0.33
-Nodes (4): Test CSV read/write cycle., Test writing and reading CSV files., Test that metadata is preserved in CSV workflow., TestCSVRoundTrip
-
-### Community 662 - "TestPerformance"
-Cohesion: 0.33
-Nodes (4): Performance regression tests for CI.      Run with: pytest tests/io/test_anton_p, SC-004: Load time <2s for 10,000 points., Export 10k points should complete in <5s., TestPerformance
-
-### Community 663 - "TestAntonPaarReader"
-Cohesion: 0.33
-Nodes (4): Tests for Anton Paar reader (7.7)., Parse minimal Anton Paar export and extract units/labels., Hz frequency input is normalized to rad/s., TestAntonPaarReader
 
 ### Community 664 - "TestLogPipelineStage"
 Cohesion: 0.50
 Nodes (3): Tests for log_pipeline_stage context manager., Test that pipeline-specific context is logged., TestLogPipelineStage
 
-### Community 665 - "TestFitLAOS"
-Cohesion: 0.33
-Nodes (4): Viscous variant LAOS fit works., Tests for _fit_laos implementation., _fit_laos returns self for fluent API., TestFitLAOS
-
-### Community 666 - "TestFIKHLimitingBehavior"
-Cohesion: 0.33
-Nodes (4): Test FIKH limiting behavior as α → 1., Test that α → 1 gives exponential-like relaxation., Test that small α gives slower structure recovery., TestFIKHLimitingBehavior
-
-### Community 667 - "TestGENERICThermodynamics"
-Cohesion: 0.25
-Nodes (5): Property-based tests for GENERIC model thermodynamic consistency., Entropy production rate >= 0 (second law of thermodynamics)., Entropy production is small at near-equilibrium states., Free energy is finite for valid state., TestGENERICThermodynamics
-
-### Community 668 - "test_herschel_bulkley.py"
-Cohesion: 0.33
-Nodes (4): Tests for Herschel-Bulkley model.  This module tests the Herschel-Bulkley model, Test model_function for Bayesian inference compatibility., Test that model_function output matches predict., TestHerschelBulkleyModelFunction
+### Community 668 - "TestHerschelBulkleyModelFunction"
+Cohesion: 0.50
+Nodes (3): Test model_function for Bayesian inference compatibility., Test that model_function output matches predict., TestHerschelBulkleyModelFunction
 
 ### Community 669 - "TestHerschelBulkleyPhysicalBehavior"
 Cohesion: 0.33
@@ -3519,18 +3272,6 @@ Nodes (4): Test physical behavior of Herschel-Bulkley model., Test that yield st
 ### Community 670 - "DatasetTree"
 Cohesion: 0.08
 Nodes (21): QPoint, QTreeWidget, QTreeWidgetItem, DatasetTree, Path, QWidget, Create the root project item., Add dataset to tree.          Parameters         ----------         dataset_stat (+13 more)
-
-### Community 671 - "TestPowerLawFitting"
-Cohesion: 0.33
-Nodes (4): Test parameter fitting for Power Law model., Test fitting with synthetic data., Test fit_predict method., TestPowerLawFitting
-
-### Community 672 - "TestPowerLawPerformance"
-Cohesion: 0.33
-Nodes (4): Test JAX performance optimizations., Test that JIT compilation works., Test that vectorization works correctly., TestPowerLawPerformance
-
-### Community 673 - "TestPowerLawModelFunction"
-Cohesion: 0.33
-Nodes (4): Test model_function for Bayesian inference compatibility., Test that model_function output matches predict., Test that model_function works with JAX arrays., TestPowerLawModelFunction
 
 ### Community 674 - "TestVLBNonlocalFene"
 Cohesion: 0.33
@@ -3588,29 +3329,13 @@ Nodes (5): **Foundational Textbooks**, **Fractional Calculus**, 📚 Key Referen
 Cohesion: 0.33
 Nodes (4): Tests for nonlocal flow curve prediction., Test flow curve output shape and finiteness., Test flow curve is monotonically increasing., TestNonlocalFlowCurve
 
-### Community 690 - "TestISMFluidVsGlass"
-Cohesion: 0.33
-Nodes (4): Tests comparing fluid and glass behavior in ISM., Test fluid state has no yield stress., Test glass state has yield stress., TestISMFluidVsGlass
-
-### Community 691 - "TestModelFunction"
-Cohesion: 0.25
-Nodes (5): Tests for model_function (Bayesian interface)., Test model_function for SAOS., Test model_function output matches predict_saos for oscillation.          Dive, Test model_function output matches predict for flow_curve., TestModelFunction
-
 ### Community 692 - "TensorialEPM"
-Cohesion: 0.04
-Nodes (70): Check if this is a scalar (not tensorial) EPM.          Returns False for Tensor, 3-Component Tensorial Lattice EPM.      A mesoscopic model for amorphous solids, Fit tensorial-EPM parameters to shear-stress data.          Currently supports *, Initialize the Tensorial EPM.          Args:             L: Lattice size (LxL gr, TensorialEPM, Test that TensorialEPM is constructable and its forward / fit paths work.      T, test_tensorial_epm_scaffold(), Tests for Tensorial EPM model.  This module tests the full tensorial (3-componen (+62 more)
-
-### Community 693 - "TestMittagLefflerPerformance"
-Cohesion: 0.33
-Nodes (4): Test performance characteristics., Test execution speed (already JIT compiled)., Test performance on large arrays., TestMittagLefflerPerformance
+Cohesion: 0.03
+Nodes (91): Array, RheoData, Initialize tensorial stress field.          Args:             key: PRNG key (unu, Check if this is a scalar (not tensorial) EPM.          Returns False for Tensor, Extract parameters as dictionary for kernel calls.          Extends base class m, Perform one tensorial EPM time step.          Delegates to tensorial_epm_step ke, Extract shear stress component from stress tensor.          Args:             st, Compute normal stress differences from stress tensor.          For plane strain: (+83 more)
 
 ### Community 696 - "TestPronySeries"
 Cohesion: 0.33
 Nodes (4): Test Prony series accuracy for multi-mode representation., Test single-mode Prony series (Maxwell).          ANSYS single-mode: G(t) = G_0, Test two-mode Prony series matching ANSYS reference.          ANSYS two-mode: G(, TestPronySeries
-
-### Community 697 - "TestSAOS"
-Cohesion: 0.20
-Nodes (6): Tests for SAOS predictions., Test SAOS prediction., Test |G*| prediction via test_mode='oscillation'., Test terminal regime scaling: G' ~ ω², G'' ~ ω., Test SAOS matches effective Maxwell model with G_eff = f_B_eq·G., TestSAOS
 
 ### Community 698 - "🛠️ Building the Documentation Locally"
 Cohesion: 0.50
@@ -3620,10 +3345,6 @@ Nodes (4): Build HTML, Build PDF (Optional), 🛠️ Building the Documentation 
 Cohesion: 0.50
 Nodes (4): **Coverage**, 📊 Documentation Statistics, **Quality Metrics**, **Research Foundation**
 
-### Community 700 - "TestFluidityLocalBayesian"
-Cohesion: 0.33
-Nodes (4): Test Bayesian inference for FluidityLocal., Bayesian inference for flow curve should converge with good diagnostics., Bayesian inference for SAOS should converge., TestFluidityLocalBayesian
-
 ### Community 701 - "clean_notebook"
 Cohesion: 0.67
 Nodes (3): clean_notebook(), main(), Reads a notebook, clears all outputs and execution counts, and saves it back.
@@ -3632,21 +3353,13 @@ Nodes (3): clean_notebook(), main(), Reads a notebook, clears all outputs and ex
 Cohesion: 0.50
 Nodes (3): Visual regression scaffold aligned to GUI SPEC.md golden images., Smoke check golden files exist (replace with real renders when available)., test_home_page_visual_golden()
 
-### Community 706 - "TestFluidityLocalNLSQToNUTS"
-Cohesion: 0.33
-Nodes (4): Test complete NLSQ → NUTS pipeline for FluidityLocal., NLSQ warm-start should improve Bayesian convergence., Full NLSQ → NUTS pipeline for flow curve with diagnostics.          Note: Fluidi, TestFluidityLocalNLSQToNUTS
-
-### Community 708 - "TestCreepSimulation"
+### Community 704 - "TestBayesianPipelineMultiChain"
 Cohesion: 0.20
-Nodes (6): Tests for creep simulation., Test creep simulation runs., Test strain increases during creep., Test creep with rate return., Test creep requires eta_s > 0 for stability., TestCreepSimulation
+Nodes (6): Tests for multi-chain parallelization in BayesianPipeline., Test that num_chains parameter is exposed and works correctly., Test that default num_chains in BayesianPipeline is 4., Test that multi-chain sampling provides better R-hat estimates., Test that single chain mode still works for quick demos., TestBayesianPipelineMultiChain
 
 ### Community 710 - "conftest.py"
 Cohesion: 0.50
 Nodes (3): _clean_parallel_config(), Shared fixtures for parallel module tests., Reset parallel config state before and after each test.      Ensures no test pol
-
-### Community 719 - "TestFlowCurve"
-Cohesion: 0.20
-Nodes (6): Tests for flow curve (steady shear) predictions., Test flow curve prediction returns correct shape, positive, finite., Test direct predict_flow_curve method., Test flow curve with viscosity and N1., Multi-mode with constant breakage should be Newtonian (constant viscosity)., TestFlowCurve
 
 ### Community 732 - "TestVonMisesPlots"
 Cohesion: 0.33
@@ -3660,41 +3373,9 @@ Nodes (4): Test time-domain plotting functions., Test plotting relaxation data.,
 Cohesion: 0.33
 Nodes (4): Test frequency-domain plotting functions., Test plotting complex modulus (G' and G'')., Test plotting real modulus only., TestPlotFrequencyDomain
 
-### Community 735 - "TestPlotFlowCurve"
-Cohesion: 0.33
-Nodes (4): Test flow curve plotting functions., Test plotting viscosity vs shear rate., Test plotting shear stress vs shear rate., TestPlotFlowCurve
-
-### Community 736 - "TestPlotResiduals"
-Cohesion: 0.33
-Nodes (4): Test residual plotting functions., Test plotting residuals., Test plotting data with predictions and residuals., TestPlotResiduals
-
 ### Community 737 - "TestPublicationQuality"
 Cohesion: 0.33
 Nodes (4): Test publication-quality output., Test that publication-quality settings are applied., Test default style settings., TestPublicationQuality
-
-### Community 739 - "TestModulusFrequencyTemplate"
-Cohesion: 0.33
-Nodes (4): Test modulus-frequency plotting template., Test G' and G'' vs frequency plot., Test plotting on single axis., TestModulusFrequencyTemplate
-
-### Community 740 - ".fit_bayesian"
-Cohesion: 0.40
-Nodes (3): BayesianResult, Perform Bayesian inference using NumPyro NUTS sampler.          This method dele, Get stored Bayesian inference result.          Returns:             BayesianResu
-
-### Community 741 - "._transform"
-Cohesion: 0.40
-Nodes (3): Internal transform implementation to be overridden by subclasses.          Args:, Transform the data.          Args:             data: Input data (RheoData or lis, Apply all transforms in sequence.          Args:             data: Input data (R
-
-### Community 742 - "._fit"
-Cohesion: 0.40
-Nodes (3): ArrayLike, Helper to extract time and strain from inputs.          Args:             X:, Fit model parameters to data.          Args:             X: Time/Strain input
-
-### Community 773 - "TestScoreNaNHandling"
-Cohesion: 0.50
-Nodes (3): Verify score() returns NaN instead of 0.0 for broken predictions., score() should return NaN when predictions contain NaN., TestScoreNaNHandling
-
-### Community 774 - "TestAliases"
-Cohesion: 0.50
-Nodes (3): Test convenience aliases., Test that all aliases work correctly., TestAliases
 
 ### Community 776 - "TestFractionalModelsRelaxation"
 Cohesion: 0.50
@@ -3704,37 +3385,37 @@ Nodes (3): Comprehensive tests for all 11 fractional models in relaxation mode.,
 Cohesion: 0.50
 Nodes (4): _get_simulation_ids(), _get_simulation_pairs(), Get sorted (model_name, protocol_value) pairs for simulation-only tests., Generate descriptive test IDs for simulation pairs.
 
-### Community 2723 - "TestGlassTransition"
-Cohesion: 0.15
-Nodes (8): precompile_flow_curve_solver(), Pre-compile the diffrax ODE solver for fast subsequent calls.          Triggers, Stub when diffrax not available., Tests for glass transition behavior., Test properties in fluid state (ε < 0)., Test properties in glass state (ε > 0)., Test behavior at critical point (ε ≈ 0)., TestGlassTransition
-
 ### Community 2728 - ".test_conventional_generic_oscillation_match"
 Cohesion: 0.50
 Nodes (3): Property-based tests for consistency between SGRConventional and SGRGeneric., SGRConventional and SGRGeneric should give identical oscillation predictions., TestModelComparison
+
+### Community 2730 - "TestRelaxationSimulation"
+Cohesion: 0.20
+Nodes (6): Tests for stress relaxation simulation., Test relaxation simulation runs without error., Test relaxation returns correct shape., Test relaxation stress is finite., Test stress decays during relaxation., TestRelaxationSimulation
 
 ### Community 2755 - "TestStartupSimulation"
 Cohesion: 0.20
 Nodes (6): Tests for multi-mode startup simulation., Test startup simulation runs.          Note: Multi-mode ODE has JIT compatibil, Test startup approaches steady state., Test startup with per-mode stress return., Test startup via predict() with protocol kwargs., TestStartupSimulation
 
 ## Knowledge Gaps
-- **696 isolated node(s):** `$schema`, `title`, `description`, `type`, `type` (+691 more)
+- **638 isolated node(s):** `$schema`, `title`, `description`, `type`, `type` (+633 more)
   These have ≤1 connection - possible missing edges or undocumented components.
-- **167 thin communities (<3 nodes) omitted from report** — run `graphify query` to explore isolated nodes.
+- **203 thin communities (<3 nodes) omitted from report** — run `graphify query` to explore isolated nodes.
 
 ## Suggested Questions
 _Questions this graph is uniquely positioned to answer:_
 
-- **Why does `ModelRegistry` connect `ModelRegistry` to `ParameterSet`, `RheoData`, `TestHVMDamage`, `TestHVNMCreep`, `Maxwell`, `Pipeline`, `ValueError`, `TestInstantiation`, `TestCatesMaxwellLimit`, `TestFlowCurve`, `FitResult`, `TestStartupSimulation`, `TestLAOSSimulation`, `SGRGeneric`, `TestPhysicalConsistency`, `test_loop_bridge.py`, `BatchPipeline`, `ITTMCTIsotropic`, `Zener`, `FIKH`, `SGRConventional`, `FitPage`, `SpringPot`, `TestBayesianInterface`, `ITTMCTSchematic`, `LatticeEPM`, `PipelineBuilder`, `TestFlowCurve`, `FluidityLocal`, `_kernels_diffrax.py`, `TNTStickyRouse`, `TestLAOSSimulation`, `TestMaxwellLimits`, `BayesianService`, `PowerLaw`, `VLBLocal`, `conftest.py`, `FluidityNonlocal`, `TestDMTRegistry`, `_kernels.py`, `FluiditySaramitoLocal`, `HVNMLocal`, `TestEquilibriumStructure`, `TestSAOS`, `fit_controller.py`, `FMLIKH`, `test_hvnm.py`, `TestBayesianInterface`, `TestRelaxationSimulation`, `TNTSingleMode`, `TestFitOscillation`, `DMTLocal`, `GiesekusMultiMode`, `schematic.py`, `hebraud_lequeux.py`, `HVMLocal`, `Carreau`, `TestDMTLocalSAOS`, `test_hvm.py`, `TestHVMBayesian`, `FitResult`, `MIKH`, `STZConventional`, `GiesekusSingleMode`, `Bingham`, `VLBVariant`, `FractionalMaxwellModel`, `local.py`, `MLIKH`, `test_dmt.py`, `TestIntrospectionHelpers`, `ModelComparisonPipeline`, `TestVLBLocalCreep`, `TestVLBLocalRelaxation`, `_base.py`, `SimpleModel`, `TestNonAffineVariant`, `FluiditySaramitoNonlocal`, `ModelComparison`, `TestFitLAOS`, `TestInstantiation`, `Registry`, `test_single_mode.py`, `TestFlowCurve`, `GeneralizedMaxwell`, `TestModelFunction`, `TensorialEPM`, `TestSAOS`, `Cross`, `FractionalMaxwellGel`, `SPPYieldStress`, `test_multi_species.py`, `TestStartupSimulation`, `TestCreepSimulation`, `test_dmta_removal.py`, `main`, `TestFlowCurve`, `DMTNonlocal`, `FractionalKelvinVoigt`, `HebraudLequeux`, `TestHVMStartup`, `.generate`, `FractionalJeffreysModel`, `BatchTestModel`, `BayesianPipeline`, `get_logger`, `create_global_parser`, `_VizTestTransform`, `FractionalKelvinVoigtZener`, `FractionalPoyntingThomson`, `SPPAmplitudeSweepPipeline`, `TestHVMSAOS`, `VLBNonlocal`, `TestVLBMultiNetworkAnalytical`, `FractionalBurgersModel`, `parallel_load`, `TestHVNMLimitingCases`, `TNTCates`, `test_single_mode.py`, `TestPipelineExport`, `HerschelBulkley`, `import_dataset`, `TestFluidityLocalModelFunction`, `TestFluidityNonlocalModelFunction`, `TestMaxwellOscillation`, `TestSpringPotOscillation`, `TestInstantiation`, `TestPhysicalConsistency`, `TestVLBVariantCreation`, `TestVLBBellPhysics`, `TestZenerOscillation`, `TestFluidityNonlocalShearBanding`, `FractionalMaxwellLiquid`, `TestVLBVariantRegression`, `TestHVNMFlowCurve`, `CarreauYasuda`, `TestDMTNonlocal`, `parallel_map`, `test_cates.py`, `TestComposedVariants`, `test_multi_mode.py`, `TestFluidityPredictWithoutFit`, `TestDMTBayesian`, `TestHVNMSAOS`, `TestModeEnum`, `test_local.py`, `TestSpringPotRelaxation`, `TestSpringPotEdgeCases`, `TestZenerCreep`, `TestDMTLocalCreation`, `TestDMTLocalCreep`, `TNTLoopBridge`, `test_sticky_rouse.py`, `TestModelFunctionCompleteness`, `TestParameterManagement`, `TestHVMCreep`, `TestHVMFlowCurve`, `TestHVMRelaxation`, `TestHVMLAOS`, `TestHVNMStartup`, `BayesianMixin`, `TestDMTLocalStartup`, `TestF002KwargsCache`, `PipelineConfigureRunStep`, `TestInstantiation`, `TNTMultiSpecies`, `TestMaxwellLimit`, `TestStartupSimulation`, `TestPhysicalConsistency`, `TestBellVariant`, `TestFENEVariant`, `TestFluidityLocalFlowCurve`, `_ExportTestModel`, `TestDMTLocalLAOS`, `TestHVNMRelaxation`, `TestMaxwellEdgeCases`, `TestDMTLocalRelaxation`?**
-  _High betweenness centrality (0.175) - this node is a cross-community bridge._
-- **Why does `RheoData` connect `RheoData` to `ParameterSet`, `.update_metadata`, `TransformService`, `Maxwell`, `Pipeline`, `ValueError`, `load_anton_paar`, `TestRotationalLoading`, `ImportWizard`, `FitResult`, `BatchPipeline`, `WorkspaceWindow`, `json.py`, `load_csv`, `TestPlotRheoData`, `Zener`, `SGRConventional`, `FitPage`, `SpringPot`, `test_plot_service_golden.py`, `LatticeEPM`, `TestRelaxationLoading`, `RheoJAXMainWindow`, `TestErrorHandling`, `PipelineBuilder`, `mittag_leffler_e`, `BayesianService`, `PowerLaw`, `test_anton_paar.py`, `conftest.py`, `TestRheoDataDomainSupport`, `PipelineExecutionService`, `AppState`, `__init__.py`, `ExportPage`, `TestRheoDataSerialization`, `TestIKHProtocols`, `TestToRheoDataDoubleCount`, `TestDetectTestModeFlow`, `test_transform_plotter.py`, `TestDetectTestModeFlowVsRelaxation`, `plot_model_fit`, `AnalysisExporter`, `is_monotonic_decreasing`, `TestCSVReaderEdgeCases`, `RheoJaxValidationWarning`, `TestDataIntegrity`, `UnsupportedDataError`, `ModelRegistry`, `TestJSONSerialization`, `TestHerschelBulkleyRheoData`, `Carreau`, `TestPowerLawRheoData`, `TestPowerLawBasics`, `TestPowerLawNumericalStability`, `TransformPlotter`, `prony_conversion.py`, `TestMIKHBayesian`, `FitResult`, `TestMLIKHFitting`, `MIKH`, `__init__.py`, `TestHerschelBulkleyNumericalStability`, `SPPDecomposer`, `TestShearBanding`, `TestThixotropyKinetics`, `TestModeEnum`, `Bingham`, `TestExportFormats`, `TestTransformPlotterDispatch`, `FractionalMaxwellModel`, `TestUncertaintyBand`, `._predict`, `ModelComparisonPipeline`, `.fit_bayesian`, `test_transform_flow.py`, `load_npz`, `SmoothDerivative`, `SimpleModel`, `_modulus_labels`, `Mastercurve`, `test_phase2_performance.py`, `test_spp_integration.py`, `ModelComparison`, `TestCSVRoundTrip`, `TestPerformance`, `TestAntonPaarReader`, `test_metrics.py`, `test_herschel_bulkley.py`, `TestHerschelBulkleyPhysicalBehavior`, `FFTAnalysis`, `TestPowerLawFitting`, `TestPowerLawPerformance`, `TestPowerLawModelFunction`, `Registry`, `save_excel`, `TestOWChirp`, `TestHerschelBulkleyBasics`, `SpectrumInversion`, `TestHerschelBulkleyFitting`, `TestModeDetection`, `TensorialEPM`, `TestPronySeries`, `Cross`, `FractionalMaxwellGel`, `SPPYieldStress`, `test_dmta_removal.py`, `anton_paar.py`, `_coerce_ndarray`, `MockBayesianModel`, `_SpyModel`, `FractionalKelvinVoigt`, `parse_rheocompass_intervals`, `.generate`, `TestPlotTimeDomain`, `run_profiling.py`, `TestPlotFlowCurve`, `TestPlotFrequencyDomain`, `TestPlotResiduals`, `test_carreau.py`, `TestPublicationQuality`, `.fit_bayesian`, `TestModulusFrequencyTemplate`, `BatchTestModel`, `TestY2ColTranslation`, `MutationNumber`, `get_logger`, `load_trios`, `check_r_hat`, `cmd_transform.py`, `TestFractionalModelsRelaxation`, `_VizTestTransform`, `test_spp_golden_parity.py`, `SPPAmplitudeSweepPipeline`, `TestV032PerformanceIntegration`, `save_intervals_to_excel`, `._fit`, `create_rheo_data_creep`, `main`, `.slice`, `TestRheoDataCreation`, `TestCoxMerz`, `txt.py`, `.shape`, `EPMBase`, `TestPipelineExport`, `HerschelBulkley`, `import_dataset`, `FitOrchestrator`, `SRFS`, `lve_envelope`, `TestMaxwellOscillation`, `TestSpringPotOscillation`, `TestZenerOscillation`, `FractionalMaxwellLiquid`, `._predict`, `CarreauYasuda`, `TestMLIKHProtocolFitting`, `test_trios_chunked_integrity.py`, `TestModeEnum`, `TestRheoDataValidation`, `TestSpringPotRelaxation`, `TestSpringPotEdgeCases`, `TestZenerCreep`, `MockBayesianModel`, `TestOscillatoryLoading`, `test_cross.py`, `BayesianMixin`, `TestPowerLawPredictions`, `detect_data_range_decades`, `._transform`, `TestRheoDataNumpyCompatibility`, `TestCreepLoading`, `_ExportTestModel`, `TestMultiInterval`, `TestMaxwellEdgeCases`?**
-  _High betweenness centrality (0.162) - this node is a cross-community bridge._
-- **Why does `get_logger()` connect `get_logger` to `_yaml_runner.py`, `Envelope`, `main`, `ParameterSet`, `compute_diagnostics`, `TransformService`, `create_global_parser`, `cmd_transform.py`, `ValueError`, `load_npz`, `__init__.py`, `FractionalJeffreysInitializer`, `FractionalKelvinVoigtInitializer`, `FitResult`, `test_logging_integration.py`, `PreviewWorker`, `test_fractional_initializers.py`, `test_prony.py`, `json.py`, `load_csv`, `auto_p0.py`, `FractionalMaxwellModelInitializer`, `SGRConventional`, `plot_moduli_evolution`, `worker_pool.py`, `initialize_equilibrium`, `Registry`, `BayesianService`, `save_excel`, `AppState`, `SpectrumInversion`, `main`, `ExportPage`, `__init__.py`, `IconProvider`, `mct_kernels.py`, `_make_mock_spp_results`, `TestGetLogger`, `create_parser`, `__init__.py`, `epm_plots.py`, `txt.py`, `BaseInitializer`, `PipelineConfig`, `main`, `anton_paar.py`, `RheoJaxValidationWarning`, `ModelRegistry`, `UnsupportedDataError`, `EPMBase`, `compatibility.py`, `sgr_population_balance.py`, `schematic.py`, `hebraud_lequeux.py`, `main`, `prony_conversion.py`, `hessian_ci`, `get_template`, `spp.py`, `ImportWorker`, `from_yaml`, `__init__.py`, `STZConventional`, `PreprocessingResult`, `percus_yevick_sk`, `physics_checks.py`, `spp_kernels.py`, `TRIOSExperiment`, `test_column_mapping.py`, `check_wide_frequency_range`, `local.py`?**
-  _High betweenness centrality (0.093) - this node is a cross-community bridge._
+- **Why does `RheoData` connect `RheoData` to `.update_metadata`, `FitWorker`, `TransformService`, `Maxwell`, `ValueError`, `Pipeline`, `TestFFTPlot`, `DataService`, `BatchPipeline`, `AppState`, `__init__.py`, `load_csv`, `TestPlotRheoData`, `Zener`, `SGRConventional`, `FitPage`, `SpringPot`, `LatticeEPM`, `TestBinghamModelFunction`, `RheoJAXMainWindow`, `PipelineBuilder`, `mittag_leffler_e`, `DatasetLibrary`, `arviz_plot_kwargs`, `nlsq_optimize`, `conftest.py`, `state.py`, `__init__.py`, `ExportPage`, `TestRheoDataSerialization`, `TestIKHProtocols`, `TestMastercurvePlot`, `test_arviz_diagnostics.py`, `plot_model_fit`, `AnalysisExporter`, `TestMonotonicityChecks`, `RheoJaxValidationWarning`, `TestDataIntegrity`, `ModelRegistry`, `TestJSONSerialization`, `.metadata`, `TestHerschelBulkleyRheoData`, `test_carreau.py`, `TransformPlotter`, `prony_conversion.py`, `TestMIKHBayesian`, `FitResult`, `excel.py`, `MIKH`, `test_multi_file.py`, `TestHerschelBulkleyNumericalStability`, `SPPDecomposer`, `MastercurvePipeline`, `TestMLIKHFitting`, `TestModeEnum`, `Bingham`, `TestExportFormats`, `TestTransformPlotterDispatch`, `FractionalMaxwellModel`, `TestUncertaintyBand`, `BayesianMixin`, `load_npz`, `SmoothDerivative`, `SimpleModel`, `TestModulusLabels`, `Mastercurve`, `test_phase2_performance.py`, `ModelComparison`, `run_fit_isolated`, `TestHerschelBulkleyModelFunction`, `TestHerschelBulkleyPhysicalBehavior`, `FFTAnalysis`, `Registry`, `save_excel`, `TestHerschelBulkleyBasics`, `TestHerschelBulkleyFitting`, `TensorialEPM`, `TestPronySeries`, `ParameterTable`, `TestCrossBasics`, `FractionalMaxwellGel`, `ModelComparisonPipeline`, `TestBayesianPipelineMultiChain`, `.create`, `test_dmta_removal.py`, `load_anton_paar`, `.shape`, `MockBayesianModel`, `_SpyModel`, `FractionalKelvinVoigt`, `TestPlotTimeDomain`, `run_profiling.py`, `TestPlotFrequencyDomain`, `TestPublicationQuality`, `_translate_y2_col`, `BayesianPipeline`, `check_model_compatibility`, `TestMutationNumber`, `ModelService`, `check_r_hat`, `TestFractionalModelsRelaxation`, `test_spp_golden_parity.py`, `inference_data_from_dict`, `SPPYieldStress`, `create_rheo_data_creep`, `json.py`, `NumpyJSONEncoder`, `txt.py`, `TransformPipeline`, `HerschelBulkley`, `FitState`, `FitOrchestrator`, `lve_envelope`, `FractionalMaxwellLiquid`, `._predict`, `CarreauYasuda`, `TestMLIKHProtocolFitting`, `TestLVEEnvelopeTransform`, `test_trios_chunked_integrity.py`, `_kernels.py`, `test_model_config.py`, `test_export_and_project.py`, `TestBinghamStability`, `TestCarreauYasudaBasics`, `MockBayesianModel`, `PowerLaw`, `._transform`, `TestBinghamBasics`, `TestBinghamFitting`, `TestBinghamPhysicalBehavior`, `TestCrossStability`?**
+  _High betweenness centrality (0.176) - this node is a cross-community bridge._
+- **Why does `ModelRegistry` connect `ModelRegistry` to `RheoData`, `FitWorker`, `TestHVNMCreep`, `Maxwell`, `Pipeline`, `test_vlb.py`, `TestCatesMaxwellLimit`, `TestFlowCurve`, `BatchPipeline`, `SGRGeneric`, `test_loop_bridge.py`, `load_csv`, `ITTMCTIsotropic`, `Zener`, `FIKH`, `SGRConventional`, `FitPage`, `SpringPot`, `TestMaxwellLimits`, `ITTMCTSchematic`, `LatticeEPM`, `PipelineBuilder`, `TestFlowCurve`, `FluidityLocal`, `_kernels_diffrax.py`, `TNTStickyRouse`, `TestLAOSSimulation`, `_kernels_diffrax.py`, `PipelineConfigureRunStep`, `nlsq_optimize`, `conftest.py`, `FluidityNonlocal`, `TestDMTRegistry`, `FluiditySaramitoLocal`, `HVNMLocal`, `TestEquilibriumStructure`, `ProtocolModelStep`, `FMLIKH`, `AnalysisExporter`, `TestCreepSimulation`, `DMTLocal`, `GiesekusMultiMode`, `schematic.py`, `hebraud_lequeux.py`, `HVMLocal`, `TestDMTLocalSAOS`, `TestHVMLimitingCases`, `TestHVMBayesian`, `FitResult`, `MIKH`, `MastercurvePipeline`, `STZConventional`, `GiesekusSingleMode`, `Bingham`, `VLBVariant`, `FractionalMaxwellModel`, `local.py`, `MLIKH`, `test_dmt.py`, `test_registry_consistency.py`, `TestVLBLocalRelaxation`, `TestVLBLocalCreep`, `BayesianMixin`, `TestHVNMInterphase`, `SimpleModel`, `TestNonAffineVariant`, `ModelComparison`, `TNTSingleMode`, `Registry`, `test_single_mode.py`, `TestRelaxationSimulation`, `GeneralizedMaxwell`, `TensorialEPM`, `ParameterTable`, `FractionalMaxwellGel`, `ModelComparisonPipeline`, `.create`, `TestStartupSimulation`, `test_dmta_removal.py`, `main`, `DMTNonlocal`, `FractionalKelvinVoigt`, `HebraudLequeux`, `TestHVMStartup`, `FractionalJeffreysModel`, `FractionalBurgersModel`, `BayesianPipeline`, `ModelService`, `CancellationError`, `FractionalKelvinVoigtZener`, `FractionalPoyntingThomson`, `VLBNonlocal`, `vlb_fene_factor`, `SPPYieldStress`, `TestVLBMultiNetworkAnalytical`, `FractionalZenerSolidLiquid`, `TestHVNMLimitingCases`, `TNTCates`, `TestVLBTemperature`, `test_single_mode.py`, `HerschelBulkley`, `FitState`, `TestFluidityLocalModelFunction`, `TestFluidityNonlocalModelFunction`, `TestInstantiation`, `TestPhysicalConsistency`, `TestVLBVariantCreation`, `TestVLBBellPhysics`, `TestFluidityLocalOscillation`, `TestFluidityNonlocalShearBanding`, `FractionalMaxwellLiquid`, `TestFluidityNonlocalSmoke`, `TestInstantiation`, `TestVLBUtilities`, `TestVLBVariantProtocols`, `TestVLBVariantRegression`, `CarreauYasuda`, `TestDMTNonlocal`, `parallel_map`, `test_cates.py`, `TestBayesianInterface`, `TestComposedVariants`, `test_multi_mode.py`, `TestFluidityPredictWithoutFit`, `TestDMTBayesian`, `_kernels.py`, `TestHVNMSAOS`, `test_local.py`, `TestDMTLocalFlowCurve`, `TestDMTLocalCreation`, `TestDMTLocalCreep`, `TNTLoopBridge`, `TestInstantiation`, `test_sticky_rouse.py`, `TestParameterManagement`, `TestHVMCreep`, `TestHVMFlowCurve`, `TestHVMRelaxation`, `TestHVMLAOS`, `TestHVNMStartup`, `TestSAOS`, `FractionalZenerLiquidLiquid`, `TestRelaxationSimulation`, `TestBayesianInterface`, `TestDMTLocalStartup`, `TestF002KwargsCache`, `TestVLBBellFeneCombined`, `TestInstantiation`, `PowerLaw`, `TNTMultiSpecies`, `TestStartupSimulation`, `TestPhysicalConsistency`, `TestBellVariant`, `TestFENEVariant`, `TestCreepSimulation`, `TestFitCreep`, `TestDMTLocalLAOS`, `TestHVNMRelaxation`, `TestFluidityNonlocalTransient`, `TestVLBVariantBayesian`?**
+  _High betweenness centrality (0.166) - this node is a cross-community bridge._
+- **Why does `safe_import_jax()` connect `ModelRegistry` to `test_nlsq_optimization.py`, `FitWorker`, `Maxwell`, `test_parameter_schema.py`, `test_vlb.py`, `test_loop_bridge.py`, `load_csv`, `LatticeEPM`, `_kernels_diffrax.py`, `mittag_leffler_e`, `_kernels_diffrax.py`, `nlsq_optimize`, `conftest.py`, `_kernels.py`, `__init__.py`, `test_spp_plots.py`, `_kernels.py`, `IconProvider`, `HVNMLocal`, `FitPlotter`, `mct_kernels.py`, `_kernels.py`, `test_arviz_diagnostics.py`, `epm_plots.py`, `test_fikh_thermal.py`, `test_fractional_zener_family.py`, `schematic.py`, `hebraud_lequeux.py`, `test_kernels.py`, `ParameterSet`, `prony_conversion.py`, `TestNonexponentialRelaxation`, `test_fikh.py`, `SPPDecomposer`, `STZConventional`, `percus_yevick_sk`, `test_vlb_nonlocal.py`, `get_default_workers`, `test_fluidity_nlsq_nuts_pipeline.py`, `FractionalMaxwellModel`, `local.py`, `test_dmt.py`, `main`, `BayesianMixin`, `_kernels.py`, `__init__.py`, `test_phase2_performance.py`, `QWidget`, `test_spp_kernels.py`, `run_fit_isolated`, `test_epm_kernels.py`, `test_bayesian.py`, `test_single_mode.py`, `device.py`, `test_physics.py`, `GeneralizedMaxwell`, `TensorialEPM`, `ModelComparisonPipeline`, `.create`, `sgr_population_balance.py`, `test_batch_vectorize.py`, `TestFloat64ImportOrder`, `hessian_ci`, `run_profiling.py`, `main.py`, `MenuBar`, `test_epm_kernels_tensorial.py`, `Gp`, `plot_lissajous`, `ModelService`, `CancellationError`, `spp_kernels.py`, `initialize_equilibrium`, `NumpyJSONEncoder`, `test_generalized_maxwell_warm_start.py`, `test_single_mode.py`, `verify_float64`, `TestPlotModuliEvolution`, `test_sgr_generic_extended.py`, `test_cates.py`, `test_multi_mode.py`, `test_trios_chunked_integrity.py`, `create_spp_report`, `_kernels.py`, `pool.py`, `test_local.py`, `plot_cole_cole`, `test_sticky_rouse.py`, `TestPlot3DTrajectory`, `micro_benchmarks.py`, `PowerLaw`, `test_sgr_parity.py`, `test_physics.py`?**
+  _High betweenness centrality (0.100) - this node is a cross-community bridge._
 - **Are the 490 inferred relationships involving `RheoData` (e.g. with `BaseModel` and `._detect_optimization_strategy()`) actually correct?**
   _`RheoData` has 490 INFERRED edges - model-reasoned connections that need verification._
 - **Are the 425 inferred relationships involving `ModelRegistry` (e.g. with `FitResult` and `ModelComparison`) actually correct?**
   _`ModelRegistry` has 425 INFERRED edges - model-reasoned connections that need verification._
-- **Are the 411 inferred relationships involving `ValueError` (e.g. with `_fit_single()` and `_load_from_envelope()`) actually correct?**
-  _`ValueError` has 411 INFERRED edges - model-reasoned connections that need verification._
+- **Are the 412 inferred relationships involving `ValueError` (e.g. with `_fit_single()` and `_load_from_envelope()`) actually correct?**
+  _`ValueError` has 412 INFERRED edges - model-reasoned connections that need verification._
 - **Are the 163 inferred relationships involving `ParameterSet` (e.g. with `BaseModel` and `BaseTransform`) actually correct?**
   _`ParameterSet` has 163 INFERRED edges - model-reasoned connections that need verification._

--- a/graphify-out/manifest.json
+++ b/graphify-out/manifest.json
@@ -1,5202 +1,5217 @@
 {
   "docs/source/conf.py": {
-    "mtime": 1783318201.7230153,
+    "mtime": 1783376924.602853,
     "ast_hash": "bbd3583e22059e63518bfc2972fa31cd",
     "semantic_hash": "bbd3583e22059e63518bfc2972fa31cd"
   },
   "rheojax/__init__.py": {
-    "mtime": 1783318203.3129878,
+    "mtime": 1783376926.2018487,
     "ast_hash": "699932f5ff80c06d418513bc5ab6af41",
     "semantic_hash": "699932f5ff80c06d418513bc5ab6af41"
   },
   "rheojax/cli/__init__.py": {
-    "mtime": 1783318203.3129878,
+    "mtime": 1783376926.2018487,
     "ast_hash": "dc9de96a737355314e1c3c19d63849f7",
     "semantic_hash": "dc9de96a737355314e1c3c19d63849f7"
   },
   "rheojax/cli/_envelope.py": {
-    "mtime": 1783318203.3129878,
+    "mtime": 1783376926.2028487,
     "ast_hash": "192bbdb9bd8fc60b6f30dd2df0611ac5",
     "semantic_hash": "192bbdb9bd8fc60b6f30dd2df0611ac5"
   },
   "rheojax/cli/_globals.py": {
-    "mtime": 1783318203.3129878,
+    "mtime": 1783376926.2028487,
     "ast_hash": "fe199e9b358cf6bd2c7ff6d16ef9a784",
     "semantic_hash": "fe199e9b358cf6bd2c7ff6d16ef9a784"
   },
   "rheojax/cli/_output.py": {
-    "mtime": 1783318203.3129878,
+    "mtime": 1783376926.2028487,
     "ast_hash": "f86bfbf4343f29347be071cb3e372de4",
     "semantic_hash": "f86bfbf4343f29347be071cb3e372de4"
   },
   "rheojax/cli/_templates.py": {
-    "mtime": 1783318203.3129878,
+    "mtime": 1783376926.2028487,
     "ast_hash": "c5ba94cb19886f18b396c46410b2ba58",
     "semantic_hash": "c5ba94cb19886f18b396c46410b2ba58"
   },
   "rheojax/cli/_yaml_runner.py": {
-    "mtime": 1783318203.3129878,
+    "mtime": 1783376926.2028487,
     "ast_hash": "2fdd0e8a619a9abbe8bdc8db003e7828",
     "semantic_hash": ""
   },
   "rheojax/cli/_yaml_schema.py": {
-    "mtime": 1783318203.3129878,
+    "mtime": 1783376926.2028487,
     "ast_hash": "b6446ce13b832f239c5f1da244289824",
     "semantic_hash": "b6446ce13b832f239c5f1da244289824"
   },
   "rheojax/cli/bayesian.py": {
-    "mtime": 1783318203.3129878,
+    "mtime": 1783376926.2028487,
     "ast_hash": "79124ef073b1bcf64231488ea93d0781",
     "semantic_hash": ""
   },
   "rheojax/cli/cmd_batch.py": {
-    "mtime": 1783318203.3129878,
+    "mtime": 1783376926.2028487,
     "ast_hash": "5238ada2039822aee3e2880d67a3c2f6",
     "semantic_hash": "5238ada2039822aee3e2880d67a3c2f6"
   },
   "rheojax/cli/cmd_export.py": {
-    "mtime": 1783318203.3129878,
+    "mtime": 1783376926.2028487,
     "ast_hash": "fe7442f9beff8a1d8f58b77a3da6433a",
     "semantic_hash": "fe7442f9beff8a1d8f58b77a3da6433a"
   },
   "rheojax/cli/cmd_load.py": {
-    "mtime": 1783318203.3129878,
+    "mtime": 1783376926.2028487,
     "ast_hash": "b697f5b50d6d0581b36f122b3b09c912",
     "semantic_hash": "b697f5b50d6d0581b36f122b3b09c912"
   },
   "rheojax/cli/cmd_pipeline.py": {
-    "mtime": 1783318203.3129878,
+    "mtime": 1783376926.2028487,
     "ast_hash": "faca1b8f340c03647dc82c5b714e2e86",
     "semantic_hash": "faca1b8f340c03647dc82c5b714e2e86"
   },
   "rheojax/cli/cmd_run.py": {
-    "mtime": 1783318203.3129878,
+    "mtime": 1783376926.2028487,
     "ast_hash": "bdbe7c3d05ef5d4eb02329572aceb1e3",
     "semantic_hash": "bdbe7c3d05ef5d4eb02329572aceb1e3"
   },
   "rheojax/cli/cmd_transform.py": {
-    "mtime": 1783318203.3129878,
+    "mtime": 1783376926.2028487,
     "ast_hash": "821e3f05ea4c70c851d7c4485d868d6c",
     "semantic_hash": "821e3f05ea4c70c851d7c4485d868d6c"
   },
   "rheojax/cli/fit.py": {
-    "mtime": 1783318203.3129878,
+    "mtime": 1783376926.2028487,
     "ast_hash": "599489a03e505ca18f3108554ce58466",
     "semantic_hash": ""
   },
   "rheojax/cli/main.py": {
-    "mtime": 1783318203.3129878,
+    "mtime": 1783376926.2028487,
     "ast_hash": "3701e1bf8364dd3c17d41878183a66de",
     "semantic_hash": ""
   },
   "rheojax/cli/spp.py": {
-    "mtime": 1783318203.3129878,
+    "mtime": 1783376926.2028487,
     "ast_hash": "3060ff534f4f5988341a707ad1e12dc0",
     "semantic_hash": "3060ff534f4f5988341a707ad1e12dc0"
   },
   "rheojax/core/__init__.py": {
-    "mtime": 1783318203.3129878,
+    "mtime": 1783376926.2028487,
     "ast_hash": "c13aae6efbe38c9022ae2a8b89330389",
     "semantic_hash": "c13aae6efbe38c9022ae2a8b89330389"
   },
   "rheojax/core/arviz_utils.py": {
-    "mtime": 1783318203.3129878,
+    "mtime": 1783376926.2028487,
     "ast_hash": "88e49e7cfbfb48263c66d43c33c39a30",
     "semantic_hash": "88e49e7cfbfb48263c66d43c33c39a30"
   },
   "rheojax/core/base.py": {
-    "mtime": 1783318203.3139877,
+    "mtime": 1783376926.2038488,
     "ast_hash": "584658d5736f85532b3101c56270e970",
     "semantic_hash": ""
   },
   "rheojax/core/bayesian.py": {
-    "mtime": 1783318203.3139877,
+    "mtime": 1783376926.2038488,
     "ast_hash": "54fcbf2939f453aa0e8600206dca4dcb",
     "semantic_hash": "54fcbf2939f453aa0e8600206dca4dcb"
   },
   "rheojax/core/bayesian_diagnostics.py": {
-    "mtime": 1783318203.3139877,
+    "mtime": 1783376926.2038488,
     "ast_hash": "c65dd512e5fded1698f9866718c01cfd",
     "semantic_hash": "c65dd512e5fded1698f9866718c01cfd"
   },
   "rheojax/core/bayesian_result.py": {
-    "mtime": 1783318203.3139877,
+    "mtime": 1783376926.2038488,
     "ast_hash": "62f50f1163d12311e3f5c30eb388f1aa",
     "semantic_hash": "62f50f1163d12311e3f5c30eb388f1aa"
   },
   "rheojax/core/data.py": {
-    "mtime": 1783318203.3139877,
+    "mtime": 1783376926.2038488,
     "ast_hash": "c14a7ffa8711db2627a3225976dec2ab",
     "semantic_hash": "c14a7ffa8711db2627a3225976dec2ab"
   },
   "rheojax/core/fit_orchestrator.py": {
-    "mtime": 1783318203.3139877,
+    "mtime": 1783376926.2038488,
     "ast_hash": "35dcd9f8222321052d95275403896763",
     "semantic_hash": "35dcd9f8222321052d95275403896763"
   },
   "rheojax/core/fit_result.py": {
-    "mtime": 1783318203.3139877,
+    "mtime": 1783376926.2038488,
     "ast_hash": "49c4dc2ad3bde72710f323ca4840e81f",
     "semantic_hash": "49c4dc2ad3bde72710f323ca4840e81f"
   },
   "rheojax/core/inventory.py": {
-    "mtime": 1783318203.3139877,
+    "mtime": 1783376926.2038488,
     "ast_hash": "ebf43a166ca57ad02b7c161b5a4df345",
     "semantic_hash": "ebf43a166ca57ad02b7c161b5a4df345"
   },
   "rheojax/core/jax_config.py": {
-    "mtime": 1783318203.3139877,
+    "mtime": 1783376926.2038488,
     "ast_hash": "d901b24e2bfb8a9498c67537427efbee",
     "semantic_hash": "d901b24e2bfb8a9498c67537427efbee"
   },
   "rheojax/core/numpyro_model_builder.py": {
-    "mtime": 1783318203.3139877,
+    "mtime": 1783376926.2038488,
     "ast_hash": "e0cbf8c54d53635a40c4216be1d3d4e9",
     "semantic_hash": "e0cbf8c54d53635a40c4216be1d3d4e9"
   },
   "rheojax/core/parameters.py": {
-    "mtime": 1783318203.3149877,
+    "mtime": 1783376926.2048488,
     "ast_hash": "5fedb919a0e26072ddb7d9379e589fef",
     "semantic_hash": ""
   },
   "rheojax/core/post_fit_validator.py": {
-    "mtime": 1783318203.3149877,
+    "mtime": 1783376926.2048488,
     "ast_hash": "840feafc57d006cb45ce9c72d7e6c7a7",
     "semantic_hash": "840feafc57d006cb45ce9c72d7e6c7a7"
   },
   "rheojax/core/registry.py": {
-    "mtime": 1783318203.3149877,
+    "mtime": 1783376926.2048488,
     "ast_hash": "4997d6461f2d8ec52f687f32ced75003",
     "semantic_hash": "4997d6461f2d8ec52f687f32ced75003"
   },
   "rheojax/core/test_modes.py": {
-    "mtime": 1783318203.3149877,
+    "mtime": 1783376926.2048488,
     "ast_hash": "f107afcba420ca25e34db590785a846f",
     "semantic_hash": "f107afcba420ca25e34db590785a846f"
   },
   "rheojax/gui/__init__.py": {
-    "mtime": 1783318203.3149877,
+    "mtime": 1783376926.2048488,
     "ast_hash": "c07706e4175ff212b9c23508f5b2b45b",
     "semantic_hash": "c07706e4175ff212b9c23508f5b2b45b"
   },
   "rheojax/gui/app/__init__.py": {
-    "mtime": 1783318203.3149877,
+    "mtime": 1783376926.2048488,
     "ast_hash": "ddbfc63655308551d2305fdae23309af",
     "semantic_hash": "ddbfc63655308551d2305fdae23309af"
   },
   "rheojax/gui/app/main_window.py": {
-    "mtime": 1783318203.3149877,
-    "ast_hash": "52aae58bd9519851b5ddb73046d8ce0e",
+    "mtime": 1783376926.2048488,
+    "ast_hash": "d27544990f61dec16f3180472d3aa33b",
     "semantic_hash": ""
   },
   "rheojax/gui/app/menu_bar.py": {
-    "mtime": 1783318203.3159878,
+    "mtime": 1783376926.2058487,
     "ast_hash": "1552dc0dc65f51382e1c0b5759f73e75",
     "semantic_hash": "1552dc0dc65f51382e1c0b5759f73e75"
   },
   "rheojax/gui/app/status_bar.py": {
-    "mtime": 1783318203.3159878,
+    "mtime": 1783376926.2058487,
     "ast_hash": "579fbd75f0b7ccedfdd1ee3242a1f778",
     "semantic_hash": ""
   },
   "rheojax/gui/app/toolbar.py": {
-    "mtime": 1783318203.3159878,
+    "mtime": 1783376926.2058487,
     "ast_hash": "dabc68b8ede2fcf3bf535559d8053e8c",
     "semantic_hash": "dabc68b8ede2fcf3bf535559d8053e8c"
   },
   "rheojax/gui/compat.py": {
-    "mtime": 1783318203.3159878,
+    "mtime": 1783376926.2058487,
     "ast_hash": "90db359b4219703394a041122c6a6549",
     "semantic_hash": "90db359b4219703394a041122c6a6549"
   },
   "rheojax/gui/dialogs/__init__.py": {
-    "mtime": 1783318203.3159878,
+    "mtime": 1783376926.2058487,
     "ast_hash": "a46ba53723c659edf105ae24bf04ac17",
     "semantic_hash": "a46ba53723c659edf105ae24bf04ac17"
   },
   "rheojax/gui/dialogs/about.py": {
-    "mtime": 1783318203.3159878,
+    "mtime": 1783376926.2058487,
     "ast_hash": "8dbf72aae7acebf594dcff32c22ac25e",
     "semantic_hash": "8dbf72aae7acebf594dcff32c22ac25e"
   },
   "rheojax/gui/dialogs/bayesian_options.py": {
-    "mtime": 1783318203.3159878,
+    "mtime": 1783376926.2058487,
     "ast_hash": "2dd5ba5761406fd90b3b21d91050f17a",
     "semantic_hash": ""
   },
   "rheojax/gui/dialogs/column_mapper.py": {
-    "mtime": 1783318203.3159878,
+    "mtime": 1783376926.2058487,
     "ast_hash": "84a4a298e2fe628e28b312629cc51ba8",
     "semantic_hash": "84a4a298e2fe628e28b312629cc51ba8"
   },
   "rheojax/gui/dialogs/export_options.py": {
-    "mtime": 1783318203.3159878,
+    "mtime": 1783376926.2058487,
     "ast_hash": "86b2d888323e2988d43ebe201d892b58",
     "semantic_hash": "86b2d888323e2988d43ebe201d892b58"
   },
   "rheojax/gui/dialogs/fitting_options.py": {
-    "mtime": 1783318203.3159878,
+    "mtime": 1783376926.2058487,
     "ast_hash": "86ac9c463f19ca9da5427552795566bc",
     "semantic_hash": "86ac9c463f19ca9da5427552795566bc"
   },
   "rheojax/gui/dialogs/import_wizard.py": {
-    "mtime": 1783318203.3159878,
+    "mtime": 1783376926.2058487,
     "ast_hash": "e17bbdb1702e5e03ccc753209de9f94d",
     "semantic_hash": ""
   },
   "rheojax/gui/dialogs/pipeline_templates.py": {
-    "mtime": 1783318203.3159878,
+    "mtime": 1783376926.2058487,
     "ast_hash": "973bbea75e206256562bd418275b5dd4",
     "semantic_hash": "973bbea75e206256562bd418275b5dd4"
   },
   "rheojax/gui/dialogs/preferences.py": {
-    "mtime": 1783318203.3159878,
+    "mtime": 1783376926.2058487,
     "ast_hash": "84f6b48dcf3453ba7a89963f2c288945",
     "semantic_hash": "84f6b48dcf3453ba7a89963f2c288945"
   },
   "rheojax/gui/jobs/__init__.py": {
-    "mtime": 1783318203.3169878,
+    "mtime": 1783376926.2068486,
     "ast_hash": "f8bc9bbdcbc4f64483f54714f1baa8c1",
     "semantic_hash": "f8bc9bbdcbc4f64483f54714f1baa8c1"
   },
   "rheojax/gui/jobs/_cleanup.py": {
-    "mtime": 1783318203.3169878,
+    "mtime": 1783376926.2068486,
     "ast_hash": "73e6005c893ca9f7046f726d3ab48067",
     "semantic_hash": "73e6005c893ca9f7046f726d3ab48067"
   },
   "rheojax/gui/jobs/bayesian_worker.py": {
-    "mtime": 1783318203.3169878,
+    "mtime": 1783376926.2068486,
     "ast_hash": "12784da5e52928d177d8569980a59b16",
     "semantic_hash": ""
   },
   "rheojax/gui/jobs/cancellation.py": {
-    "mtime": 1783318203.3169878,
+    "mtime": 1783376926.2068486,
     "ast_hash": "f5382a0e5162564f212932d74c1001ea",
     "semantic_hash": "f5382a0e5162564f212932d74c1001ea"
   },
   "rheojax/gui/jobs/export_worker.py": {
-    "mtime": 1783318203.3169878,
+    "mtime": 1783376926.2068486,
     "ast_hash": "a0ee1c0227845ecb329468added416c0",
     "semantic_hash": "a0ee1c0227845ecb329468added416c0"
   },
   "rheojax/gui/jobs/fit_worker.py": {
-    "mtime": 1783318203.3169878,
+    "mtime": 1783376926.2068486,
     "ast_hash": "d77250029a6157381d3d945d5f347264",
     "semantic_hash": ""
   },
   "rheojax/gui/jobs/import_worker.py": {
-    "mtime": 1783318203.3169878,
+    "mtime": 1783376926.2068486,
     "ast_hash": "8fc1044d12f230ff40d9b3fb59d99d28",
     "semantic_hash": "8fc1044d12f230ff40d9b3fb59d99d28"
   },
   "rheojax/gui/jobs/preview_worker.py": {
-    "mtime": 1783318203.3169878,
+    "mtime": 1783376926.2068486,
     "ast_hash": "68deab3263af4cceeda63a1075f530ae",
     "semantic_hash": "68deab3263af4cceeda63a1075f530ae"
   },
   "rheojax/gui/jobs/process_adapter.py": {
-    "mtime": 1783318203.3169878,
+    "mtime": 1783376926.2078488,
     "ast_hash": "b98658fc3a4fcd8ee8645f099875d62d",
     "semantic_hash": ""
   },
   "rheojax/gui/jobs/subprocess_bayesian.py": {
-    "mtime": 1783318203.3179877,
+    "mtime": 1783376926.2078488,
     "ast_hash": "445b379cb95be849f521b4e92616b041",
     "semantic_hash": ""
   },
   "rheojax/gui/jobs/subprocess_fit.py": {
-    "mtime": 1783318203.3179877,
+    "mtime": 1783376926.2078488,
     "ast_hash": "c01d1cd034723e28db09c223e1ea9621",
     "semantic_hash": "c01d1cd034723e28db09c223e1ea9621"
   },
   "rheojax/gui/jobs/test_jobs.py": {
-    "mtime": 1783318203.3179877,
+    "mtime": 1783376926.2078488,
     "ast_hash": "9532c56318dc1be0b45b85a356ac4034",
     "semantic_hash": ""
   },
   "rheojax/gui/jobs/transform_worker.py": {
-    "mtime": 1783318203.3179877,
+    "mtime": 1783376926.2078488,
     "ast_hash": "ff1a2bb2177caef903cbf1bf4e4c4921",
     "semantic_hash": "ff1a2bb2177caef903cbf1bf4e4c4921"
   },
   "rheojax/gui/jobs/worker_pool.py": {
-    "mtime": 1783318203.3179877,
+    "mtime": 1783376926.2078488,
     "ast_hash": "a103dcb87ee6e3480aa19449843d6780",
     "semantic_hash": ""
   },
   "rheojax/gui/main.py": {
-    "mtime": 1783318203.3179877,
-    "ast_hash": "a4f314e9df36c4f395b7881039783a97",
+    "mtime": 1783376926.2078488,
+    "ast_hash": "a2b0c6291781957fc1d64e5d53de6419",
     "semantic_hash": ""
   },
   "rheojax/gui/pages/__init__.py": {
-    "mtime": 1783318203.3179877,
+    "mtime": 1783376926.2078488,
     "ast_hash": "f535312b256a670450de4c0a7197fe8f",
     "semantic_hash": "f535312b256a670450de4c0a7197fe8f"
   },
   "rheojax/gui/pages/bayesian_page.py": {
-    "mtime": 1783318906.793951,
+    "mtime": 1783376926.2078488,
     "ast_hash": "5df4c76f50c709ce4a962d8f31467456",
     "semantic_hash": ""
   },
   "rheojax/gui/pages/data_page.py": {
-    "mtime": 1783318806.6005342,
+    "mtime": 1783376926.2088487,
     "ast_hash": "779397c9460623f5d8347071b12487db",
     "semantic_hash": ""
   },
   "rheojax/gui/pages/diagnostics_page.py": {
-    "mtime": 1783318960.8206701,
+    "mtime": 1783376926.2088487,
     "ast_hash": "2ead0bea483b9d2e4a4e6fc8065a1586",
     "semantic_hash": ""
   },
   "rheojax/gui/pages/export_page.py": {
-    "mtime": 1783318203.3189876,
+    "mtime": 1783376926.2088487,
     "ast_hash": "5acdf3204bae99f5af8e0519de6f11a1",
     "semantic_hash": ""
   },
   "rheojax/gui/pages/fit_page.py": {
-    "mtime": 1783318850.5702674,
+    "mtime": 1783376926.2088487,
     "ast_hash": "c07baca8de4c1e4623a3da1e7bb87234",
     "semantic_hash": ""
   },
   "rheojax/gui/pages/home_page.py": {
-    "mtime": 1783318976.9255905,
+    "mtime": 1783376926.2088487,
     "ast_hash": "daf6f0b5ffcb28cdd296fbd8bd4b8081",
     "semantic_hash": ""
   },
   "rheojax/gui/pages/transform_page.py": {
-    "mtime": 1783318203.3189876,
+    "mtime": 1783376926.2088487,
     "ast_hash": "a023fd51586b02ae2fb420e824eb9e45",
     "semantic_hash": "a023fd51586b02ae2fb420e824eb9e45"
   },
   "rheojax/gui/resources/__init__.py": {
-    "mtime": 1783318203.3189876,
+    "mtime": 1783376926.2088487,
     "ast_hash": "24d93c770d1e6af3e6701bd26541d9f0",
     "semantic_hash": "24d93c770d1e6af3e6701bd26541d9f0"
   },
   "rheojax/gui/resources/styles/__init__.py": {
-    "mtime": 1783318203.3199878,
+    "mtime": 1783376926.2098486,
     "ast_hash": "b39bbf0a5def09f6d8fbf4c22e1729d6",
     "semantic_hash": "b39bbf0a5def09f6d8fbf4c22e1729d6"
   },
   "rheojax/gui/resources/styles/example_usage.py": {
-    "mtime": 1783318203.3199878,
+    "mtime": 1783376926.2098486,
     "ast_hash": "fe3d4bcc3f5d37c26a2a66d4599f90b8",
     "semantic_hash": "fe3d4bcc3f5d37c26a2a66d4599f90b8"
   },
   "rheojax/gui/resources/styles/plot_styles/__init__.py": {
-    "mtime": 1783318203.3199878,
+    "mtime": 1783376926.2098486,
     "ast_hash": "6a71df35cea44e0745f4390e1e7ff029",
     "semantic_hash": "6a71df35cea44e0745f4390e1e7ff029"
   },
   "rheojax/gui/services/__init__.py": {
-    "mtime": 1783318203.3199878,
+    "mtime": 1783376926.2098486,
     "ast_hash": "64163379daddfeda7d6c4306319be659",
     "semantic_hash": "64163379daddfeda7d6c4306319be659"
   },
   "rheojax/gui/services/bayesian_service.py": {
-    "mtime": 1783318203.3199878,
+    "mtime": 1783376926.2098486,
     "ast_hash": "2a25f0c553b1ed5ff761a9a8fb3f4e6e",
     "semantic_hash": ""
   },
   "rheojax/gui/services/data_service.py": {
-    "mtime": 1783318203.3199878,
+    "mtime": 1783376926.2108488,
     "ast_hash": "6938a9e2028f5293b0acc05f3b9f43f9",
     "semantic_hash": ""
   },
   "rheojax/gui/services/export_service.py": {
-    "mtime": 1783318203.3199878,
+    "mtime": 1783376926.2108488,
     "ast_hash": "29845a0dda1034167884c0e1cd631280",
     "semantic_hash": "29845a0dda1034167884c0e1cd631280"
   },
   "rheojax/gui/services/model_service.py": {
-    "mtime": 1783318203.3209877,
+    "mtime": 1783376926.2108488,
     "ast_hash": "0d06d314de3c42449c4f137f320b2343",
     "semantic_hash": ""
   },
   "rheojax/gui/services/pipeline_execution_service.py": {
-    "mtime": 1783318203.3209877,
+    "mtime": 1783376926.2108488,
     "ast_hash": "52f7b55b9993a0d57c7adc9b366cd0b7",
     "semantic_hash": ""
   },
   "rheojax/gui/services/plot_service.py": {
-    "mtime": 1783318203.3209877,
+    "mtime": 1783376926.2108488,
     "ast_hash": "ec48bbc0d935d27880ed43d5b18c9117",
     "semantic_hash": "ec48bbc0d935d27880ed43d5b18c9117"
   },
   "rheojax/gui/services/transform_service.py": {
-    "mtime": 1783318203.3209877,
+    "mtime": 1783376926.2108488,
     "ast_hash": "d94ef8b7692ff8dcb2e0388022f54f26",
     "semantic_hash": ""
   },
   "rheojax/gui/state/__init__.py": {
-    "mtime": 1783318203.3209877,
+    "mtime": 1783376926.2108488,
     "ast_hash": "5e84c3e3a2082ccd0365f9dd4c35c2ae",
     "semantic_hash": "5e84c3e3a2082ccd0365f9dd4c35c2ae"
   },
   "rheojax/gui/state/actions.py": {
-    "mtime": 1783318203.3209877,
+    "mtime": 1783376926.2108488,
     "ast_hash": "398b8e3ab249320297cf12d0e66ed007",
     "semantic_hash": "398b8e3ab249320297cf12d0e66ed007"
   },
   "rheojax/gui/state/reducers/__init__.py": {
-    "mtime": 1783318203.3209877,
+    "mtime": 1783376926.2118487,
     "ast_hash": "b6d8852e31dbecdadcb4b73e9721fd11",
     "semantic_hash": "b6d8852e31dbecdadcb4b73e9721fd11"
   },
   "rheojax/gui/state/reducers/bayesian_reducers.py": {
-    "mtime": 1783318203.3209877,
+    "mtime": 1783376926.2118487,
     "ast_hash": "a91a2e9d8217d9b21e9276c81ab82589",
     "semantic_hash": "a91a2e9d8217d9b21e9276c81ab82589"
   },
   "rheojax/gui/state/reducers/data_reducers.py": {
-    "mtime": 1783318203.3209877,
+    "mtime": 1783376926.2118487,
     "ast_hash": "3022fd0c2467359fcaf28117e165d2f4",
     "semantic_hash": ""
   },
   "rheojax/gui/state/reducers/fitting_reducers.py": {
-    "mtime": 1783318203.3209877,
+    "mtime": 1783376926.2118487,
     "ast_hash": "f6d20256595461b856f1ae2c680a8c29",
     "semantic_hash": ""
   },
   "rheojax/gui/state/reducers/model_reducers.py": {
-    "mtime": 1783318203.3209877,
+    "mtime": 1783376926.2118487,
     "ast_hash": "f995d7d0344af10f530aa6a7c4a1b057",
     "semantic_hash": "f995d7d0344af10f530aa6a7c4a1b057"
   },
   "rheojax/gui/state/reducers/pipeline_reducers.py": {
-    "mtime": 1783318203.3209877,
+    "mtime": 1783376926.2118487,
     "ast_hash": "e3bc1d0899b1938280a1cf7e6e7b762d",
     "semantic_hash": ""
   },
   "rheojax/gui/state/reducers/project_reducers.py": {
-    "mtime": 1783318203.3209877,
+    "mtime": 1783376926.2118487,
     "ast_hash": "a2494539dde7893c9c4e3ab92b330a44",
     "semantic_hash": ""
   },
   "rheojax/gui/state/reducers/ui_reducers.py": {
-    "mtime": 1783318203.3219876,
+    "mtime": 1783376926.2118487,
     "ast_hash": "faed0f10b1140b108eb3e81f8cbb75f0",
     "semantic_hash": ""
   },
   "rheojax/gui/state/selectors.py": {
-    "mtime": 1783318203.3219876,
+    "mtime": 1783376926.2118487,
     "ast_hash": "5adcd6d253fa729981a46a09985e979c",
     "semantic_hash": "5adcd6d253fa729981a46a09985e979c"
   },
   "rheojax/gui/state/signals.py": {
-    "mtime": 1783318203.3219876,
+    "mtime": 1783376926.2118487,
     "ast_hash": "7f996306e7f5321913c5626439e134ec",
     "semantic_hash": ""
   },
   "rheojax/gui/state/store.py": {
-    "mtime": 1783318203.3219876,
+    "mtime": 1783376926.2118487,
     "ast_hash": "ec80f0befa5ac59a78d17709aed3f876",
     "semantic_hash": ""
   },
   "rheojax/gui/utils/__init__.py": {
-    "mtime": 1783318203.3219876,
+    "mtime": 1783376926.2118487,
     "ast_hash": "17b08e29220d1cc543767254c8086cb5",
     "semantic_hash": "17b08e29220d1cc543767254c8086cb5"
   },
   "rheojax/gui/utils/_dependency_guard.py": {
-    "mtime": 1783318203.3219876,
+    "mtime": 1783376926.2118487,
     "ast_hash": "8251f5c1b5b1c84530f2630981173f96",
     "semantic_hash": "8251f5c1b5b1c84530f2630981173f96"
   },
   "rheojax/gui/utils/config.py": {
-    "mtime": 1783318203.3219876,
+    "mtime": 1783376926.2118487,
     "ast_hash": "485e09914ed372a2323d83c87c0a8f99",
     "semantic_hash": ""
   },
   "rheojax/gui/utils/icons.py": {
-    "mtime": 1783318203.3219876,
+    "mtime": 1783376926.2118487,
     "ast_hash": "dbc353612f6c52671f19389440390304",
     "semantic_hash": "dbc353612f6c52671f19389440390304"
   },
   "rheojax/gui/utils/jax_utils.py": {
-    "mtime": 1783318203.3219876,
+    "mtime": 1783376926.2118487,
     "ast_hash": "640822b90218f0440477c8cd91dacbfe",
     "semantic_hash": "640822b90218f0440477c8cd91dacbfe"
   },
   "rheojax/gui/utils/layout_helpers.py": {
-    "mtime": 1783318203.3219876,
+    "mtime": 1783376926.2118487,
     "ast_hash": "e2b4a3ac8238e9f0c7727ca583d0fe5d",
     "semantic_hash": "e2b4a3ac8238e9f0c7727ca583d0fe5d"
   },
   "rheojax/gui/utils/logging.py": {
-    "mtime": 1783318203.3219876,
-    "ast_hash": "8ce07d23dbed721483bc914b2fc8398f",
-    "semantic_hash": "8ce07d23dbed721483bc914b2fc8398f"
+    "mtime": 1783376926.2128487,
+    "ast_hash": "cda87500c1f27618ef9ac1340b019296",
+    "semantic_hash": ""
   },
   "rheojax/gui/utils/pipeline_serializer.py": {
-    "mtime": 1783318203.3219876,
+    "mtime": 1783376926.2128487,
     "ast_hash": "a922f8885155a5095a047b4574ff50e6",
     "semantic_hash": "a922f8885155a5095a047b4574ff50e6"
   },
   "rheojax/gui/utils/provenance.py": {
-    "mtime": 1783318203.3219876,
+    "mtime": 1783376926.2128487,
     "ast_hash": "fb55cbe2dc66ba61fc6e45bb14fd9b5d",
     "semantic_hash": "fb55cbe2dc66ba61fc6e45bb14fd9b5d"
   },
   "rheojax/gui/utils/rheodata.py": {
-    "mtime": 1783318203.3219876,
+    "mtime": 1783376926.2128487,
     "ast_hash": "5cbcf10760910bc021154d6c33f6acb4",
     "semantic_hash": "5cbcf10760910bc021154d6c33f6acb4"
   },
   "rheojax/gui/utils/seeds.py": {
-    "mtime": 1783318203.3219876,
+    "mtime": 1783376926.2128487,
     "ast_hash": "c9510b12b56c4647acb30c6529dbaf4b",
     "semantic_hash": "c9510b12b56c4647acb30c6529dbaf4b"
   },
   "rheojax/gui/utils/style_helpers.py": {
-    "mtime": 1783318203.3219876,
+    "mtime": 1783376926.2128487,
     "ast_hash": "433898eb6afea2d5ebe727218d4f9872",
     "semantic_hash": "433898eb6afea2d5ebe727218d4f9872"
   },
   "rheojax/gui/widgets/__init__.py": {
-    "mtime": 1783318203.3219876,
+    "mtime": 1783376926.2128487,
     "ast_hash": "c6499d716bab95045030f6dcc0574b81",
     "semantic_hash": "c6499d716bab95045030f6dcc0574b81"
   },
   "rheojax/gui/widgets/arviz_canvas.py": {
-    "mtime": 1783318203.3229876,
+    "mtime": 1783376926.2128487,
     "ast_hash": "1a0328132e6f26d4b40ed7517c7545c3",
     "semantic_hash": ""
   },
   "rheojax/gui/widgets/base_arviz_widget.py": {
-    "mtime": 1783318203.3229876,
+    "mtime": 1783376926.2128487,
     "ast_hash": "6772e5d2f7e4491114537e08437bf013",
     "semantic_hash": "6772e5d2f7e4491114537e08437bf013"
   },
   "rheojax/gui/widgets/batch_panel.py": {
-    "mtime": 1783318203.3229876,
+    "mtime": 1783376926.2128487,
     "ast_hash": "21711cb22181571c4803a3b2a954f83a",
     "semantic_hash": "21711cb22181571c4803a3b2a954f83a"
   },
   "rheojax/gui/widgets/dataset_tree.py": {
-    "mtime": 1783318815.2834802,
+    "mtime": 1783376926.2128487,
     "ast_hash": "a8db6a5b4f81862a110e9c33f5a9c36b",
     "semantic_hash": ""
   },
   "rheojax/gui/widgets/empty_state.py": {
-    "mtime": 1783318203.3229876,
+    "mtime": 1783376926.2128487,
     "ast_hash": "54afa08204577f0b47b6fcc3b3288aef",
     "semantic_hash": "54afa08204577f0b47b6fcc3b3288aef"
   },
   "rheojax/gui/widgets/jax_status.py": {
-    "mtime": 1783318203.3229876,
+    "mtime": 1783376926.2128487,
     "ast_hash": "86369e8d0a9bf8f5b0b0e0941daeef3a",
     "semantic_hash": ""
   },
   "rheojax/gui/widgets/multi_view.py": {
-    "mtime": 1783318921.0128748,
+    "mtime": 1783376926.2128487,
     "ast_hash": "0c8f066af326a181ff5115e0b8e119b0",
     "semantic_hash": ""
   },
   "rheojax/gui/widgets/parameter_form.py": {
-    "mtime": 1783318203.3229876,
+    "mtime": 1783376926.2128487,
     "ast_hash": "ce01651d1342ba27de83ead9a4697092",
     "semantic_hash": "ce01651d1342ba27de83ead9a4697092"
   },
   "rheojax/gui/widgets/parameter_table.py": {
-    "mtime": 1783318775.1117363,
+    "mtime": 1783376926.2128487,
     "ast_hash": "3c7821e5f45bbaa627ea9867fe183d6e",
     "semantic_hash": ""
   },
   "rheojax/gui/widgets/pipeline_chips.py": {
-    "mtime": 1783318805.7475395,
+    "mtime": 1783376926.2128487,
     "ast_hash": "1e1c1866c33f3e595ecca0dba0ac2492",
     "semantic_hash": ""
   },
   "rheojax/gui/widgets/pipeline_sidebar.py": {
-    "mtime": 1783318860.3422105,
+    "mtime": 1783376926.2138486,
     "ast_hash": "91799e6d40e9cfce701c8469a43f7226",
     "semantic_hash": ""
   },
   "rheojax/gui/widgets/pipeline_step_delegate.py": {
-    "mtime": 1783318787.4106562,
+    "mtime": 1783376926.2138486,
     "ast_hash": "9b00134ff188cb07d9bb3f2947942213",
     "semantic_hash": ""
   },
   "rheojax/gui/widgets/plot_canvas.py": {
-    "mtime": 1783318944.4987528,
+    "mtime": 1783376926.2138486,
     "ast_hash": "4bddd886e60b3f5ed4a9af7034be4d53",
     "semantic_hash": ""
   },
   "rheojax/gui/widgets/plot_widget.py": {
-    "mtime": 1783318888.856049,
+    "mtime": 1783376926.2138486,
     "ast_hash": "f8ced73fa8a99ebb19e68351014c947a",
     "semantic_hash": ""
   },
   "rheojax/gui/widgets/priors_editor.py": {
-    "mtime": 1783318203.3229876,
+    "mtime": 1783376926.2138486,
     "ast_hash": "bfa971b9b23980884c84f03223828ed4",
     "semantic_hash": ""
   },
   "rheojax/gui/widgets/pyqtgraph_canvas.py": {
-    "mtime": 1783318964.0746539,
+    "mtime": 1783376926.2138486,
     "ast_hash": "8c0a2ad700a192a80ee5a26aa15ec4d1",
     "semantic_hash": ""
   },
   "rheojax/gui/widgets/residuals_panel.py": {
-    "mtime": 1783318849.9082713,
+    "mtime": 1783376926.2138486,
     "ast_hash": "e0d2579f574b7f09ccb761539e14c743",
     "semantic_hash": ""
   },
   "rheojax/gui/widgets/results_panel.py": {
-    "mtime": 1783318203.3239877,
+    "mtime": 1783376926.2138486,
     "ast_hash": "88f7038d571c3ec91ab3326a4d03622e",
     "semantic_hash": "88f7038d571c3ec91ab3326a4d03622e"
   },
   "rheojax/gui/widgets/workspace_container.py": {
-    "mtime": 1783318203.3239877,
+    "mtime": 1783376926.2138486,
     "ast_hash": "bdf1f81543131bd947eac4de2f083cbb",
     "semantic_hash": "bdf1f81543131bd947eac4de2f083cbb"
   },
   "rheojax/io/__init__.py": {
-    "mtime": 1783318203.3249876,
+    "mtime": 1783376926.2148488,
     "ast_hash": "e3629181a55afe2fc61bae6e4b2f9895",
     "semantic_hash": "e3629181a55afe2fc61bae6e4b2f9895"
   },
   "rheojax/io/_exceptions.py": {
-    "mtime": 1783318203.3249876,
+    "mtime": 1783376926.2148488,
     "ast_hash": "b7a2ad9a1c54515bbcbacb264030c83d",
     "semantic_hash": ""
   },
   "rheojax/io/analysis_exporter.py": {
-    "mtime": 1783318203.3249876,
+    "mtime": 1783376926.2158487,
     "ast_hash": "736bf3ce1c037c1bc4bbf04c6ddd8772",
     "semantic_hash": "736bf3ce1c037c1bc4bbf04c6ddd8772"
   },
   "rheojax/io/json_encoder.py": {
-    "mtime": 1783318203.3249876,
+    "mtime": 1783376926.2158487,
     "ast_hash": "d3bd2826a8b05f40d66fb9676eed473e",
     "semantic_hash": "d3bd2826a8b05f40d66fb9676eed473e"
   },
   "rheojax/io/readers/__init__.py": {
-    "mtime": 1783318203.3249876,
+    "mtime": 1783376926.2158487,
     "ast_hash": "cca6ff05220f2236ba0196cd1009e4d9",
     "semantic_hash": "cca6ff05220f2236ba0196cd1009e4d9"
   },
   "rheojax/io/readers/_column_mapping.py": {
-    "mtime": 1783318203.3249876,
+    "mtime": 1783376926.2158487,
     "ast_hash": "c6573297a2604bee30fe8809cf6bcc33",
     "semantic_hash": "c6573297a2604bee30fe8809cf6bcc33"
   },
   "rheojax/io/readers/_utils.py": {
-    "mtime": 1783318203.3249876,
+    "mtime": 1783376926.2158487,
     "ast_hash": "7b29fe04d5f7d4a139bbffe68ba8e7ad",
     "semantic_hash": ""
   },
   "rheojax/io/readers/_validation.py": {
-    "mtime": 1783318203.3249876,
+    "mtime": 1783376926.2158487,
     "ast_hash": "7fc5d107ed8803d75f203ec43fb1c222",
     "semantic_hash": "7fc5d107ed8803d75f203ec43fb1c222"
   },
   "rheojax/io/readers/anton_paar.py": {
-    "mtime": 1783318203.3259876,
+    "mtime": 1783376926.2158487,
     "ast_hash": "3cbf17e959849d3499e7807ae6b7923a",
     "semantic_hash": ""
   },
   "rheojax/io/readers/auto.py": {
-    "mtime": 1783318203.3259876,
+    "mtime": 1783376926.2158487,
     "ast_hash": "03cf41f297bd7d026f4ab375090578ec",
     "semantic_hash": ""
   },
   "rheojax/io/readers/csv_reader.py": {
-    "mtime": 1783318203.3259876,
+    "mtime": 1783376926.2158487,
     "ast_hash": "84a4c43bb03029836a7e313f6d8e8dde",
     "semantic_hash": ""
   },
   "rheojax/io/readers/excel_reader.py": {
-    "mtime": 1783318203.3259876,
+    "mtime": 1783376926.2158487,
     "ast_hash": "2960b5ae980e925d8cdbc624294f7ae6",
     "semantic_hash": "2960b5ae980e925d8cdbc624294f7ae6"
   },
   "rheojax/io/readers/multi_file.py": {
-    "mtime": 1783318203.3259876,
+    "mtime": 1783376926.2158487,
     "ast_hash": "2a2dc33ecaee0f4ddaa588f1718362a9",
     "semantic_hash": "2a2dc33ecaee0f4ddaa588f1718362a9"
   },
   "rheojax/io/readers/trios/__init__.py": {
-    "mtime": 1783318203.3259876,
+    "mtime": 1783376926.2168486,
     "ast_hash": "b6bd635c482aec56abe401396aa481f2",
     "semantic_hash": "b6bd635c482aec56abe401396aa481f2"
   },
   "rheojax/io/readers/trios/common.py": {
-    "mtime": 1783318203.3259876,
+    "mtime": 1783376926.2168486,
     "ast_hash": "78b8868f59db469ef9a7181620fe7ed5",
     "semantic_hash": ""
   },
   "rheojax/io/readers/trios/csv.py": {
-    "mtime": 1783318203.3259876,
+    "mtime": 1783376926.2168486,
     "ast_hash": "6bae715fd45b321d547659f0a809be67",
     "semantic_hash": "6bae715fd45b321d547659f0a809be67"
   },
   "rheojax/io/readers/trios/excel.py": {
-    "mtime": 1783318203.3259876,
+    "mtime": 1783376926.2168486,
     "ast_hash": "b5630759afc78470a1b92d60c2d62d8a",
     "semantic_hash": ""
   },
   "rheojax/io/readers/trios/json.py": {
-    "mtime": 1783318203.3259876,
+    "mtime": 1783376926.2168486,
     "ast_hash": "66aafc4be074e520647525be3bd730db",
     "semantic_hash": "66aafc4be074e520647525be3bd730db"
   },
   "rheojax/io/readers/trios/schema/TRIOSJSONExportSchema.json": {
-    "mtime": 1783318203.3269875,
+    "mtime": 1783376926.2168486,
     "ast_hash": "83efd753f8c3f841c4471d9eb512ad35",
     "semantic_hash": "83efd753f8c3f841c4471d9eb512ad35"
   },
   "rheojax/io/readers/trios/schema/__init__.py": {
-    "mtime": 1783318203.3269875,
+    "mtime": 1783376926.2168486,
     "ast_hash": "76cd59b2a3a6c3616edcb2db8d109c06",
     "semantic_hash": "76cd59b2a3a6c3616edcb2db8d109c06"
   },
   "rheojax/io/readers/trios/schema/dataset.py": {
-    "mtime": 1783318203.3269875,
+    "mtime": 1783376926.2168486,
     "ast_hash": "e8de4ee917dc9a4086e89ce819a59987",
     "semantic_hash": "e8de4ee917dc9a4086e89ce819a59987"
   },
   "rheojax/io/readers/trios/schema/experiment.py": {
-    "mtime": 1783318203.3269875,
+    "mtime": 1783376926.2168486,
     "ast_hash": "990de59ff56997939a5938f7376fe859",
     "semantic_hash": "990de59ff56997939a5938f7376fe859"
   },
   "rheojax/io/readers/trios/txt.py": {
-    "mtime": 1783318203.3269875,
+    "mtime": 1783376926.2168486,
     "ast_hash": "87c8d519e4a1d9b8906b541dd8aa63a7",
     "semantic_hash": ""
   },
   "rheojax/io/spp_export.py": {
-    "mtime": 1783318203.3269875,
+    "mtime": 1783376926.2168486,
     "ast_hash": "0fd3d81dc9f5e8c5adbf91b800f20a45",
     "semantic_hash": "0fd3d81dc9f5e8c5adbf91b800f20a45"
   },
   "rheojax/io/writers/__init__.py": {
-    "mtime": 1783318203.3269875,
+    "mtime": 1783376926.2168486,
     "ast_hash": "3632636103305ce01e31a3afc9f50ed0",
     "semantic_hash": "3632636103305ce01e31a3afc9f50ed0"
   },
   "rheojax/io/writers/excel_writer.py": {
-    "mtime": 1783318203.3269875,
+    "mtime": 1783376926.2168486,
     "ast_hash": "2f571375e4e3b13ded6bbdeb9201971a",
     "semantic_hash": "2f571375e4e3b13ded6bbdeb9201971a"
   },
   "rheojax/io/writers/hdf5_writer.py": {
-    "mtime": 1783318203.3269875,
+    "mtime": 1783376926.2178488,
     "ast_hash": "d28fe4a9f688872e692540c3e4ec9e1d",
     "semantic_hash": "d28fe4a9f688872e692540c3e4ec9e1d"
   },
   "rheojax/io/writers/npz_writer.py": {
-    "mtime": 1783318203.3269875,
+    "mtime": 1783376926.2178488,
     "ast_hash": "fab15af5151f20b37baa11a797343604",
     "semantic_hash": "fab15af5151f20b37baa11a797343604"
   },
   "rheojax/logging/__init__.py": {
-    "mtime": 1783318203.3269875,
+    "mtime": 1783376926.2178488,
     "ast_hash": "826ca4459e19d36ecea4aca9c74c156a",
     "semantic_hash": "826ca4459e19d36ecea4aca9c74c156a"
   },
   "rheojax/logging/config.py": {
-    "mtime": 1783318203.3269875,
+    "mtime": 1783376926.2178488,
     "ast_hash": "bf1b3abc093e1fb361be9b6706ac3b09",
     "semantic_hash": "bf1b3abc093e1fb361be9b6706ac3b09"
   },
   "rheojax/logging/context.py": {
-    "mtime": 1783318203.3269875,
+    "mtime": 1783376926.2178488,
     "ast_hash": "97db23415215df93e1bec68e3e7c609d",
     "semantic_hash": "97db23415215df93e1bec68e3e7c609d"
   },
   "rheojax/logging/formatters.py": {
-    "mtime": 1783318203.3269875,
+    "mtime": 1783376926.2178488,
     "ast_hash": "c5096d649807a7828a5300c87c4b1e60",
     "semantic_hash": "c5096d649807a7828a5300c87c4b1e60"
   },
   "rheojax/logging/handlers.py": {
-    "mtime": 1783318203.3269875,
+    "mtime": 1783376926.2178488,
     "ast_hash": "ac4566ff07ccef947a975fb5765516b0",
     "semantic_hash": "ac4566ff07ccef947a975fb5765516b0"
   },
   "rheojax/logging/logger.py": {
-    "mtime": 1783318203.3269875,
+    "mtime": 1783376926.2178488,
     "ast_hash": "385d335ba027e613dc0cd33117396ed6",
     "semantic_hash": ""
   },
   "rheojax/models/__init__.py": {
-    "mtime": 1783318203.3269875,
+    "mtime": 1783376926.2178488,
     "ast_hash": "27b628621d731f00b7aadaf9e6f5a415",
     "semantic_hash": "27b628621d731f00b7aadaf9e6f5a415"
   },
   "rheojax/models/classical/__init__.py": {
-    "mtime": 1783318203.3279874,
+    "mtime": 1783376926.2178488,
     "ast_hash": "cb3fee86630348487c23e69832fa69dd",
     "semantic_hash": "cb3fee86630348487c23e69832fa69dd"
   },
   "rheojax/models/classical/maxwell.py": {
-    "mtime": 1783318203.3279874,
+    "mtime": 1783376926.2178488,
     "ast_hash": "c537992b559b07e2e04f19842dbe5d64",
     "semantic_hash": ""
   },
   "rheojax/models/classical/springpot.py": {
-    "mtime": 1783318203.3279874,
+    "mtime": 1783376926.2178488,
     "ast_hash": "c0f5c59c40e9f8f81050106f9ed1e9bf",
     "semantic_hash": ""
   },
   "rheojax/models/classical/zener.py": {
-    "mtime": 1783318203.3279874,
+    "mtime": 1783376926.2178488,
     "ast_hash": "7d61e58f8f77e53f7211bd03e8ccef9a",
     "semantic_hash": ""
   },
   "rheojax/models/dmt/__init__.py": {
-    "mtime": 1783318203.3279874,
+    "mtime": 1783376926.2178488,
     "ast_hash": "c2b245b9fdaa0d3a04039493ebd76c54",
     "semantic_hash": "c2b245b9fdaa0d3a04039493ebd76c54"
   },
   "rheojax/models/dmt/_base.py": {
-    "mtime": 1783318203.3279874,
+    "mtime": 1783376926.2178488,
     "ast_hash": "84855b36b35d0e0cba74b2d3999ca6fd",
     "semantic_hash": "84855b36b35d0e0cba74b2d3999ca6fd"
   },
   "rheojax/models/dmt/_kernels.py": {
-    "mtime": 1783318203.3279874,
+    "mtime": 1783376926.2178488,
     "ast_hash": "ca30e95eb341add52d9cb42a046d77e9",
     "semantic_hash": "ca30e95eb341add52d9cb42a046d77e9"
   },
   "rheojax/models/dmt/local.py": {
-    "mtime": 1783318203.3279874,
+    "mtime": 1783376926.2188487,
     "ast_hash": "3a9249108dfecac52bda7890c16d7e89",
     "semantic_hash": ""
   },
   "rheojax/models/dmt/nonlocal_model.py": {
-    "mtime": 1783318203.3279874,
+    "mtime": 1783376926.2188487,
     "ast_hash": "166a1b11ba2af4399b2a905841ecd95d",
     "semantic_hash": ""
   },
   "rheojax/models/epm/__init__.py": {
-    "mtime": 1783318203.3279874,
+    "mtime": 1783376926.2188487,
     "ast_hash": "86398fe1f9b2a7bfd562e33a644bef6f",
     "semantic_hash": "86398fe1f9b2a7bfd562e33a644bef6f"
   },
   "rheojax/models/epm/base.py": {
-    "mtime": 1783318203.3279874,
+    "mtime": 1783376926.2188487,
     "ast_hash": "90955166b8474e3546111861994d9823",
     "semantic_hash": "90955166b8474e3546111861994d9823"
   },
   "rheojax/models/epm/lattice.py": {
-    "mtime": 1783318203.3289876,
+    "mtime": 1783376926.2188487,
     "ast_hash": "77242d4ce1482fa69c200965cd58d070",
     "semantic_hash": ""
   },
   "rheojax/models/epm/tensor.py": {
-    "mtime": 1783318203.3289876,
+    "mtime": 1783376926.2188487,
     "ast_hash": "57d5aa9c02892b54708c2407fc5b7f2c",
     "semantic_hash": ""
   },
   "rheojax/models/fikh/__init__.py": {
-    "mtime": 1783318203.3289876,
+    "mtime": 1783376926.2188487,
     "ast_hash": "f0eca08b3823ae918de9465f2ae66b4b",
     "semantic_hash": "f0eca08b3823ae918de9465f2ae66b4b"
   },
   "rheojax/models/fikh/_base.py": {
-    "mtime": 1783318203.3289876,
+    "mtime": 1783376926.2188487,
     "ast_hash": "9f657dbdf5ec75c7dd6c3d92e867527f",
     "semantic_hash": "9f657dbdf5ec75c7dd6c3d92e867527f"
   },
   "rheojax/models/fikh/_caputo.py": {
-    "mtime": 1783318203.3289876,
+    "mtime": 1783376926.2188487,
     "ast_hash": "946d0fd9ec78fe1bd8bf9b46a5c2d608",
     "semantic_hash": "946d0fd9ec78fe1bd8bf9b46a5c2d608"
   },
   "rheojax/models/fikh/_kernels.py": {
-    "mtime": 1783318203.3289876,
+    "mtime": 1783376926.2188487,
     "ast_hash": "1cd3949f7ec89c48116b6ce50c6d94d8",
     "semantic_hash": "1cd3949f7ec89c48116b6ce50c6d94d8"
   },
   "rheojax/models/fikh/_thermal.py": {
-    "mtime": 1783318203.3289876,
+    "mtime": 1783376926.2188487,
     "ast_hash": "f16d6c68a0e0296382648e0b9428ebdc",
     "semantic_hash": "f16d6c68a0e0296382648e0b9428ebdc"
   },
   "rheojax/models/fikh/fikh.py": {
-    "mtime": 1783318203.3289876,
+    "mtime": 1783376926.2198486,
     "ast_hash": "160aff414cb498fda483f83677521c9d",
     "semantic_hash": ""
   },
   "rheojax/models/fikh/fmlikh.py": {
-    "mtime": 1783318203.3289876,
+    "mtime": 1783376926.2198486,
     "ast_hash": "8cadd4a67ac5849655d35da1c3d5baf6",
     "semantic_hash": ""
   },
   "rheojax/models/flow/__init__.py": {
-    "mtime": 1783318203.3289876,
+    "mtime": 1783376926.2198486,
     "ast_hash": "04b6b50fc2cddafa76796b4de88693b7",
     "semantic_hash": "04b6b50fc2cddafa76796b4de88693b7"
   },
   "rheojax/models/flow/bingham.py": {
-    "mtime": 1783318203.3289876,
+    "mtime": 1783376926.2198486,
     "ast_hash": "5c41c2a51a87e000aef68b1cad5e7121",
     "semantic_hash": ""
   },
   "rheojax/models/flow/carreau.py": {
-    "mtime": 1783318203.3289876,
+    "mtime": 1783376926.2198486,
     "ast_hash": "1cb4c5ff2b69c27fd5532fd72194e026",
     "semantic_hash": ""
   },
   "rheojax/models/flow/carreau_yasuda.py": {
-    "mtime": 1783318203.3289876,
+    "mtime": 1783376926.2198486,
     "ast_hash": "57a74b8efbd977e1ca514d90e3f1b345",
     "semantic_hash": ""
   },
   "rheojax/models/flow/cross.py": {
-    "mtime": 1783318203.3299875,
+    "mtime": 1783376926.2198486,
     "ast_hash": "8a793e0123c9ca0e34f87adba547a1d2",
     "semantic_hash": ""
   },
   "rheojax/models/flow/herschel_bulkley.py": {
-    "mtime": 1783318203.3299875,
+    "mtime": 1783376926.2198486,
     "ast_hash": "9bb7a1e17aa9a499944f973dee0228e4",
     "semantic_hash": ""
   },
   "rheojax/models/flow/power_law.py": {
-    "mtime": 1783318203.3299875,
+    "mtime": 1783376926.2198486,
     "ast_hash": "6948053d84f3091ddf5d20b23efb6804",
     "semantic_hash": ""
   },
   "rheojax/models/fluidity/__init__.py": {
-    "mtime": 1783318203.3299875,
+    "mtime": 1783376926.2198486,
     "ast_hash": "0863e2dfaa2aea7b2ccef3285301eada",
     "semantic_hash": "0863e2dfaa2aea7b2ccef3285301eada"
   },
   "rheojax/models/fluidity/_base.py": {
-    "mtime": 1783318203.3299875,
+    "mtime": 1783376926.2198486,
     "ast_hash": "aca102bfddc610b4a94f9d20785412bc",
     "semantic_hash": "aca102bfddc610b4a94f9d20785412bc"
   },
   "rheojax/models/fluidity/_kernels.py": {
-    "mtime": 1783318203.3299875,
+    "mtime": 1783376926.2198486,
     "ast_hash": "c9e78619703ecf971a864acd90842dd5",
     "semantic_hash": "c9e78619703ecf971a864acd90842dd5"
   },
   "rheojax/models/fluidity/local.py": {
-    "mtime": 1783318203.3299875,
+    "mtime": 1783376926.2198486,
     "ast_hash": "394e83628a866c55a42b309fa0b8ff77",
     "semantic_hash": ""
   },
   "rheojax/models/fluidity/nonlocal_model.py": {
-    "mtime": 1783318203.3299875,
+    "mtime": 1783376926.2208486,
     "ast_hash": "f1cb36b4c863ccb3f409a58797712402",
     "semantic_hash": ""
   },
   "rheojax/models/fluidity/saramito/__init__.py": {
-    "mtime": 1783318203.3299875,
+    "mtime": 1783376926.2208486,
     "ast_hash": "7cb67c9e45168ad5e5a60652ee11094c",
     "semantic_hash": "7cb67c9e45168ad5e5a60652ee11094c"
   },
   "rheojax/models/fluidity/saramito/_base.py": {
-    "mtime": 1783318203.3299875,
+    "mtime": 1783376926.2208486,
     "ast_hash": "64392135a91f59e538976b82838fbb60",
     "semantic_hash": "64392135a91f59e538976b82838fbb60"
   },
   "rheojax/models/fluidity/saramito/_kernels.py": {
-    "mtime": 1783318203.3299875,
+    "mtime": 1783376926.2208486,
     "ast_hash": "d371edcd84e2ca4a95bb138503972656",
     "semantic_hash": "d371edcd84e2ca4a95bb138503972656"
   },
   "rheojax/models/fluidity/saramito/local.py": {
-    "mtime": 1783318203.3309875,
+    "mtime": 1783376926.2208486,
     "ast_hash": "313ea54b1abae6b8f115b016e82012b9",
     "semantic_hash": ""
   },
   "rheojax/models/fluidity/saramito/nonlocal_model.py": {
-    "mtime": 1783318203.3309875,
+    "mtime": 1783376926.2208486,
     "ast_hash": "d8a927a38816bc1291ef541242942f54",
     "semantic_hash": ""
   },
   "rheojax/models/fractional/__init__.py": {
-    "mtime": 1783318203.3309875,
+    "mtime": 1783376926.2208486,
     "ast_hash": "6ef314609ae1d1e5a297643b59f55442",
     "semantic_hash": "6ef314609ae1d1e5a297643b59f55442"
   },
   "rheojax/models/fractional/fractional_burgers.py": {
-    "mtime": 1783318203.3309875,
+    "mtime": 1783376926.2208486,
     "ast_hash": "76820b3a298085cc06da1541f63aa660",
     "semantic_hash": ""
   },
   "rheojax/models/fractional/fractional_jeffreys.py": {
-    "mtime": 1783318203.3309875,
+    "mtime": 1783376926.2208486,
     "ast_hash": "7722a0f97895390443f44237b325b094",
     "semantic_hash": ""
   },
   "rheojax/models/fractional/fractional_kelvin_voigt.py": {
-    "mtime": 1783318203.3309875,
+    "mtime": 1783376926.2208486,
     "ast_hash": "fa8986d816543d2c3fb2324ae35cf84f",
     "semantic_hash": ""
   },
   "rheojax/models/fractional/fractional_kv_zener.py": {
-    "mtime": 1783318203.3309875,
+    "mtime": 1783376926.2208486,
     "ast_hash": "eaa872c205f5511b1ec05231c7951457",
     "semantic_hash": ""
   },
   "rheojax/models/fractional/fractional_maxwell_gel.py": {
-    "mtime": 1783318203.3309875,
+    "mtime": 1783376926.2218487,
     "ast_hash": "610033ea24026c698291582a0d34a463",
     "semantic_hash": ""
   },
   "rheojax/models/fractional/fractional_maxwell_liquid.py": {
-    "mtime": 1783318203.3309875,
+    "mtime": 1783376926.2218487,
     "ast_hash": "1fabb9f04e2c545b9b342346666f159c",
     "semantic_hash": ""
   },
   "rheojax/models/fractional/fractional_maxwell_model.py": {
-    "mtime": 1783318203.3309875,
+    "mtime": 1783376926.2218487,
     "ast_hash": "13105368c82864c11e400fad8549849c",
     "semantic_hash": ""
   },
   "rheojax/models/fractional/fractional_mixin.py": {
-    "mtime": 1783318203.3309875,
+    "mtime": 1783376926.2218487,
     "ast_hash": "1ee972e75a4db835c0d50e37d8c2a66d",
     "semantic_hash": "1ee972e75a4db835c0d50e37d8c2a66d"
   },
   "rheojax/models/fractional/fractional_poynting_thomson.py": {
-    "mtime": 1783318203.3319874,
+    "mtime": 1783376926.2218487,
     "ast_hash": "cf3fe814df8e28f5bda0253048a15dbd",
     "semantic_hash": ""
   },
   "rheojax/models/fractional/fractional_zener_ll.py": {
-    "mtime": 1783318203.3319874,
+    "mtime": 1783376926.2218487,
     "ast_hash": "04a717e9f57b43bea4084cf86d778657",
     "semantic_hash": ""
   },
   "rheojax/models/fractional/fractional_zener_sl.py": {
-    "mtime": 1783318203.3319874,
+    "mtime": 1783376926.2218487,
     "ast_hash": "88587b5ccc0af62632e51128291765d1",
     "semantic_hash": ""
   },
   "rheojax/models/fractional/fractional_zener_ss.py": {
-    "mtime": 1783318203.3319874,
+    "mtime": 1783376926.2218487,
     "ast_hash": "ab7adb8c885c6c827a7b7ba9f4be7067",
     "semantic_hash": ""
   },
   "rheojax/models/giesekus/__init__.py": {
-    "mtime": 1783318203.3319874,
+    "mtime": 1783376926.2218487,
     "ast_hash": "69f10df5ecbd02ad1289966ec5789c1e",
     "semantic_hash": "69f10df5ecbd02ad1289966ec5789c1e"
   },
   "rheojax/models/giesekus/_base.py": {
-    "mtime": 1783318203.3319874,
+    "mtime": 1783376926.2218487,
     "ast_hash": "b51872e5f9cab4d4e1d11cc864bd78ce",
     "semantic_hash": "b51872e5f9cab4d4e1d11cc864bd78ce"
   },
   "rheojax/models/giesekus/_kernels.py": {
-    "mtime": 1783318203.3319874,
+    "mtime": 1783376926.2218487,
     "ast_hash": "c05818cf6d0dd932b67fffdbce0ac54c",
     "semantic_hash": "c05818cf6d0dd932b67fffdbce0ac54c"
   },
   "rheojax/models/giesekus/multi_mode.py": {
-    "mtime": 1783318203.3319874,
+    "mtime": 1783376926.2228487,
     "ast_hash": "0f74f2059f279b348fdd4933ae7b3336",
     "semantic_hash": ""
   },
   "rheojax/models/giesekus/single_mode.py": {
-    "mtime": 1783318203.3319874,
+    "mtime": 1783376926.2228487,
     "ast_hash": "d4161ddd49333b5372d1bd77992cd446",
     "semantic_hash": ""
   },
   "rheojax/models/hl/__init__.py": {
-    "mtime": 1783318203.3319874,
+    "mtime": 1783376926.2228487,
     "ast_hash": "50ca1bddcd65ddfc84faf60824d114d8",
     "semantic_hash": "50ca1bddcd65ddfc84faf60824d114d8"
   },
   "rheojax/models/hl/hebraud_lequeux.py": {
-    "mtime": 1783318203.3329875,
+    "mtime": 1783376926.2228487,
     "ast_hash": "1a428ed887d7d211982674189dfcf0be",
     "semantic_hash": ""
   },
   "rheojax/models/hvm/__init__.py": {
-    "mtime": 1783318203.3329875,
+    "mtime": 1783376926.2228487,
     "ast_hash": "b5437bfcaa1935fa8ebef55b4473416b",
     "semantic_hash": "b5437bfcaa1935fa8ebef55b4473416b"
   },
   "rheojax/models/hvm/_base.py": {
-    "mtime": 1783318203.3329875,
+    "mtime": 1783376926.2228487,
     "ast_hash": "a4c18eb2ebe07fd442355ad06e6e2967",
     "semantic_hash": "a4c18eb2ebe07fd442355ad06e6e2967"
   },
   "rheojax/models/hvm/_kernels.py": {
-    "mtime": 1783318203.3329875,
+    "mtime": 1783376926.2228487,
     "ast_hash": "22a3be591baf9a889c6a22ff3310c3f2",
     "semantic_hash": "22a3be591baf9a889c6a22ff3310c3f2"
   },
   "rheojax/models/hvm/_kernels_diffrax.py": {
-    "mtime": 1783318203.3329875,
+    "mtime": 1783376926.2228487,
     "ast_hash": "2acaf4d5453590eac15321db50aeae38",
     "semantic_hash": "2acaf4d5453590eac15321db50aeae38"
   },
   "rheojax/models/hvm/local.py": {
-    "mtime": 1783318203.3329875,
+    "mtime": 1783376926.2228487,
     "ast_hash": "58d985825fe7e886615f9aa93bc2f0ab",
     "semantic_hash": ""
   },
   "rheojax/models/hvnm/__init__.py": {
-    "mtime": 1783318203.3329875,
+    "mtime": 1783376926.2238486,
     "ast_hash": "4cdc8f346e54b357bc7e11f82b61fa4a",
     "semantic_hash": "4cdc8f346e54b357bc7e11f82b61fa4a"
   },
   "rheojax/models/hvnm/_base.py": {
-    "mtime": 1783318203.3329875,
+    "mtime": 1783376926.2238486,
     "ast_hash": "798182d730ad52574e8afc35f4d70ad6",
     "semantic_hash": "798182d730ad52574e8afc35f4d70ad6"
   },
   "rheojax/models/hvnm/_kernels.py": {
-    "mtime": 1783318203.3329875,
+    "mtime": 1783376926.2238486,
     "ast_hash": "5f5ca2936fc0d05f740328cef2d44348",
     "semantic_hash": "5f5ca2936fc0d05f740328cef2d44348"
   },
   "rheojax/models/hvnm/_kernels_diffrax.py": {
-    "mtime": 1783318203.3329875,
+    "mtime": 1783376926.2238486,
     "ast_hash": "e2c78d9391f833d72cb11dbc4a8ca10d",
     "semantic_hash": "e2c78d9391f833d72cb11dbc4a8ca10d"
   },
   "rheojax/models/hvnm/local.py": {
-    "mtime": 1783318203.3329875,
+    "mtime": 1783376926.2238486,
     "ast_hash": "b65ab3c2a717ee112e2d15dadc594c20",
     "semantic_hash": ""
   },
   "rheojax/models/ikh/__init__.py": {
-    "mtime": 1783318203.3339875,
+    "mtime": 1783376926.2238486,
     "ast_hash": "95d6039410730853f78b63c4217e69da",
     "semantic_hash": "95d6039410730853f78b63c4217e69da"
   },
   "rheojax/models/ikh/_base.py": {
-    "mtime": 1783318203.3339875,
+    "mtime": 1783376926.2238486,
     "ast_hash": "ec1fe715d75c22018e695993670b76da",
     "semantic_hash": "ec1fe715d75c22018e695993670b76da"
   },
   "rheojax/models/ikh/_kernels.py": {
-    "mtime": 1783318203.3339875,
+    "mtime": 1783376926.2238486,
     "ast_hash": "aa7aecf6f86f8c0b9bb9c9eecad8df0f",
     "semantic_hash": "aa7aecf6f86f8c0b9bb9c9eecad8df0f"
   },
   "rheojax/models/ikh/mikh.py": {
-    "mtime": 1783318203.3339875,
+    "mtime": 1783376926.2238486,
     "ast_hash": "e77f3a1e17d1138a36f8b5332d5ddbd0",
     "semantic_hash": ""
   },
   "rheojax/models/ikh/ml_ikh.py": {
-    "mtime": 1783318203.3339875,
+    "mtime": 1783376926.2238486,
     "ast_hash": "6fbb7795c85f0134bf3166c511e485b5",
     "semantic_hash": ""
   },
   "rheojax/models/itt_mct/__init__.py": {
-    "mtime": 1783318203.3339875,
+    "mtime": 1783376926.2238486,
     "ast_hash": "5a0c7952933e1aae0f1e2c8ab99e79b8",
     "semantic_hash": "5a0c7952933e1aae0f1e2c8ab99e79b8"
   },
   "rheojax/models/itt_mct/_base.py": {
-    "mtime": 1783318203.3339875,
+    "mtime": 1783376926.2248487,
     "ast_hash": "3f0f0b63d4902080805493f267cf71b7",
     "semantic_hash": "3f0f0b63d4902080805493f267cf71b7"
   },
   "rheojax/models/itt_mct/_kernels.py": {
-    "mtime": 1783318203.3339875,
+    "mtime": 1783376926.2248487,
     "ast_hash": "0d98199aa29233eb7f436525caab4016",
     "semantic_hash": "0d98199aa29233eb7f436525caab4016"
   },
   "rheojax/models/itt_mct/_kernels_diffrax.py": {
-    "mtime": 1783318203.3339875,
+    "mtime": 1783376926.2248487,
     "ast_hash": "187d1a67f778c55dfe0ef4af2f599cef",
     "semantic_hash": "187d1a67f778c55dfe0ef4af2f599cef"
   },
   "rheojax/models/itt_mct/isotropic.py": {
-    "mtime": 1783318203.3339875,
+    "mtime": 1783376926.2248487,
     "ast_hash": "1a8bf597b0f243d32672c548324909bd",
     "semantic_hash": ""
   },
   "rheojax/models/itt_mct/schematic.py": {
-    "mtime": 1783318203.3349874,
+    "mtime": 1783376926.2248487,
     "ast_hash": "d56f5785506f07ee0368096e844db6c3",
     "semantic_hash": ""
   },
   "rheojax/models/multimode/__init__.py": {
-    "mtime": 1783318203.3349874,
+    "mtime": 1783376926.2248487,
     "ast_hash": "d897f922a2631dbc99fa19886e8649cb",
     "semantic_hash": "d897f922a2631dbc99fa19886e8649cb"
   },
   "rheojax/models/multimode/generalized_maxwell.py": {
-    "mtime": 1783318203.3349874,
+    "mtime": 1783376926.2248487,
     "ast_hash": "7c0df71e53591b3637434def93168a11",
     "semantic_hash": ""
   },
   "rheojax/models/sgr/__init__.py": {
-    "mtime": 1783318203.3349874,
+    "mtime": 1783376926.2248487,
     "ast_hash": "6fb1fd24838377d107c06b6993e7ad48",
     "semantic_hash": "6fb1fd24838377d107c06b6993e7ad48"
   },
   "rheojax/models/sgr/sgr_conventional.py": {
-    "mtime": 1783318203.3349874,
+    "mtime": 1783376926.2258487,
     "ast_hash": "4e150cfb3a2403e38c9e4761e84f175c",
     "semantic_hash": ""
   },
   "rheojax/models/sgr/sgr_generic.py": {
-    "mtime": 1783318203.3359873,
+    "mtime": 1783376926.2258487,
     "ast_hash": "ba95a8af9b60f63a7e76d88e1611016e",
     "semantic_hash": ""
   },
   "rheojax/models/spp/__init__.py": {
-    "mtime": 1783318203.3359873,
+    "mtime": 1783376926.2258487,
     "ast_hash": "982796bc212b4aa8215876b20d01364e",
     "semantic_hash": "982796bc212b4aa8215876b20d01364e"
   },
   "rheojax/models/spp/spp_yield_stress.py": {
-    "mtime": 1783318203.3359873,
+    "mtime": 1783376926.2258487,
     "ast_hash": "1ad447177726f26e855582e200967463",
     "semantic_hash": ""
   },
   "rheojax/models/stz/__init__.py": {
-    "mtime": 1783318203.3359873,
+    "mtime": 1783376926.2258487,
     "ast_hash": "85cac239cca98266065a0a1f2bf730f6",
     "semantic_hash": "85cac239cca98266065a0a1f2bf730f6"
   },
   "rheojax/models/stz/_base.py": {
-    "mtime": 1783318203.3359873,
+    "mtime": 1783376926.2258487,
     "ast_hash": "6f427805bd85edf9aac04c52a7b051f8",
     "semantic_hash": "6f427805bd85edf9aac04c52a7b051f8"
   },
   "rheojax/models/stz/_kernels.py": {
-    "mtime": 1783318203.3359873,
+    "mtime": 1783376926.2258487,
     "ast_hash": "598ff93c20a43a56ff16e16308ebc1e7",
     "semantic_hash": "598ff93c20a43a56ff16e16308ebc1e7"
   },
   "rheojax/models/stz/conventional.py": {
-    "mtime": 1783318203.3359873,
+    "mtime": 1783376926.2268486,
     "ast_hash": "822037fdfefa955f55557e44fb3c9d61",
     "semantic_hash": ""
   },
   "rheojax/models/tnt/__init__.py": {
-    "mtime": 1783318203.3359873,
+    "mtime": 1783376926.2268486,
     "ast_hash": "0aca6ab71af0f3dcfbc29aaa15a4041a",
     "semantic_hash": "0aca6ab71af0f3dcfbc29aaa15a4041a"
   },
   "rheojax/models/tnt/_base.py": {
-    "mtime": 1783318203.3359873,
+    "mtime": 1783376926.2268486,
     "ast_hash": "e39f1c82d3f4f56ab0dce21600dea18a",
     "semantic_hash": "e39f1c82d3f4f56ab0dce21600dea18a"
   },
   "rheojax/models/tnt/_kernels.py": {
-    "mtime": 1783318203.3359873,
+    "mtime": 1783376926.2268486,
     "ast_hash": "1d3d7a25e74dc7710e6b8857f4cf5caf",
     "semantic_hash": "1d3d7a25e74dc7710e6b8857f4cf5caf"
   },
   "rheojax/models/tnt/cates.py": {
-    "mtime": 1783318203.3359873,
+    "mtime": 1783376926.2268486,
     "ast_hash": "d5bcf2fb951cdde8f641ddec281f1729",
     "semantic_hash": ""
   },
   "rheojax/models/tnt/loop_bridge.py": {
-    "mtime": 1783318203.3369875,
+    "mtime": 1783376926.2268486,
     "ast_hash": "459219bff2d58f52146a4aa3ff95125e",
     "semantic_hash": ""
   },
   "rheojax/models/tnt/multi_species.py": {
-    "mtime": 1783318203.3369875,
+    "mtime": 1783376926.2268486,
     "ast_hash": "fc7d0bbc77445d80db7aa779f8973e22",
     "semantic_hash": ""
   },
   "rheojax/models/tnt/single_mode.py": {
-    "mtime": 1783318203.3369875,
+    "mtime": 1783376926.2268486,
     "ast_hash": "1ab9538c88c1e5fc69167bcc946adb92",
     "semantic_hash": ""
   },
   "rheojax/models/tnt/sticky_rouse.py": {
-    "mtime": 1783318203.3369875,
+    "mtime": 1783376926.2278488,
     "ast_hash": "07bf7b464bbcb3540d4375375f28b597",
     "semantic_hash": ""
   },
   "rheojax/models/vlb/__init__.py": {
-    "mtime": 1783318203.3369875,
+    "mtime": 1783376926.2278488,
     "ast_hash": "1e163ed7ec2dad4d68dcaf72929ce594",
     "semantic_hash": "1e163ed7ec2dad4d68dcaf72929ce594"
   },
   "rheojax/models/vlb/_base.py": {
-    "mtime": 1783318203.3369875,
+    "mtime": 1783376926.2278488,
     "ast_hash": "e93d3f7b19c50041db8285ecf921a8c4",
     "semantic_hash": ""
   },
   "rheojax/models/vlb/_kernels.py": {
-    "mtime": 1783318203.3369875,
+    "mtime": 1783376926.2278488,
     "ast_hash": "5a729f5cde7a0302546f02f9cc728a4a",
     "semantic_hash": "5a729f5cde7a0302546f02f9cc728a4a"
   },
   "rheojax/models/vlb/local.py": {
-    "mtime": 1783318203.3379874,
+    "mtime": 1783376926.2278488,
     "ast_hash": "c6bf95eaa77e3372590af8817b62c65a",
     "semantic_hash": ""
   },
   "rheojax/models/vlb/multi_network.py": {
-    "mtime": 1783318203.3379874,
+    "mtime": 1783376926.2278488,
     "ast_hash": "a150e9bc81f0b19085f6bdec3b7fa27e",
     "semantic_hash": ""
   },
   "rheojax/models/vlb/nonlocal_model.py": {
-    "mtime": 1783318203.3379874,
+    "mtime": 1783376926.2278488,
     "ast_hash": "ad433fc268485612d240bf8312fb582c",
     "semantic_hash": ""
   },
   "rheojax/models/vlb/variant.py": {
-    "mtime": 1783318203.3379874,
+    "mtime": 1783376926.2278488,
     "ast_hash": "8bb06f4909e235c9c687e0ffe49f28e7",
     "semantic_hash": ""
   },
   "rheojax/parallel/__init__.py": {
-    "mtime": 1783318203.3379874,
+    "mtime": 1783376926.2278488,
     "ast_hash": "9a9e511fe52747b21c19986d66ef1b54",
     "semantic_hash": "9a9e511fe52747b21c19986d66ef1b54"
   },
   "rheojax/parallel/api.py": {
-    "mtime": 1783318203.3379874,
+    "mtime": 1783376926.2288487,
     "ast_hash": "962e605d9d87e9c4104477d31dd472f3",
     "semantic_hash": "962e605d9d87e9c4104477d31dd472f3"
   },
   "rheojax/parallel/config.py": {
-    "mtime": 1783318203.3379874,
+    "mtime": 1783376926.2288487,
     "ast_hash": "f28a9ddf3cd8ffad199bf743246eaf7a",
     "semantic_hash": "f28a9ddf3cd8ffad199bf743246eaf7a"
   },
   "rheojax/parallel/pool.py": {
-    "mtime": 1783318203.3379874,
+    "mtime": 1783376926.2288487,
     "ast_hash": "ff715909124cd0aaef01806a1e13d52b",
     "semantic_hash": "ff715909124cd0aaef01806a1e13d52b"
   },
   "rheojax/pipeline/__init__.py": {
-    "mtime": 1783318203.3379874,
+    "mtime": 1783376926.2288487,
     "ast_hash": "e043b530c6f2b8b15fc877ede27d6ee2",
     "semantic_hash": "e043b530c6f2b8b15fc877ede27d6ee2"
   },
   "rheojax/pipeline/base.py": {
-    "mtime": 1783318203.3379874,
+    "mtime": 1783376926.2288487,
     "ast_hash": "af57666db9c036ae08d75e79bdf3c3e9",
     "semantic_hash": "af57666db9c036ae08d75e79bdf3c3e9"
   },
   "rheojax/pipeline/batch.py": {
-    "mtime": 1783318203.3379874,
+    "mtime": 1783376926.2288487,
     "ast_hash": "353b63ffe467ca380745ee3e17526fb9",
     "semantic_hash": ""
   },
   "rheojax/pipeline/bayesian.py": {
-    "mtime": 1783318203.3389874,
+    "mtime": 1783376926.2288487,
     "ast_hash": "d71de7acb18cc22c6535482a9994ea38",
     "semantic_hash": "d71de7acb18cc22c6535482a9994ea38"
   },
   "rheojax/pipeline/builder.py": {
-    "mtime": 1783318203.3389874,
+    "mtime": 1783376926.2288487,
     "ast_hash": "cafd22370f6305950a1f41ae658c0566",
     "semantic_hash": "cafd22370f6305950a1f41ae658c0566"
   },
   "rheojax/pipeline/workflows.py": {
-    "mtime": 1783318203.3389874,
+    "mtime": 1783376926.2288487,
     "ast_hash": "1909ba73c4811e6796e312ca16cfba8d",
     "semantic_hash": "1909ba73c4811e6796e312ca16cfba8d"
   },
   "rheojax/transforms/__init__.py": {
-    "mtime": 1783318203.3389874,
+    "mtime": 1783376926.2288487,
     "ast_hash": "019e7c081542bc3e99a515deedbdb017",
     "semantic_hash": "019e7c081542bc3e99a515deedbdb017"
   },
   "rheojax/transforms/cox_merz.py": {
-    "mtime": 1783318203.3389874,
+    "mtime": 1783376926.2288487,
     "ast_hash": "77f585fe31dccd5bddf30b9f5e8fd11a",
     "semantic_hash": ""
   },
   "rheojax/transforms/fft_analysis.py": {
-    "mtime": 1783318203.3389874,
+    "mtime": 1783376926.2298486,
     "ast_hash": "089c0a5852087b48e2198fb0d7d2b7e7",
     "semantic_hash": "089c0a5852087b48e2198fb0d7d2b7e7"
   },
   "rheojax/transforms/lve_envelope.py": {
-    "mtime": 1783318203.3389874,
+    "mtime": 1783376926.2298486,
     "ast_hash": "f8f58aed56a0e32ece4e95ebfcb3a5e5",
     "semantic_hash": ""
   },
   "rheojax/transforms/mastercurve.py": {
-    "mtime": 1783318203.3389874,
+    "mtime": 1783376926.2298486,
     "ast_hash": "e8805a44d106efe1e8756e53a911b545",
     "semantic_hash": "e8805a44d106efe1e8756e53a911b545"
   },
   "rheojax/transforms/mutation_number.py": {
-    "mtime": 1783318203.3389874,
+    "mtime": 1783376926.2298486,
     "ast_hash": "2805695c84657802d330ba42e739f18f",
     "semantic_hash": "2805695c84657802d330ba42e739f18f"
   },
   "rheojax/transforms/owchirp.py": {
-    "mtime": 1783318203.3389874,
+    "mtime": 1783376926.2298486,
     "ast_hash": "446a2ea95b0539f9e25e012506bdb444",
     "semantic_hash": "446a2ea95b0539f9e25e012506bdb444"
   },
   "rheojax/transforms/prony_conversion.py": {
-    "mtime": 1783318203.3389874,
+    "mtime": 1783376926.2298486,
     "ast_hash": "5bc69b0c5710f1e5a892601437ee3066",
     "semantic_hash": ""
   },
   "rheojax/transforms/smooth_derivative.py": {
-    "mtime": 1783318203.3399873,
+    "mtime": 1783376926.2298486,
     "ast_hash": "34b6cad8ae9c014a29f2d124e6618734",
     "semantic_hash": "34b6cad8ae9c014a29f2d124e6618734"
   },
   "rheojax/transforms/spectrum_inversion.py": {
-    "mtime": 1783318203.3399873,
+    "mtime": 1783376926.2298486,
     "ast_hash": "e50d7e702a3bf785cbd955ea75b5dc0a",
     "semantic_hash": "e50d7e702a3bf785cbd955ea75b5dc0a"
   },
   "rheojax/transforms/spp_decomposer.py": {
-    "mtime": 1783318203.3399873,
+    "mtime": 1783376926.2298486,
     "ast_hash": "3f1f6cf53e2d941f2f8864f6b73c8ba6",
     "semantic_hash": "3f1f6cf53e2d941f2f8864f6b73c8ba6"
   },
   "rheojax/transforms/srfs.py": {
-    "mtime": 1783318203.3399873,
+    "mtime": 1783376926.2298486,
     "ast_hash": "8fc8741d29ffb2c696fe0b0e802f9787",
     "semantic_hash": "8fc8741d29ffb2c696fe0b0e802f9787"
   },
   "rheojax/utils/__init__.py": {
-    "mtime": 1783318203.3399873,
+    "mtime": 1783376926.2298486,
     "ast_hash": "8c05095f5c3062c5404c66d492b4276a",
     "semantic_hash": "8c05095f5c3062c5404c66d492b4276a"
   },
   "rheojax/utils/compatibility.py": {
-    "mtime": 1783318203.3399873,
+    "mtime": 1783376926.2298486,
     "ast_hash": "9ebd87167450e69cc2bbd814e48afb9e",
     "semantic_hash": ""
   },
   "rheojax/utils/data_quality.py": {
-    "mtime": 1783318203.3399873,
+    "mtime": 1783376926.2308486,
     "ast_hash": "873067ee74fb2701264e08f3892d8664",
     "semantic_hash": "873067ee74fb2701264e08f3892d8664"
   },
   "rheojax/utils/device.py": {
-    "mtime": 1783318203.3399873,
+    "mtime": 1783376926.2308486,
     "ast_hash": "5f7a97102a6f5d399eed1e43c9d66799",
     "semantic_hash": "5f7a97102a6f5d399eed1e43c9d66799"
   },
   "rheojax/utils/epm_kernels.py": {
-    "mtime": 1783318203.3399873,
+    "mtime": 1783376926.2308486,
     "ast_hash": "913d86cc11d210f6486b12afb120e9a2",
     "semantic_hash": "913d86cc11d210f6486b12afb120e9a2"
   },
   "rheojax/utils/epm_kernels_tensorial.py": {
-    "mtime": 1783318203.3399873,
+    "mtime": 1783376926.2308486,
     "ast_hash": "ba585a95b02ac59fa8d380dbbc9933f6",
     "semantic_hash": ""
   },
   "rheojax/utils/hl_kernels.py": {
-    "mtime": 1783318203.3399873,
+    "mtime": 1783376926.2308486,
     "ast_hash": "d36a00c626165f4b73a62ca035f63721",
     "semantic_hash": "d36a00c626165f4b73a62ca035f63721"
   },
   "rheojax/utils/initialization/__init__.py": {
-    "mtime": 1783318203.3399873,
+    "mtime": 1783376926.2308486,
     "ast_hash": "e17955517b885b864bb60eacb4657335",
     "semantic_hash": "e17955517b885b864bb60eacb4657335"
   },
   "rheojax/utils/initialization/auto_p0.py": {
-    "mtime": 1783318203.3409872,
+    "mtime": 1783376926.2308486,
     "ast_hash": "b0864621cf5eed390473021431c39dd7",
     "semantic_hash": "b0864621cf5eed390473021431c39dd7"
   },
   "rheojax/utils/initialization/base.py": {
-    "mtime": 1783318203.3409872,
+    "mtime": 1783376926.2308486,
     "ast_hash": "ea1fefa6af2ab0893559bd4107cb473b",
     "semantic_hash": "ea1fefa6af2ab0893559bd4107cb473b"
   },
   "rheojax/utils/initialization/constants.py": {
-    "mtime": 1783318203.3409872,
+    "mtime": 1783376926.2308486,
     "ast_hash": "f8f29746ecdc08d231e3a61f9e78dea0",
     "semantic_hash": "f8f29746ecdc08d231e3a61f9e78dea0"
   },
   "rheojax/utils/initialization/fractional_burgers.py": {
-    "mtime": 1783318203.3409872,
+    "mtime": 1783376926.2308486,
     "ast_hash": "40fee641571c749d8bfeb2c52064e73c",
     "semantic_hash": "40fee641571c749d8bfeb2c52064e73c"
   },
   "rheojax/utils/initialization/fractional_jeffreys.py": {
-    "mtime": 1783318203.3409872,
+    "mtime": 1783376926.2308486,
     "ast_hash": "2d7a0240b288547a729357353f11cb51",
     "semantic_hash": "2d7a0240b288547a729357353f11cb51"
   },
   "rheojax/utils/initialization/fractional_kelvin_voigt.py": {
-    "mtime": 1783318203.3409872,
+    "mtime": 1783376926.2308486,
     "ast_hash": "80b9a7d7eaf7d69a0e5de52469005ca7",
     "semantic_hash": "80b9a7d7eaf7d69a0e5de52469005ca7"
   },
   "rheojax/utils/initialization/fractional_kv_zener.py": {
-    "mtime": 1783318203.3409872,
+    "mtime": 1783376926.2308486,
     "ast_hash": "51e75d30a897cb53419d30113bd8d60a",
     "semantic_hash": "51e75d30a897cb53419d30113bd8d60a"
   },
   "rheojax/utils/initialization/fractional_maxwell_gel.py": {
-    "mtime": 1783318203.3409872,
+    "mtime": 1783376926.2308486,
     "ast_hash": "b8ef46934f267917eb73e5d722e699ec",
     "semantic_hash": "b8ef46934f267917eb73e5d722e699ec"
   },
   "rheojax/utils/initialization/fractional_maxwell_liquid.py": {
-    "mtime": 1783318203.3409872,
+    "mtime": 1783376926.2308486,
     "ast_hash": "cbffb35dcbf7c97e73b78bfe1b915a99",
     "semantic_hash": "cbffb35dcbf7c97e73b78bfe1b915a99"
   },
   "rheojax/utils/initialization/fractional_maxwell_model.py": {
-    "mtime": 1783318203.3409872,
+    "mtime": 1783376926.2308486,
     "ast_hash": "7fc6c8994522e12a5792d16f59176a68",
     "semantic_hash": "7fc6c8994522e12a5792d16f59176a68"
   },
   "rheojax/utils/initialization/fractional_poynting_thomson.py": {
-    "mtime": 1783318203.3409872,
+    "mtime": 1783376926.2308486,
     "ast_hash": "4a055fa3982a11c7205e27c6d5cbb24d",
     "semantic_hash": "4a055fa3982a11c7205e27c6d5cbb24d"
   },
   "rheojax/utils/initialization/fractional_zener_ll.py": {
-    "mtime": 1783318203.3409872,
+    "mtime": 1783376926.2308486,
     "ast_hash": "61e548c9c6fa4efe2831dc9256a84b8e",
     "semantic_hash": "61e548c9c6fa4efe2831dc9256a84b8e"
   },
   "rheojax/utils/initialization/fractional_zener_sl.py": {
-    "mtime": 1783318203.3409872,
+    "mtime": 1783376926.2308486,
     "ast_hash": "074299584cd1ad017de74d5d0f476cd3",
     "semantic_hash": "074299584cd1ad017de74d5d0f476cd3"
   },
   "rheojax/utils/initialization/fractional_zener_ss.py": {
-    "mtime": 1783318203.3409872,
+    "mtime": 1783376926.2308486,
     "ast_hash": "b4f0ff97384e938264798716d8ca08bc",
     "semantic_hash": "b4f0ff97384e938264798716d8ca08bc"
   },
   "rheojax/utils/mct_kernels.py": {
-    "mtime": 1783318203.3409872,
+    "mtime": 1783376926.2318487,
     "ast_hash": "54c487bf319b4dfc075f2fdf6c2a30ba",
     "semantic_hash": "54c487bf319b4dfc075f2fdf6c2a30ba"
   },
   "rheojax/utils/metrics.py": {
-    "mtime": 1783318203.3409872,
+    "mtime": 1783376926.2318487,
     "ast_hash": "eca185af2734c6914b47428b093cc21b",
     "semantic_hash": "eca185af2734c6914b47428b093cc21b"
   },
   "rheojax/utils/mittag_leffler.py": {
-    "mtime": 1783318203.3409872,
+    "mtime": 1783376926.2318487,
     "ast_hash": "0a05e73a2a843f706fcc0c4dd67b9668",
     "semantic_hash": "0a05e73a2a843f706fcc0c4dd67b9668"
   },
   "rheojax/utils/model_selection.py": {
-    "mtime": 1783318203.3409872,
+    "mtime": 1783376926.2318487,
     "ast_hash": "c35c4a4471f3a47bddfe063aac0ef39e",
     "semantic_hash": "c35c4a4471f3a47bddfe063aac0ef39e"
   },
   "rheojax/utils/optimization.py": {
-    "mtime": 1783318203.3419874,
+    "mtime": 1783376926.2318487,
     "ast_hash": "9c7a8a7d6bab7f12cc15b275176bc7f3",
     "semantic_hash": ""
   },
   "rheojax/utils/physics_checks.py": {
-    "mtime": 1783318203.3419874,
+    "mtime": 1783376926.2318487,
     "ast_hash": "aea9f0b9a15305b0de2777a1fe5e9460",
     "semantic_hash": "aea9f0b9a15305b0de2777a1fe5e9460"
   },
   "rheojax/utils/prony.py": {
-    "mtime": 1783318203.3419874,
+    "mtime": 1783376926.2318487,
     "ast_hash": "190aa7d6540bd1a864c9c1ace2455861",
     "semantic_hash": ""
   },
   "rheojax/utils/protocol_preprocessing.py": {
-    "mtime": 1783318203.3419874,
+    "mtime": 1783376926.2318487,
     "ast_hash": "b612b207d5244cd685169d6d01b0634a",
     "semantic_hash": "b612b207d5244cd685169d6d01b0634a"
   },
   "rheojax/utils/sgr_kernels.py": {
-    "mtime": 1783318203.3419874,
+    "mtime": 1783376926.2328486,
     "ast_hash": "222c9407c535f130f95f6073d58025d0",
     "semantic_hash": "222c9407c535f130f95f6073d58025d0"
   },
   "rheojax/utils/sgr_monte_carlo.py": {
-    "mtime": 1783318203.3419874,
+    "mtime": 1783376926.2328486,
     "ast_hash": "445d64669b60b591d96624bf86c067d8",
     "semantic_hash": "445d64669b60b591d96624bf86c067d8"
   },
   "rheojax/utils/sgr_population_balance.py": {
-    "mtime": 1783318203.3419874,
+    "mtime": 1783376926.2328486,
     "ast_hash": "b7cac60c06092ee5d10d9cfb4faba72f",
     "semantic_hash": "b7cac60c06092ee5d10d9cfb4faba72f"
   },
   "rheojax/utils/spp_kernels.py": {
-    "mtime": 1783318203.3429873,
+    "mtime": 1783376926.2328486,
     "ast_hash": "8b995cfc3a70e6a22528edf78b9ba442",
     "semantic_hash": "8b995cfc3a70e6a22528edf78b9ba442"
   },
   "rheojax/utils/structure_factor.py": {
-    "mtime": 1783318203.3429873,
+    "mtime": 1783376926.2328486,
     "ast_hash": "580c899830dee6e6a3e7fd513802f92f",
     "semantic_hash": "580c899830dee6e6a3e7fd513802f92f"
   },
   "rheojax/utils/uncertainty.py": {
-    "mtime": 1783318203.3429873,
+    "mtime": 1783376926.2328486,
     "ast_hash": "651fced20da7d77fecbad27b66d31c80",
     "semantic_hash": "651fced20da7d77fecbad27b66d31c80"
   },
   "rheojax/utils/volterra_creep.py": {
-    "mtime": 1783318203.3429873,
+    "mtime": 1783376926.2328486,
     "ast_hash": "d7ce4b30c1105000740e77ee601f4e72",
     "semantic_hash": "d7ce4b30c1105000740e77ee601f4e72"
   },
   "rheojax/visualization/__init__.py": {
-    "mtime": 1783318203.3429873,
+    "mtime": 1783376926.2328486,
     "ast_hash": "4d35f44b99a80c67a8cab3944f9731ab",
     "semantic_hash": "4d35f44b99a80c67a8cab3944f9731ab"
   },
   "rheojax/visualization/epm_plots.py": {
-    "mtime": 1783318203.3429873,
+    "mtime": 1783376926.2328486,
     "ast_hash": "fa91d7f22a2785e27a30fee3cdeecfa5",
     "semantic_hash": "fa91d7f22a2785e27a30fee3cdeecfa5"
   },
   "rheojax/visualization/fit_plotter.py": {
-    "mtime": 1783318203.3429873,
+    "mtime": 1783376926.2338486,
     "ast_hash": "1a35f2aebf0d47997a5418566c9f1cf9",
     "semantic_hash": "1a35f2aebf0d47997a5418566c9f1cf9"
   },
   "rheojax/visualization/plotter.py": {
-    "mtime": 1783318203.3439872,
+    "mtime": 1783376926.2338486,
     "ast_hash": "753e8ff5ee9058a9c511a9d39f436687",
     "semantic_hash": "753e8ff5ee9058a9c511a9d39f436687"
   },
   "rheojax/visualization/spp_plots.py": {
-    "mtime": 1783318203.3439872,
+    "mtime": 1783376926.2338486,
     "ast_hash": "9d98d310956a7bb4940fbd6ce7505746",
     "semantic_hash": "9d98d310956a7bb4940fbd6ce7505746"
   },
   "rheojax/visualization/templates.py": {
-    "mtime": 1783318203.3439872,
+    "mtime": 1783376926.2338486,
     "ast_hash": "170a0b959597c51d1e32316b94e6f33a",
     "semantic_hash": ""
   },
   "rheojax/visualization/transform_plotter.py": {
-    "mtime": 1783318203.3439872,
+    "mtime": 1783376926.2338486,
     "ast_hash": "a8126cc261a45474e79c93cec1689bd8",
     "semantic_hash": ""
   },
   "scripts/check_notebook_execution.py": {
-    "mtime": 1783318203.3439872,
+    "mtime": 1783376926.2338486,
     "ast_hash": "66e07b0044baf0104e0b48d34b117b97",
     "semantic_hash": ""
   },
   "scripts/clean_notebook_outputs.py": {
-    "mtime": 1783318203.3439872,
+    "mtime": 1783376926.2338486,
     "ast_hash": "91d4335c8801aa87b5c0a79ecd14f8b2",
     "semantic_hash": "91d4335c8801aa87b5c0a79ecd14f8b2"
   },
   "scripts/gen_inputs.py": {
-    "mtime": 1783318203.3439872,
+    "mtime": 1783376926.2338486,
     "ast_hash": "538d7875e9a117f2059282c9087cce72",
     "semantic_hash": "538d7875e9a117f2059282c9087cce72"
   },
   "scripts/micro_benchmarks.py": {
-    "mtime": 1783318203.3439872,
+    "mtime": 1783376926.2348487,
     "ast_hash": "6d2e2db04e3d35129568d6105f9a3dad",
     "semantic_hash": ""
   },
   "scripts/run_all_notebooks.py": {
-    "mtime": 1783318203.3449872,
+    "mtime": 1783376926.2348487,
     "ast_hash": "2ba43accbf33681cafa4f0c5e5f024f6",
     "semantic_hash": ""
   },
   "scripts/run_oreo.R": {
-    "mtime": 1783318203.3449872,
+    "mtime": 1783376926.2348487,
     "ast_hash": "e10c7d78bced3fa9ec8159e021d78277",
     "semantic_hash": "e10c7d78bced3fa9ec8159e021d78277"
   },
   "scripts/run_profiling.py": {
-    "mtime": 1783318203.3449872,
+    "mtime": 1783376926.2348487,
     "ast_hash": "f0acf92baad2fdf17a0b2f92f47607eb",
     "semantic_hash": ""
   },
   "scripts/run_rheojax.py": {
-    "mtime": 1783318203.3449872,
+    "mtime": 1783376926.2348487,
     "ast_hash": "ffc8d3c2ce57b25c5f7f6e54b600d5f0",
     "semantic_hash": "ffc8d3c2ce57b25c5f7f6e54b600d5f0"
   },
   "scripts/run_single_notebook_96h.py": {
-    "mtime": 1783318203.3449872,
+    "mtime": 1783376926.2348487,
     "ast_hash": "e91d5ad3db108077f0fec0ea61c4afb5",
     "semantic_hash": "e91d5ad3db108077f0fec0ea61c4afb5"
   },
   "scripts/run_sppplus_v2p1.m": {
-    "mtime": 1783318203.3449872,
+    "mtime": 1783376926.2348487,
     "ast_hash": "8d4ff7c69ec14c1ad1a94140bf3f8ae9",
     "semantic_hash": "8d4ff7c69ec14c1ad1a94140bf3f8ae9"
   },
   "scripts/validate_model_docs.py": {
-    "mtime": 1783318203.3449872,
+    "mtime": 1783376926.2348487,
     "ast_hash": "db94f8a17511ac4851b995a3a672ecc4",
     "semantic_hash": ""
   },
   "tests/__init__.py": {
-    "mtime": 1783318203.3449872,
+    "mtime": 1783376926.2348487,
     "ast_hash": "fe7dd3c0bcc917afd389302ace7ee6a7",
     "semantic_hash": "fe7dd3c0bcc917afd389302ace7ee6a7"
   },
   "tests/benchmarks/test_gmm_element_search.py": {
-    "mtime": 1783318203.3449872,
+    "mtime": 1783376926.2348487,
     "ast_hash": "088df8ad1a1d5d6e2c956a906f63f9a8",
     "semantic_hash": "088df8ad1a1d5d6e2c956a906f63f9a8"
   },
   "tests/benchmarks/test_mastercurve_vmap.py": {
-    "mtime": 1783318203.3449872,
+    "mtime": 1783376926.2348487,
     "ast_hash": "3f2da68919d6c738ce8091154391a540",
     "semantic_hash": ""
   },
   "tests/benchmarks/test_phase2_performance.py": {
-    "mtime": 1783318203.3449872,
+    "mtime": 1783376926.2348487,
     "ast_hash": "1a80ba8e1ea91a8c68e65b7ccd6eadb4",
     "semantic_hash": ""
   },
   "tests/cli/__init__.py": {
-    "mtime": 1783318203.3449872,
+    "mtime": 1783376926.2348487,
     "ast_hash": "d41d8cd98f00b204e9800998ecf8427e",
     "semantic_hash": "d41d8cd98f00b204e9800998ecf8427e"
   },
   "tests/cli/test_cmd_batch.py": {
-    "mtime": 1783318203.3449872,
+    "mtime": 1783376926.2348487,
     "ast_hash": "64cd8ee800a036567a32d58f263c03d8",
     "semantic_hash": "64cd8ee800a036567a32d58f263c03d8"
   },
   "tests/cli/test_cmd_export.py": {
-    "mtime": 1783318203.3449872,
+    "mtime": 1783376926.2348487,
     "ast_hash": "d8c6df5afdeb9f5212cba160c99e41c3",
     "semantic_hash": "d8c6df5afdeb9f5212cba160c99e41c3"
   },
   "tests/cli/test_cmd_load.py": {
-    "mtime": 1783318203.3449872,
+    "mtime": 1783376926.2348487,
     "ast_hash": "88d61255e3acc654619161cedd1e5062",
     "semantic_hash": "88d61255e3acc654619161cedd1e5062"
   },
   "tests/cli/test_cmd_pipeline.py": {
-    "mtime": 1783318203.3449872,
+    "mtime": 1783376926.2348487,
     "ast_hash": "5a50d9f629b2786ca34c82200e1419c2",
     "semantic_hash": "5a50d9f629b2786ca34c82200e1419c2"
   },
   "tests/cli/test_cmd_run.py": {
-    "mtime": 1783318203.3449872,
+    "mtime": 1783376926.2348487,
     "ast_hash": "07e62e12d6fe29e92f38449a7fc4d86d",
     "semantic_hash": "07e62e12d6fe29e92f38449a7fc4d86d"
   },
   "tests/cli/test_cmd_transform.py": {
-    "mtime": 1783318203.3449872,
+    "mtime": 1783376926.2348487,
     "ast_hash": "78e34d70c2067cb44a1d84086b2964ae",
     "semantic_hash": "78e34d70c2067cb44a1d84086b2964ae"
   },
   "tests/cli/test_envelope.py": {
-    "mtime": 1783318203.3449872,
+    "mtime": 1783376926.2348487,
     "ast_hash": "009f3b311ad41b3a885bc36d38cb7cbb",
     "semantic_hash": "009f3b311ad41b3a885bc36d38cb7cbb"
   },
   "tests/cli/test_globals.py": {
-    "mtime": 1783318203.3449872,
+    "mtime": 1783376926.2348487,
     "ast_hash": "66d4e99ea56b34268fece23bfa200a5f",
     "semantic_hash": "66d4e99ea56b34268fece23bfa200a5f"
   },
   "tests/cli/test_main_dispatch.py": {
-    "mtime": 1783318203.3449872,
+    "mtime": 1783376926.2348487,
     "ast_hash": "7f8403d970aff185d6bb9b626011816f",
     "semantic_hash": "7f8403d970aff185d6bb9b626011816f"
   },
   "tests/cli/test_output.py": {
-    "mtime": 1783318203.3449872,
+    "mtime": 1783376926.2348487,
     "ast_hash": "0da5a6109b7b9de1e99a60eb00ff3e0c",
     "semantic_hash": "0da5a6109b7b9de1e99a60eb00ff3e0c"
   },
   "tests/cli/test_templates.py": {
-    "mtime": 1783318203.3449872,
+    "mtime": 1783376926.2348487,
     "ast_hash": "212bfd5fc83cdfcc85edd885cd0f3650",
     "semantic_hash": "212bfd5fc83cdfcc85edd885cd0f3650"
   },
   "tests/cli/test_yaml_runner.py": {
-    "mtime": 1783318203.3449872,
+    "mtime": 1783376926.2348487,
     "ast_hash": "56c754a63c6a491145b5de3a3622f884",
     "semantic_hash": "56c754a63c6a491145b5de3a3622f884"
   },
   "tests/cli/test_yaml_schema.py": {
-    "mtime": 1783318203.3449872,
+    "mtime": 1783376926.2358487,
     "ast_hash": "e50befc5eee607de4e6391232e29b5f9",
     "semantic_hash": "e50befc5eee607de4e6391232e29b5f9"
   },
   "tests/conftest.py": {
-    "mtime": 1783318203.3459873,
+    "mtime": 1783376926.2358487,
     "ast_hash": "ca0f2fa367addf1b114bca27a64f34f3",
     "semantic_hash": "ca0f2fa367addf1b114bca27a64f34f3"
   },
   "tests/core/__init__.py": {
-    "mtime": 1783318203.3459873,
+    "mtime": 1783376926.2358487,
     "ast_hash": "7cffa47fe5b2fc2cdb7f0b70316697cc",
     "semantic_hash": "7cffa47fe5b2fc2cdb7f0b70316697cc"
   },
   "tests/core/test_base.py": {
-    "mtime": 1783318203.3459873,
+    "mtime": 1783376926.2358487,
     "ast_hash": "1b689a30ec38f1b878e869ad210498a1",
     "semantic_hash": "1b689a30ec38f1b878e869ad210498a1"
   },
   "tests/core/test_base_edge_cases.py": {
-    "mtime": 1783318203.3459873,
+    "mtime": 1783376926.2358487,
     "ast_hash": "f527e899150d814511c5c3d00a590032",
     "semantic_hash": "f527e899150d814511c5c3d00a590032"
   },
   "tests/core/test_basemodel_integration.py": {
-    "mtime": 1783318203.3459873,
+    "mtime": 1783376926.2358487,
     "ast_hash": "b408628598ed4e927765cdbfc7149d7b",
     "semantic_hash": "b408628598ed4e927765cdbfc7149d7b"
   },
   "tests/core/test_bayesian.py": {
-    "mtime": 1783318203.3459873,
+    "mtime": 1783376926.2358487,
     "ast_hash": "64b819fd97e333c49d08d70f4ed704e2",
     "semantic_hash": ""
   },
   "tests/core/test_bayesian_diagnostics.py": {
-    "mtime": 1783318203.3459873,
+    "mtime": 1783376926.2358487,
     "ast_hash": "927e88cb83971a46c1aafa1663fcb232",
     "semantic_hash": "927e88cb83971a46c1aafa1663fcb232"
   },
   "tests/core/test_bayesian_edge_cases.py": {
-    "mtime": 1783318203.3459873,
+    "mtime": 1783376926.2358487,
     "ast_hash": "c0d31d0c6e3bac706206183af101e213",
     "semantic_hash": ""
   },
   "tests/core/test_bayesian_mode_closure.py": {
-    "mtime": 1783318203.3459873,
+    "mtime": 1783376926.2358487,
     "ast_hash": "9b63ed4ba1d386c9f11c767e93d77fa2",
     "semantic_hash": ""
   },
   "tests/core/test_data.py": {
-    "mtime": 1783318203.3459873,
+    "mtime": 1783376926.2358487,
     "ast_hash": "e6bc023d000f3d9b04c11a90bea0a7b0",
     "semantic_hash": "e6bc023d000f3d9b04c11a90bea0a7b0"
   },
   "tests/core/test_fit_result.py": {
-    "mtime": 1783318203.3459873,
+    "mtime": 1783376926.2358487,
     "ast_hash": "847ab2dd0217ac1f7dfddd812517b689",
     "semantic_hash": "847ab2dd0217ac1f7dfddd812517b689"
   },
   "tests/core/test_float64_precision.py": {
-    "mtime": 1783318203.3459873,
+    "mtime": 1783376926.2358487,
     "ast_hash": "1d88162dd2806f6cc715423bfe4f6b3e",
     "semantic_hash": "1d88162dd2806f6cc715423bfe4f6b3e"
   },
   "tests/core/test_jax_config.py": {
-    "mtime": 1783318203.3459873,
+    "mtime": 1783376926.2358487,
     "ast_hash": "de0519975bc45c0d75cf23f2a5f38244",
     "semantic_hash": "de0519975bc45c0d75cf23f2a5f38244"
   },
   "tests/core/test_model_transform_registry.py": {
-    "mtime": 1783318203.3459873,
+    "mtime": 1783376926.2358487,
     "ast_hash": "248c1da3ae461763552b89ea13e401b3",
     "semantic_hash": "248c1da3ae461763552b89ea13e401b3"
   },
   "tests/core/test_parameters.py": {
-    "mtime": 1783318203.3459873,
+    "mtime": 1783376926.2358487,
     "ast_hash": "df75579ce78088433e43adfea7b390c5",
     "semantic_hash": "df75579ce78088433e43adfea7b390c5"
   },
   "tests/core/test_registry.py": {
-    "mtime": 1783318203.3459873,
+    "mtime": 1783376926.2368486,
     "ast_hash": "90d3078bf144dc89655d07e21493a8ff",
     "semantic_hash": ""
   },
   "tests/core/test_registry_consistency.py": {
-    "mtime": 1783318203.3459873,
+    "mtime": 1783376926.2368486,
     "ast_hash": "5b9087a9c2ebe5780b2657ea0350a5be",
     "semantic_hash": "5b9087a9c2ebe5780b2657ea0350a5be"
   },
   "tests/core/test_test_modes.py": {
-    "mtime": 1783318203.3459873,
+    "mtime": 1783376926.2368486,
     "ast_hash": "f26e4516b77ff01f17b2d8501e858328",
     "semantic_hash": ""
   },
   "tests/examples/test_hl_fast_overlays.py": {
-    "mtime": 1783318203.3469872,
+    "mtime": 1783376926.2368486,
     "ast_hash": "5975885ac745ffaba1f7aae0879a3275",
     "semantic_hash": "5975885ac745ffaba1f7aae0879a3275"
   },
   "tests/examples/test_hvm_fit_demo.py": {
-    "mtime": 1783318203.3469872,
+    "mtime": 1783376926.2368486,
     "ast_hash": "865ed7572a8fea46707ed288d8b3ee36",
     "semantic_hash": "865ed7572a8fea46707ed288d8b3ee36"
   },
   "tests/fixtures/generate_test_data.py": {
-    "mtime": 1783318203.3469872,
+    "mtime": 1783376926.2368486,
     "ast_hash": "b54276ffd1d172ce4aebb75ac23eecb4",
     "semantic_hash": ""
   },
   "tests/fixtures/trios/relaxation.json": {
-    "mtime": 1783318203.3469872,
+    "mtime": 1783376926.2368486,
     "ast_hash": "5965d90736a98213f490c4e16a679659",
     "semantic_hash": "5965d90736a98213f490c4e16a679659"
   },
   "tests/gui/__init__.py": {
-    "mtime": 1783318203.355987,
+    "mtime": 1783376926.2458487,
     "ast_hash": "807fa2da51227d6da03f1fba560ce5c3",
     "semantic_hash": "807fa2da51227d6da03f1fba560ce5c3"
   },
   "tests/gui/conftest.py": {
-    "mtime": 1783318203.355987,
+    "mtime": 1783376926.2458487,
     "ast_hash": "16cdc6e3a851659fb7b9b9c8b20ef161",
     "semantic_hash": ""
   },
   "tests/gui/test_batch_panel.py": {
-    "mtime": 1783318203.357987,
+    "mtime": 1783376926.2478485,
     "ast_hash": "61c7870e747bde736ce72121ec5a2aac",
     "semantic_hash": "61c7870e747bde736ce72121ec5a2aac"
   },
   "tests/gui/test_bayesian_fit_plot_only.py": {
-    "mtime": 1783318203.357987,
+    "mtime": 1783376926.2478485,
     "ast_hash": "dd3965f7b5b4045cfa6dd4ada53c16df",
     "semantic_hash": "dd3965f7b5b4045cfa6dd4ada53c16df"
   },
   "tests/gui/test_bayesian_full_parity.py": {
-    "mtime": 1783318203.357987,
+    "mtime": 1783376926.2478485,
     "ast_hash": "4a5aa1a77ab517bec6a03240ace17a66",
     "semantic_hash": "4a5aa1a77ab517bec6a03240ace17a66"
   },
   "tests/gui/test_bayesian_full_parity_gmm.py": {
-    "mtime": 1783318203.357987,
+    "mtime": 1783376926.2478485,
     "ast_hash": "aeb686c319088a14cc702f598443b06b",
     "semantic_hash": "aeb686c319088a14cc702f598443b06b"
   },
   "tests/gui/test_bayesian_headless.py": {
-    "mtime": 1783318203.357987,
+    "mtime": 1783376926.2478485,
     "ast_hash": "4a4c321f7055efda69570d0f1d11634a",
     "semantic_hash": "4a4c321f7055efda69570d0f1d11634a"
   },
   "tests/gui/test_bayesian_integration_short.py": {
-    "mtime": 1783318203.357987,
+    "mtime": 1783376926.2478485,
     "ast_hash": "890c07ecd2dfb0f7a881ef9877e920d2",
     "semantic_hash": "890c07ecd2dfb0f7a881ef9877e920d2"
   },
   "tests/gui/test_bayesian_long_parity.py": {
-    "mtime": 1783318203.357987,
+    "mtime": 1783376926.2478485,
     "ast_hash": "b3168b98b7c8df2317dcaeee06da10f2",
     "semantic_hash": "b3168b98b7c8df2317dcaeee06da10f2"
   },
   "tests/gui/test_bayesian_presets_config.py": {
-    "mtime": 1783318203.357987,
+    "mtime": 1783376926.2478485,
     "ast_hash": "a6565a59218d9573201d438a19db6c47",
     "semantic_hash": "a6565a59218d9573201d438a19db6c47"
   },
   "tests/gui/test_bayesian_visual_parity.py": {
-    "mtime": 1783318203.357987,
+    "mtime": 1783376926.2478485,
     "ast_hash": "a43764d434039b69e9c52acafe4870bd",
     "semantic_hash": "a43764d434039b69e9c52acafe4870bd"
   },
   "tests/gui/test_crash_prevention.py": {
-    "mtime": 1783318203.357987,
+    "mtime": 1783376926.2478485,
     "ast_hash": "917065c74c23d7d4612e99ab4cec6af5",
     "semantic_hash": ""
   },
   "tests/gui/test_design_tokens_accessibility.py": {
-    "mtime": 1783318203.357987,
+    "mtime": 1783376926.2478485,
     "ast_hash": "7c7489e0fd788c7a91dab847af07361d",
     "semantic_hash": ""
   },
   "tests/gui/test_diagnostics_bayesian_transfer.py": {
-    "mtime": 1783318203.357987,
+    "mtime": 1783376926.2478485,
     "ast_hash": "5571de97e48309b358c788fe7cb221b9",
     "semantic_hash": "5571de97e48309b358c788fe7cb221b9"
   },
   "tests/gui/test_fit_page_parameters.py": {
-    "mtime": 1783318203.357987,
+    "mtime": 1783376926.2478485,
     "ast_hash": "5aa5cb6bd468dd7c0b94d1003ce89893",
     "semantic_hash": "5aa5cb6bd468dd7c0b94d1003ce89893"
   },
   "tests/gui/test_fit_subprocess_no_segfault.py": {
-    "mtime": 1783318203.357987,
+    "mtime": 1783376926.2478485,
     "ast_hash": "62e79371d477a9fdc94f29cc438beec6",
     "semantic_hash": "62e79371d477a9fdc94f29cc438beec6"
   },
   "tests/gui/test_gui_integration.py": {
-    "mtime": 1783318203.358987,
+    "mtime": 1783376926.2488487,
     "ast_hash": "3bb6af7f2c749ee2161ce21e3b592288",
     "semantic_hash": ""
   },
   "tests/gui/test_gui_performance.py": {
-    "mtime": 1783318203.358987,
+    "mtime": 1783376926.2488487,
     "ast_hash": "51620b882519a07362ae5b1921ba9ebe",
     "semantic_hash": "51620b882519a07362ae5b1921ba9ebe"
   },
   "tests/gui/test_gui_smoke.py": {
-    "mtime": 1783318203.358987,
+    "mtime": 1783376926.2488487,
     "ast_hash": "d3c99136c5bd6708459c4090b225cf2c",
     "semantic_hash": ""
   },
   "tests/gui/test_icons.py": {
-    "mtime": 1783318203.358987,
+    "mtime": 1783376926.2488487,
     "ast_hash": "01e104d0044d5b78c677a93523b9a48a",
     "semantic_hash": ""
   },
   "tests/gui/test_logging_utils.py": {
-    "mtime": 1783318203.358987,
-    "ast_hash": "edc0562364fc0d4d038c721d9e992c4c",
-    "semantic_hash": "edc0562364fc0d4d038c721d9e992c4c"
+    "mtime": 1783376926.2488487,
+    "ast_hash": "9f7736121cd1cd3cf9549347314cf3fc",
+    "semantic_hash": ""
   },
   "tests/gui/test_menu_actions.py": {
-    "mtime": 1783318203.358987,
+    "mtime": 1783376926.2488487,
     "ast_hash": "b38084b3d86286ee80c4080855397199",
     "semantic_hash": ""
   },
   "tests/gui/test_parameter_form.py": {
-    "mtime": 1783318203.358987,
+    "mtime": 1783376926.2488487,
     "ast_hash": "dc7ea75bc6465be6d82951f019408efb",
     "semantic_hash": "dc7ea75bc6465be6d82951f019408efb"
   },
   "tests/gui/test_pipeline_execution_service.py": {
-    "mtime": 1783318203.358987,
+    "mtime": 1783376926.2488487,
     "ast_hash": "5f3ed006c6e023dc606847ce3ecf95cb",
     "semantic_hash": ""
   },
   "tests/gui/test_pipeline_serializer.py": {
-    "mtime": 1783318203.358987,
+    "mtime": 1783376926.2488487,
     "ast_hash": "a10957169836da5968d6304fe4d982dd",
     "semantic_hash": ""
   },
   "tests/gui/test_pipeline_step_config.py": {
-    "mtime": 1783318203.358987,
+    "mtime": 1783376926.2488487,
     "ast_hash": "a8a07c1440b18e6a70ea909e835fdf69",
     "semantic_hash": ""
   },
   "tests/gui/test_process_worker.py": {
-    "mtime": 1783318203.358987,
+    "mtime": 1783376926.2488487,
     "ast_hash": "32b4884d86ba3a5f239673e76ef03b43",
     "semantic_hash": "32b4884d86ba3a5f239673e76ef03b43"
   },
   "tests/gui/test_regressions_stability.py": {
-    "mtime": 1783318203.358987,
+    "mtime": 1783376926.2488487,
     "ast_hash": "04555ee26ad629ecc6f3a2bebbf131dd",
     "semantic_hash": ""
   },
   "tests/gui/test_sidebar_and_navigate.py": {
-    "mtime": 1783318203.358987,
+    "mtime": 1783376926.2488487,
     "ast_hash": "b3081984c4b528f5330b84300dfb3e55",
     "semantic_hash": "b3081984c4b528f5330b84300dfb3e55"
   },
   "tests/gui/test_transform_page_redesign.py": {
-    "mtime": 1783318203.359987,
+    "mtime": 1783376926.2498486,
     "ast_hash": "84f53d01042ae4e93236fa08e5082b81",
     "semantic_hash": "84f53d01042ae4e93236fa08e5082b81"
   },
   "tests/gui/test_transform_presets.py": {
-    "mtime": 1783318203.359987,
+    "mtime": 1783376926.2498486,
     "ast_hash": "ec4c124e7c43d5300d220773fc17a774",
     "semantic_hash": "ec4c124e7c43d5300d220773fc17a774"
   },
   "tests/gui/test_transform_service_params.py": {
-    "mtime": 1783318203.359987,
+    "mtime": 1783376926.2498486,
     "ast_hash": "39e535f29c8f6d1c555168d4aaf49b95",
     "semantic_hash": ""
   },
   "tests/gui/test_visual_pipeline_state.py": {
-    "mtime": 1783318203.359987,
+    "mtime": 1783376926.2498486,
     "ast_hash": "fcd287c0aeeddb9905ed39b1e6d7eadb",
     "semantic_hash": "fcd287c0aeeddb9905ed39b1e6d7eadb"
   },
   "tests/gui/test_visual_regression.py": {
-    "mtime": 1783318203.359987,
+    "mtime": 1783376926.2498486,
     "ast_hash": "e6bf9b9dc36104efe63356b628dc99a6",
     "semantic_hash": ""
   },
   "tests/gui/test_workflow_switching.py": {
-    "mtime": 1783318203.359987,
+    "mtime": 1783376926.2498486,
     "ast_hash": "542730a65f408f62eb8d6153652a6456",
     "semantic_hash": "542730a65f408f62eb8d6153652a6456"
   },
   "tests/gui/visual/capture_golden_screens.py": {
-    "mtime": 1783318203.359987,
+    "mtime": 1783376926.2498486,
     "ast_hash": "2379794008ae18d6e5d24a62ee152fae",
     "semantic_hash": "2379794008ae18d6e5d24a62ee152fae"
   },
   "tests/gui/visual/test_plot_service_golden.py": {
-    "mtime": 1783318203.359987,
+    "mtime": 1783376926.2498486,
     "ast_hash": "76670947d1155cbafe779177d48dbb74",
     "semantic_hash": "76670947d1155cbafe779177d48dbb74"
   },
   "tests/gui/visual/test_visual_regression_spec_scaffold.py": {
-    "mtime": 1783318203.359987,
+    "mtime": 1783376926.2498486,
     "ast_hash": "783dd1fb31aac1b8128e9c850bd634b2",
     "semantic_hash": "783dd1fb31aac1b8128e9c850bd634b2"
   },
   "tests/hypothesis/__init__.py": {
-    "mtime": 1783318203.3619869,
+    "mtime": 1783376926.2508485,
     "ast_hash": "c25d91f55741a270a578df1522848f93",
     "semantic_hash": "c25d91f55741a270a578df1522848f93"
   },
   "tests/hypothesis/test_sgr_properties.py": {
-    "mtime": 1783318203.3619869,
+    "mtime": 1783376926.2518487,
     "ast_hash": "5ba5951ee98341b74ed2e5c6a91f7061",
     "semantic_hash": ""
   },
   "tests/integration/__init__.py": {
-    "mtime": 1783318203.3619869,
+    "mtime": 1783376926.2518487,
     "ast_hash": "3ac49245e3fbf4b8ec2b38b6ac30cd47",
     "semantic_hash": "3ac49245e3fbf4b8ec2b38b6ac30cd47"
   },
   "tests/integration/test_bayesian_dataset_state.py": {
-    "mtime": 1783318203.3619869,
+    "mtime": 1783376926.2518487,
     "ast_hash": "cd59320c0e5726da0275f35bb510aee4",
     "semantic_hash": "cd59320c0e5726da0275f35bb510aee4"
   },
   "tests/integration/test_cli_yaml_roundtrip.py": {
-    "mtime": 1783318203.3619869,
+    "mtime": 1783376926.2518487,
     "ast_hash": "94937835346dbaf5d9a3646e622b7b4a",
     "semantic_hash": "94937835346dbaf5d9a3646e622b7b4a"
   },
   "tests/integration/test_epm_pipeline.py": {
-    "mtime": 1783318203.3619869,
+    "mtime": 1783376926.2518487,
     "ast_hash": "786c7ca9ccb7e65b624c26d101f377b4",
     "semantic_hash": "786c7ca9ccb7e65b624c26d101f377b4"
   },
   "tests/integration/test_export_and_project.py": {
-    "mtime": 1783318203.3619869,
+    "mtime": 1783376926.2518487,
     "ast_hash": "4f7f50668bab6da43ac8eda5c1e6e740",
     "semantic_hash": "4f7f50668bab6da43ac8eda5c1e6e740"
   },
   "tests/integration/test_gmm_element_search_workflow.py": {
-    "mtime": 1783318203.3619869,
+    "mtime": 1783376926.2518487,
     "ast_hash": "7ec3cf0638d87318d5430bab66ef0eb4",
     "semantic_hash": "7ec3cf0638d87318d5430bab66ef0eb4"
   },
   "tests/integration/test_io_roundtrip.py": {
-    "mtime": 1783318203.3619869,
+    "mtime": 1783376926.2518487,
     "ast_hash": "fc1603de5075aad196f8865feeb14cd5",
     "semantic_hash": "fc1603de5075aad196f8865feeb14cd5"
   },
   "tests/integration/test_load_bayesian_smoke.py": {
-    "mtime": 1783318203.3619869,
+    "mtime": 1783376926.2518487,
     "ast_hash": "874a24fa2490d8231a6dd382a4e1fa64",
     "semantic_hash": "874a24fa2490d8231a6dd382a4e1fa64"
   },
   "tests/integration/test_load_fit_smoke.py": {
-    "mtime": 1783318203.3619869,
+    "mtime": 1783376926.2518487,
     "ast_hash": "9ab0b729d5ad26369af73dba7e4ed96f",
     "semantic_hash": "9ab0b729d5ad26369af73dba7e4ed96f"
   },
   "tests/integration/test_mode_aware_bayesian_workflow.py": {
-    "mtime": 1783318203.3619869,
+    "mtime": 1783376926.2518487,
     "ast_hash": "ef36b9dd5596d329a31d24bcf8ed6cf6",
     "semantic_hash": ""
   },
   "tests/integration/test_nlsq_numpyro_workflow.py": {
-    "mtime": 1783318203.3619869,
+    "mtime": 1783376926.2518487,
     "ast_hash": "cb199dd6b30c73da14761948d162e828",
     "semantic_hash": ""
   },
   "tests/integration/test_sgr_integration.py": {
-    "mtime": 1783318203.3619869,
+    "mtime": 1783376926.2518487,
     "ast_hash": "77cad8e98bc98124011f5f4b04c65cd3",
     "semantic_hash": ""
   },
   "tests/integration/test_sgr_parity.py": {
-    "mtime": 1783318203.3619869,
+    "mtime": 1783376926.2518487,
     "ast_hash": "080b5cc479b78e468f437d135ddb9c2d",
     "semantic_hash": ""
   },
   "tests/integration/test_spp_golden_parity.py": {
-    "mtime": 1783318203.3619869,
+    "mtime": 1783376926.2518487,
     "ast_hash": "62e1d7e53394b36c4c82540ceedd6477",
     "semantic_hash": "62e1d7e53394b36c4c82540ceedd6477"
   },
   "tests/integration/test_spp_integration.py": {
-    "mtime": 1783318203.3619869,
+    "mtime": 1783376926.2518487,
     "ast_hash": "ad595cb34c5846b5ba995ece9d90fffc",
     "semantic_hash": "ad595cb34c5846b5ba995ece9d90fffc"
   },
   "tests/integration/test_spp_integration_spp_yield.py": {
-    "mtime": 1783318203.3619869,
+    "mtime": 1783376926.2518487,
     "ast_hash": "a3e663f332fc2c6e47ae08279326bd86",
     "semantic_hash": "a3e663f332fc2c6e47ae08279326bd86"
   },
   "tests/integration/test_transform_flow.py": {
-    "mtime": 1783318203.3619869,
+    "mtime": 1783376926.2518487,
     "ast_hash": "85e21f700819253b20c749a2c9ffd0d9",
     "semantic_hash": "85e21f700819253b20c749a2c9ffd0d9"
   },
   "tests/integration/test_v0_3_2_performance.py": {
-    "mtime": 1783318203.3619869,
+    "mtime": 1783376926.2518487,
     "ast_hash": "4855b138542ec3c00bd43da4914e7297",
     "semantic_hash": ""
   },
   "tests/io/conftest.py": {
-    "mtime": 1783318203.3619869,
+    "mtime": 1783376926.2518487,
     "ast_hash": "578c313b99e27532a178a53221c8cb59",
     "semantic_hash": "578c313b99e27532a178a53221c8cb59"
   },
   "tests/io/test_analysis_exporter.py": {
-    "mtime": 1783318203.362987,
+    "mtime": 1783376926.2518487,
     "ast_hash": "c0ed3fd52610d7ba9ef1a45ee314c626",
     "semantic_hash": "c0ed3fd52610d7ba9ef1a45ee314c626"
   },
   "tests/io/test_anton_paar.py": {
-    "mtime": 1783318203.362987,
+    "mtime": 1783376926.2518487,
     "ast_hash": "7511d9e43d1c196405c02db1154960f9",
     "semantic_hash": "7511d9e43d1c196405c02db1154960f9"
   },
   "tests/io/test_column_mapping.py": {
-    "mtime": 1783318203.362987,
+    "mtime": 1783376926.2518487,
     "ast_hash": "2d21e2f2b009bfcd096e49bf5bb05f80",
     "semantic_hash": "2d21e2f2b009bfcd096e49bf5bb05f80"
   },
   "tests/io/test_csv_detection.py": {
-    "mtime": 1783318203.362987,
+    "mtime": 1783376926.2518487,
     "ast_hash": "371f9a072e5d7236e9af032b5d2c020a",
     "semantic_hash": "371f9a072e5d7236e9af032b5d2c020a"
   },
   "tests/io/test_io_fixes.py": {
-    "mtime": 1783318203.362987,
+    "mtime": 1783376926.2528486,
     "ast_hash": "fbc3a23b98773df64d143c046ebea919",
     "semantic_hash": ""
   },
   "tests/io/test_multi_file.py": {
-    "mtime": 1783318203.362987,
+    "mtime": 1783376926.2528486,
     "ast_hash": "47a0c0d70c99d7532be3a5f5da4947d5",
     "semantic_hash": "47a0c0d70c99d7532be3a5f5da4947d5"
   },
   "tests/io/test_npz_writer.py": {
-    "mtime": 1783318203.362987,
+    "mtime": 1783376926.2528486,
     "ast_hash": "af0645d99c486c56aa675de553b2ed2f",
     "semantic_hash": "af0645d99c486c56aa675de553b2ed2f"
   },
   "tests/io/test_protocol_metadata.py": {
-    "mtime": 1783318203.362987,
+    "mtime": 1783376926.2528486,
     "ast_hash": "68bfb153d8aa5cf5fa94185bfb98de23",
     "semantic_hash": "68bfb153d8aa5cf5fa94185bfb98de23"
   },
   "tests/io/test_readers.py": {
-    "mtime": 1783318203.362987,
+    "mtime": 1783376926.2528486,
     "ast_hash": "27a8abafb35a65a305c46bb3e944a1bb",
     "semantic_hash": ""
   },
   "tests/io/test_spp_export.py": {
-    "mtime": 1783318203.362987,
+    "mtime": 1783376926.2528486,
     "ast_hash": "5976bda3f7cad633a7ca4150a598cc3b",
     "semantic_hash": "5976bda3f7cad633a7ca4150a598cc3b"
   },
   "tests/io/test_trios_auto_chunk.py": {
-    "mtime": 1783318203.362987,
+    "mtime": 1783376926.2528486,
     "ast_hash": "3ab6bf3de2b66a87a7c52946f72e0737",
     "semantic_hash": ""
   },
   "tests/io/test_trios_chunked.py": {
-    "mtime": 1783318203.362987,
+    "mtime": 1783376926.2528486,
     "ast_hash": "bca0cb5e3b1ba3d06b71d2fc56f94db8",
     "semantic_hash": ""
   },
   "tests/io/test_trios_chunked_integrity.py": {
-    "mtime": 1783318203.362987,
+    "mtime": 1783376926.2528486,
     "ast_hash": "036eea4b517c14984efa38ed0940332e",
     "semantic_hash": ""
   },
   "tests/io/test_trios_memory_profiling.py": {
-    "mtime": 1783318203.362987,
+    "mtime": 1783376926.2528486,
     "ast_hash": "8f919f9aaf6ff5d5fd36934b5e6c21f2",
     "semantic_hash": ""
   },
   "tests/io/test_trios_real_data.py": {
-    "mtime": 1783318203.362987,
+    "mtime": 1783376926.2528486,
     "ast_hash": "74278cdf986d93f56e3d9818f91ab138",
     "semantic_hash": "74278cdf986d93f56e3d9818f91ab138"
   },
   "tests/io/test_unit_conversion.py": {
-    "mtime": 1783318203.363987,
+    "mtime": 1783376926.2528486,
     "ast_hash": "6c88e8ce44dc75fdee628068ee6aecba",
     "semantic_hash": "6c88e8ce44dc75fdee628068ee6aecba"
   },
   "tests/io/test_validation.py": {
-    "mtime": 1783318203.363987,
+    "mtime": 1783376926.2528486,
     "ast_hash": "e8fa179ee041d0a0421fd65fd8779e8f",
     "semantic_hash": "e8fa179ee041d0a0421fd65fd8779e8f"
   },
   "tests/io/test_writers.py": {
-    "mtime": 1783318203.363987,
+    "mtime": 1783376926.2528486,
     "ast_hash": "994377736983bd42a58aaf6ef42b80cf",
     "semantic_hash": "994377736983bd42a58aaf6ef42b80cf"
   },
   "tests/logging/__init__.py": {
-    "mtime": 1783318203.363987,
+    "mtime": 1783376926.2528486,
     "ast_hash": "8f4c385649d955a5d0722a3bfb6e63ac",
     "semantic_hash": "8f4c385649d955a5d0722a3bfb6e63ac"
   },
   "tests/logging/test_config.py": {
-    "mtime": 1783318203.363987,
+    "mtime": 1783376926.2528486,
     "ast_hash": "610e5a42c6c4c72ecae8c2f4be4bfc1a",
     "semantic_hash": "610e5a42c6c4c72ecae8c2f4be4bfc1a"
   },
   "tests/logging/test_context.py": {
-    "mtime": 1783318203.363987,
+    "mtime": 1783376926.2528486,
     "ast_hash": "be65d83dc5264b5f628f74b0ac5609ea",
     "semantic_hash": "be65d83dc5264b5f628f74b0ac5609ea"
   },
   "tests/logging/test_logger.py": {
-    "mtime": 1783318203.363987,
+    "mtime": 1783376926.2528486,
     "ast_hash": "5863c3406e74e779d6629e26f66e32f8",
     "semantic_hash": "5863c3406e74e779d6629e26f66e32f8"
   },
   "tests/logging/test_logging_integration.py": {
-    "mtime": 1783318203.363987,
+    "mtime": 1783376926.2528486,
     "ast_hash": "5686a63d419cb36054c90a17ba004434",
     "semantic_hash": "5686a63d419cb36054c90a17ba004434"
   },
   "tests/models/__init__.py": {
-    "mtime": 1783318203.363987,
+    "mtime": 1783376926.2538486,
     "ast_hash": "09789325da1adfbfcee4451877d2022e",
     "semantic_hash": "09789325da1adfbfcee4451877d2022e"
   },
   "tests/models/classical/__init__.py": {
-    "mtime": 1783318203.363987,
+    "mtime": 1783376926.2538486,
     "ast_hash": "fc6d1114230957d75e5efe7aa76add60",
     "semantic_hash": "fc6d1114230957d75e5efe7aa76add60"
   },
   "tests/models/classical/test_maxwell.py": {
-    "mtime": 1783318203.363987,
+    "mtime": 1783376926.2538486,
     "ast_hash": "8483dd14a8d58c3789cf59fdc935f3c2",
     "semantic_hash": "8483dd14a8d58c3789cf59fdc935f3c2"
   },
   "tests/models/classical/test_springpot.py": {
-    "mtime": 1783318203.363987,
+    "mtime": 1783376926.2538486,
     "ast_hash": "372b9196c7d4b59e8532ea034089c7c6",
     "semantic_hash": "372b9196c7d4b59e8532ea034089c7c6"
   },
   "tests/models/classical/test_zener.py": {
-    "mtime": 1783318203.363987,
+    "mtime": 1783376926.2538486,
     "ast_hash": "f0448b92dd5698f34607ca8b66188917",
     "semantic_hash": "f0448b92dd5698f34607ca8b66188917"
   },
   "tests/models/dmt/__init__.py": {
-    "mtime": 1783318203.363987,
+    "mtime": 1783376926.2538486,
     "ast_hash": "8fb1c30946468cd70d918611cc363c2f",
     "semantic_hash": "8fb1c30946468cd70d918611cc363c2f"
   },
   "tests/models/dmt/test_dmt.py": {
-    "mtime": 1783318203.363987,
+    "mtime": 1783376926.2538486,
     "ast_hash": "9be6701f53d4ce16ba6a2bcb745042e2",
     "semantic_hash": ""
   },
   "tests/models/epm/__init__.py": {
-    "mtime": 1783318203.363987,
+    "mtime": 1783376926.2538486,
     "ast_hash": "63dda2e0afc31bb5ed9f3782ad08e7ce",
     "semantic_hash": "63dda2e0afc31bb5ed9f3782ad08e7ce"
   },
   "tests/models/epm/test_epm_base.py": {
-    "mtime": 1783318203.363987,
+    "mtime": 1783376926.2538486,
     "ast_hash": "8a6291db5bc537b84926d95dcb963e37",
     "semantic_hash": "8a6291db5bc537b84926d95dcb963e37"
   },
   "tests/models/epm/test_lattice_epm.py": {
-    "mtime": 1783318203.363987,
+    "mtime": 1783376926.2538486,
     "ast_hash": "c41560d67043b5c6a821908d5412d813",
     "semantic_hash": ""
   },
   "tests/models/epm/test_tensorial_epm.py": {
-    "mtime": 1783318203.363987,
+    "mtime": 1783376926.2538486,
     "ast_hash": "9a09e233f91913348d891f901d8a727c",
     "semantic_hash": ""
   },
   "tests/models/fikh/__init__.py": {
-    "mtime": 1783318203.363987,
+    "mtime": 1783376926.2538486,
     "ast_hash": "96c0eadfb0983238a2d060db139f726d",
     "semantic_hash": "96c0eadfb0983238a2d060db139f726d"
   },
   "tests/models/fikh/test_fikh.py": {
-    "mtime": 1783318203.364987,
+    "mtime": 1783376926.2538486,
     "ast_hash": "ba9217e2609e6e969fc1efaf27d452af",
     "semantic_hash": ""
   },
   "tests/models/fikh/test_fikh_caputo.py": {
-    "mtime": 1783318203.364987,
+    "mtime": 1783376926.2538486,
     "ast_hash": "ac28ba794d9212089e331b6a7cd8d9c1",
     "semantic_hash": "ac28ba794d9212089e331b6a7cd8d9c1"
   },
   "tests/models/fikh/test_fikh_thermal.py": {
-    "mtime": 1783318203.364987,
+    "mtime": 1783376926.2538486,
     "ast_hash": "576d0cd79a5f3303d1072b4428eb9219",
     "semantic_hash": "576d0cd79a5f3303d1072b4428eb9219"
   },
   "tests/models/fikh/test_fmlikh.py": {
-    "mtime": 1783318203.364987,
+    "mtime": 1783376926.2538486,
     "ast_hash": "79651aebc129f281e816d01611718392",
     "semantic_hash": "79651aebc129f281e816d01611718392"
   },
   "tests/models/flow/__init__.py": {
-    "mtime": 1783318203.364987,
+    "mtime": 1783376926.2538486,
     "ast_hash": "c135fd29ae5423d70b6223664bc66bc1",
     "semantic_hash": "c135fd29ae5423d70b6223664bc66bc1"
   },
   "tests/models/flow/test_bingham.py": {
-    "mtime": 1783318203.364987,
+    "mtime": 1783376926.2538486,
     "ast_hash": "7495db7d4770de781fa44f0e950a44a2",
     "semantic_hash": "7495db7d4770de781fa44f0e950a44a2"
   },
   "tests/models/flow/test_carreau.py": {
-    "mtime": 1783318203.364987,
+    "mtime": 1783376926.2538486,
     "ast_hash": "84ed3130fa87abd22ce0ddddf17e913b",
     "semantic_hash": "84ed3130fa87abd22ce0ddddf17e913b"
   },
   "tests/models/flow/test_carreau_yasuda.py": {
-    "mtime": 1783318203.364987,
+    "mtime": 1783376926.2548485,
     "ast_hash": "98db15081227b67cde4ae88079a93cbb",
     "semantic_hash": "98db15081227b67cde4ae88079a93cbb"
   },
   "tests/models/flow/test_cross.py": {
-    "mtime": 1783318203.364987,
+    "mtime": 1783376926.2548485,
     "ast_hash": "d1147c06f1b90cf2b100cc303ed537a1",
     "semantic_hash": "d1147c06f1b90cf2b100cc303ed537a1"
   },
   "tests/models/flow/test_herschel_bulkley.py": {
-    "mtime": 1783318203.364987,
+    "mtime": 1783376926.2548485,
     "ast_hash": "dc97a54e76dfa45c269c6efba64d6d00",
     "semantic_hash": "dc97a54e76dfa45c269c6efba64d6d00"
   },
   "tests/models/flow/test_power_law.py": {
-    "mtime": 1783318203.364987,
+    "mtime": 1783376926.2548485,
     "ast_hash": "10606ae81257123887a2738f14925529",
     "semantic_hash": "10606ae81257123887a2738f14925529"
   },
   "tests/models/fluidity/__init__.py": {
-    "mtime": 1783318203.364987,
+    "mtime": 1783376926.2548485,
     "ast_hash": "cdaf98b7e185ca4d5a371dd1e69af567",
     "semantic_hash": "cdaf98b7e185ca4d5a371dd1e69af567"
   },
   "tests/models/fluidity/saramito/__init__.py": {
-    "mtime": 1783318203.364987,
+    "mtime": 1783376926.2548485,
     "ast_hash": "b8c2b50823ecc5bf845aebb8bafa6c2b",
     "semantic_hash": "b8c2b50823ecc5bf845aebb8bafa6c2b"
   },
   "tests/models/fluidity/saramito/test_kernels.py": {
-    "mtime": 1783318203.364987,
+    "mtime": 1783376926.2548485,
     "ast_hash": "2f559aa80d1e463d9601c5b93e5d4975",
     "semantic_hash": "2f559aa80d1e463d9601c5b93e5d4975"
   },
   "tests/models/fluidity/saramito/test_local.py": {
-    "mtime": 1783318203.364987,
+    "mtime": 1783376926.2548485,
     "ast_hash": "e70bb2c4cf7d1e6b224ed5fb52229a61",
     "semantic_hash": ""
   },
   "tests/models/fluidity/saramito/test_nonlocal.py": {
-    "mtime": 1783318203.364987,
+    "mtime": 1783376926.2548485,
     "ast_hash": "1a260d46ee9ca90a3a91d725ec85b076",
     "semantic_hash": "1a260d46ee9ca90a3a91d725ec85b076"
   },
   "tests/models/fluidity/saramito/test_physics.py": {
-    "mtime": 1783318203.364987,
+    "mtime": 1783376926.2548485,
     "ast_hash": "9f59ff8e37e6ddd0712ae004e7b6b56b",
     "semantic_hash": "9f59ff8e37e6ddd0712ae004e7b6b56b"
   },
   "tests/models/fluidity/test_identifiability.py": {
-    "mtime": 1783318203.364987,
+    "mtime": 1783376926.2548485,
     "ast_hash": "e11cb95b25e63f4161837965d10d2229",
     "semantic_hash": "e11cb95b25e63f4161837965d10d2229"
   },
   "tests/models/fluidity/test_integration.py": {
-    "mtime": 1783318203.3659868,
+    "mtime": 1783376926.2548485,
     "ast_hash": "08e63901ec1cf09665421dc69a547b2c",
     "semantic_hash": ""
   },
   "tests/models/fluidity/test_kernels.py": {
-    "mtime": 1783318203.3659868,
+    "mtime": 1783376926.2548485,
     "ast_hash": "ae517d77519bcd8cdd57737cfb084f05",
     "semantic_hash": "ae517d77519bcd8cdd57737cfb084f05"
   },
   "tests/models/fluidity/test_local.py": {
-    "mtime": 1783318203.3659868,
+    "mtime": 1783376926.2548485,
     "ast_hash": "6d9e63e045c8359653d3f58bb62adc0a",
     "semantic_hash": "6d9e63e045c8359653d3f58bb62adc0a"
   },
   "tests/models/fluidity/test_nonlocal.py": {
-    "mtime": 1783318203.3659868,
+    "mtime": 1783376926.2548485,
     "ast_hash": "8a845d84d4298853952f149060df6084",
     "semantic_hash": "8a845d84d4298853952f149060df6084"
   },
   "tests/models/fluidity/test_parameter_schema.py": {
-    "mtime": 1783318203.3659868,
+    "mtime": 1783376926.2548485,
     "ast_hash": "8692e5cdf392ee4a0188e84ff1a8a3d6",
     "semantic_hash": "8692e5cdf392ee4a0188e84ff1a8a3d6"
   },
   "tests/models/fluidity/test_predict_without_fit.py": {
-    "mtime": 1783318203.3659868,
+    "mtime": 1783376926.2548485,
     "ast_hash": "9170480348154c4cc7e6769968e2f297",
     "semantic_hash": "9170480348154c4cc7e6769968e2f297"
   },
   "tests/models/fractional/__init__.py": {
-    "mtime": 1783318203.3659868,
+    "mtime": 1783376926.2548485,
     "ast_hash": "a1f778fb0112ecf9d3f4f70d62ef5060",
     "semantic_hash": "a1f778fb0112ecf9d3f4f70d62ef5060"
   },
   "tests/models/fractional/test_fractional_maxwell_liquid.py": {
-    "mtime": 1783318203.3659868,
+    "mtime": 1783376926.2558486,
     "ast_hash": "c709ed997586c9cc26a7f1a0ad1fe9e6",
     "semantic_hash": "c709ed997586c9cc26a7f1a0ad1fe9e6"
   },
   "tests/models/fractional/test_fractional_maxwell_model.py": {
-    "mtime": 1783318203.3659868,
+    "mtime": 1783376926.2558486,
     "ast_hash": "4e72e72a917cd7fc8dce1324db113592",
     "semantic_hash": "4e72e72a917cd7fc8dce1324db113592"
   },
   "tests/models/fractional/test_fractional_mixin.py": {
-    "mtime": 1783318203.3659868,
+    "mtime": 1783376926.2558486,
     "ast_hash": "3747397554b200f3897f14010d7d411f",
     "semantic_hash": ""
   },
   "tests/models/fractional/test_fractional_variants.py": {
-    "mtime": 1783318203.3659868,
+    "mtime": 1783376926.2558486,
     "ast_hash": "80455ee32c766958e304d622bb977c65",
     "semantic_hash": "80455ee32c766958e304d622bb977c65"
   },
   "tests/models/fractional/test_fractional_zener_family.py": {
-    "mtime": 1783318203.3659868,
+    "mtime": 1783376926.2558486,
     "ast_hash": "221c662c527b95656f3800f41ce70d81",
     "semantic_hash": "221c662c527b95656f3800f41ce70d81"
   },
   "tests/models/fractional/test_fractional_zener_sl.py": {
-    "mtime": 1783318203.3659868,
+    "mtime": 1783376926.2558486,
     "ast_hash": "9cd67d2b4ed3e0c980157d11d852dc93",
     "semantic_hash": "9cd67d2b4ed3e0c980157d11d852dc93"
   },
   "tests/models/fractional/test_optimization_validation.py": {
-    "mtime": 1783318203.3659868,
+    "mtime": 1783376926.2558486,
     "ast_hash": "62d2e96f610bd533a717503b2f1eb39c",
     "semantic_hash": ""
   },
   "tests/models/giesekus/__init__.py": {
-    "mtime": 1783318203.3659868,
+    "mtime": 1783376926.2558486,
     "ast_hash": "3bf52e706cb3ed736333df10fac160b0",
     "semantic_hash": "3bf52e706cb3ed736333df10fac160b0"
   },
   "tests/models/giesekus/test_bayesian.py": {
-    "mtime": 1783318203.3659868,
+    "mtime": 1783376926.2558486,
     "ast_hash": "9e20f672a7c78bd531490ba552f66362",
     "semantic_hash": "9e20f672a7c78bd531490ba552f66362"
   },
   "tests/models/giesekus/test_kernels.py": {
-    "mtime": 1783318203.3659868,
+    "mtime": 1783376926.2558486,
     "ast_hash": "c28d654c7b2e307e98f94d06860684ec",
     "semantic_hash": ""
   },
   "tests/models/giesekus/test_multi_mode.py": {
-    "mtime": 1783318203.3659868,
+    "mtime": 1783376926.2558486,
     "ast_hash": "a12ad639d602a1eea0598ec4eea8b8c0",
     "semantic_hash": "a12ad639d602a1eea0598ec4eea8b8c0"
   },
   "tests/models/giesekus/test_physics.py": {
-    "mtime": 1783318203.3659868,
+    "mtime": 1783376926.2558486,
     "ast_hash": "e0e14969da995ecd11db2fa046fcc71e",
     "semantic_hash": ""
   },
   "tests/models/giesekus/test_single_mode.py": {
-    "mtime": 1783318203.366987,
+    "mtime": 1783376926.2558486,
     "ast_hash": "bee42eea49d215dfb1552942ce6c7e41",
     "semantic_hash": "bee42eea49d215dfb1552942ce6c7e41"
   },
   "tests/models/hl/__init__.py": {
-    "mtime": 1783318203.366987,
+    "mtime": 1783376926.2558486,
     "ast_hash": "b01418cf53f1af8f50a98d2fd38d572c",
     "semantic_hash": "b01418cf53f1af8f50a98d2fd38d572c"
   },
   "tests/models/hl/test_hebraud_lequeux.py": {
-    "mtime": 1783318203.366987,
+    "mtime": 1783376926.2558486,
     "ast_hash": "52c3113b31aadc117a8d98e208258851",
     "semantic_hash": "52c3113b31aadc117a8d98e208258851"
   },
   "tests/models/hvm/__init__.py": {
-    "mtime": 1783318203.366987,
+    "mtime": 1783376926.2558486,
     "ast_hash": "1cbdc386dbb9dccc401019f3151e6623",
     "semantic_hash": "1cbdc386dbb9dccc401019f3151e6623"
   },
   "tests/models/hvm/test_hvm.py": {
-    "mtime": 1783318203.366987,
+    "mtime": 1783376926.2558486,
     "ast_hash": "41f860e0ded6d9cecff54cbf1522e81e",
     "semantic_hash": "41f860e0ded6d9cecff54cbf1522e81e"
   },
   "tests/models/hvnm/__init__.py": {
-    "mtime": 1783318203.366987,
+    "mtime": 1783376926.2558486,
     "ast_hash": "d41d8cd98f00b204e9800998ecf8427e",
     "semantic_hash": "d41d8cd98f00b204e9800998ecf8427e"
   },
   "tests/models/hvnm/test_hvnm.py": {
-    "mtime": 1783318203.366987,
+    "mtime": 1783376926.2568486,
     "ast_hash": "fa51d843bab2e6fb1593defb0adcc782",
     "semantic_hash": "fa51d843bab2e6fb1593defb0adcc782"
   },
   "tests/models/ikh/__init__.py": {
-    "mtime": 1783318203.366987,
+    "mtime": 1783376926.2568486,
     "ast_hash": "61937022a11d4854c76f72845a4faa6c",
     "semantic_hash": "61937022a11d4854c76f72845a4faa6c"
   },
   "tests/models/ikh/test_ikh.py": {
-    "mtime": 1783318203.366987,
+    "mtime": 1783376926.2568486,
     "ast_hash": "d7d5ef4087041d924ef18470855e3d43",
     "semantic_hash": ""
   },
   "tests/models/ikh/test_ikh_fitting.py": {
-    "mtime": 1783318203.366987,
+    "mtime": 1783376926.2568486,
     "ast_hash": "b175ddad5755e29b775f5db6b0e2b01c",
     "semantic_hash": ""
   },
   "tests/models/ikh/test_ikh_variants.py": {
-    "mtime": 1783318203.366987,
+    "mtime": 1783376926.2568486,
     "ast_hash": "7b3c9101c05d49cfefe0c941621955ce",
     "semantic_hash": "7b3c9101c05d49cfefe0c941621955ce"
   },
   "tests/models/itt_mct/__init__.py": {
-    "mtime": 1783318203.366987,
+    "mtime": 1783376926.2568486,
     "ast_hash": "a846afff2281dd06bf99e531b733575a",
     "semantic_hash": "a846afff2281dd06bf99e531b733575a"
   },
   "tests/models/itt_mct/test_isotropic.py": {
-    "mtime": 1783318203.366987,
+    "mtime": 1783376926.2568486,
     "ast_hash": "69986b02a86ffe6de097e674389e9be4",
     "semantic_hash": "69986b02a86ffe6de097e674389e9be4"
   },
   "tests/models/itt_mct/test_method_scipy_default.py": {
-    "mtime": 1783318203.366987,
+    "mtime": 1783376926.2568486,
     "ast_hash": "1326a2fc25c6385cfe29a2d25c220ee2",
     "semantic_hash": "1326a2fc25c6385cfe29a2d25c220ee2"
   },
   "tests/models/itt_mct/test_performance.py": {
-    "mtime": 1783318203.366987,
+    "mtime": 1783376926.2568486,
     "ast_hash": "f2f8120eb9624e60948d02a7fa090c5d",
     "semantic_hash": ""
   },
   "tests/models/itt_mct/test_protocols.py": {
-    "mtime": 1783318203.366987,
+    "mtime": 1783376926.2568486,
     "ast_hash": "3bdc9b56ab35032936a3b937c27387bd",
     "semantic_hash": "3bdc9b56ab35032936a3b937c27387bd"
   },
   "tests/models/itt_mct/test_schematic.py": {
-    "mtime": 1783318203.366987,
+    "mtime": 1783376926.2568486,
     "ast_hash": "cefadc4777910faac453e8f6b2f2e809",
     "semantic_hash": "cefadc4777910faac453e8f6b2f2e809"
   },
   "tests/models/itt_mct/test_two_time_memory.py": {
-    "mtime": 1783318203.366987,
+    "mtime": 1783376926.2568486,
     "ast_hash": "643e2d5833eaf506828f095ff76d8664",
     "semantic_hash": "643e2d5833eaf506828f095ff76d8664"
   },
   "tests/models/multimode/__init__.py": {
-    "mtime": 1783318203.366987,
+    "mtime": 1783376926.2568486,
     "ast_hash": "78821a745198b42ee78a7f037b333f1b",
     "semantic_hash": "78821a745198b42ee78a7f037b333f1b"
   },
   "tests/models/multimode/test_generalized_maxwell.py": {
-    "mtime": 1783318203.367987,
+    "mtime": 1783376926.2568486,
     "ast_hash": "21cda492f119c11af5d82ea0da7ba7e6",
     "semantic_hash": ""
   },
   "tests/models/multimode/test_generalized_maxwell_warm_start.py": {
-    "mtime": 1783318203.367987,
+    "mtime": 1783376926.2568486,
     "ast_hash": "c8ca370ddf889b0487c7430122f1dd66",
     "semantic_hash": ""
   },
   "tests/models/multimode/test_gmm_bayesian.py": {
-    "mtime": 1783318203.367987,
+    "mtime": 1783376926.2568486,
     "ast_hash": "dfeecfc283cc811ebaca784bfdd63dd0",
     "semantic_hash": ""
   },
   "tests/models/multimode/test_gmm_bayesian_safety.py": {
-    "mtime": 1783318203.367987,
+    "mtime": 1783376926.2568486,
     "ast_hash": "73cc92242b3dbb207744340561fe6af1",
     "semantic_hash": "73cc92242b3dbb207744340561fe6af1"
   },
   "tests/models/sgr/__init__.py": {
-    "mtime": 1783318203.367987,
+    "mtime": 1783376926.2568486,
     "ast_hash": "4083fd583fc0c0eb308b7cc1816993d2",
     "semantic_hash": "4083fd583fc0c0eb308b7cc1816993d2"
   },
   "tests/models/sgr/test_sgr_conventional.py": {
-    "mtime": 1783318203.367987,
+    "mtime": 1783376926.2568486,
     "ast_hash": "4619ff9d416d87d2b6f22cbdd50f3138",
     "semantic_hash": ""
   },
   "tests/models/sgr/test_sgr_generic.py": {
-    "mtime": 1783318203.367987,
+    "mtime": 1783376926.2578485,
     "ast_hash": "30bc0804eb0d60bedd1e74ef33388570",
     "semantic_hash": ""
   },
   "tests/models/sgr/test_sgr_generic_extended.py": {
-    "mtime": 1783318203.367987,
+    "mtime": 1783376926.2578485,
     "ast_hash": "570c3da4a38908e8903ac7e98ac51c75",
     "semantic_hash": ""
   },
   "tests/models/spp/__init__.py": {
-    "mtime": 1783318203.367987,
+    "mtime": 1783376926.2578485,
     "ast_hash": "6451c4e594e864fbeb8de8db5deb3b87",
     "semantic_hash": "6451c4e594e864fbeb8de8db5deb3b87"
   },
   "tests/models/spp/test_spp_yield_stress.py": {
-    "mtime": 1783318203.367987,
+    "mtime": 1783376926.2578485,
     "ast_hash": "85b7f17a43b48c24eb7b190f5f411e72",
     "semantic_hash": "85b7f17a43b48c24eb7b190f5f411e72"
   },
   "tests/models/stz/__init__.py": {
-    "mtime": 1783318203.367987,
+    "mtime": 1783376926.2578485,
     "ast_hash": "fc2d1b7fdab3ee79228dcacbc708aa4f",
     "semantic_hash": "fc2d1b7fdab3ee79228dcacbc708aa4f"
   },
   "tests/models/stz/test_coverage.py": {
-    "mtime": 1783318203.367987,
+    "mtime": 1783376926.2578485,
     "ast_hash": "49b1c69057bbd0cd8d7e789cb3983aab",
     "semantic_hash": ""
   },
   "tests/models/stz/test_creep_elastic_offset.py": {
-    "mtime": 1783318203.367987,
+    "mtime": 1783376926.2578485,
     "ast_hash": "f48a5544f487cdc7f9a7c425d5eaa87b",
     "semantic_hash": ""
   },
   "tests/models/stz/test_flow_transient.py": {
-    "mtime": 1783318203.367987,
+    "mtime": 1783376926.2578485,
     "ast_hash": "451f65db43b81ab20f38c9f1971ef736",
     "semantic_hash": "451f65db43b81ab20f38c9f1971ef736"
   },
   "tests/models/stz/test_integration.py": {
-    "mtime": 1783318203.367987,
+    "mtime": 1783376926.2578485,
     "ast_hash": "21ee37e3a158ad6b7f80dcf7345dd320",
     "semantic_hash": "21ee37e3a158ad6b7f80dcf7345dd320"
   },
   "tests/models/stz/test_kernels.py": {
-    "mtime": 1783318203.367987,
+    "mtime": 1783376926.2578485,
     "ast_hash": "a14d72c862002e197ccd6418dd0ea23d",
     "semantic_hash": "a14d72c862002e197ccd6418dd0ea23d"
   },
   "tests/models/stz/test_oscillatory.py": {
-    "mtime": 1783318203.367987,
+    "mtime": 1783376926.2578485,
     "ast_hash": "b717c6a2f8d83b81dd129fb972a543aa",
     "semantic_hash": "b717c6a2f8d83b81dd129fb972a543aa"
   },
   "tests/models/test_model_imports.py": {
-    "mtime": 1783318203.367987,
+    "mtime": 1783376926.2578485,
     "ast_hash": "3fd8e3691e37cbe757d55b2738d86cfd",
     "semantic_hash": ""
   },
   "tests/models/tnt/__init__.py": {
-    "mtime": 1783318203.367987,
+    "mtime": 1783376926.2578485,
     "ast_hash": "d41d8cd98f00b204e9800998ecf8427e",
     "semantic_hash": "d41d8cd98f00b204e9800998ecf8427e"
   },
   "tests/models/tnt/test_cates.py": {
-    "mtime": 1783318203.3689868,
+    "mtime": 1783376926.2578485,
     "ast_hash": "2f5b182cc4dcdcdd871e7936c7e6ff69",
     "semantic_hash": "2f5b182cc4dcdcdd871e7936c7e6ff69"
   },
   "tests/models/tnt/test_loop_bridge.py": {
-    "mtime": 1783318203.3689868,
+    "mtime": 1783376926.2578485,
     "ast_hash": "96d46ea573fd2feb7edb6995f6062f78",
     "semantic_hash": "96d46ea573fd2feb7edb6995f6062f78"
   },
   "tests/models/tnt/test_multi_species.py": {
-    "mtime": 1783318203.3689868,
+    "mtime": 1783376926.2578485,
     "ast_hash": "753bf4470b91e507a58dd284509bb1c9",
     "semantic_hash": "753bf4470b91e507a58dd284509bb1c9"
   },
   "tests/models/tnt/test_single_mode.py": {
-    "mtime": 1783318203.3689868,
+    "mtime": 1783376926.2578485,
     "ast_hash": "a57cdd49d01c22b69502ad8dbe8fc90f",
     "semantic_hash": ""
   },
   "tests/models/tnt/test_sticky_rouse.py": {
-    "mtime": 1783318203.3689868,
+    "mtime": 1783376926.2578485,
     "ast_hash": "255594d53b516d321aa7338b6b142251",
     "semantic_hash": "255594d53b516d321aa7338b6b142251"
   },
   "tests/models/vlb/__init__.py": {
-    "mtime": 1783318203.3689868,
+    "mtime": 1783376926.2578485,
     "ast_hash": "e91ada4e1cbb27e7c8283558b44564b8",
     "semantic_hash": "e91ada4e1cbb27e7c8283558b44564b8"
   },
   "tests/models/vlb/test_vlb.py": {
-    "mtime": 1783318203.3689868,
+    "mtime": 1783376926.2588487,
     "ast_hash": "d871e30a02a01d181ffc230d748cf0ff",
     "semantic_hash": "d871e30a02a01d181ffc230d748cf0ff"
   },
   "tests/models/vlb/test_vlb_nonlocal.py": {
-    "mtime": 1783318203.3689868,
+    "mtime": 1783376926.2588487,
     "ast_hash": "3112013bc68d8c88e4899a5e2fab5c45",
     "semantic_hash": "3112013bc68d8c88e4899a5e2fab5c45"
   },
   "tests/models/vlb/test_vlb_variant.py": {
-    "mtime": 1783318203.3689868,
+    "mtime": 1783376926.2588487,
     "ast_hash": "266f4d830e736951c34464d2e4203dda",
     "semantic_hash": "266f4d830e736951c34464d2e4203dda"
   },
   "tests/parallel/__init__.py": {
-    "mtime": 1783318203.3689868,
+    "mtime": 1783376926.2588487,
     "ast_hash": "d41d8cd98f00b204e9800998ecf8427e",
     "semantic_hash": "d41d8cd98f00b204e9800998ecf8427e"
   },
   "tests/parallel/conftest.py": {
-    "mtime": 1783318203.3689868,
+    "mtime": 1783376926.2588487,
     "ast_hash": "2cf64b5de031c493c7a6b46f07bf0b4c",
     "semantic_hash": "2cf64b5de031c493c7a6b46f07bf0b4c"
   },
   "tests/parallel/test_api.py": {
-    "mtime": 1783318203.3689868,
+    "mtime": 1783376926.2588487,
     "ast_hash": "bf26d846f6063bf620123dc5f9206dff",
     "semantic_hash": "bf26d846f6063bf620123dc5f9206dff"
   },
   "tests/parallel/test_config.py": {
-    "mtime": 1783318203.3689868,
+    "mtime": 1783376926.2588487,
     "ast_hash": "1294f213e602218b4e26aa7859a2f39a",
     "semantic_hash": "1294f213e602218b4e26aa7859a2f39a"
   },
   "tests/parallel/test_imports.py": {
-    "mtime": 1783318203.3689868,
+    "mtime": 1783376926.2588487,
     "ast_hash": "9b5cb1e9b4bd6ec1dc45f1ddb5e2ec1a",
     "semantic_hash": "9b5cb1e9b4bd6ec1dc45f1ddb5e2ec1a"
   },
   "tests/parallel/test_integration.py": {
-    "mtime": 1783318203.3689868,
+    "mtime": 1783376926.2588487,
     "ast_hash": "e740e2f2010b7fa9f0fdd9e6dabdb1ce",
     "semantic_hash": "e740e2f2010b7fa9f0fdd9e6dabdb1ce"
   },
   "tests/parallel/test_pool.py": {
-    "mtime": 1783318203.3689868,
+    "mtime": 1783376926.2588487,
     "ast_hash": "f6f9dbd9e4e22a49f0bad8b85fc80523",
     "semantic_hash": "f6f9dbd9e4e22a49f0bad8b85fc80523"
   },
   "tests/parallel/test_warmup.py": {
-    "mtime": 1783318203.3689868,
+    "mtime": 1783376926.2588487,
     "ast_hash": "26c44cab039f4f79e497a030a9926f78",
     "semantic_hash": "26c44cab039f4f79e497a030a9926f78"
   },
   "tests/pipeline/__init__.py": {
-    "mtime": 1783318203.3689868,
+    "mtime": 1783376926.2588487,
     "ast_hash": "33fc98f27629c378ce11304ce64a9a7a",
     "semantic_hash": "33fc98f27629c378ce11304ce64a9a7a"
   },
   "tests/pipeline/test_arviz_diagnostics.py": {
-    "mtime": 1783318203.3689868,
+    "mtime": 1783376926.2588487,
     "ast_hash": "0e0af7bc3650a80fc951c558ed2572cb",
     "semantic_hash": "0e0af7bc3650a80fc951c558ed2572cb"
   },
   "tests/pipeline/test_batch.py": {
-    "mtime": 1783318203.3689868,
+    "mtime": 1783376926.2588487,
     "ast_hash": "9c6d3ca867cbe07fdd79de329f804434",
     "semantic_hash": "9c6d3ca867cbe07fdd79de329f804434"
   },
   "tests/pipeline/test_batch_parallel.py": {
-    "mtime": 1783318203.3689868,
+    "mtime": 1783376926.2588487,
     "ast_hash": "7ca38cb1bd647e15fdede2a21e49ee37",
     "semantic_hash": "7ca38cb1bd647e15fdede2a21e49ee37"
   },
   "tests/pipeline/test_batch_vectorize.py": {
-    "mtime": 1783318203.3699868,
+    "mtime": 1783376926.2588487,
     "ast_hash": "295615d580b9d2c0117ead485454f9fd",
     "semantic_hash": "295615d580b9d2c0117ead485454f9fd"
   },
   "tests/pipeline/test_bayesian_pipeline.py": {
-    "mtime": 1783318203.3699868,
+    "mtime": 1783376926.2588487,
     "ast_hash": "bf1d2b19c649afe93e767cd722404980",
     "semantic_hash": ""
   },
   "tests/pipeline/test_builder.py": {
-    "mtime": 1783318203.3699868,
+    "mtime": 1783376926.2588487,
     "ast_hash": "e77c4c152f0c1d34a42032ff844929af",
     "semantic_hash": ""
   },
   "tests/pipeline/test_builder_extensions.py": {
-    "mtime": 1783318203.3699868,
+    "mtime": 1783376926.2588487,
     "ast_hash": "39bf91f8aa74ea39f847126d7a3f955b",
     "semantic_hash": "39bf91f8aa74ea39f847126d7a3f955b"
   },
   "tests/pipeline/test_device_memory.py": {
-    "mtime": 1783318203.3699868,
+    "mtime": 1783376926.2588487,
     "ast_hash": "cd49cf621420116d6ebfa809ff9b4da2",
     "semantic_hash": "cd49cf621420116d6ebfa809ff9b4da2"
   },
   "tests/pipeline/test_mastercurve_parallel.py": {
-    "mtime": 1783318203.3699868,
+    "mtime": 1783376926.2588487,
     "ast_hash": "82ed5f7d8bc520c4ed499db029d1470c",
     "semantic_hash": "82ed5f7d8bc520c4ed499db029d1470c"
   },
   "tests/pipeline/test_model_comparison_parallel.py": {
-    "mtime": 1783318203.3699868,
+    "mtime": 1783376926.2588487,
     "ast_hash": "6e8232284acffe5ce3b91c0db1b71c2d",
     "semantic_hash": ""
   },
   "tests/pipeline/test_pipeline_base.py": {
-    "mtime": 1783318203.3699868,
+    "mtime": 1783376926.2588487,
     "ast_hash": "589e2381eeb8c8026e406f62afcd9fea",
     "semantic_hash": "589e2381eeb8c8026e406f62afcd9fea"
   },
   "tests/pipeline/test_pipeline_visualization.py": {
-    "mtime": 1783318203.3699868,
+    "mtime": 1783376926.2588487,
     "ast_hash": "f02d11ba36451b9980de1f6a5dec1550",
     "semantic_hash": "f02d11ba36451b9980de1f6a5dec1550"
   },
   "tests/pipeline/test_spp_pipeline_defaults.py": {
-    "mtime": 1783318203.3699868,
+    "mtime": 1783376926.2588487,
     "ast_hash": "b4df88a55e9c43098b54b786e0e57a5f",
     "semantic_hash": "b4df88a55e9c43098b54b786e0e57a5f"
   },
   "tests/pipeline/test_workflows.py": {
-    "mtime": 1783318203.3699868,
+    "mtime": 1783376926.2588487,
     "ast_hash": "5e362f8fbf1a774a54f0fecb2ab6d0f2",
     "semantic_hash": "5e362f8fbf1a774a54f0fecb2ab6d0f2"
   },
   "tests/regression/__init__.py": {
-    "mtime": 1783318203.3699868,
+    "mtime": 1783376926.2598486,
     "ast_hash": "d41d8cd98f00b204e9800998ecf8427e",
     "semantic_hash": "d41d8cd98f00b204e9800998ecf8427e"
   },
   "tests/regression/test_round9_prevention.py": {
-    "mtime": 1783318203.3699868,
+    "mtime": 1783376926.2598486,
     "ast_hash": "6e088eee120c57c7b1a5f3b20eb7349e",
     "semantic_hash": ""
   },
   "tests/test_fit_result.py": {
-    "mtime": 1783318203.3699868,
+    "mtime": 1783376926.2598486,
     "ast_hash": "6671687ff69374a124a18f94c165e296",
     "semantic_hash": "6671687ff69374a124a18f94c165e296"
   },
   "tests/test_import.py": {
-    "mtime": 1783318203.3699868,
+    "mtime": 1783376926.2598486,
     "ast_hash": "95ba2c669d87e71d7ba0a31aaf1b9327",
     "semantic_hash": "95ba2c669d87e71d7ba0a31aaf1b9327"
   },
   "tests/test_notebook_execution_consistency.py": {
-    "mtime": 1783318203.3699868,
+    "mtime": 1783376926.2598486,
     "ast_hash": "fac952c515946a0ac197cf3b0dd28883",
     "semantic_hash": ""
   },
   "tests/test_performance_f9.py": {
-    "mtime": 1783318203.3699868,
+    "mtime": 1783376926.2598486,
     "ast_hash": "8ef56ba7d5d55b77f7edaae2459fe8ad",
     "semantic_hash": ""
   },
   "tests/test_project_structure.py": {
-    "mtime": 1783318203.3699868,
+    "mtime": 1783376926.2598486,
     "ast_hash": "6ee04bf759c3e7b6c31a6d05905f37fa",
     "semantic_hash": ""
   },
   "tests/transforms/__init__.py": {
-    "mtime": 1783318203.3699868,
+    "mtime": 1783376926.2598486,
     "ast_hash": "95bec7d6a8ca5f8c714020df0efc2c8e",
     "semantic_hash": "95bec7d6a8ca5f8c714020df0efc2c8e"
   },
   "tests/transforms/test_batch_transform.py": {
-    "mtime": 1783318203.3699868,
+    "mtime": 1783376926.2598486,
     "ast_hash": "c526b851859269705dfe1574645a01a2",
     "semantic_hash": "c526b851859269705dfe1574645a01a2"
   },
   "tests/transforms/test_cox_merz.py": {
-    "mtime": 1783318203.3699868,
+    "mtime": 1783376926.2598486,
     "ast_hash": "e0bc32a2a3ffffe5a3ceff23e5155014",
     "semantic_hash": "e0bc32a2a3ffffe5a3ceff23e5155014"
   },
   "tests/transforms/test_fft_analysis.py": {
-    "mtime": 1783318203.3699868,
+    "mtime": 1783376926.2598486,
     "ast_hash": "7136032e9b8ede911a5dce697524462f",
     "semantic_hash": "7136032e9b8ede911a5dce697524462f"
   },
   "tests/transforms/test_lve_envelope.py": {
-    "mtime": 1783318203.3699868,
+    "mtime": 1783376926.2598486,
     "ast_hash": "7e4fbde30620bcab6b12d65ed756d9b8",
     "semantic_hash": "7e4fbde30620bcab6b12d65ed756d9b8"
   },
   "tests/transforms/test_mastercurve.py": {
-    "mtime": 1783318203.3699868,
+    "mtime": 1783376926.2598486,
     "ast_hash": "107b166ebcd03fa11abfa3d59c0f1c37",
     "semantic_hash": "107b166ebcd03fa11abfa3d59c0f1c37"
   },
   "tests/transforms/test_mastercurve_autoshift.py": {
-    "mtime": 1783318203.3709867,
+    "mtime": 1783376926.2598486,
     "ast_hash": "95516c5e0f52b4979b45142a9a09bf6a",
     "semantic_hash": "95516c5e0f52b4979b45142a9a09bf6a"
   },
   "tests/transforms/test_mutation_number.py": {
-    "mtime": 1783318203.3709867,
+    "mtime": 1783376926.2598486,
     "ast_hash": "5c00513dabc6f1611abb59f1d4fc4047",
     "semantic_hash": "5c00513dabc6f1611abb59f1d4fc4047"
   },
   "tests/transforms/test_owchirp.py": {
-    "mtime": 1783318203.3709867,
+    "mtime": 1783376926.2598486,
     "ast_hash": "6ca40cd5f9dd817b96d20cc08c6ab962",
     "semantic_hash": "6ca40cd5f9dd817b96d20cc08c6ab962"
   },
   "tests/transforms/test_prony_conversion.py": {
-    "mtime": 1783318203.3709867,
+    "mtime": 1783376926.2598486,
     "ast_hash": "1a84031c4499e7be668a591d814bab1a",
     "semantic_hash": "1a84031c4499e7be668a591d814bab1a"
   },
   "tests/transforms/test_smooth_derivative.py": {
-    "mtime": 1783318203.3709867,
+    "mtime": 1783376926.2598486,
     "ast_hash": "bd041d22a2bc6fdcb3e70fa4e098d274",
     "semantic_hash": "bd041d22a2bc6fdcb3e70fa4e098d274"
   },
   "tests/transforms/test_spectrum_inversion.py": {
-    "mtime": 1783318203.3709867,
+    "mtime": 1783376926.2598486,
     "ast_hash": "557f1cb97c96d8686bf5d4cd09724794",
     "semantic_hash": "557f1cb97c96d8686bf5d4cd09724794"
   },
   "tests/transforms/test_spp_decomposer.py": {
-    "mtime": 1783318203.3709867,
+    "mtime": 1783376926.2598486,
     "ast_hash": "7b19743666140cb8a48aaf598af775b5",
     "semantic_hash": "7b19743666140cb8a48aaf598af775b5"
   },
   "tests/transforms/test_srfs.py": {
-    "mtime": 1783318203.3709867,
+    "mtime": 1783376926.2598486,
     "ast_hash": "32fb970040189a1e023c130072faf9e8",
     "semantic_hash": ""
   },
   "tests/utils/__init__.py": {
-    "mtime": 1783318203.3709867,
+    "mtime": 1783376926.2598486,
     "ast_hash": "d41d8cd98f00b204e9800998ecf8427e",
     "semantic_hash": "d41d8cd98f00b204e9800998ecf8427e"
   },
   "tests/utils/initialization/test_base_initializer.py": {
-    "mtime": 1783318203.3709867,
+    "mtime": 1783376926.2598486,
     "ast_hash": "636b0149150c399ec81d3e4a25a6f194",
     "semantic_hash": "636b0149150c399ec81d3e4a25a6f194"
   },
   "tests/utils/initialization/test_fractional_initializers.py": {
-    "mtime": 1783318203.3709867,
+    "mtime": 1783376926.2598486,
     "ast_hash": "04f3cb56431bb611c0b0f9738a96ff83",
     "semantic_hash": "04f3cb56431bb611c0b0f9738a96ff83"
   },
   "tests/utils/test_auto_p0.py": {
-    "mtime": 1783318203.3709867,
+    "mtime": 1783376926.2598486,
     "ast_hash": "94037a18498cb9b16a541c595a9446aa",
     "semantic_hash": "94037a18498cb9b16a541c595a9446aa"
   },
   "tests/utils/test_compatibility.py": {
-    "mtime": 1783318203.3709867,
+    "mtime": 1783376926.2608485,
     "ast_hash": "32e46d66eaaf601db3e4219f12460715",
     "semantic_hash": "32e46d66eaaf601db3e4219f12460715"
   },
   "tests/utils/test_data_quality.py": {
-    "mtime": 1783318203.3709867,
+    "mtime": 1783376926.2608485,
     "ast_hash": "146db780eef101b288d7018db705891e",
     "semantic_hash": "146db780eef101b288d7018db705891e"
   },
   "tests/utils/test_device.py": {
-    "mtime": 1783318203.3709867,
+    "mtime": 1783376926.2608485,
     "ast_hash": "7c295d651f85885c0a526ce84d4e104c",
     "semantic_hash": "7c295d651f85885c0a526ce84d4e104c"
   },
   "tests/utils/test_epm_kernels.py": {
-    "mtime": 1783318203.3709867,
+    "mtime": 1783376926.2608485,
     "ast_hash": "d0d369c25cf317efefdfc51387620055",
     "semantic_hash": "d0d369c25cf317efefdfc51387620055"
   },
   "tests/utils/test_epm_kernels_tensorial.py": {
-    "mtime": 1783318203.3709867,
+    "mtime": 1783376926.2608485,
     "ast_hash": "851093977c3375acdb3d7489e53e8120",
     "semantic_hash": ""
   },
   "tests/utils/test_gmm_alias_and_decay.py": {
-    "mtime": 1783318203.3709867,
+    "mtime": 1783376926.2608485,
     "ast_hash": "baf501e137716b731799225980d81340",
     "semantic_hash": "baf501e137716b731799225980d81340"
   },
   "tests/utils/test_hl_kernels.py": {
-    "mtime": 1783318203.3709867,
+    "mtime": 1783376926.2608485,
     "ast_hash": "fe023041c27b2e75fe1528e7cb2c5ac3",
     "semantic_hash": "fe023041c27b2e75fe1528e7cb2c5ac3"
   },
   "tests/utils/test_initialization.py": {
-    "mtime": 1783318203.3709867,
+    "mtime": 1783376926.2608485,
     "ast_hash": "d3a0a747342575d29d7a0878c54df5c1",
     "semantic_hash": "d3a0a747342575d29d7a0878c54df5c1"
   },
   "tests/utils/test_initialization_backward_compat.py": {
-    "mtime": 1783318203.3709867,
+    "mtime": 1783376926.2608485,
     "ast_hash": "f497ee76c00683d6459c584e21c06e81",
     "semantic_hash": "f497ee76c00683d6459c584e21c06e81"
   },
   "tests/utils/test_mct_kernels.py": {
-    "mtime": 1783318203.3709867,
+    "mtime": 1783376926.2608485,
     "ast_hash": "f87d4c282015fcef299c23169645ce72",
     "semantic_hash": "f87d4c282015fcef299c23169645ce72"
   },
   "tests/utils/test_metrics.py": {
-    "mtime": 1783318203.3709867,
+    "mtime": 1783376926.2608485,
     "ast_hash": "e7e311e54d28ea0a278bc144d550a1fb",
     "semantic_hash": "e7e311e54d28ea0a278bc144d550a1fb"
   },
   "tests/utils/test_mittag_leffler.py": {
-    "mtime": 1783318203.3709867,
+    "mtime": 1783376926.2608485,
     "ast_hash": "50ef908fc8dca4d9e7c8bdad9c3a483f",
     "semantic_hash": ""
   },
   "tests/utils/test_ml_convergence.py": {
-    "mtime": 1783318203.3709867,
+    "mtime": 1783376926.2608485,
     "ast_hash": "8743d94fdee0de469fe66e426bfbd718",
     "semantic_hash": "8743d94fdee0de469fe66e426bfbd718"
   },
   "tests/utils/test_model_selection.py": {
-    "mtime": 1783318203.3719869,
+    "mtime": 1783376926.2608485,
     "ast_hash": "d923b02b1781f02937910ab0d137d9fc",
     "semantic_hash": "d923b02b1781f02937910ab0d137d9fc"
   },
   "tests/utils/test_nlsq_optimization.py": {
-    "mtime": 1783318203.3719869,
+    "mtime": 1783376926.2608485,
     "ast_hash": "05f1b4585e787d239b998efa61f6b9f0",
     "semantic_hash": ""
   },
   "tests/utils/test_optimization.py": {
-    "mtime": 1783318203.3719869,
+    "mtime": 1783376926.2608485,
     "ast_hash": "53b19bbda23ae71b0dbb6d8b376db9fe",
     "semantic_hash": ""
   },
   "tests/utils/test_physics_checks.py": {
-    "mtime": 1783318203.3719869,
+    "mtime": 1783376926.2608485,
     "ast_hash": "e7d4b689c1c6af58cf4dd0143c7d7360",
     "semantic_hash": "e7d4b689c1c6af58cf4dd0143c7d7360"
   },
   "tests/utils/test_placeholder_model_guard.py": {
-    "mtime": 1783318203.3719869,
+    "mtime": 1783376926.2608485,
     "ast_hash": "012c9cce88c35e835b51a6c84b425f10",
     "semantic_hash": "012c9cce88c35e835b51a6c84b425f10"
   },
   "tests/utils/test_prony.py": {
-    "mtime": 1783318203.3719869,
+    "mtime": 1783376926.2608485,
     "ast_hash": "87350a83a8020a0ecfe74316b3442d07",
     "semantic_hash": "87350a83a8020a0ecfe74316b3442d07"
   },
   "tests/utils/test_protocol_preprocessing.py": {
-    "mtime": 1783318203.3719869,
+    "mtime": 1783376926.2608485,
     "ast_hash": "ff2eee93ed03163fd7f946bd2657d1d6",
     "semantic_hash": "ff2eee93ed03163fd7f946bd2657d1d6"
   },
   "tests/utils/test_sgr_kernels.py": {
-    "mtime": 1783318203.3719869,
+    "mtime": 1783376926.2608485,
     "ast_hash": "5fdb82ad925c4a6dfe858f5008765905",
     "semantic_hash": ""
   },
   "tests/utils/test_sgr_monte_carlo.py": {
-    "mtime": 1783318203.3719869,
+    "mtime": 1783376926.2608485,
     "ast_hash": "3a77f52a7ff5a4d8f72f13c6580cc53e",
     "semantic_hash": "3a77f52a7ff5a4d8f72f13c6580cc53e"
   },
   "tests/utils/test_sgr_population_balance.py": {
-    "mtime": 1783318203.3719869,
+    "mtime": 1783376926.2608485,
     "ast_hash": "47c4711938ae275dad97a0cb939436e3",
     "semantic_hash": "47c4711938ae275dad97a0cb939436e3"
   },
   "tests/utils/test_spp_kernels.py": {
-    "mtime": 1783318203.3719869,
+    "mtime": 1783376926.2608485,
     "ast_hash": "c1c278eae5721cd05a4bc976146684e6",
     "semantic_hash": "c1c278eae5721cd05a4bc976146684e6"
   },
   "tests/utils/test_structure_factor.py": {
-    "mtime": 1783318203.3719869,
+    "mtime": 1783376926.2608485,
     "ast_hash": "57001f5057132ff05bad49b336f98128",
     "semantic_hash": "57001f5057132ff05bad49b336f98128"
   },
   "tests/utils/test_uncertainty.py": {
-    "mtime": 1783318203.3719869,
+    "mtime": 1783376926.2618484,
     "ast_hash": "8dc0bfab825f012db973b4503dda1261",
     "semantic_hash": ""
   },
   "tests/utils/test_volterra_creep.py": {
-    "mtime": 1783318203.3719869,
+    "mtime": 1783376926.2618484,
     "ast_hash": "e49ccbc27841b2da85d6a329dbf13233",
     "semantic_hash": "e49ccbc27841b2da85d6a329dbf13233"
   },
   "tests/validation/test_bayesian_ansys_apdl.py": {
-    "mtime": 1783318203.3719869,
+    "mtime": 1783376926.2618484,
     "ast_hash": "9211705daa23de14e64fee48c305ea3f",
     "semantic_hash": ""
   },
   "tests/validation/test_bayesian_mode_aware.py": {
-    "mtime": 1783318203.3719869,
+    "mtime": 1783376926.2618484,
     "ast_hash": "028f624228b3884b95db7c9ad006d2d8",
     "semantic_hash": ""
   },
   "tests/validation/test_epm_nlsq_nuts_pipeline.py": {
-    "mtime": 1783318203.3719869,
+    "mtime": 1783376926.2618484,
     "ast_hash": "f9ab4064d02709661ed3e9e6491881d6",
     "semantic_hash": "f9ab4064d02709661ed3e9e6491881d6"
   },
   "tests/validation/test_fluidity_nlsq_nuts_pipeline.py": {
-    "mtime": 1783318203.3719869,
+    "mtime": 1783376926.2618484,
     "ast_hash": "da29e1783c11c287404839f9d2d3c7c5",
     "semantic_hash": ""
   },
   "tests/validation/test_migrated_notebooks.py": {
-    "mtime": 1783318203.3729868,
+    "mtime": 1783376926.2618484,
     "ast_hash": "6f039dc4dcf5cce51fb5a77aa7867ba8",
     "semantic_hash": ""
   },
   "tests/validation/test_protocol_validation.py": {
-    "mtime": 1783318203.3729868,
+    "mtime": 1783376926.2618484,
     "ast_hash": "89da38a297ed8dd6b03b68b64ca6c126",
     "semantic_hash": ""
   },
   "tests/validation/test_tensorial_epm_validation.py": {
-    "mtime": 1783318203.3729868,
+    "mtime": 1783376926.2618484,
     "ast_hash": "838a2f0cc3ec3c1aa6442de9c30771e7",
     "semantic_hash": ""
   },
   "tests/visualization/__init__.py": {
-    "mtime": 1783318203.3729868,
+    "mtime": 1783376926.2618484,
     "ast_hash": "aa06c670e647d99e9c78fc00842874f5",
     "semantic_hash": "aa06c670e647d99e9c78fc00842874f5"
   },
   "tests/visualization/test_epm_plots_tensorial.py": {
-    "mtime": 1783318203.3729868,
+    "mtime": 1783376926.2618484,
     "ast_hash": "197b731d8942c6baedfbe1c396e294e4",
     "semantic_hash": "197b731d8942c6baedfbe1c396e294e4"
   },
   "tests/visualization/test_fit_plotter.py": {
-    "mtime": 1783318203.3729868,
+    "mtime": 1783376926.2618484,
     "ast_hash": "d5e22b89a92f38a1122a88a32db10f9b",
     "semantic_hash": "d5e22b89a92f38a1122a88a32db10f9b"
   },
   "tests/visualization/test_plotter.py": {
-    "mtime": 1783318203.3729868,
+    "mtime": 1783376926.2618484,
     "ast_hash": "6331ef0f63da5341dbdda3b41ae079e7",
     "semantic_hash": "6331ef0f63da5341dbdda3b41ae079e7"
   },
   "tests/visualization/test_spp_plots.py": {
-    "mtime": 1783318203.3729868,
+    "mtime": 1783376926.2628486,
     "ast_hash": "10820266679f72abc474979fa25fbc65",
     "semantic_hash": "10820266679f72abc474979fa25fbc65"
   },
   "tests/visualization/test_templates.py": {
-    "mtime": 1783318203.3729868,
+    "mtime": 1783376926.2628486,
     "ast_hash": "d0e204a0c636d16b1e82cc60fc1a0ae5",
     "semantic_hash": "d0e204a0c636d16b1e82cc60fc1a0ae5"
   },
   "tests/visualization/test_transform_plotter.py": {
-    "mtime": 1783318203.3729868,
+    "mtime": 1783376926.2628486,
     "ast_hash": "ebf0d57effa4268535e9d1f1ffc76897",
     "semantic_hash": ""
   },
   "docs/README.md": {
-    "mtime": 1783318201.7190154,
+    "mtime": 1783376924.598853,
     "ast_hash": "669b288369ff9bf2e6c814f7b6b3d419",
     "semantic_hash": "669b288369ff9bf2e6c814f7b6b3d419"
   },
   "docs/STRUCTURE.md": {
-    "mtime": 1783318201.7200153,
+    "mtime": 1783376924.598853,
     "ast_hash": "cdf37bc4afa511a6a3cb09ef7c201d71",
     "semantic_hash": "cdf37bc4afa511a6a3cb09ef7c201d71"
   },
   "docs/architecture-overview.md": {
-    "mtime": 1783318201.7200153,
+    "mtime": 1783376924.598853,
     "ast_hash": "0b50c98e1dfe269f01a94f5b16a70aae",
     "semantic_hash": "0b50c98e1dfe269f01a94f5b16a70aae"
   },
   "docs/architecture-review-2026-04-06.md": {
-    "mtime": 1783318201.7200153,
+    "mtime": 1783376924.598853,
     "ast_hash": "69a47fe984777bc2221d9d6a1caeed09",
     "semantic_hash": "69a47fe984777bc2221d9d6a1caeed09"
   },
   "docs/examples/README.md": {
-    "mtime": 1783318201.7200153,
+    "mtime": 1783376924.598853,
     "ast_hash": "3153b2e14fa00a94ac0a8698b00c01b9",
     "semantic_hash": "3153b2e14fa00a94ac0a8698b00c01b9"
   },
   "docs/internal/spp_parity_reference.md": {
-    "mtime": 1783318201.7200153,
+    "mtime": 1783376924.598853,
     "ast_hash": "3138c395d0303901a49f3083aea01812",
     "semantic_hash": "3138c395d0303901a49f3083aea01812"
   },
   "docs/internal/spp_parity_status.md": {
-    "mtime": 1783318201.7200153,
+    "mtime": 1783376924.598853,
     "ast_hash": "9eb34d4e8fd3c3aa1b7b5eda94e28408",
     "semantic_hash": "9eb34d4e8fd3c3aa1b7b5eda94e28408"
   },
   "docs/model-test-mode-compatibility.md": {
-    "mtime": 1783318201.7200153,
+    "mtime": 1783376924.599853,
     "ast_hash": "d77ac1c7095714e5653b3cafc9d39137",
     "semantic_hash": "d77ac1c7095714e5653b3cafc9d39137"
   },
   "docs/source/_guides/model_documentation_style.rst": {
-    "mtime": 1783318201.7200153,
+    "mtime": 1783376924.599853,
     "ast_hash": "eb82cd3889389ff38cab6ffcb725c9c8",
     "semantic_hash": "eb82cd3889389ff38cab6ffcb725c9c8"
   },
   "docs/source/_includes/bayesian_workflow.rst": {
-    "mtime": 1783318201.7200153,
+    "mtime": 1783376924.599853,
     "ast_hash": "03f6d52d2691e4db7d54237c45fa5554",
     "semantic_hash": "03f6d52d2691e4db7d54237c45fa5554"
   },
   "docs/source/_includes/fractional_seealso.rst": {
-    "mtime": 1783318201.7200153,
+    "mtime": 1783376924.599853,
     "ast_hash": "ceadc70c2dffbe307c10df600d09ac87",
     "semantic_hash": "ceadc70c2dffbe307c10df600d09ac87"
   },
   "docs/source/_includes/glass_transition_physics.rst": {
-    "mtime": 1783318201.7210152,
+    "mtime": 1783376924.599853,
     "ast_hash": "fb9d3202eeaff74d98b0311bcfdc771d",
     "semantic_hash": "fb9d3202eeaff74d98b0311bcfdc771d"
   },
   "docs/source/_includes/thixotropy_foundations.rst": {
-    "mtime": 1783318201.7210152,
+    "mtime": 1783376924.599853,
     "ast_hash": "8ac3eec0246f24cc0aeec69c82378e10",
     "semantic_hash": "8ac3eec0246f24cc0aeec69c82378e10"
   },
   "docs/source/_includes/transient_network_foundations.rst": {
-    "mtime": 1783318201.7210152,
+    "mtime": 1783376924.599853,
     "ast_hash": "cb178fc969a37229c522709f3458b70c",
     "semantic_hash": "cb178fc969a37229c522709f3458b70c"
   },
   "docs/source/_templates/model_handbook_template.rst": {
-    "mtime": 1783318201.7210152,
+    "mtime": 1783376924.600853,
     "ast_hash": "682b36eb28ddedea9dfa8f5b71ff9773",
     "semantic_hash": "682b36eb28ddedea9dfa8f5b71ff9773"
   },
   "docs/source/api/core.rst": {
-    "mtime": 1783318201.7210152,
+    "mtime": 1783376924.600853,
     "ast_hash": "0d0fa5fe40aafd04bc6f037a70e20bbd",
     "semantic_hash": "0d0fa5fe40aafd04bc6f037a70e20bbd"
   },
   "docs/source/api/io.rst": {
-    "mtime": 1783318201.7210152,
+    "mtime": 1783376924.600853,
     "ast_hash": "f58b6c20239f3837b04bedfabaac05cc",
     "semantic_hash": "f58b6c20239f3837b04bedfabaac05cc"
   },
   "docs/source/api/logging.rst": {
-    "mtime": 1783318201.7210152,
+    "mtime": 1783376924.600853,
     "ast_hash": "9cee2768fc3571127965125f2e38e687",
     "semantic_hash": "9cee2768fc3571127965125f2e38e687"
   },
   "docs/source/api/models.rst": {
-    "mtime": 1783318201.7210152,
+    "mtime": 1783376924.600853,
     "ast_hash": "619d0cd1dc712bfb72c6f368e9b33f96",
     "semantic_hash": "619d0cd1dc712bfb72c6f368e9b33f96"
   },
   "docs/source/api/pipeline.rst": {
-    "mtime": 1783318201.7220154,
+    "mtime": 1783376924.6018531,
     "ast_hash": "dc44219938f14d1357587ce17664f8ff",
     "semantic_hash": "dc44219938f14d1357587ce17664f8ff"
   },
   "docs/source/api/spp_models.rst": {
-    "mtime": 1783318201.7220154,
+    "mtime": 1783376924.6018531,
     "ast_hash": "de82c204ce0eee754d4d25507a6bbe0d",
     "semantic_hash": "de82c204ce0eee754d4d25507a6bbe0d"
   },
   "docs/source/api/transforms.rst": {
-    "mtime": 1783318201.7220154,
+    "mtime": 1783376924.6018531,
     "ast_hash": "fd63c8e990f0cd11eb1d417d8b08463b",
     "semantic_hash": "fd63c8e990f0cd11eb1d417d8b08463b"
   },
   "docs/source/api/utils.rst": {
-    "mtime": 1783318201.7220154,
+    "mtime": 1783376924.6018531,
     "ast_hash": "5b21c3d1870098612b5e4d46396559d3",
     "semantic_hash": "5b21c3d1870098612b5e4d46396559d3"
   },
   "docs/source/api/visualization.rst": {
-    "mtime": 1783318201.7220154,
+    "mtime": 1783376924.6018531,
     "ast_hash": "9f6bfdc43f8c3547903d6d197dd777a2",
     "semantic_hash": "9f6bfdc43f8c3547903d6d197dd777a2"
   },
   "docs/source/api_reference.rst": {
-    "mtime": 1783318201.7220154,
+    "mtime": 1783376924.6018531,
     "ast_hash": "8bbd565e7ed32225b80a66b04c74daf4",
     "semantic_hash": "8bbd565e7ed32225b80a66b04c74daf4"
   },
   "docs/source/architecture/fitting_transforms_prompt.md": {
-    "mtime": 1783318201.7220154,
+    "mtime": 1783376924.602853,
     "ast_hash": "efa9d3fd715e6718ee1dacba67500f49",
     "semantic_hash": "efa9d3fd715e6718ee1dacba67500f49"
   },
   "docs/source/architecture/io_architecture.rst": {
-    "mtime": 1783318201.7230153,
+    "mtime": 1783376924.602853,
     "ast_hash": "f2877f07b2ab69832f1c9ba6804bd262",
     "semantic_hash": "f2877f07b2ab69832f1c9ba6804bd262"
   },
   "docs/source/developer/architecture.rst": {
-    "mtime": 1783318201.7230153,
+    "mtime": 1783376924.602853,
     "ast_hash": "cfd7e6c1f94ebc1f64a1b7ea8fa413c0",
     "semantic_hash": "cfd7e6c1f94ebc1f64a1b7ea8fa413c0"
   },
   "docs/source/developer/contributing.rst": {
-    "mtime": 1783318201.7230153,
+    "mtime": 1783376924.602853,
     "ast_hash": "d75ab47ae2285961f1ff1190722184a5",
     "semantic_hash": "d75ab47ae2285961f1ff1190722184a5"
   },
   "docs/source/development_status.rst": {
-    "mtime": 1783318201.7230153,
+    "mtime": 1783376924.602853,
     "ast_hash": "577019bd08b6020fd41c66b0f2bba1fc",
     "semantic_hash": "577019bd08b6020fd41c66b0f2bba1fc"
   },
   "docs/source/examples/index.rst": {
-    "mtime": 1783318201.7230153,
+    "mtime": 1783376924.603853,
     "ast_hash": "717def7605440ccae20968ad5e23c9c3",
     "semantic_hash": "717def7605440ccae20968ad5e23c9c3"
   },
   "docs/source/index.rst": {
-    "mtime": 1783318201.7230153,
+    "mtime": 1783376924.603853,
     "ast_hash": "8f4dd2abd5bead91f483eb28053e042d",
     "semantic_hash": "8f4dd2abd5bead91f483eb28053e042d"
   },
   "docs/source/installation.rst": {
-    "mtime": 1783318201.7240152,
+    "mtime": 1783376924.603853,
     "ast_hash": "bc5a87ac391fb98d13d436c965b356d6",
     "semantic_hash": "bc5a87ac391fb98d13d436c965b356d6"
   },
   "docs/source/models/classical/index.rst": {
-    "mtime": 1783318201.7240152,
+    "mtime": 1783376924.603853,
     "ast_hash": "1c85d586ec3f0247132b9cc5fe1fe03c",
     "semantic_hash": "1c85d586ec3f0247132b9cc5fe1fe03c"
   },
   "docs/source/models/classical/maxwell.rst": {
-    "mtime": 1783318201.7240152,
+    "mtime": 1783376924.603853,
     "ast_hash": "ed4c1105fef982bbc44f8c1c2566690e",
     "semantic_hash": "ed4c1105fef982bbc44f8c1c2566690e"
   },
   "docs/source/models/classical/springpot.rst": {
-    "mtime": 1783318201.7240152,
+    "mtime": 1783376924.6048532,
     "ast_hash": "05f209f66f97467b63df207ca94177fe",
     "semantic_hash": "05f209f66f97467b63df207ca94177fe"
   },
   "docs/source/models/classical/zener.rst": {
-    "mtime": 1783318201.7250152,
+    "mtime": 1783376924.6048532,
     "ast_hash": "333d9a6bdcc2782bf822dfc4b593df44",
     "semantic_hash": "333d9a6bdcc2782bf822dfc4b593df44"
   },
   "docs/source/models/dmt/dmt.rst": {
-    "mtime": 1783318201.7250152,
+    "mtime": 1783376924.6048532,
     "ast_hash": "104fdfc50512651ce9b9cd6bdbd1e16c",
     "semantic_hash": "104fdfc50512651ce9b9cd6bdbd1e16c"
   },
   "docs/source/models/dmt/index.rst": {
-    "mtime": 1783318201.7250152,
+    "mtime": 1783376924.6048532,
     "ast_hash": "e217268bc086ab02cc932f745c3612b8",
     "semantic_hash": "e217268bc086ab02cc932f745c3612b8"
   },
   "docs/source/models/epm/index.rst": {
-    "mtime": 1783318201.7250152,
+    "mtime": 1783376924.6048532,
     "ast_hash": "84915bf9466ffd18bf7780737e291262",
     "semantic_hash": "84915bf9466ffd18bf7780737e291262"
   },
   "docs/source/models/epm/lattice_epm.rst": {
-    "mtime": 1783318201.726015,
+    "mtime": 1783376924.605853,
     "ast_hash": "346f1c6bcbbf86fe70fd03fd9da9fbb9",
     "semantic_hash": "346f1c6bcbbf86fe70fd03fd9da9fbb9"
   },
   "docs/source/models/epm/tensorial_epm.rst": {
-    "mtime": 1783318201.726015,
+    "mtime": 1783376924.605853,
     "ast_hash": "c5671aa2d73ee09f1916aa825b41b122",
     "semantic_hash": "c5671aa2d73ee09f1916aa825b41b122"
   },
   "docs/source/models/fikh/fikh.rst": {
-    "mtime": 1783318201.726015,
+    "mtime": 1783376924.605853,
     "ast_hash": "1bac3cd0540e73859580a5f5cabd9829",
     "semantic_hash": "1bac3cd0540e73859580a5f5cabd9829"
   },
   "docs/source/models/fikh/fmlikh.rst": {
-    "mtime": 1783318201.726015,
+    "mtime": 1783376924.605853,
     "ast_hash": "fa1f0bc7dc66cb2d5fd0ade60444edb1",
     "semantic_hash": "fa1f0bc7dc66cb2d5fd0ade60444edb1"
   },
   "docs/source/models/fikh/index.rst": {
-    "mtime": 1783318201.726015,
+    "mtime": 1783376924.606853,
     "ast_hash": "3fc5d75858bf8da946c72f8740a96913",
     "semantic_hash": "3fc5d75858bf8da946c72f8740a96913"
   },
   "docs/source/models/flow/bingham.rst": {
-    "mtime": 1783318201.7270153,
+    "mtime": 1783376924.606853,
     "ast_hash": "b14bb3e01df2c81d5b76b4f947cd54f9",
     "semantic_hash": "b14bb3e01df2c81d5b76b4f947cd54f9"
   },
   "docs/source/models/flow/carreau.rst": {
-    "mtime": 1783318201.7270153,
+    "mtime": 1783376924.606853,
     "ast_hash": "b97976b9982a47a81c23039ad1779ae6",
     "semantic_hash": "b97976b9982a47a81c23039ad1779ae6"
   },
   "docs/source/models/flow/carreau_yasuda.rst": {
-    "mtime": 1783318201.7270153,
+    "mtime": 1783376924.606853,
     "ast_hash": "626620fdd62371617558943ac926bcd1",
     "semantic_hash": "626620fdd62371617558943ac926bcd1"
   },
   "docs/source/models/flow/cross.rst": {
-    "mtime": 1783318201.7270153,
+    "mtime": 1783376924.606853,
     "ast_hash": "f0d88d0937765135db8d7697b1ce506c",
     "semantic_hash": "f0d88d0937765135db8d7697b1ce506c"
   },
   "docs/source/models/flow/herschel_bulkley.rst": {
-    "mtime": 1783318201.7270153,
+    "mtime": 1783376924.606853,
     "ast_hash": "8e17deb3a959bd774583df2d1bac6afc",
     "semantic_hash": "8e17deb3a959bd774583df2d1bac6afc"
   },
   "docs/source/models/flow/index.rst": {
-    "mtime": 1783318201.7270153,
+    "mtime": 1783376924.606853,
     "ast_hash": "4ff2ac7e188c89346ff4639109e207e6",
     "semantic_hash": "4ff2ac7e188c89346ff4639109e207e6"
   },
   "docs/source/models/flow/power_law.rst": {
-    "mtime": 1783318201.7270153,
+    "mtime": 1783376924.607853,
     "ast_hash": "04aa7b0388d48a1b399e94dd0b2022f9",
     "semantic_hash": "04aa7b0388d48a1b399e94dd0b2022f9"
   },
   "docs/source/models/fluidity/fluidity_local.rst": {
-    "mtime": 1783318201.7280152,
+    "mtime": 1783376924.607853,
     "ast_hash": "f2839b949c92052c90a60438e9c9d088",
     "semantic_hash": "f2839b949c92052c90a60438e9c9d088"
   },
   "docs/source/models/fluidity/fluidity_nonlocal.rst": {
-    "mtime": 1783318201.7280152,
+    "mtime": 1783376924.607853,
     "ast_hash": "b1cc11a9864057cadf8d57665ae38d4b",
     "semantic_hash": "b1cc11a9864057cadf8d57665ae38d4b"
   },
   "docs/source/models/fluidity/identifiability.rst": {
-    "mtime": 1783318201.7280152,
+    "mtime": 1783376924.607853,
     "ast_hash": "bdc29e06b9ed75fbf61f869b81d56372",
     "semantic_hash": "bdc29e06b9ed75fbf61f869b81d56372"
   },
   "docs/source/models/fluidity/index.rst": {
-    "mtime": 1783318201.7280152,
+    "mtime": 1783376924.607853,
     "ast_hash": "b59d15559dc955e464300c046a9a53a5",
     "semantic_hash": "b59d15559dc955e464300c046a9a53a5"
   },
   "docs/source/models/fluidity/saramito_evp.rst": {
-    "mtime": 1783318201.7280152,
+    "mtime": 1783376924.607853,
     "ast_hash": "0275bb972883576112f888ca5e55ccdd",
     "semantic_hash": "0275bb972883576112f888ca5e55ccdd"
   },
   "docs/source/models/fractional/fractional_burgers.rst": {
-    "mtime": 1783318201.7280152,
+    "mtime": 1783376924.607853,
     "ast_hash": "2dd9e5c7738476cf5881bdfbb3793d33",
     "semantic_hash": "2dd9e5c7738476cf5881bdfbb3793d33"
   },
   "docs/source/models/fractional/fractional_jeffreys.rst": {
-    "mtime": 1783318201.729015,
+    "mtime": 1783376924.608853,
     "ast_hash": "b5b73c45bcb814b92b67075bb0c1351a",
     "semantic_hash": "b5b73c45bcb814b92b67075bb0c1351a"
   },
   "docs/source/models/fractional/fractional_kelvin_voigt.rst": {
-    "mtime": 1783318201.729015,
+    "mtime": 1783376924.608853,
     "ast_hash": "ae169d4741f7f553a4a8861df9c7acfc",
     "semantic_hash": "ae169d4741f7f553a4a8861df9c7acfc"
   },
   "docs/source/models/fractional/fractional_kv_zener.rst": {
-    "mtime": 1783318201.729015,
+    "mtime": 1783376924.608853,
     "ast_hash": "68b225c99238a7153a9ee0537a1e0b55",
     "semantic_hash": "68b225c99238a7153a9ee0537a1e0b55"
   },
   "docs/source/models/fractional/fractional_maxwell_gel.rst": {
-    "mtime": 1783318201.729015,
+    "mtime": 1783376924.608853,
     "ast_hash": "342e2f38f515ad360feb1a1b2e35d2f6",
     "semantic_hash": "342e2f38f515ad360feb1a1b2e35d2f6"
   },
   "docs/source/models/fractional/fractional_maxwell_liquid.rst": {
-    "mtime": 1783318201.729015,
+    "mtime": 1783376924.608853,
     "ast_hash": "2927b79dea402cfc79124b21d0722970",
     "semantic_hash": "2927b79dea402cfc79124b21d0722970"
   },
   "docs/source/models/fractional/fractional_maxwell_model.rst": {
-    "mtime": 1783318201.729015,
+    "mtime": 1783376924.608853,
     "ast_hash": "58443a5cf3380a9c12e9a927583b4cc1",
     "semantic_hash": "58443a5cf3380a9c12e9a927583b4cc1"
   },
   "docs/source/models/fractional/fractional_poynting_thomson.rst": {
-    "mtime": 1783318201.729015,
+    "mtime": 1783376924.608853,
     "ast_hash": "8da29054f14d17c44a45d6c71248e4cb",
     "semantic_hash": "8da29054f14d17c44a45d6c71248e4cb"
   },
   "docs/source/models/fractional/fractional_zener_ll.rst": {
-    "mtime": 1783318201.729015,
+    "mtime": 1783376924.609853,
     "ast_hash": "96d86a64e1be32b46047313e7d94939b",
     "semantic_hash": "96d86a64e1be32b46047313e7d94939b"
   },
   "docs/source/models/fractional/fractional_zener_sl.rst": {
-    "mtime": 1783318201.730015,
+    "mtime": 1783376924.609853,
     "ast_hash": "9d18a43bf62ee4755e0c4cac817a8045",
     "semantic_hash": "9d18a43bf62ee4755e0c4cac817a8045"
   },
   "docs/source/models/fractional/fractional_zener_ss.rst": {
-    "mtime": 1783318201.730015,
+    "mtime": 1783376924.609853,
     "ast_hash": "4b074c11cdacaa5acfa35757fc68c3e7",
     "semantic_hash": "4b074c11cdacaa5acfa35757fc68c3e7"
   },
   "docs/source/models/fractional/index.rst": {
-    "mtime": 1783318201.730015,
+    "mtime": 1783376924.609853,
     "ast_hash": "19cb8c1fdd88975f83fdb6463ba179f9",
     "semantic_hash": "19cb8c1fdd88975f83fdb6463ba179f9"
   },
   "docs/source/models/giesekus/giesekus.rst": {
-    "mtime": 1783318201.730015,
+    "mtime": 1783376924.609853,
     "ast_hash": "6ca5d45ed901d252c753b9504b652366",
     "semantic_hash": "6ca5d45ed901d252c753b9504b652366"
   },
   "docs/source/models/giesekus/index.rst": {
-    "mtime": 1783318201.730015,
+    "mtime": 1783376924.609853,
     "ast_hash": "1f6b6a2528cce36fd3da325fbbffbe8e",
     "semantic_hash": "1f6b6a2528cce36fd3da325fbbffbe8e"
   },
   "docs/source/models/hl/hebraud_lequeux.rst": {
-    "mtime": 1783318201.730015,
+    "mtime": 1783376924.609853,
     "ast_hash": "7a49b78cafbf560aa98db7e2bf3ea94f",
     "semantic_hash": "7a49b78cafbf560aa98db7e2bf3ea94f"
   },
   "docs/source/models/hl/index.rst": {
-    "mtime": 1783318201.730015,
+    "mtime": 1783376924.610853,
     "ast_hash": "d6966138b6af1504514bcb4cf1e8db4b",
     "semantic_hash": "d6966138b6af1504514bcb4cf1e8db4b"
   },
   "docs/source/models/hvm/hvm.rst": {
-    "mtime": 1783318201.730015,
+    "mtime": 1783376924.610853,
     "ast_hash": "e8ea82033d6cf673afcd121f6f760ff4",
     "semantic_hash": "e8ea82033d6cf673afcd121f6f760ff4"
   },
   "docs/source/models/hvm/hvm_advanced.rst": {
-    "mtime": 1783318201.7310152,
+    "mtime": 1783376924.610853,
     "ast_hash": "d9b1896828f949ce8e2b5c2ab707a3ce",
     "semantic_hash": "d9b1896828f949ce8e2b5c2ab707a3ce"
   },
   "docs/source/models/hvm/hvm_knowledge.rst": {
-    "mtime": 1783318201.7310152,
+    "mtime": 1783376924.610853,
     "ast_hash": "4d62b501d665369d02efa71865fd8561",
     "semantic_hash": "4d62b501d665369d02efa71865fd8561"
   },
   "docs/source/models/hvm/hvm_protocols.rst": {
-    "mtime": 1783318201.7310152,
+    "mtime": 1783376924.610853,
     "ast_hash": "a64c7ab5906dbdc80a1f371895a199f7",
     "semantic_hash": "a64c7ab5906dbdc80a1f371895a199f7"
   },
   "docs/source/models/hvm/index.rst": {
-    "mtime": 1783318201.7310152,
+    "mtime": 1783376924.610853,
     "ast_hash": "4ff596880fd885b529b9a983a9e7e106",
     "semantic_hash": "4ff596880fd885b529b9a983a9e7e106"
   },
   "docs/source/models/hvnm/hvnm.rst": {
-    "mtime": 1783318201.7310152,
+    "mtime": 1783376924.610853,
     "ast_hash": "3c3a9619acb435559f95ac07bf55e870",
     "semantic_hash": "3c3a9619acb435559f95ac07bf55e870"
   },
   "docs/source/models/hvnm/hvnm_advanced.rst": {
-    "mtime": 1783318201.7310152,
+    "mtime": 1783376924.610853,
     "ast_hash": "fe08fbdc7ef08aa813699aa1457578dd",
     "semantic_hash": "fe08fbdc7ef08aa813699aa1457578dd"
   },
   "docs/source/models/hvnm/hvnm_knowledge.rst": {
-    "mtime": 1783318201.7310152,
+    "mtime": 1783376924.610853,
     "ast_hash": "37a97cf5b7ed88f786d9847460f3188f",
     "semantic_hash": "37a97cf5b7ed88f786d9847460f3188f"
   },
   "docs/source/models/hvnm/hvnm_protocols.rst": {
-    "mtime": 1783318201.7310152,
+    "mtime": 1783376924.610853,
     "ast_hash": "57e0800a624c63133112788ec3185b51",
     "semantic_hash": "57e0800a624c63133112788ec3185b51"
   },
   "docs/source/models/hvnm/index.rst": {
-    "mtime": 1783318201.7310152,
+    "mtime": 1783376924.610853,
     "ast_hash": "70aba7c0b175d03156f2a860eb4987d4",
     "semantic_hash": "70aba7c0b175d03156f2a860eb4987d4"
   },
   "docs/source/models/ikh/index.rst": {
-    "mtime": 1783318201.7310152,
+    "mtime": 1783376924.610853,
     "ast_hash": "d1d45fcac0a5791345b856163754febc",
     "semantic_hash": "d1d45fcac0a5791345b856163754febc"
   },
   "docs/source/models/ikh/mikh.rst": {
-    "mtime": 1783318201.7310152,
+    "mtime": 1783376924.612853,
     "ast_hash": "a7ef07cada34dd0d8c9387e59ab57686",
     "semantic_hash": "a7ef07cada34dd0d8c9387e59ab57686"
   },
   "docs/source/models/ikh/ml_ikh.rst": {
-    "mtime": 1783318201.7320151,
+    "mtime": 1783376924.612853,
     "ast_hash": "b6761077390c18d7cac3e0f792e130f1",
     "semantic_hash": "b6761077390c18d7cac3e0f792e130f1"
   },
   "docs/source/models/index.rst": {
-    "mtime": 1783318201.7320151,
+    "mtime": 1783376924.612853,
     "ast_hash": "7e4e7ac13ed7e918757d198f69651514",
     "semantic_hash": "7e4e7ac13ed7e918757d198f69651514"
   },
   "docs/source/models/itt_mct/index.rst": {
-    "mtime": 1783318201.7320151,
+    "mtime": 1783376924.612853,
     "ast_hash": "3b632a6fffaa8d63da0435ffd0ee77be",
     "semantic_hash": "3b632a6fffaa8d63da0435ffd0ee77be"
   },
   "docs/source/models/itt_mct/itt_mct_isotropic.rst": {
-    "mtime": 1783318201.7320151,
+    "mtime": 1783376924.612853,
     "ast_hash": "8cc84a218f691c972364fb7490a394d1",
     "semantic_hash": "8cc84a218f691c972364fb7490a394d1"
   },
   "docs/source/models/itt_mct/itt_mct_protocols.rst": {
-    "mtime": 1783318201.7320151,
+    "mtime": 1783376924.612853,
     "ast_hash": "59439b079498c6bb8058b6ee7ac25d64",
     "semantic_hash": "59439b079498c6bb8058b6ee7ac25d64"
   },
   "docs/source/models/itt_mct/itt_mct_schematic.rst": {
-    "mtime": 1783318201.7320151,
+    "mtime": 1783376924.612853,
     "ast_hash": "e938c4b2fe29798ab4798122d11f25b4",
     "semantic_hash": "e938c4b2fe29798ab4798122d11f25b4"
   },
   "docs/source/models/multi_mode/generalized_maxwell.rst": {
-    "mtime": 1783318201.7320151,
+    "mtime": 1783376924.613853,
     "ast_hash": "62d5faa8c7b57a80d6c37f826c20f2f2",
     "semantic_hash": "62d5faa8c7b57a80d6c37f826c20f2f2"
   },
   "docs/source/models/sgr/index.rst": {
-    "mtime": 1783318201.7320151,
+    "mtime": 1783376924.613853,
     "ast_hash": "4c157e0bcc591f6c52bf72c8bf6ea116",
     "semantic_hash": "4c157e0bcc591f6c52bf72c8bf6ea116"
   },
   "docs/source/models/sgr/sgr_conventional.rst": {
-    "mtime": 1783318201.733015,
+    "mtime": 1783376924.613853,
     "ast_hash": "a74e6bcb215ad648754b02ab6b8707bc",
     "semantic_hash": "a74e6bcb215ad648754b02ab6b8707bc"
   },
   "docs/source/models/sgr/sgr_generic.rst": {
-    "mtime": 1783318201.733015,
+    "mtime": 1783376924.613853,
     "ast_hash": "24f1d1e7b730ca234abffa4903923941",
     "semantic_hash": "24f1d1e7b730ca234abffa4903923941"
   },
   "docs/source/models/spp/index.rst": {
-    "mtime": 1783318201.733015,
+    "mtime": 1783376924.613853,
     "ast_hash": "096fe25a1a3efc514ae7759f146610be",
     "semantic_hash": "096fe25a1a3efc514ae7759f146610be"
   },
   "docs/source/models/spp/spp_decomposer.rst": {
-    "mtime": 1783318201.733015,
+    "mtime": 1783376924.614853,
     "ast_hash": "c4148e6a41ea4fa80510bd0181d6cfa4",
     "semantic_hash": "c4148e6a41ea4fa80510bd0181d6cfa4"
   },
   "docs/source/models/spp/spp_yield_stress.rst": {
-    "mtime": 1783318201.733015,
+    "mtime": 1783376924.614853,
     "ast_hash": "d01bf353a0a9e672f50122eeee998f49",
     "semantic_hash": "d01bf353a0a9e672f50122eeee998f49"
   },
   "docs/source/models/stz/index.rst": {
-    "mtime": 1783318201.733015,
+    "mtime": 1783376924.614853,
     "ast_hash": "de2fe0afe4b08a02e388bf573924163a",
     "semantic_hash": "de2fe0afe4b08a02e388bf573924163a"
   },
   "docs/source/models/stz/stz_conventional.rst": {
-    "mtime": 1783318201.734015,
+    "mtime": 1783376924.614853,
     "ast_hash": "3bd1054dc6073497582c88bade7d3021",
     "semantic_hash": "3bd1054dc6073497582c88bade7d3021"
   },
   "docs/source/models/summary.rst": {
-    "mtime": 1783318201.734015,
+    "mtime": 1783376924.615853,
     "ast_hash": "45d2a6743a250d4ab974a7fcce49b204",
     "semantic_hash": "45d2a6743a250d4ab974a7fcce49b204"
   },
   "docs/source/models/tnt/index.rst": {
-    "mtime": 1783318201.734015,
+    "mtime": 1783376924.615853,
     "ast_hash": "5faf8f88715f2d6fe459a157624c44d2",
     "semantic_hash": "5faf8f88715f2d6fe459a157624c44d2"
   },
   "docs/source/models/tnt/tnt_bell.rst": {
-    "mtime": 1783318201.734015,
+    "mtime": 1783376924.615853,
     "ast_hash": "54fe64c5533516d5a298c60b5034f985",
     "semantic_hash": "54fe64c5533516d5a298c60b5034f985"
   },
   "docs/source/models/tnt/tnt_cates.rst": {
-    "mtime": 1783318201.734015,
+    "mtime": 1783376924.615853,
     "ast_hash": "343b8d163cd331f9684e495217d21f1b",
     "semantic_hash": "343b8d163cd331f9684e495217d21f1b"
   },
   "docs/source/models/tnt/tnt_fene_p.rst": {
-    "mtime": 1783318201.734015,
+    "mtime": 1783376924.616853,
     "ast_hash": "b68f25f48b0a4619916d5babdd278043",
     "semantic_hash": "b68f25f48b0a4619916d5babdd278043"
   },
   "docs/source/models/tnt/tnt_knowledge_extraction.rst": {
-    "mtime": 1783318201.7350152,
+    "mtime": 1783376924.616853,
     "ast_hash": "abbaac575958f20df5e4b08cdd0dc2d9",
     "semantic_hash": "abbaac575958f20df5e4b08cdd0dc2d9"
   },
   "docs/source/models/tnt/tnt_loop_bridge.rst": {
-    "mtime": 1783318201.7350152,
+    "mtime": 1783376924.616853,
     "ast_hash": "736a32b857edfb0c9030ed773c8e4438",
     "semantic_hash": "736a32b857edfb0c9030ed773c8e4438"
   },
   "docs/source/models/tnt/tnt_multi_species.rst": {
-    "mtime": 1783318201.7350152,
+    "mtime": 1783376924.616853,
     "ast_hash": "8919404f4428cb7984e90c5166889658",
     "semantic_hash": "8919404f4428cb7984e90c5166889658"
   },
   "docs/source/models/tnt/tnt_non_affine.rst": {
-    "mtime": 1783318201.736015,
+    "mtime": 1783376924.616853,
     "ast_hash": "58fa55f3aa38c49043cd5479258069bf",
     "semantic_hash": "58fa55f3aa38c49043cd5479258069bf"
   },
   "docs/source/models/tnt/tnt_protocols.rst": {
-    "mtime": 1783318201.736015,
+    "mtime": 1783376924.616853,
     "ast_hash": "6e4ddff379ad446aa243ac36a664b773",
     "semantic_hash": "6e4ddff379ad446aa243ac36a664b773"
   },
   "docs/source/models/tnt/tnt_sticky_rouse.rst": {
-    "mtime": 1783318201.736015,
+    "mtime": 1783376924.616853,
     "ast_hash": "fecab540e9bd89e976011e2535562a68",
     "semantic_hash": "fecab540e9bd89e976011e2535562a68"
   },
   "docs/source/models/tnt/tnt_stretch_creation.rst": {
-    "mtime": 1783318201.736015,
+    "mtime": 1783376924.616853,
     "ast_hash": "b90eef8dc25ecad37129f00f2f898b7c",
     "semantic_hash": "b90eef8dc25ecad37129f00f2f898b7c"
   },
   "docs/source/models/tnt/tnt_tanaka_edwards.rst": {
-    "mtime": 1783318201.736015,
+    "mtime": 1783376924.618853,
     "ast_hash": "b1721716163882a6974feb9d376d3331",
     "semantic_hash": "b1721716163882a6974feb9d376d3331"
   },
   "docs/source/models/vlb/index.rst": {
-    "mtime": 1783318201.737015,
+    "mtime": 1783376924.618853,
     "ast_hash": "0a04fa37a3e699a78f6377d2b23ddbc0",
     "semantic_hash": "0a04fa37a3e699a78f6377d2b23ddbc0"
   },
   "docs/source/models/vlb/vlb.rst": {
-    "mtime": 1783318201.737015,
+    "mtime": 1783376924.618853,
     "ast_hash": "a85041aec8b55e6c752aa7190d066fab",
     "semantic_hash": "a85041aec8b55e6c752aa7190d066fab"
   },
   "docs/source/models/vlb/vlb_advanced.rst": {
-    "mtime": 1783318201.737015,
+    "mtime": 1783376924.618853,
     "ast_hash": "992f31f8b67e83ab02828ca1ddda2f2c",
     "semantic_hash": "992f31f8b67e83ab02828ca1ddda2f2c"
   },
   "docs/source/models/vlb/vlb_knowledge.rst": {
-    "mtime": 1783318201.737015,
+    "mtime": 1783376924.618853,
     "ast_hash": "adf4baa63fdc34febfafae55e9968f22",
     "semantic_hash": "adf4baa63fdc34febfafae55e9968f22"
   },
   "docs/source/models/vlb/vlb_nonlocal.rst": {
-    "mtime": 1783318201.737015,
+    "mtime": 1783376924.618853,
     "ast_hash": "8515b2ff72040a7d52ae6973489900e6",
     "semantic_hash": "8515b2ff72040a7d52ae6973489900e6"
   },
   "docs/source/models/vlb/vlb_protocols.rst": {
-    "mtime": 1783318201.737015,
+    "mtime": 1783376924.618853,
     "ast_hash": "1b1cfac319bf31516dcd881ece985b8b",
     "semantic_hash": "1b1cfac319bf31516dcd881ece985b8b"
   },
   "docs/source/models/vlb/vlb_variant.rst": {
-    "mtime": 1783318201.737015,
+    "mtime": 1783376924.618853,
     "ast_hash": "36bf27cafc5f9051ac668c7a1d05148d",
     "semantic_hash": "36bf27cafc5f9051ac668c7a1d05148d"
   },
   "docs/source/quickstart.rst": {
-    "mtime": 1783318201.737015,
+    "mtime": 1783376924.618853,
     "ast_hash": "92d7946968d79181f106384b8e531647",
     "semantic_hash": "92d7946968d79181f106384b8e531647"
   },
   "docs/source/transforms/cox_merz.rst": {
-    "mtime": 1783318201.737015,
+    "mtime": 1783376924.618853,
     "ast_hash": "66306ebd641a36db1c4958fb81d61dd3",
     "semantic_hash": "66306ebd641a36db1c4958fb81d61dd3"
   },
   "docs/source/transforms/fft.rst": {
-    "mtime": 1783318201.737015,
+    "mtime": 1783376924.618853,
     "ast_hash": "de5d3c95a656a5d84bf94b8d7559979c",
     "semantic_hash": "de5d3c95a656a5d84bf94b8d7559979c"
   },
   "docs/source/transforms/index.rst": {
-    "mtime": 1783318201.737015,
+    "mtime": 1783376924.619853,
     "ast_hash": "a34ee80159a33d2f1bf180536b0f4379",
     "semantic_hash": "a34ee80159a33d2f1bf180536b0f4379"
   },
   "docs/source/transforms/lve_envelope.rst": {
-    "mtime": 1783318201.737015,
+    "mtime": 1783376924.619853,
     "ast_hash": "f9bebcbfe2a3d56e5c6d6ca29b4bc4f7",
     "semantic_hash": "f9bebcbfe2a3d56e5c6d6ca29b4bc4f7"
   },
   "docs/source/transforms/mastercurve.rst": {
-    "mtime": 1783318201.737015,
+    "mtime": 1783376924.619853,
     "ast_hash": "fc67cca6f33313d3fc50a96467d24a9d",
     "semantic_hash": "fc67cca6f33313d3fc50a96467d24a9d"
   },
   "docs/source/transforms/mutation_number.rst": {
-    "mtime": 1783318201.738015,
+    "mtime": 1783376924.619853,
     "ast_hash": "0e8fdc73caf078216f9cea470784dd99",
     "semantic_hash": "0e8fdc73caf078216f9cea470784dd99"
   },
   "docs/source/transforms/owchirp.rst": {
-    "mtime": 1783318201.738015,
+    "mtime": 1783376924.619853,
     "ast_hash": "f86b73a8d611b96840969ef0b3f6aadf",
     "semantic_hash": "f86b73a8d611b96840969ef0b3f6aadf"
   },
   "docs/source/transforms/prony_conversion.rst": {
-    "mtime": 1783318201.738015,
+    "mtime": 1783376924.619853,
     "ast_hash": "c71605dacf513b0a564ecc64324abc4a",
     "semantic_hash": "c71605dacf513b0a564ecc64324abc4a"
   },
   "docs/source/transforms/smooth_derivative.rst": {
-    "mtime": 1783318201.738015,
+    "mtime": 1783376924.619853,
     "ast_hash": "c5838df13b1eb60b002923a1019edf4f",
     "semantic_hash": "c5838df13b1eb60b002923a1019edf4f"
   },
   "docs/source/transforms/spectrum_inversion.rst": {
-    "mtime": 1783318201.738015,
+    "mtime": 1783376924.619853,
     "ast_hash": "364beeade05378e456e3dc61ddc0cf99",
     "semantic_hash": "364beeade05378e456e3dc61ddc0cf99"
   },
   "docs/source/transforms/spp.rst": {
-    "mtime": 1783318201.738015,
+    "mtime": 1783376924.619853,
     "ast_hash": "a65cc569cc7e49c354dffbd1be7018ad",
     "semantic_hash": "a65cc569cc7e49c354dffbd1be7018ad"
   },
   "docs/source/transforms/srfs.rst": {
-    "mtime": 1783318201.738015,
+    "mtime": 1783376924.619853,
     "ast_hash": "d585bd13c7df2796e08ea960b3d7f24e",
     "semantic_hash": "d585bd13c7df2796e08ea960b3d7f24e"
   },
   "docs/source/transforms/summary.rst": {
-    "mtime": 1783318201.738015,
+    "mtime": 1783376924.620853,
     "ast_hash": "0d5bf474ece099a73ed5c14b394098af",
     "semantic_hash": "0d5bf474ece099a73ed5c14b394098af"
   },
   "docs/source/user_guide/01_fundamentals/index.rst": {
-    "mtime": 1783318201.738015,
+    "mtime": 1783376924.620853,
     "ast_hash": "b44b9ffd48153363e3a36fa658010fbc",
     "semantic_hash": "b44b9ffd48153363e3a36fa658010fbc"
   },
   "docs/source/user_guide/01_fundamentals/material_classification.rst": {
-    "mtime": 1783318201.738015,
+    "mtime": 1783376924.620853,
     "ast_hash": "8480a2a5dfbd0534102bd8cc8668ee83",
     "semantic_hash": "8480a2a5dfbd0534102bd8cc8668ee83"
   },
   "docs/source/user_guide/01_fundamentals/model_capabilities.rst": {
-    "mtime": 1783318201.738015,
+    "mtime": 1783376924.620853,
     "ast_hash": "8897e92b6a5b13d4cd3003f397d766c9",
     "semantic_hash": "8897e92b6a5b13d4cd3003f397d766c9"
   },
   "docs/source/user_guide/01_fundamentals/parameter_interpretation.rst": {
-    "mtime": 1783318201.7390149,
+    "mtime": 1783376924.620853,
     "ast_hash": "f2767275d273567256ab1abe6b1197ca",
     "semantic_hash": "f2767275d273567256ab1abe6b1197ca"
   },
   "docs/source/user_guide/01_fundamentals/test_modes.rst": {
-    "mtime": 1783318201.7390149,
+    "mtime": 1783376924.620853,
     "ast_hash": "913237a6ead02b7dee7f50fd0d17995e",
     "semantic_hash": "913237a6ead02b7dee7f50fd0d17995e"
   },
   "docs/source/user_guide/01_fundamentals/what_is_rheology.rst": {
-    "mtime": 1783318201.7390149,
+    "mtime": 1783376924.620853,
     "ast_hash": "3f532bb787d34974fe6926f78cd5b3e2",
     "semantic_hash": "3f532bb787d34974fe6926f78cd5b3e2"
   },
   "docs/source/user_guide/02_model_usage/fitting_strategies.rst": {
-    "mtime": 1783318201.7390149,
+    "mtime": 1783376924.620853,
     "ast_hash": "7c215c545201a5f3df3241c0ab8c454e",
     "semantic_hash": "7c215c545201a5f3df3241c0ab8c454e"
   },
   "docs/source/user_guide/02_model_usage/getting_started.rst": {
-    "mtime": 1783318201.7390149,
+    "mtime": 1783376924.620853,
     "ast_hash": "4ef28fecd44f8a0858589673db313275",
     "semantic_hash": "4ef28fecd44f8a0858589673db313275"
   },
   "docs/source/user_guide/02_model_usage/index.rst": {
-    "mtime": 1783318201.7390149,
+    "mtime": 1783376924.620853,
     "ast_hash": "a44f3bb994e42c7a398388eeec4cbc67",
     "semantic_hash": "a44f3bb994e42c7a398388eeec4cbc67"
   },
   "docs/source/user_guide/02_model_usage/model_families.rst": {
-    "mtime": 1783318201.7390149,
+    "mtime": 1783376924.620853,
     "ast_hash": "4e6ab66798998663d731bdfab268af49",
     "semantic_hash": "4e6ab66798998663d731bdfab268af49"
   },
   "docs/source/user_guide/02_model_usage/model_selection.rst": {
-    "mtime": 1783318201.7390149,
+    "mtime": 1783376924.620853,
     "ast_hash": "e42fe2971897dbbb2c4cc0ed67f89c38",
     "semantic_hash": "e42fe2971897dbbb2c4cc0ed67f89c38"
   },
   "docs/source/user_guide/03_advanced_topics/bayesian_inference.rst": {
-    "mtime": 1783318201.7390149,
+    "mtime": 1783376924.6218529,
     "ast_hash": "633e1b775812697f4b22185a310ba500",
     "semantic_hash": "633e1b775812697f4b22185a310ba500"
   },
   "docs/source/user_guide/03_advanced_topics/constitutive_ode_models.rst": {
-    "mtime": 1783318201.7390149,
+    "mtime": 1783376924.6218529,
     "ast_hash": "05c687f8df67a2f4f9dfbee155988217",
     "semantic_hash": "05c687f8df67a2f4f9dfbee155988217"
   },
   "docs/source/user_guide/03_advanced_topics/dense_suspensions_glasses.rst": {
-    "mtime": 1783318201.740015,
+    "mtime": 1783376924.6218529,
     "ast_hash": "d844c6724ffaac174ff79b10353c69a8",
     "semantic_hash": "d844c6724ffaac174ff79b10353c69a8"
   },
   "docs/source/user_guide/03_advanced_topics/fractional_viscoelasticity_reference.rst": {
-    "mtime": 1783318201.740015,
+    "mtime": 1783376924.6218529,
     "ast_hash": "03bfdd0988b6d583841c8313a6be0381",
     "semantic_hash": "03bfdd0988b6d583841c8313a6be0381"
   },
   "docs/source/user_guide/03_advanced_topics/index.rst": {
-    "mtime": 1783318201.740015,
+    "mtime": 1783376924.6218529,
     "ast_hash": "0aef63dcca25bdb9db852693e759e804",
     "semantic_hash": "0aef63dcca25bdb9db852693e759e804"
   },
   "docs/source/user_guide/03_advanced_topics/multi_technique_fitting.rst": {
-    "mtime": 1783318201.740015,
+    "mtime": 1783376924.6218529,
     "ast_hash": "32ce40185ac1fee455fd8e53143e92a7",
     "semantic_hash": "32ce40185ac1fee455fd8e53143e92a7"
   },
   "docs/source/user_guide/03_advanced_topics/polymer_network_models.rst": {
-    "mtime": 1783318201.740015,
+    "mtime": 1783376924.622853,
     "ast_hash": "6c14c6fc3232feb36dd3a72c5a64a5a0",
     "semantic_hash": "6c14c6fc3232feb36dd3a72c5a64a5a0"
   },
   "docs/source/user_guide/03_advanced_topics/sgr_analysis.rst": {
-    "mtime": 1783318201.740015,
+    "mtime": 1783376924.622853,
     "ast_hash": "cfddac396f145b9f00d0935b38f2c329",
     "semantic_hash": "cfddac396f145b9f00d0935b38f2c329"
   },
   "docs/source/user_guide/03_advanced_topics/spp_analysis.rst": {
-    "mtime": 1783318201.740015,
+    "mtime": 1783376924.622853,
     "ast_hash": "fa5f305212e19c176b1e644cf7c33163",
     "semantic_hash": "fa5f305212e19c176b1e644cf7c33163"
   },
   "docs/source/user_guide/03_advanced_topics/thixotropy_yielding.rst": {
-    "mtime": 1783318201.741015,
+    "mtime": 1783376924.622853,
     "ast_hash": "19761c9c4f9264b3fa374848c748defd",
     "semantic_hash": "19761c9c4f9264b3fa374848c748defd"
   },
   "docs/source/user_guide/03_advanced_topics/time_temperature_superposition.rst": {
-    "mtime": 1783318201.741015,
+    "mtime": 1783376924.622853,
     "ast_hash": "d729709fbdc91e4ee552e25ba9c62992",
     "semantic_hash": "d729709fbdc91e4ee552e25ba9c62992"
   },
   "docs/source/user_guide/03_advanced_topics/transforms_complete.rst": {
-    "mtime": 1783318201.741015,
+    "mtime": 1783376924.622853,
     "ast_hash": "6ba7c1f4bb3775938fc33de071bac5b8",
     "semantic_hash": "6ba7c1f4bb3775938fc33de071bac5b8"
   },
   "docs/source/user_guide/03_advanced_topics/vitrimer_models.rst": {
-    "mtime": 1783318201.741015,
+    "mtime": 1783376924.622853,
     "ast_hash": "5bfd092eee610cd5b2cbedab9f3ff341",
     "semantic_hash": "5bfd092eee610cd5b2cbedab9f3ff341"
   },
   "docs/source/user_guide/04_practical_guides/batch_processing.rst": {
-    "mtime": 1783318201.741015,
+    "mtime": 1783376924.622853,
     "ast_hash": "06948033ffe276129ea89a6fde66ac70",
     "semantic_hash": "06948033ffe276129ea89a6fde66ac70"
   },
   "docs/source/user_guide/04_practical_guides/data_formats.rst": {
-    "mtime": 1783318201.741015,
+    "mtime": 1783376924.622853,
     "ast_hash": "31ade4e43a16d6d6bd1312cfd3fddecc",
     "semantic_hash": "31ade4e43a16d6d6bd1312cfd3fddecc"
   },
   "docs/source/user_guide/04_practical_guides/data_io.rst": {
-    "mtime": 1783318201.741015,
+    "mtime": 1783376924.622853,
     "ast_hash": "9c10ffbfbea93c69f56eae8ef6a7eed4",
     "semantic_hash": "9c10ffbfbea93c69f56eae8ef6a7eed4"
   },
   "docs/source/user_guide/04_practical_guides/index.rst": {
-    "mtime": 1783318201.741015,
+    "mtime": 1783376924.622853,
     "ast_hash": "9e8002e1c0936df5268e874c4c013343",
     "semantic_hash": "9e8002e1c0936df5268e874c4c013343"
   },
   "docs/source/user_guide/04_practical_guides/model_inventory.rst": {
-    "mtime": 1783318201.741015,
+    "mtime": 1783376924.622853,
     "ast_hash": "030cc3510f6f1221932de04e26f08ffd",
     "semantic_hash": "030cc3510f6f1221932de04e26f08ffd"
   },
   "docs/source/user_guide/04_practical_guides/modular_api.rst": {
-    "mtime": 1783318201.741015,
+    "mtime": 1783376924.622853,
     "ast_hash": "118ea9457466f6e5b39fde81a08c71fe",
     "semantic_hash": "118ea9457466f6e5b39fde81a08c71fe"
   },
   "docs/source/user_guide/04_practical_guides/pipeline_api.rst": {
-    "mtime": 1783318201.742015,
+    "mtime": 1783376924.622853,
     "ast_hash": "02aa01aa7fac3f45b49c1b5f6a9d6ac8",
     "semantic_hash": "02aa01aa7fac3f45b49c1b5f6a9d6ac8"
   },
   "docs/source/user_guide/04_practical_guides/trios_format.rst": {
-    "mtime": 1783318201.742015,
+    "mtime": 1783376924.622853,
     "ast_hash": "4585f825252885872ba2060278edd160",
     "semantic_hash": "4585f825252885872ba2060278edd160"
   },
   "docs/source/user_guide/04_practical_guides/visualization.rst": {
-    "mtime": 1783318201.742015,
+    "mtime": 1783376924.622853,
     "ast_hash": "dc035ab7bbf877dcbbd65d770709e711",
     "semantic_hash": "dc035ab7bbf877dcbbd65d770709e711"
   },
   "docs/source/user_guide/05_appendices/experimental_design.rst": {
-    "mtime": 1783318201.742015,
+    "mtime": 1783376924.622853,
     "ast_hash": "74827f7c5f9ca822eeb4a578d9cc4cb4",
     "semantic_hash": "74827f7c5f9ca822eeb4a578d9cc4cb4"
   },
   "docs/source/user_guide/05_appendices/glossary.rst": {
-    "mtime": 1783318201.742015,
+    "mtime": 1783376924.622853,
     "ast_hash": "5ee4c1802d9f803430a1d1d3fce4f7cf",
     "semantic_hash": "5ee4c1802d9f803430a1d1d3fce4f7cf"
   },
   "docs/source/user_guide/05_appendices/index.rst": {
-    "mtime": 1783318201.742015,
+    "mtime": 1783376924.622853,
     "ast_hash": "919ae8af7a851787a7c2bab299a8956e",
     "semantic_hash": "919ae8af7a851787a7c2bab299a8956e"
   },
   "docs/source/user_guide/05_appendices/material_database.rst": {
-    "mtime": 1783318201.742015,
+    "mtime": 1783376924.622853,
     "ast_hash": "47b7c694824e877c1cc726481225d143",
     "semantic_hash": "47b7c694824e877c1cc726481225d143"
   },
   "docs/source/user_guide/05_appendices/troubleshooting.rst": {
-    "mtime": 1783318201.742015,
+    "mtime": 1783376924.622853,
     "ast_hash": "1f3fb1f2b9cb5ca1a817ebdba4da4275",
     "semantic_hash": "1f3fb1f2b9cb5ca1a817ebdba4da4275"
   },
   "docs/source/user_guide/06_gui/bayesian_inference.rst": {
-    "mtime": 1783318201.742015,
+    "mtime": 1783376924.622853,
     "ast_hash": "273f199cd4fc7b6affdbc847a509fcc1",
     "semantic_hash": "273f199cd4fc7b6affdbc847a509fcc1"
   },
   "docs/source/user_guide/06_gui/data_loading.rst": {
-    "mtime": 1783318201.742015,
+    "mtime": 1783376924.622853,
     "ast_hash": "f0af5fc22b78d3a348fab3fe6c33aadf",
     "semantic_hash": "f0af5fc22b78d3a348fab3fe6c33aadf"
   },
   "docs/source/user_guide/06_gui/diagnostics.rst": {
-    "mtime": 1783318201.742015,
+    "mtime": 1783376924.624853,
     "ast_hash": "275423b5d6cb00de18ba9e6861922718",
     "semantic_hash": "275423b5d6cb00de18ba9e6861922718"
   },
   "docs/source/user_guide/06_gui/exporting.rst": {
-    "mtime": 1783318201.742015,
+    "mtime": 1783376924.624853,
     "ast_hash": "737c937f4b983d6d0d35958bfaae10d8",
     "semantic_hash": "737c937f4b983d6d0d35958bfaae10d8"
   },
   "docs/source/user_guide/06_gui/getting_started.rst": {
-    "mtime": 1783318201.742015,
+    "mtime": 1783376924.624853,
     "ast_hash": "91a24b2a8f8f4ecbc8f371b6dcffce07",
     "semantic_hash": "91a24b2a8f8f4ecbc8f371b6dcffce07"
   },
   "docs/source/user_guide/06_gui/index.rst": {
-    "mtime": 1783318201.742015,
+    "mtime": 1783376924.624853,
     "ast_hash": "3ca90baf3e8ab26269079ba6d5a23b85",
     "semantic_hash": "3ca90baf3e8ab26269079ba6d5a23b85"
   },
   "docs/source/user_guide/06_gui/keyboard_shortcuts.rst": {
-    "mtime": 1783318201.742015,
+    "mtime": 1783376924.624853,
     "ast_hash": "43b75cd0ad82921c10e4dc4ea98fa697",
     "semantic_hash": "43b75cd0ad82921c10e4dc4ea98fa697"
   },
   "docs/source/user_guide/06_gui/menu_reference.rst": {
-    "mtime": 1783318201.742015,
+    "mtime": 1783376924.624853,
     "ast_hash": "0a85faa66e2e4164f1e2b384c9318299",
     "semantic_hash": "0a85faa66e2e4164f1e2b384c9318299"
   },
   "docs/source/user_guide/06_gui/model_fitting.rst": {
-    "mtime": 1783318201.742015,
+    "mtime": 1783376924.624853,
     "ast_hash": "61b0fe68949669c208a415501d238368",
     "semantic_hash": "61b0fe68949669c208a415501d238368"
   },
   "docs/source/user_guide/06_gui/transforms.rst": {
-    "mtime": 1783318201.742015,
+    "mtime": 1783376924.624853,
     "ast_hash": "e727baef0258514364d74f41f73d7c84",
     "semantic_hash": "e727baef0258514364d74f41f73d7c84"
   },
   "docs/source/user_guide/index.rst": {
-    "mtime": 1783318201.742015,
+    "mtime": 1783376924.624853,
     "ast_hash": "db2791f0eb2fd5870f9e48e5950f5817",
     "semantic_hash": "db2791f0eb2fd5870f9e48e5950f5817"
   },
   "docs/source/verification/index.rst": {
-    "mtime": 1783318201.742015,
+    "mtime": 1783376924.624853,
     "ast_hash": "6136c514d09c520f9c30f4b9652d4260",
     "semantic_hash": "6136c514d09c520f9c30f4b9652d4260"
   },
   "docs/tech-stack.md": {
-    "mtime": 1783318201.7430148,
+    "mtime": 1783376924.624853,
     "ast_hash": "13583e16696fe6e0222adbac1a2dc25d",
     "semantic_hash": "13583e16696fe6e0222adbac1a2dc25d"
   },
   "docs/verification/classical_lve_equations.md": {
-    "mtime": 1783318201.7430148,
+    "mtime": 1783376924.624853,
     "ast_hash": "6e73cb01fa15d417b9be5b8d75f538d8",
     "semantic_hash": "6e73cb01fa15d417b9be5b8d75f538d8"
   },
   "docs/verification/dmt_literature_verification.md": {
-    "mtime": 1783318201.7430148,
+    "mtime": 1783376924.624853,
     "ast_hash": "1c202f5bb387b3e79513fc2e71e5d049",
     "semantic_hash": "1c202f5bb387b3e79513fc2e71e5d049"
   },
   "docs/verification/epm_validation_report_2026-03-29.md": {
-    "mtime": 1783318201.7430148,
+    "mtime": 1783376924.624853,
     "ast_hash": "fa4f3076c310d6a766a8a114c2f90a6e",
     "semantic_hash": "fa4f3076c310d6a766a8a114c2f90a6e"
   },
   "docs/verification/fikh_validation_report_2026-03-29.md": {
-    "mtime": 1783318201.7430148,
+    "mtime": 1783376924.624853,
     "ast_hash": "0672eadc8e98c3a528c9fc37cae4f93f",
     "semantic_hash": "0672eadc8e98c3a528c9fc37cae4f93f"
   },
   "docs/verification/fluidity_saramito_equations.rst": {
-    "mtime": 1783318201.7430148,
+    "mtime": 1783376924.624853,
     "ast_hash": "0e285630538ea0724ad23c4df65f5242",
     "semantic_hash": "0e285630538ea0724ad23c4df65f5242"
   },
   "docs/verification/fractional_models_equation_verification.md": {
-    "mtime": 1783318201.7430148,
+    "mtime": 1783376924.624853,
     "ast_hash": "6833fe0d700f0b04a42f7e90e7ada236",
     "semantic_hash": "6833fe0d700f0b04a42f7e90e7ada236"
   },
   "docs/verification/giesekus_math_verification.md": {
-    "mtime": 1783318201.7430148,
+    "mtime": 1783376924.624853,
     "ast_hash": "7041fd530b579422552da2e3e3a5ca87",
     "semantic_hash": "7041fd530b579422552da2e3e3a5ca87"
   },
   "docs/verification/gmm_canonical_equations.rst": {
-    "mtime": 1783318201.7430148,
+    "mtime": 1783376924.624853,
     "ast_hash": "a059f7c9968c61410b643b2209b34b70",
     "semantic_hash": "a059f7c9968c61410b643b2209b34b70"
   },
   "docs/verification/hl_model_equations.md": {
-    "mtime": 1783318201.7430148,
+    "mtime": 1783376924.624853,
     "ast_hash": "f5414bce495ff794137c1f0d63765368",
     "semantic_hash": "f5414bce495ff794137c1f0d63765368"
   },
   "docs/verification/hvm_literature_review.md": {
-    "mtime": 1783318201.7430148,
+    "mtime": 1783376924.624853,
     "ast_hash": "26272a0b183e27e5ad2ce34f48fce1e9",
     "semantic_hash": "26272a0b183e27e5ad2ce34f48fce1e9"
   },
   "docs/verification/itt_mct_literature_equations.md": {
-    "mtime": 1783318201.7430148,
+    "mtime": 1783376924.624853,
     "ast_hash": "185b2ba8c18d817bf8ca8e8624428f26",
     "semantic_hash": "185b2ba8c18d817bf8ca8e8624428f26"
   },
   "docs/verification/saos_validity_transient_networks.md": {
-    "mtime": 1783318201.7430148,
+    "mtime": 1783376924.624853,
     "ast_hash": "055d7185d747e053703c281b360d89e0",
     "semantic_hash": "055d7185d747e053703c281b360d89e0"
   },
   "docs/verification/tnt_equations_verification.rst": {
-    "mtime": 1783318201.744015,
+    "mtime": 1783376924.624853,
     "ast_hash": "57fc911a253a27ccaf0f59c3e63d8541",
     "semantic_hash": "57fc911a253a27ccaf0f59c3e63d8541"
   },
   "docs/verification/vlb_equation_verification.md": {
-    "mtime": 1783318201.744015,
+    "mtime": 1783376924.624853,
     "ast_hash": "6f6ede0b327a0f4546ee96ee331d6428",
     "semantic_hash": "6f6ede0b327a0f4546ee96ee331d6428"
   },
   "rheojax/gui/README.md": {
-    "mtime": 1783318203.3149877,
+    "mtime": 1783376926.2048488,
     "ast_hash": "91eeec4ccf7f65030a00834695ea89ff",
     "semantic_hash": "91eeec4ccf7f65030a00834695ea89ff"
   },
   "rheojax/gui/STRUCTURE_VALIDATION.md": {
-    "mtime": 1783318203.3149877,
+    "mtime": 1783376926.2048488,
     "ast_hash": "d895a60322db8a1c00636e1f445e6f49",
     "semantic_hash": "d895a60322db8a1c00636e1f445e6f49"
   },
   "rheojax/gui/jobs/IMPLEMENTATION_SUMMARY.md": {
-    "mtime": 1783318203.3169878,
+    "mtime": 1783376926.2068486,
     "ast_hash": "1b40cf8877d5b657941cf71967976441",
     "semantic_hash": "1b40cf8877d5b657941cf71967976441"
   },
   "rheojax/gui/jobs/README.md": {
-    "mtime": 1783318203.3169878,
+    "mtime": 1783376926.2068486,
     "ast_hash": "460b96f9eccb64d10dcb42416cb49b3f",
     "semantic_hash": "460b96f9eccb64d10dcb42416cb49b3f"
   },
   "rheojax/gui/resources/styles/README.md": {
-    "mtime": 1783318203.3189876,
+    "mtime": 1783376926.2098486,
     "ast_hash": "07f6e9f680c4963bd546746e1c5d4dde",
     "semantic_hash": "07f6e9f680c4963bd546746e1c5d4dde"
   },
   "rheojax/gui/state/USAGE.md": {
-    "mtime": 1783318203.3209877,
+    "mtime": 1783376926.2108488,
     "ast_hash": "2e4df18825603cfc0465256316968cc5",
     "semantic_hash": "2e4df18825603cfc0465256316968cc5"
   },
   "scripts/notebook_execution_baseline.txt": {
-    "mtime": 1783318203.3449872,
+    "mtime": 1783376926.2348487,
     "ast_hash": "d87c3ac11356258ecbeb3e928573c944",
     "semantic_hash": "d87c3ac11356258ecbeb3e928573c944"
   },
   "tests/fixtures/BASELINE_REPORT.md": {
-    "mtime": 1783318203.3469872,
+    "mtime": 1783376926.2368486,
     "ast_hash": "13b9af261f76164f9d9c1152915bff34",
     "semantic_hash": "13b9af261f76164f9d9c1152915bff34"
   },
   "tests/fixtures/README.md": {
-    "mtime": 1783318203.3469872,
+    "mtime": 1783376926.2368486,
     "ast_hash": "262fc4e88b37a3107b35c7dafb799aa3",
     "semantic_hash": "262fc4e88b37a3107b35c7dafb799aa3"
   },
   "tests/fixtures/readers/space_delimited.txt": {
-    "mtime": 1783318203.3469872,
+    "mtime": 1783376926.2368486,
     "ast_hash": "9b63256afd37b3b01d84f320ca38c227",
     "semantic_hash": "9b63256afd37b3b01d84f320ca38c227"
   },
   "tests/fixtures/readers/tab_delimited.txt": {
-    "mtime": 1783318203.3469872,
+    "mtime": 1783376926.2368486,
     "ast_hash": "27f1360b13f5df35b9373b108e20c02d",
     "semantic_hash": "27f1360b13f5df35b9373b108e20c02d"
   },
   "tests/fixtures/trios/flow_ramp.txt": {
-    "mtime": 1783318203.3469872,
+    "mtime": 1783376926.2368486,
     "ast_hash": "9d083a938b6b7ce40f78624e74fcfb5e",
     "semantic_hash": "9d083a938b6b7ce40f78624e74fcfb5e"
   },
   "tests/fixtures/trios_synthetic_10mb.txt": {
-    "mtime": 1783318203.352987,
+    "mtime": 1783376926.2428486,
     "ast_hash": "0f63b5325bbe0d439f8b5d0c197da710",
     "semantic_hash": "0f63b5325bbe0d439f8b5d0c197da710"
   },
   "tests/fixtures/trios_synthetic_1mb.txt": {
-    "mtime": 1783318203.352987,
+    "mtime": 1783376926.2438486,
     "ast_hash": "8f6bc5fb7c7766647f38fc47d06b4f2b",
     "semantic_hash": "8f6bc5fb7c7766647f38fc47d06b4f2b"
   },
   "tests/fixtures/trios_synthetic_5mb.txt": {
-    "mtime": 1783318203.355987,
+    "mtime": 1783376926.2458487,
     "ast_hash": "da44f059bd2409948f4e232161db9fb1",
     "semantic_hash": "da44f059bd2409948f4e232161db9fb1"
   },
   "tests/gui/README.md": {
-    "mtime": 1783318203.355987,
+    "mtime": 1783376926.2458487,
     "ast_hash": "6d48774e82afe3e5202c5334e2891637",
     "semantic_hash": "6d48774e82afe3e5202c5334e2891637"
   },
   "tests/validation/README.md": {
-    "mtime": 1783318203.3719869,
+    "mtime": 1783376926.2618484,
     "ast_hash": "cc1fc31424361a6c65fb680e7063d5df",
     "semantic_hash": "cc1fc31424361a6c65fb680e7063d5df"
   },
   "docs/verification/ikh_literature_verification.md": {
-    "mtime": 1783318201.7430148,
+    "mtime": 1783376924.624853,
     "ast_hash": "d69e405f575a864106219e4f1ad92a31",
     "semantic_hash": "d69e405f575a864106219e4f1ad92a31"
   },
   "docs/verification/spp_equations_verification.md": {
-    "mtime": 1783318201.744015,
+    "mtime": 1783376924.624853,
     "ast_hash": "dae63d9cdebd5ba1b5195a0c78518b2d",
     "semantic_hash": "dae63d9cdebd5ba1b5195a0c78518b2d"
   },
   "docs/verification/vitrimer_nanocomposite_constitutive_models.md": {
-    "mtime": 1783318201.744015,
+    "mtime": 1783376924.624853,
     "ast_hash": "059302be0aac293f16ec4008aedd448f",
     "semantic_hash": "059302be0aac293f16ec4008aedd448f"
   },
   "rheojax/gui/resources/icons/bayesian.svg": {
-    "mtime": 1783318203.3189876,
+    "mtime": 1783376926.2098486,
     "ast_hash": "0d41553e705a3c45463796de9d266cc9",
     "semantic_hash": "0d41553e705a3c45463796de9d266cc9"
   },
   "rheojax/gui/resources/icons/check-white.svg": {
-    "mtime": 1783318203.3189876,
+    "mtime": 1783376926.2098486,
     "ast_hash": "556109a7b5c687a1b38fdf8729efdc7e",
     "semantic_hash": "556109a7b5c687a1b38fdf8729efdc7e"
   },
   "rheojax/gui/resources/icons/chevron-down.svg": {
-    "mtime": 1783318203.3189876,
+    "mtime": 1783376926.2098486,
     "ast_hash": "96c725274a7277d3b76cda99386cd2da",
     "semantic_hash": "96c725274a7277d3b76cda99386cd2da"
   },
   "rheojax/gui/resources/icons/chevron-right.svg": {
-    "mtime": 1783318203.3189876,
+    "mtime": 1783376926.2098486,
     "ast_hash": "446834b2a72ee8325bb46f114c3cd628",
     "semantic_hash": "446834b2a72ee8325bb46f114c3cd628"
   },
   "rheojax/gui/resources/icons/close.svg": {
-    "mtime": 1783318203.3189876,
+    "mtime": 1783376926.2098486,
     "ast_hash": "2e8b73f3da64e42019b99567e3e08d95",
     "semantic_hash": "2e8b73f3da64e42019b99567e3e08d95"
   },
   "rheojax/gui/resources/icons/export.svg": {
-    "mtime": 1783318203.3189876,
+    "mtime": 1783376926.2098486,
     "ast_hash": "34e9e34cfec6caae47c2af9d6ba82325",
     "semantic_hash": "34e9e34cfec6caae47c2af9d6ba82325"
   },
   "rheojax/gui/resources/icons/fit.svg": {
-    "mtime": 1783318203.3189876,
+    "mtime": 1783376926.2098486,
     "ast_hash": "2a665897191d039589a108e1f6e9546c",
     "semantic_hash": "2a665897191d039589a108e1f6e9546c"
   },
   "rheojax/gui/resources/icons/load.svg": {
-    "mtime": 1783318203.3189876,
+    "mtime": 1783376926.2098486,
     "ast_hash": "d02a33b11d630cb171541105001f29cb",
     "semantic_hash": "d02a33b11d630cb171541105001f29cb"
   },
   "rheojax/gui/resources/icons/rheojax.svg": {
-    "mtime": 1783318203.3189876,
+    "mtime": 1783376926.2098486,
     "ast_hash": "54f36f6f93c739bca3fac1e9eff3685a",
     "semantic_hash": "54f36f6f93c739bca3fac1e9eff3685a"
   },
   "rheojax/gui/resources/icons/window.svg": {
-    "mtime": 1783318203.3189876,
+    "mtime": 1783376926.2098486,
     "ast_hash": "4f75a7203de0312b7a9c56902a9bd127",
     "semantic_hash": "4f75a7203de0312b7a9c56902a9bd127"
   },
   "tests/gui/golden_images/arviz_canvas_empty.png": {
-    "mtime": 1783318203.356987,
+    "mtime": 1783376926.2468486,
     "ast_hash": "4f4c2c97492bc6d6bf2e21db6cb6fce1",
     "semantic_hash": "4f4c2c97492bc6d6bf2e21db6cb6fce1"
   },
   "tests/gui/golden_images/bayesian_page.png": {
-    "mtime": 1783318203.356987,
+    "mtime": 1783376926.2468486,
     "ast_hash": "77b70f3855c47529b7f2873e76fc3fb6",
     "semantic_hash": "77b70f3855c47529b7f2873e76fc3fb6"
   },
   "tests/gui/golden_images/export_page.png": {
-    "mtime": 1783318203.356987,
+    "mtime": 1783376926.2468486,
     "ast_hash": "77b70f3855c47529b7f2873e76fc3fb6",
     "semantic_hash": "77b70f3855c47529b7f2873e76fc3fb6"
   },
   "tests/gui/golden_images/fit_page_with_results.png": {
-    "mtime": 1783318203.356987,
+    "mtime": 1783376926.2468486,
     "ast_hash": "77b70f3855c47529b7f2873e76fc3fb6",
     "semantic_hash": "77b70f3855c47529b7f2873e76fc3fb6"
   },
   "tests/gui/golden_images/home_page_dark.png": {
-    "mtime": 1783318203.356987,
+    "mtime": 1783376926.2468486,
     "ast_hash": "77b70f3855c47529b7f2873e76fc3fb6",
     "semantic_hash": "77b70f3855c47529b7f2873e76fc3fb6"
   },
   "tests/gui/golden_images/home_page_light.png": {
-    "mtime": 1783318203.356987,
+    "mtime": 1783376926.2468486,
     "ast_hash": "77b70f3855c47529b7f2873e76fc3fb6",
     "semantic_hash": "77b70f3855c47529b7f2873e76fc3fb6"
   },
   "tests/gui/golden_images/multiview_panel0.png": {
-    "mtime": 1783318203.356987,
+    "mtime": 1783376926.2468486,
     "ast_hash": "ec2cd55a3452f077a14b942dca88b2f2",
     "semantic_hash": "ec2cd55a3452f077a14b942dca88b2f2"
   },
   "tests/gui/golden_images/plot_canvas_line.png": {
-    "mtime": 1783318203.356987,
+    "mtime": 1783376926.2468486,
     "ast_hash": "ccf0a654885abe1e698be3357c8020b8",
     "semantic_hash": "ccf0a654885abe1e698be3357c8020b8"
   },
   "tests/gui/golden_images/plot_canvas_loglog.png": {
-    "mtime": 1783318203.356987,
+    "mtime": 1783376926.2468486,
     "ast_hash": "8b015c1dc9d061c431c2685e52de1340",
     "semantic_hash": "8b015c1dc9d061c431c2685e52de1340"
   },
   "tests/gui/golden_images/plot_canvas_scatter.png": {
-    "mtime": 1783318203.356987,
+    "mtime": 1783376926.2468486,
     "ast_hash": "f1796a992f7d5cd9fe496799c8a919c8",
     "semantic_hash": "f1796a992f7d5cd9fe496799c8a919c8"
   },
   "tests/gui/golden_images/residuals_histogram.png": {
-    "mtime": 1783318203.356987,
+    "mtime": 1783376926.2478485,
     "ast_hash": "a8422f8ce53df230de8e453ca917bb85",
     "semantic_hash": "a8422f8ce53df230de8e453ca917bb85"
   },
   "tests/gui/golden_images/residuals_qq.png": {
-    "mtime": 1783318203.357987,
+    "mtime": 1783376926.2478485,
     "ast_hash": "f3e00022fcbb983a627f528670e9276e",
     "semantic_hash": "f3e00022fcbb983a627f528670e9276e"
   },
   "tests/gui/golden_images/residuals_vs_fitted.png": {
-    "mtime": 1783318203.357987,
+    "mtime": 1783376926.2478485,
     "ast_hash": "623cab1c65c132ef428dd8e91546f042",
     "semantic_hash": "623cab1c65c132ef428dd8e91546f042"
   },
   "tests/gui/golden_images/transform_page.png": {
-    "mtime": 1783318203.357987,
+    "mtime": 1783376926.2478485,
     "ast_hash": "77b70f3855c47529b7f2873e76fc3fb6",
     "semantic_hash": "77b70f3855c47529b7f2873e76fc3fb6"
   },
   "tests/gui/visual/golden_images/bayesian_page.png": {
-    "mtime": 1783318203.359987,
+    "mtime": 1783376926.2498486,
     "ast_hash": "b63218b51a014ec432e1413fc29b169c",
     "semantic_hash": "b63218b51a014ec432e1413fc29b169c"
   },
   "tests/gui/visual/golden_images/export_page.png": {
-    "mtime": 1783318203.359987,
+    "mtime": 1783376926.2498486,
     "ast_hash": "b63218b51a014ec432e1413fc29b169c",
     "semantic_hash": "b63218b51a014ec432e1413fc29b169c"
   },
   "tests/gui/visual/golden_images/fit_page_with_results.png": {
-    "mtime": 1783318203.359987,
+    "mtime": 1783376926.2498486,
     "ast_hash": "b63218b51a014ec432e1413fc29b169c",
     "semantic_hash": "b63218b51a014ec432e1413fc29b169c"
   },
   "tests/gui/visual/golden_images/fit_plot.png": {
-    "mtime": 1783318203.359987,
+    "mtime": 1783376926.2498486,
     "ast_hash": "81883221b4ecfe82dc31f4e2edc1f24a",
     "semantic_hash": "81883221b4ecfe82dc31f4e2edc1f24a"
   },
   "tests/gui/visual/golden_images/home_page_dark.png": {
-    "mtime": 1783318203.359987,
+    "mtime": 1783376926.2498486,
     "ast_hash": "b63218b51a014ec432e1413fc29b169c",
     "semantic_hash": "b63218b51a014ec432e1413fc29b169c"
   },
   "tests/gui/visual/golden_images/home_page_light.png": {
-    "mtime": 1783318203.359987,
+    "mtime": 1783376926.2498486,
     "ast_hash": "b63218b51a014ec432e1413fc29b169c",
     "semantic_hash": "b63218b51a014ec432e1413fc29b169c"
   },
   "tests/gui/visual/golden_images/transform_page.png": {
-    "mtime": 1783318203.359987,
+    "mtime": 1783376926.2498486,
     "ast_hash": "b63218b51a014ec432e1413fc29b169c",
     "semantic_hash": "b63218b51a014ec432e1413fc29b169c"
   },
   "tests/core/test_arviz_utils.py": {
-    "mtime": 1783318203.3459873,
+    "mtime": 1783376926.2358487,
     "ast_hash": "f98195a9ac67eaa5c09136df70442d0e",
     "semantic_hash": "f98195a9ac67eaa5c09136df70442d0e"
   },
   "tests/refactor/__init__.py": {
-    "mtime": 1783318203.3699868,
+    "mtime": 1783376926.2588487,
     "ast_hash": "d41d8cd98f00b204e9800998ecf8427e",
     "semantic_hash": "d41d8cd98f00b204e9800998ecf8427e"
   },
   "tests/refactor/test_dmta_removal.py": {
-    "mtime": 1783318203.3699868,
+    "mtime": 1783376926.2598486,
     "ast_hash": "d43517159dde667d402e9783fddbe5b0",
     "semantic_hash": ""
   },
   "tests/io/test_dmta_rejection.py": {
-    "mtime": 1783318203.362987,
+    "mtime": 1783376926.2518487,
     "ast_hash": "870e2aee05362a4e04c48045000e87bd",
     "semantic_hash": "870e2aee05362a4e04c48045000e87bd"
   },
   "tests/cli/test_dmta_cli.py": {
-    "mtime": 1783318203.3449872,
+    "mtime": 1783376926.2348487,
     "ast_hash": "5e21930f957e8d266164937f6122e341",
     "semantic_hash": ""
   },
   "tests/gui/test_dmta_gui.py": {
-    "mtime": 1783318203.357987,
+    "mtime": 1783376926.2478485,
     "ast_hash": "0bc84ae6ac3de35b506fce91a33a6e5b",
     "semantic_hash": "0bc84ae6ac3de35b506fce91a33a6e5b"
   },
   "tests/pipeline/test_removed_dmta_kwargs.py": {
-    "mtime": 1783318203.3699868,
+    "mtime": 1783376926.2588487,
     "ast_hash": "dc9c3c9c4ae0b48929b395582d54695f",
     "semantic_hash": "dc9c3c9c4ae0b48929b395582d54695f"
   },
   "rheojax/core/_validation.py": {
-    "mtime": 1783318203.3129878,
+    "mtime": 1783376926.2028487,
     "ast_hash": "deb10f75e6a1426d1115d80fd9461d2b",
     "semantic_hash": "deb10f75e6a1426d1115d80fd9461d2b"
   },
   "tests/core/test_validation.py": {
-    "mtime": 1783318203.3459873,
+    "mtime": 1783376926.2368486,
     "ast_hash": "6af1b04da5621d53620c1f155f104f80",
     "semantic_hash": "6af1b04da5621d53620c1f155f104f80"
   },
   "docs/source/verification/classical_lve_equations.md": {
-    "mtime": 1783318201.7430148,
+    "mtime": 1783376924.624853,
     "ast_hash": "6e73cb01fa15d417b9be5b8d75f538d8",
     "semantic_hash": "6e73cb01fa15d417b9be5b8d75f538d8"
   },
   "docs/source/verification/dmt_literature_verification.md": {
-    "mtime": 1783318201.7430148,
+    "mtime": 1783376924.624853,
     "ast_hash": "1c202f5bb387b3e79513fc2e71e5d049",
     "semantic_hash": "1c202f5bb387b3e79513fc2e71e5d049"
   },
   "docs/source/verification/epm_validation_report_2026-03-29.md": {
-    "mtime": 1783318201.7430148,
+    "mtime": 1783376924.624853,
     "ast_hash": "fa4f3076c310d6a766a8a114c2f90a6e",
     "semantic_hash": "fa4f3076c310d6a766a8a114c2f90a6e"
   },
   "docs/source/verification/fikh_validation_report_2026-03-29.md": {
-    "mtime": 1783318201.7430148,
+    "mtime": 1783376924.624853,
     "ast_hash": "0672eadc8e98c3a528c9fc37cae4f93f",
     "semantic_hash": "0672eadc8e98c3a528c9fc37cae4f93f"
   },
   "docs/source/verification/fluidity_saramito_equations.rst": {
-    "mtime": 1783318201.7430148,
+    "mtime": 1783376924.624853,
     "ast_hash": "0e285630538ea0724ad23c4df65f5242",
     "semantic_hash": "0e285630538ea0724ad23c4df65f5242"
   },
   "docs/source/verification/fractional_models_equation_verification.md": {
-    "mtime": 1783318201.7430148,
+    "mtime": 1783376924.624853,
     "ast_hash": "6833fe0d700f0b04a42f7e90e7ada236",
     "semantic_hash": "6833fe0d700f0b04a42f7e90e7ada236"
   },
   "docs/source/verification/giesekus_math_verification.md": {
-    "mtime": 1783318201.7430148,
+    "mtime": 1783376924.624853,
     "ast_hash": "7041fd530b579422552da2e3e3a5ca87",
     "semantic_hash": "7041fd530b579422552da2e3e3a5ca87"
   },
   "docs/source/verification/gmm_canonical_equations.rst": {
-    "mtime": 1783318201.7430148,
+    "mtime": 1783376924.624853,
     "ast_hash": "a059f7c9968c61410b643b2209b34b70",
     "semantic_hash": "a059f7c9968c61410b643b2209b34b70"
   },
   "docs/source/verification/hl_model_equations.md": {
-    "mtime": 1783318201.7430148,
+    "mtime": 1783376924.624853,
     "ast_hash": "f5414bce495ff794137c1f0d63765368",
     "semantic_hash": "f5414bce495ff794137c1f0d63765368"
   },
   "docs/source/verification/hvm_literature_review.md": {
-    "mtime": 1783318201.7430148,
+    "mtime": 1783376924.624853,
     "ast_hash": "26272a0b183e27e5ad2ce34f48fce1e9",
     "semantic_hash": "26272a0b183e27e5ad2ce34f48fce1e9"
   },
   "docs/source/verification/itt_mct_literature_equations.md": {
-    "mtime": 1783318201.7430148,
+    "mtime": 1783376924.624853,
     "ast_hash": "185b2ba8c18d817bf8ca8e8624428f26",
     "semantic_hash": "185b2ba8c18d817bf8ca8e8624428f26"
   },
   "docs/source/verification/saos_validity_transient_networks.md": {
-    "mtime": 1783318201.7430148,
+    "mtime": 1783376924.624853,
     "ast_hash": "055d7185d747e053703c281b360d89e0",
     "semantic_hash": "055d7185d747e053703c281b360d89e0"
   },
   "docs/source/verification/tnt_equations_verification.rst": {
-    "mtime": 1783318201.744015,
+    "mtime": 1783376924.624853,
     "ast_hash": "57fc911a253a27ccaf0f59c3e63d8541",
     "semantic_hash": "57fc911a253a27ccaf0f59c3e63d8541"
   },
   "docs/source/verification/vlb_equation_verification.md": {
-    "mtime": 1783318201.744015,
+    "mtime": 1783376924.624853,
     "ast_hash": "6f6ede0b327a0f4546ee96ee331d6428",
     "semantic_hash": "6f6ede0b327a0f4546ee96ee331d6428"
   },
   "docs/source/verification/ikh_literature_verification.md": {
-    "mtime": 1783318201.7430148,
+    "mtime": 1783376924.624853,
     "ast_hash": "d69e405f575a864106219e4f1ad92a31",
     "semantic_hash": "d69e405f575a864106219e4f1ad92a31"
   },
   "docs/source/verification/spp_equations_verification.md": {
-    "mtime": 1783318201.744015,
+    "mtime": 1783376924.624853,
     "ast_hash": "dae63d9cdebd5ba1b5195a0c78518b2d",
     "semantic_hash": "dae63d9cdebd5ba1b5195a0c78518b2d"
   },
   "docs/source/verification/vitrimer_nanocomposite_constitutive_models.md": {
-    "mtime": 1783318201.744015,
+    "mtime": 1783376924.624853,
     "ast_hash": "059302be0aac293f16ec4008aedd448f",
     "semantic_hash": "059302be0aac293f16ec4008aedd448f"
   },
   "rheojax/gui/foundation/__init__.py": {
-    "mtime": 1783318203.3159878,
+    "mtime": 1783376926.2058487,
     "ast_hash": "d41d8cd98f00b204e9800998ecf8427e",
     "semantic_hash": "d41d8cd98f00b204e9800998ecf8427e"
   },
   "rheojax/gui/foundation/contract.py": {
-    "mtime": 1783318203.3159878,
+    "mtime": 1783376926.2058487,
     "ast_hash": "a3110f011a5b0c2216fa4f4c4838353a",
     "semantic_hash": ""
   },
   "rheojax/gui/foundation/invalidation.py": {
-    "mtime": 1783318203.3159878,
+    "mtime": 1783376926.2058487,
     "ast_hash": "130046173c29581d9c472072c495340c",
     "semantic_hash": ""
   },
   "rheojax/gui/foundation/library.py": {
-    "mtime": 1783318203.3169878,
+    "mtime": 1783376926.2058487,
     "ast_hash": "5ba1daf15d0a0e6277a274d954f21e47",
     "semantic_hash": ""
   },
   "rheojax/gui/foundation/metrics.py": {
-    "mtime": 1783318203.3169878,
+    "mtime": 1783376926.2068486,
     "ast_hash": "53f0427aaad6f2a91efb10e9cfa98e26",
     "semantic_hash": ""
   },
   "rheojax/gui/foundation/pipeline_bridge.py": {
-    "mtime": 1783318203.3169878,
+    "mtime": 1783376926.2068486,
     "ast_hash": "46c1adb788d9d8d1ece5c3578ec7d201",
     "semantic_hash": ""
   },
   "rheojax/gui/foundation/priors.py": {
-    "mtime": 1783318203.3169878,
+    "mtime": 1783376926.2068486,
     "ast_hash": "2a1dcdaf325537562bae142fb2ca9112",
     "semantic_hash": "2a1dcdaf325537562bae142fb2ca9112"
   },
   "rheojax/gui/foundation/state.py": {
-    "mtime": 1783318203.3169878,
+    "mtime": 1783376926.2068486,
     "ast_hash": "6985131af8d160154608664b9dc68851",
     "semantic_hash": ""
   },
   "rheojax/gui/workspace/__init__.py": {
-    "mtime": 1783318203.3239877,
+    "mtime": 1783376926.2138486,
     "ast_hash": "d41d8cd98f00b204e9800998ecf8427e",
     "semantic_hash": "d41d8cd98f00b204e9800998ecf8427e"
   },
   "rheojax/gui/workspace/controller.py": {
-    "mtime": 1783318203.3239877,
+    "mtime": 1783376926.2138486,
     "ast_hash": "86a93757692ee8b7d09b6d4c35bc95b0",
     "semantic_hash": ""
   },
   "rheojax/gui/workspace/inspector.py": {
-    "mtime": 1783318203.3239877,
+    "mtime": 1783376926.2148488,
     "ast_hash": "a47139a37ad27b9f691741c76101343c",
     "semantic_hash": ""
   },
   "rheojax/gui/workspace/library_rail.py": {
-    "mtime": 1783318203.3239877,
+    "mtime": 1783376926.2148488,
     "ast_hash": "ee5c019e49256ec5ca6bddbd1f20c89c",
     "semantic_hash": "ee5c019e49256ec5ca6bddbd1f20c89c"
   },
   "rheojax/gui/workspace/stepper_canvas.py": {
-    "mtime": 1783318203.3239877,
+    "mtime": 1783376926.2148488,
     "ast_hash": "ccdf2dd6c579fd4b2a4fdcafb0871e1f",
     "semantic_hash": ""
   },
   "rheojax/gui/workspace/window.py": {
-    "mtime": 1783318203.3249876,
-    "ast_hash": "af6782dfe37640d78ff451cc6d16e85a",
+    "mtime": 1783383751.1025298,
+    "ast_hash": "06e8bdd6a0f1172eeaf00a4925976560",
     "semantic_hash": ""
   },
   "tests/gui/foundation/__init__.py": {
-    "mtime": 1783318203.355987,
+    "mtime": 1783376926.2458487,
     "ast_hash": "d41d8cd98f00b204e9800998ecf8427e",
     "semantic_hash": "d41d8cd98f00b204e9800998ecf8427e"
   },
   "tests/gui/foundation/test_contract.py": {
-    "mtime": 1783318203.355987,
+    "mtime": 1783376926.2458487,
     "ast_hash": "43cf3f58743eb99e0bac01260a423353",
     "semantic_hash": "43cf3f58743eb99e0bac01260a423353"
   },
   "tests/gui/foundation/test_flow_quantity.py": {
-    "mtime": 1783318203.355987,
+    "mtime": 1783376926.2458487,
     "ast_hash": "aebec84b4dc44d603ca31a1cfbe3a0c7",
     "semantic_hash": ""
   },
   "tests/gui/foundation/test_library.py": {
-    "mtime": 1783318203.355987,
+    "mtime": 1783376926.2468486,
     "ast_hash": "93389127b2d9b6d3fb8cee637e746ee6",
     "semantic_hash": ""
   },
   "tests/gui/foundation/test_metrics.py": {
-    "mtime": 1783318203.355987,
+    "mtime": 1783376926.2468486,
     "ast_hash": "7f96621880fecc75516423e67daa608b",
     "semantic_hash": "7f96621880fecc75516423e67daa608b"
   },
   "tests/gui/foundation/test_model_config.py": {
-    "mtime": 1783318203.355987,
+    "mtime": 1783376926.2468486,
     "ast_hash": "c266f09ee6d134fbfd79b4ad09bdb351",
     "semantic_hash": ""
   },
   "tests/gui/foundation/test_pipeline_bridge.py": {
-    "mtime": 1783318203.355987,
+    "mtime": 1783376926.2468486,
     "ast_hash": "f48bf6ec479ed0496712d5688c76189e",
     "semantic_hash": ""
   },
   "tests/gui/foundation/test_priors.py": {
-    "mtime": 1783318203.355987,
+    "mtime": 1783376926.2468486,
     "ast_hash": "7feb7c060c677f6566df61f0a4c1f358",
     "semantic_hash": ""
   },
   "tests/gui/foundation/test_state.py": {
-    "mtime": 1783318203.356987,
+    "mtime": 1783376926.2468486,
     "ast_hash": "a5b194241d06b58a10e329fc063e05d1",
     "semantic_hash": ""
   },
   "tests/gui/foundation/test_target_accept.py": {
-    "mtime": 1783318203.356987,
+    "mtime": 1783376926.2468486,
     "ast_hash": "b64078fd5ae68807f6628c2585092ea7",
     "semantic_hash": ""
   },
   "tests/gui/foundation/test_transform_keys.py": {
-    "mtime": 1783318203.356987,
+    "mtime": 1783376926.2468486,
     "ast_hash": "97b3428671db01683ce1beeb10d6b892",
     "semantic_hash": ""
   },
   "tests/gui/workspace/__init__.py": {
-    "mtime": 1783318203.359987,
+    "mtime": 1783376926.2498486,
     "ast_hash": "d41d8cd98f00b204e9800998ecf8427e",
     "semantic_hash": "d41d8cd98f00b204e9800998ecf8427e"
   },
   "tests/gui/workspace/test_controller.py": {
-    "mtime": 1783318203.360987,
+    "mtime": 1783376926.2508485,
     "ast_hash": "5a4415d4102cc81fb02d28b7b49de4c7",
     "semantic_hash": ""
   },
   "tests/gui/workspace/test_widgets.py": {
-    "mtime": 1783318203.360987,
+    "mtime": 1783376926.2508485,
     "ast_hash": "869739df229b3f73ceb588f8b2671a0b",
     "semantic_hash": ""
   },
   "rheojax/gui/workspace/fit/__init__.py": {
-    "mtime": 1783318203.3239877,
+    "mtime": 1783376926.2138486,
     "ast_hash": "d41d8cd98f00b204e9800998ecf8427e",
     "semantic_hash": "d41d8cd98f00b204e9800998ecf8427e"
   },
   "rheojax/gui/workspace/fit/fit_controller.py": {
-    "mtime": 1783318203.3239877,
-    "ast_hash": "f20d55c1e9d53498acac7ac9865f73dd",
+    "mtime": 1783394259.7521856,
+    "ast_hash": "1016a48389cb0c1823bf2c1739206e67",
     "semantic_hash": ""
   },
   "rheojax/gui/workspace/fit/step1_protocol_model.py": {
-    "mtime": 1783318203.3239877,
+    "mtime": 1783376926.2138486,
     "ast_hash": "552734bfc3d3423e90e1143ae3712b39",
     "semantic_hash": ""
   },
   "rheojax/gui/workspace/fit/step2_data.py": {
-    "mtime": 1783318203.3239877,
+    "mtime": 1783376926.2138486,
     "ast_hash": "f50760c2d11b2de3bd31b3b322232894",
     "semantic_hash": ""
   },
   "rheojax/gui/workspace/fit/step3_nlsq.py": {
-    "mtime": 1783318203.3239877,
-    "ast_hash": "29029e1177858219077bec7e80914765",
+    "mtime": 1783394242.0480618,
+    "ast_hash": "a17b6fee254b7e6440645b6d8d0a73e4",
     "semantic_hash": ""
   },
   "rheojax/gui/workspace/fit/step4_nuts.py": {
-    "mtime": 1783318203.3239877,
+    "mtime": 1783376926.2148488,
     "ast_hash": "0a7b59968cce3b144878a2d498a4af25",
     "semantic_hash": ""
   },
   "rheojax/gui/workspace/fit/step5_visualize.py": {
-    "mtime": 1783318203.3239877,
+    "mtime": 1783376926.2148488,
     "ast_hash": "ae9933f8c890fcc01dd49c9169301413",
     "semantic_hash": ""
   },
   "rheojax/gui/workspace/fit/step6_export.py": {
-    "mtime": 1783318203.3239877,
+    "mtime": 1783376926.2148488,
     "ast_hash": "cd7c27e70794f5069073141161471bff",
     "semantic_hash": ""
   },
   "rheojax/gui/workspace/transform/__init__.py": {
-    "mtime": 1783318203.3239877,
+    "mtime": 1783376926.2148488,
     "ast_hash": "d41d8cd98f00b204e9800998ecf8427e",
     "semantic_hash": "d41d8cd98f00b204e9800998ecf8427e"
   },
   "rheojax/gui/workspace/transform/slots_spec.py": {
-    "mtime": 1783318203.3249876,
+    "mtime": 1783376926.2148488,
     "ast_hash": "474e883f1c4abbbbccb3cbe4ae4c3d4d",
     "semantic_hash": "474e883f1c4abbbbccb3cbe4ae4c3d4d"
   },
   "rheojax/gui/workspace/transform/step1_pick.py": {
-    "mtime": 1783318203.3249876,
+    "mtime": 1783376926.2148488,
     "ast_hash": "dbdf94a4057f74fce35b985a4a8a254f",
     "semantic_hash": ""
   },
   "rheojax/gui/workspace/transform/step2_slots.py": {
-    "mtime": 1783318203.3249876,
+    "mtime": 1783376926.2148488,
     "ast_hash": "0ed2746ff271c451e32d64ae202d88e1",
     "semantic_hash": ""
   },
   "rheojax/gui/workspace/transform/step3_run.py": {
-    "mtime": 1783318203.3249876,
+    "mtime": 1783376926.2148488,
     "ast_hash": "d65d069ae7dc62d7fc6c6bbde4a4b10d",
     "semantic_hash": ""
   },
   "rheojax/gui/workspace/transform/step4_visualize.py": {
-    "mtime": 1783318203.3249876,
+    "mtime": 1783376926.2148488,
     "ast_hash": "7933f69f0a02b98de2b6db3f4a7e21fb",
     "semantic_hash": ""
   },
   "rheojax/gui/workspace/transform/step5_export.py": {
-    "mtime": 1783318203.3249876,
+    "mtime": 1783376926.2148488,
     "ast_hash": "aa0e8bc575ef748dd21a50216f89beb9",
     "semantic_hash": ""
   },
   "rheojax/gui/workspace/transform/transform_controller.py": {
-    "mtime": 1783318203.3249876,
+    "mtime": 1783376926.2148488,
     "ast_hash": "0808c7f3d329be7a2bece61ff15fe254",
     "semantic_hash": ""
   },
   "tests/gui/foundation/test_pipeline_bridge_context.py": {
-    "mtime": 1783318203.355987,
+    "mtime": 1783376926.2468486,
     "ast_hash": "330ce0f400c3dfb0d2b48d607062938d",
     "semantic_hash": ""
   },
   "tests/gui/workspace/fit/__init__.py": {
-    "mtime": 1783318203.359987,
+    "mtime": 1783376926.2498486,
     "ast_hash": "d41d8cd98f00b204e9800998ecf8427e",
     "semantic_hash": "d41d8cd98f00b204e9800998ecf8427e"
   },
   "tests/gui/workspace/fit/test_fit_controller.py": {
-    "mtime": 1783318203.359987,
+    "mtime": 1783376926.2498486,
     "ast_hash": "896e2e29011eb91fc60a5ae5c214cabc",
     "semantic_hash": ""
   },
   "tests/gui/workspace/fit/test_step1.py": {
-    "mtime": 1783318203.359987,
+    "mtime": 1783376926.2498486,
     "ast_hash": "615e2e5a7e7cc582225ac26256f2312d",
     "semantic_hash": ""
   },
   "tests/gui/workspace/fit/test_step1_config.py": {
-    "mtime": 1783318203.359987,
+    "mtime": 1783376926.2498486,
     "ast_hash": "b5da21dbd5202d54276840feafaae44c",
     "semantic_hash": ""
   },
   "tests/gui/workspace/fit/test_step2.py": {
-    "mtime": 1783318203.359987,
+    "mtime": 1783376926.2498486,
     "ast_hash": "1d79b5c5d91f07a466eac27bd32a3dd0",
     "semantic_hash": ""
   },
   "tests/gui/workspace/fit/test_step2_validation.py": {
-    "mtime": 1783318203.359987,
+    "mtime": 1783376926.2498486,
     "ast_hash": "d23a93b14e3005af1bfffa9e54ea98f3",
     "semantic_hash": ""
   },
   "tests/gui/workspace/fit/test_step3.py": {
-    "mtime": 1783318203.360987,
-    "ast_hash": "d6947af2de231ec9346e7221bc755afd",
+    "mtime": 1783394183.1156294,
+    "ast_hash": "e8990fffbb8677e35b36b4d1009351b1",
     "semantic_hash": ""
   },
   "tests/gui/workspace/fit/test_step4.py": {
-    "mtime": 1783318203.360987,
+    "mtime": 1783376926.2498486,
     "ast_hash": "749a24a4becb7a284fbd8d709e26c6f0",
     "semantic_hash": ""
   },
   "tests/gui/workspace/fit/test_step5.py": {
-    "mtime": 1783318203.360987,
+    "mtime": 1783376926.2508485,
     "ast_hash": "e62f69b53e0f8d2ebb002c3faca45a84",
     "semantic_hash": "e62f69b53e0f8d2ebb002c3faca45a84"
   },
   "tests/gui/workspace/fit/test_step6.py": {
-    "mtime": 1783318203.360987,
+    "mtime": 1783376926.2508485,
     "ast_hash": "270ce8ed933c3b367a055487e7582684",
     "semantic_hash": "270ce8ed933c3b367a055487e7582684"
   },
   "tests/gui/workspace/fit/test_step6_store_payload.py": {
-    "mtime": 1783318203.360987,
+    "mtime": 1783376926.2508485,
     "ast_hash": "2533ad44bd316132003eb36714823ecf",
     "semantic_hash": ""
   },
   "tests/gui/workspace/transform/__init__.py": {
-    "mtime": 1783318203.360987,
+    "mtime": 1783376926.2508485,
     "ast_hash": "d41d8cd98f00b204e9800998ecf8427e",
     "semantic_hash": "d41d8cd98f00b204e9800998ecf8427e"
   },
   "tests/gui/workspace/transform/test_end_to_end_slot_to_library.py": {
-    "mtime": 1783318203.360987,
+    "mtime": 1783376926.2508485,
     "ast_hash": "677c948953d40c295e0e782ccca23be1",
     "semantic_hash": "677c948953d40c295e0e782ccca23be1"
   },
   "tests/gui/workspace/transform/test_run_step_wiring.py": {
-    "mtime": 1783318203.360987,
+    "mtime": 1783376926.2508485,
     "ast_hash": "ad33517b7f56e48d17955860f5ef61de",
     "semantic_hash": ""
   },
   "tests/gui/workspace/transform/test_slots_spec.py": {
-    "mtime": 1783318203.360987,
+    "mtime": 1783376926.2508485,
     "ast_hash": "4c9c7302e09ff7185bc04c488cc08035",
     "semantic_hash": ""
   },
   "tests/gui/workspace/transform/test_step1.py": {
-    "mtime": 1783318203.360987,
+    "mtime": 1783376926.2508485,
     "ast_hash": "30116a113504155b32166799707b56b1",
     "semantic_hash": ""
   },
   "tests/gui/workspace/transform/test_step2.py": {
-    "mtime": 1783318203.360987,
+    "mtime": 1783376926.2508485,
     "ast_hash": "3de51279ef0d42c299b8c8f7f42e8e30",
     "semantic_hash": ""
   },
   "tests/gui/workspace/transform/test_step2_selectors.py": {
-    "mtime": 1783318203.360987,
+    "mtime": 1783376926.2508485,
     "ast_hash": "10738e43abb961473606781738661673",
     "semantic_hash": ""
   },
   "tests/gui/workspace/transform/test_step3.py": {
-    "mtime": 1783318203.360987,
+    "mtime": 1783376926.2508485,
     "ast_hash": "5f27212da83c5d62c5c768e3aa8ebbdf",
     "semantic_hash": "5f27212da83c5d62c5c768e3aa8ebbdf"
   },
   "tests/gui/workspace/transform/test_step4.py": {
-    "mtime": 1783318203.360987,
+    "mtime": 1783376926.2508485,
     "ast_hash": "ff53063861d7e2e15880b5bda989eb57",
     "semantic_hash": ""
   },
   "tests/gui/workspace/transform/test_step5.py": {
-    "mtime": 1783318203.3619869,
+    "mtime": 1783376926.2508485,
     "ast_hash": "effc47fb9940869b7b57157c6e32fcd0",
     "semantic_hash": ""
   },
   "tests/gui/workspace/transform/test_step5_store_payload.py": {
-    "mtime": 1783318203.3619869,
+    "mtime": 1783376926.2508485,
     "ast_hash": "de695100779fb3bfc79c50d503bbc60a",
     "semantic_hash": "de695100779fb3bfc79c50d503bbc60a"
   },
   "tests/gui/workspace/transform/test_step5_writers.py": {
-    "mtime": 1783318203.3619869,
+    "mtime": 1783376926.2508485,
     "ast_hash": "fefc9e08fb0040a67bf0986127e07972",
     "semantic_hash": ""
   },
   "tests/gui/workspace/transform/test_transform_controller.py": {
-    "mtime": 1783318203.3619869,
+    "mtime": 1783376926.2508485,
     "ast_hash": "d38e1f448c50aae816b26e821f206221",
     "semantic_hash": ""
   },
   "tests/gui/workspace/transform/test_transform_controller_validate.py": {
-    "mtime": 1783318203.3619869,
+    "mtime": 1783376926.2508485,
     "ast_hash": "a79c0ee7b25e6f03b021a025a2782b91",
     "semantic_hash": "a79c0ee7b25e6f03b021a025a2782b91"
   },
   "tests/gui/workspace/fit/test_step3_wiring.py": {
-    "mtime": 1783318203.360987,
-    "ast_hash": "8e6de5f32d8d7cb81ad7b4fe82be6fda",
+    "mtime": 1783394290.4483938,
+    "ast_hash": "6ec19b772fe36148ff4b3b42fc256add",
     "semantic_hash": ""
   },
   "tests/gui/services/__init__.py": {
-    "mtime": 1783318203.357987,
+    "mtime": 1783376926.2478485,
     "ast_hash": "d41d8cd98f00b204e9800998ecf8427e",
     "semantic_hash": "d41d8cd98f00b204e9800998ecf8427e"
   },
   "tests/gui/services/test_export_service_netcdf.py": {
-    "mtime": 1783318203.357987,
+    "mtime": 1783376926.2478485,
     "ast_hash": "298c75ff47e63d1d327c46bc59115909",
     "semantic_hash": "298c75ff47e63d1d327c46bc59115909"
   },
   "tests/gui/workspace/fit/test_step4_priors.py": {
-    "mtime": 1783318203.360987,
+    "mtime": 1783376926.2498486,
     "ast_hash": "28af18dab2448ca37c9ccad01b5aaba5",
     "semantic_hash": "28af18dab2448ca37c9ccad01b5aaba5"
   },
   "tests/gui/workspace/fit/test_step5_diagnostics.py": {
-    "mtime": 1783318203.360987,
+    "mtime": 1783376926.2508485,
     "ast_hash": "28db8f4ba4e010fa127c9eb00485fefa",
     "semantic_hash": ""
   },
   "tests/gui/workspace/fit/test_step6_writers.py": {
-    "mtime": 1783318203.360987,
+    "mtime": 1783376926.2508485,
     "ast_hash": "7b1312433056b7d8839857a17eaa43e1",
     "semantic_hash": ""
   },
   "tests/gui/services/test_bayesian_service_model_config.py": {
-    "mtime": 1783318203.357987,
+    "mtime": 1783376926.2478485,
     "ast_hash": "9146bdea6f6794053c24948326e3ac95",
     "semantic_hash": "9146bdea6f6794053c24948326e3ac95"
   },
   "tests/gui/workspace/fit/test_end_to_end_fit_to_export.py": {
-    "mtime": 1783318203.359987,
+    "mtime": 1783376926.2498486,
     "ast_hash": "09cebbf9b0f545ffa7c7389835fc81d7",
     "semantic_hash": "09cebbf9b0f545ffa7c7389835fc81d7"
   },
   "tests/gui/workspace/fit/test_fit_controller_validate.py": {
-    "mtime": 1783318203.359987,
+    "mtime": 1783376926.2498486,
     "ast_hash": "980e51aace9b9ddc2eabfd6739219237",
     "semantic_hash": ""
   },
   "rheojax/gui/foundation/import_service.py": {
-    "mtime": 1783318203.3159878,
+    "mtime": 1783376926.2058487,
     "ast_hash": "00fe2e4351851ec23938decbfd96865b",
     "semantic_hash": ""
   },
   "rheojax/gui/foundation/notifier.py": {
-    "mtime": 1783318203.3169878,
+    "mtime": 1783376926.2068486,
     "ast_hash": "1277999d1efaa91fc76353aee17ecc4c",
     "semantic_hash": ""
   },
   "rheojax/gui/foundation/project_codec.py": {
-    "mtime": 1783318203.3169878,
+    "mtime": 1783376926.2068486,
     "ast_hash": "7fe1c3140519b2be4615833c7a2f8ace",
     "semantic_hash": ""
   },
   "rheojax/gui/workspace/pipeline/__init__.py": {
-    "mtime": 1783318203.3239877,
+    "mtime": 1783376926.2148488,
     "ast_hash": "d41d8cd98f00b204e9800998ecf8427e",
     "semantic_hash": "d41d8cd98f00b204e9800998ecf8427e"
   },
   "rheojax/gui/workspace/pipeline/batch_runner.py": {
-    "mtime": 1783318203.3239877,
+    "mtime": 1783376926.2148488,
     "ast_hash": "245a05ad6f4d1b7cfed19b1f4df3b477",
     "semantic_hash": ""
   },
   "rheojax/gui/workspace/pipeline/cancel_runnable.py": {
-    "mtime": 1783318203.3239877,
+    "mtime": 1783376926.2148488,
     "ast_hash": "77bf27361a5ce69a54727d9c95bb10df",
     "semantic_hash": ""
   },
   "rheojax/gui/workspace/pipeline/controller.py": {
-    "mtime": 1783318203.3239877,
+    "mtime": 1783376926.2148488,
     "ast_hash": "9ad1675c883ab1b3547ec6865d7688be",
     "semantic_hash": ""
   },
   "rheojax/gui/workspace/pipeline/models.py": {
-    "mtime": 1783318203.3239877,
+    "mtime": 1783376926.2148488,
     "ast_hash": "92334472ce6643e355ed8b43b44cc46f",
     "semantic_hash": ""
   },
   "rheojax/gui/workspace/pipeline/step1_configure_run.py": {
-    "mtime": 1783318203.3239877,
+    "mtime": 1783376926.2148488,
     "ast_hash": "b228f326a1384bfe220ed1153c6040a8",
     "semantic_hash": ""
   },
   "tests/gui/foundation/test_import_service.py": {
-    "mtime": 1783318203.355987,
+    "mtime": 1783376926.2458487,
     "ast_hash": "dba72b7ccd592e05203c7fafbb7d236a",
     "semantic_hash": "dba72b7ccd592e05203c7fafbb7d236a"
   },
   "tests/gui/foundation/test_notifier.py": {
-    "mtime": 1783318203.355987,
+    "mtime": 1783376926.2468486,
     "ast_hash": "27c5f290fe6cac2182ffbe77a4b8f52a",
     "semantic_hash": "27c5f290fe6cac2182ffbe77a4b8f52a"
   },
   "tests/gui/foundation/test_project_codec.py": {
-    "mtime": 1783318203.356987,
+    "mtime": 1783376926.2468486,
     "ast_hash": "c8e85a7b76de9dc57b637b77fc2290cb",
     "semantic_hash": ""
   },
   "tests/gui/test_main_cli_wiring.py": {
-    "mtime": 1783318203.358987,
-    "ast_hash": "4430decec3799b0330184ef14a0b299d",
+    "mtime": 1783376926.2488487,
+    "ast_hash": "8653f547b20ba8c637aa7ff991ddd9b9",
     "semantic_hash": ""
   },
   "tests/gui/test_pipeline_execution_service_execute.py": {
-    "mtime": 1783318203.358987,
+    "mtime": 1783376926.2488487,
     "ast_hash": "a617bf57a39699455c8892d4155ab150",
     "semantic_hash": ""
   },
   "tests/gui/workspace/pipeline/__init__.py": {
-    "mtime": 1783318203.360987,
+    "mtime": 1783376926.2508485,
     "ast_hash": "d41d8cd98f00b204e9800998ecf8427e",
     "semantic_hash": "d41d8cd98f00b204e9800998ecf8427e"
   },
   "tests/gui/workspace/pipeline/test_batch_runner.py": {
-    "mtime": 1783318203.360987,
+    "mtime": 1783376926.2508485,
     "ast_hash": "002de00db0f67fb0bba0c4d0c5322317",
     "semantic_hash": ""
   },
   "tests/gui/workspace/pipeline/test_cancel_runnable.py": {
-    "mtime": 1783318203.360987,
+    "mtime": 1783376926.2508485,
     "ast_hash": "4cb7c83576590afd7dcfd8c52ddf2a19",
     "semantic_hash": "4cb7c83576590afd7dcfd8c52ddf2a19"
   },
   "tests/gui/workspace/pipeline/test_controller.py": {
-    "mtime": 1783318203.360987,
+    "mtime": 1783376926.2508485,
     "ast_hash": "d66952f17a6455a8f9422950d0330c25",
     "semantic_hash": ""
   },
   "tests/gui/workspace/pipeline/test_models.py": {
-    "mtime": 1783318203.360987,
+    "mtime": 1783376926.2508485,
     "ast_hash": "fc3f9644a265cef6830c29beaf70aa02",
     "semantic_hash": ""
   },
   "tests/gui/workspace/pipeline/test_step1_configure_run.py": {
-    "mtime": 1783318203.360987,
+    "mtime": 1783376926.2508485,
     "ast_hash": "723860c0f9e5aada18ae1555cc5074dc",
     "semantic_hash": ""
   },
   "tests/gui/workspace/test_window_active_jobs_dialog.py": {
-    "mtime": 1783318203.360987,
+    "mtime": 1783376926.2508485,
     "ast_hash": "e981741152ef8b8a1e0bd6f5c8a72800",
     "semantic_hash": ""
   },
   "tests/gui/workspace/test_window_commit_dataset.py": {
-    "mtime": 1783318203.360987,
+    "mtime": 1783376926.2508485,
     "ast_hash": "0b1de284b37a188f9e11111f215dc2a2",
     "semantic_hash": ""
   },
   "tests/gui/workspace/test_window_file_menu.py": {
-    "mtime": 1783318203.360987,
+    "mtime": 1783376926.2508485,
     "ast_hash": "adda0a24b2965b775267845fdd381f5e",
     "semantic_hash": ""
   },
   "tests/gui/workspace/test_window_pipeline_mode.py": {
-    "mtime": 1783318203.360987,
+    "mtime": 1783376926.2508485,
     "ast_hash": "a0dbc934a18cfada2ac5a3e4427e4f55",
     "semantic_hash": ""
   },
   "tests/gui/workspace/test_window_rebuild.py": {
-    "mtime": 1783318203.360987,
+    "mtime": 1783376926.2508485,
     "ast_hash": "9b508ba933c6eb6ad70de99d9f5f7c2b",
     "semantic_hash": ""
   },
   "tests/gui/workspace/transform/test_infer_output_protocol.py": {
-    "mtime": 1783318203.360987,
+    "mtime": 1783376926.2508485,
     "ast_hash": "1867f17bd19e28e1d24e8de204f3353f",
     "semantic_hash": ""
   },
   "tests/gui/workspace/test_window_import.py": {
-    "mtime": 1783318203.360987,
-    "ast_hash": "b71a61a79f980ae55f49db9859ac4687",
+    "mtime": 1783383751.1035297,
+    "ast_hash": "126491d0cdcb2f2dcf6e1ad514fd72d4",
     "semantic_hash": ""
   },
   "docs/source/user_guide/06_gui/workspace_getting_started.rst": {
-    "mtime": 1783318201.742015,
+    "mtime": 1783376924.624853,
     "ast_hash": "34c7730e89fac6f1240b01f826f00b41",
     "semantic_hash": "34c7730e89fac6f1240b01f826f00b41"
   },
   "rheojax/gui/workspace/README.md": {
-    "mtime": 1783318203.3239877,
+    "mtime": 1783376926.2138486,
     "ast_hash": "a1f9ca7c78bd1d68051cd22f4e9ca828",
     "semantic_hash": "a1f9ca7c78bd1d68051cd22f4e9ca828"
   },
   "tests/gui/test_import_wizard.py": {
-    "mtime": 1783318203.358987,
+    "mtime": 1783376926.2488487,
     "ast_hash": "bff46f97c60da9b0a797e6431671e4ba",
     "semantic_hash": ""
   },
   "tests/gui/test_parameter_table_validation.py": {
-    "mtime": 1783318203.358987,
+    "mtime": 1783376926.2488487,
     "ast_hash": "97aacbcb7126f2608c16c4d63188dc58",
+    "semantic_hash": ""
+  },
+  "rheojax/gui/widgets/log_dock.py": {
+    "mtime": 1783376926.2128487,
+    "ast_hash": "e172e679692e52db9b42fb6b8b0a0b57",
+    "semantic_hash": ""
+  },
+  "tests/gui/test_log_dock.py": {
+    "mtime": 1783376926.2488487,
+    "ast_hash": "1244c7105c7ca305118c04ccf4b0bc0e",
+    "semantic_hash": ""
+  },
+  "tests/gui/workspace/test_window_log_dock.py": {
+    "mtime": 1783376926.2508485,
+    "ast_hash": "aaa7462c4501b0a5beb8de0f1709cc70",
     "semantic_hash": ""
   }
 }

--- a/rheojax/gui/workspace/fit/fit_controller.py
+++ b/rheojax/gui/workspace/fit/fit_controller.py
@@ -109,6 +109,7 @@ def _make_fit_fn(library, fit_state, active_jobs=None):
         column_map,
         initial_params=None,
         multi_start=None,
+        options=None,
     ):
         # A real, cancellable token (not a throwaway per-restart mp.Event) so
         # window.py's "Cancel them and continue?" dialog (_maybe_confirm_active_jobs)
@@ -133,6 +134,7 @@ def _make_fit_fn(library, fit_state, active_jobs=None):
                 data_ref,
                 initial_params,
                 multi_start,
+                options,
                 token.event,
             )
         finally:
@@ -150,6 +152,7 @@ def _fit_fn_body(
     data_ref,
     initial_params,
     multi_start,
+    options,
     cancel_event,
 ):
     rheo_data = library.load_payload(data_ref)
@@ -192,7 +195,7 @@ def _fit_fn_body(
                     rheo_data.y,
                     test_mode=test_mode,
                     initial_params=start_params or {},
-                    options={},
+                    options=options or {},
                     progress_queue=progress_queue,
                     cancel_event=cancel_event,
                     dataset_id=data_ref,

--- a/rheojax/gui/workspace/fit/step3_nlsq.py
+++ b/rheojax/gui/workspace/fit/step3_nlsq.py
@@ -134,6 +134,22 @@ class NlsqStep(QWidget):
         # an overlapping fit that corrupts shared active_jobs tracking.
         self._run_btn.setEnabled(False)
         try:
+            # This step's own _ms_enabled/_ms_count widgets are the single
+            # source of truth for multi-start (outer restart loop in
+            # fit_controller). FittingOptionsDialog can also set
+            # "multistart"/"num_starts" in self._fit_options, which
+            # ModelService.fit() would translate into its OWN, separate
+            # backend-level multi-start. Passing both through would nest
+            # them: the outer loop's `count` restarts each triggering the
+            # backend's `n_starts` restarts, silently multiplying fit time.
+            # Strip a copy here (never mutate self._fit_options) so the
+            # dialog's stored state is preserved for the user to see if
+            # they reopen it, but never reaches the backend.
+            fit_options = {
+                k: v
+                for k, v in self._fit_options.items()
+                if k not in ("multistart", "num_starts")
+            }
             try:
                 res = self._fit_fn(
                     self._state.model_key,
@@ -145,7 +161,7 @@ class NlsqStep(QWidget):
                         "enabled": self._ms_enabled.isChecked(),
                         "count": self._ms_count.value(),
                     },
-                    options=self._fit_options,
+                    options=fit_options,
                 )
             except NotImplementedError:
                 # ponytail: real solver wiring is out of scope here (tracked separately);
@@ -216,7 +232,7 @@ class NlsqStep(QWidget):
                     ]
                     if sigma_parts:
                         lines.append("  ".join(sigma_parts))
-            except (ValueError, TypeError):
+            except (ValueError, TypeError, IndexError):
                 pass
 
         self._result.setText("  ".join(lines))

--- a/rheojax/gui/workspace/fit/step3_nlsq.py
+++ b/rheojax/gui/workspace/fit/step3_nlsq.py
@@ -6,6 +6,7 @@ import numpy as np
 from PySide6.QtCore import Signal
 from PySide6.QtWidgets import (
     QCheckBox,
+    QDialog,
     QLabel,
     QPushButton,
     QSpinBox,
@@ -21,7 +22,13 @@ from rheojax.gui.widgets.parameter_table import ParameterTable
 
 
 def _default_fit_fn(
-    model_key, model_config, data_ref, column_map, initial_params=None, multi_start=None
+    model_key,
+    model_config,
+    data_ref,
+    column_map,
+    initial_params=None,
+    multi_start=None,
+    options=None,
 ):
     # NOTE: `data_ref` is a str id — the real implementation must:
     # 1. Load RheoData: `library.load_payload(data_ref)` (pass library to NlsqStep at build time)
@@ -51,6 +58,9 @@ class NlsqStep(QWidget):
         self._ms_count = QSpinBox(self)
         self._ms_count.setRange(1, 64)
         self._ms_count.setValue(8)
+        self._fit_options: dict = {}
+        self._options_btn = QPushButton("⚙ Fit Options", self)
+        self._options_btn.clicked.connect(self._on_options_clicked)
         self._run_btn = QPushButton("▶ Run NLSQ", self)
         self._result = QLabel("", self)
         lay = QVBoxLayout(self)
@@ -59,6 +69,7 @@ class NlsqStep(QWidget):
             self._table,
             self._ms_enabled,
             self._ms_count,
+            self._options_btn,
             self._run_btn,
             self._result,
         ):
@@ -96,6 +107,16 @@ class NlsqStep(QWidget):
         self._ms_enabled.setChecked(enabled)
         self._ms_count.setValue(count)
 
+    def fit_options(self) -> dict:
+        return dict(self._fit_options)
+
+    def _on_options_clicked(self) -> None:
+        from rheojax.gui.dialogs.fitting_options import FittingOptionsDialog
+
+        dialog = FittingOptionsDialog(current_options=self._fit_options, parent=self)
+        if dialog.exec() == QDialog.DialogCode.Accepted:
+            self._fit_options = dialog.get_options()
+
     def run(self) -> None:
         # Multi-start config is transient widget state — not stored in FitState
         table_params = self._table.get_parameters()
@@ -124,6 +145,7 @@ class NlsqStep(QWidget):
                         "enabled": self._ms_enabled.isChecked(),
                         "count": self._ms_count.value(),
                     },
+                    options=self._fit_options,
                 )
             except NotImplementedError:
                 # ponytail: real solver wiring is out of scope here (tracked separately);

--- a/rheojax/gui/workspace/fit/step3_nlsq.py
+++ b/rheojax/gui/workspace/fit/step3_nlsq.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from collections.abc import Callable
 
+import numpy as np
 from PySide6.QtCore import Signal
 from PySide6.QtWidgets import (
     QCheckBox,
@@ -157,10 +158,46 @@ class NlsqStep(QWidget):
         if self._state.nlsq_result is None:
             self._result.setText("")
             return
-        r2 = self._state.nlsq_result.get("r_squared", float("nan"))
+        result = self._state.nlsq_result
+        r2 = result.get("r_squared", float("nan"))
         if r2 is None:
             r2 = float("nan")
-        self._result.setText(f"R²={r2:.3f}")
+        lines = [f"R²={r2:.3f}"]
+
+        chi2 = result.get("chi_squared")
+        if chi2 is not None:
+            lines.append(f"chi²={float(chi2):.6g}")
+
+        mpe = result.get("mpe")
+        if mpe is not None:
+            lines.append(f"MPE={float(mpe):.2f}%")
+
+        fit_time = result.get("fit_time")
+        if fit_time is not None:
+            lines.append(f"time={float(fit_time):.2f}s")
+
+        # Recompute locally from pcov (sorted param names + shape-checked
+        # sqrt(diag)) rather than trusting a precomputed uncertainties list's
+        # ordering against params -- mirrors the legacy shell's existing,
+        # working pattern (rheojax/gui/pages/fit_page.py:1095-1122).
+        params = result.get("params") or {}
+        pcov = result.get("pcov")
+        if pcov is not None and params:
+            param_names = sorted(params.keys())
+            try:
+                pcov_arr = np.asarray(pcov)
+                if pcov_arr.ndim == 2 and pcov_arr.shape[0] == len(param_names):
+                    sigma_parts = [
+                        f"{name}=±{np.sqrt(pcov_arr[i, i]):.3g}"
+                        for i, name in enumerate(param_names)
+                        if pcov_arr[i, i] > 0
+                    ]
+                    if sigma_parts:
+                        lines.append("  ".join(sigma_parts))
+            except (ValueError, TypeError):
+                pass
+
+        self._result.setText("  ".join(lines))
 
     def is_ready(self) -> bool:
         return bool(

--- a/rheojax/gui/workspace/window.py
+++ b/rheojax/gui/workspace/window.py
@@ -682,15 +682,25 @@ class WorkspaceWindow(QMainWindow):
         self._active_import_workers.pop(job_id, None)
         import hashlib
         import uuid
+        from collections import Counter
 
         from rheojax.gui.foundation.library import DatasetRef
         from rheojax.gui.services.data_service import DataService
 
         service = DataService()
         hash_cache: dict[str, str] = {}
-        # ponytail: multiple segments from one source file all get that
-        # file's stem as their name -- add "_segment_N" suffixing if that
-        # proves confusing in practice.
+        # Multiple segments from one source file get "<stem>_segment_N"
+        # suffixing (N starting at 1) instead of all sharing the bare stem --
+        # otherwise the rail/combo shows indistinguishable duplicate entries
+        # for e.g. a multi-frequency-segment TRIOS file. Counted up front
+        # (non-destructive .get, before the pop below) so a file that turns
+        # out to have exactly one segment keeps its plain stem name.
+        source_file_counts = Counter(
+            sf
+            for rheo_data in datasets
+            if (sf := rheo_data.metadata.get("_source_file"))
+        )
+        segment_index: dict[str, int] = {}
         for rheo_data in datasets:
             meta = rheo_data.metadata
             source_file = meta.pop("_source_file", None)
@@ -703,9 +713,19 @@ class WorkspaceWindow(QMainWindow):
                     Path(source_file).read_bytes()
                 ).hexdigest()
 
+            if source_file:
+                stem = Path(source_file).stem
+                if source_file_counts[source_file] > 1:
+                    segment_index[source_file] = segment_index.get(source_file, 0) + 1
+                    name = f"{stem}_segment_{segment_index[source_file]}"
+                else:
+                    name = stem
+            else:
+                name = "imported"
+
             ref = DatasetRef(
                 id=uuid.uuid4().hex,
-                name=Path(source_file).stem if source_file else "imported",
+                name=name,
                 protocol_type=test_mode,
                 origin="imported",
                 units={

--- a/rheojax/gui/workspace/window.py
+++ b/rheojax/gui/workspace/window.py
@@ -166,6 +166,7 @@ class WorkspaceWindow(QMainWindow):
         self._notifier.changed.connect(self._transform_bodies[1].refresh)
         self._notifier.changed.connect(self._pipeline_bodies[0].refresh)
         self._rail.import_requested.connect(self._on_import_requested)
+        self._rail.dataset_selected.connect(self._on_rail_dataset_selected)
         self._inspector = InspectorPanel(self)
         self._canvas = StepperCanvas(self._controllers[self._mode], self)
         self._wire_canvas(self._canvas)
@@ -277,6 +278,10 @@ class WorkspaceWindow(QMainWindow):
             pass
         try:
             self._rail.import_requested.disconnect(self._on_import_requested)
+        except (RuntimeError, TypeError):
+            pass
+        try:
+            self._rail.dataset_selected.disconnect(self._on_rail_dataset_selected)
         except (RuntimeError, TypeError):
             pass
         for widget in (self._canvas, self._rail, self._inspector, self._splitter):
@@ -598,6 +603,18 @@ class WorkspaceWindow(QMainWindow):
             return
 
         self._launch_import([Path(p) for p in paths])
+
+    def _on_rail_dataset_selected(self, dataset_id: str) -> None:
+        """Forward a LibraryRail click to the Fit workflow's dataset selector.
+
+        Transform's SlotsStep manages multiple per-slot combos and Pipeline's
+        PipelineConfigureRunStep selects datasets for batch execution --
+        neither has a single "make this the active dataset" concept to
+        forward to, so only Fit mode's DataStep (which has exactly that) is
+        wired here.
+        """
+        if self._mode == "fit":
+            self._fit_bodies[1].select_dataset(dataset_id)
 
     def _launch_import(
         self,

--- a/rheojax/gui/workspace/window.py
+++ b/rheojax/gui/workspace/window.py
@@ -568,9 +568,13 @@ class WorkspaceWindow(QMainWindow):
         self._state.project.dirty = True
 
     def _commit_dataset(self, ref, payload=None, overwrite: bool = False) -> None:
-        self._state.library.add(ref, overwrite=overwrite)
-        if payload is not None:
-            self._state.library.store_payload(ref.id, payload)
+        # Hold the library's lock across both calls so a concurrent reader never
+        # observes a DatasetRef registered by add() before store_payload() has
+        # written its payload (see DatasetLibrary.lock's docstring in library.py).
+        with self._state.library.lock:
+            self._state.library.add(ref, overwrite=overwrite)
+            if payload is not None:
+                self._state.library.store_payload(ref.id, payload)
         self._notifier.changed.emit()
 
     # detect_test_mode() reports "flow" for flow-curve data (F-IO-R... naming

--- a/tests/gui/workspace/fit/test_step3.py
+++ b/tests/gui/workspace/fit/test_step3.py
@@ -194,9 +194,10 @@ def test_options_dialog_cancelled_keeps_previous_options(qtbot, monkeypatch):
         FittingOptionsDialog, "exec", lambda self: QDialog.DialogCode.Rejected
     )
 
+    step._fit_options = {"ftol": 1e-9}
     step._options_btn.click()
 
-    assert step.fit_options() == {}
+    assert step.fit_options() == {"ftol": 1e-9}
 
 
 def test_run_forwards_fit_options_to_fit_fn(qtbot):
@@ -217,3 +218,35 @@ def test_run_forwards_fit_options_to_fit_fn(qtbot):
         step.run()
 
     assert calls["options"] == {"ftol": 1e-10}
+
+
+def test_run_strips_dialog_multistart_keys_from_options(qtbot):
+    """FittingOptionsDialog can set "multistart"/"num_starts" in _fit_options,
+    which ModelService.fit() would translate into its own backend-level
+    multi-start -- nesting with this step's own _ms_enabled/_ms_count outer
+    restart loop. run() must strip those two keys (and only those two) from
+    the dict passed as options=, without mutating self._fit_options itself.
+    """
+    st = FitState(
+        protocol="oscillation", model_key="maxwell", data_ref="d", column_map={"x": 0}
+    )
+    calls = {}
+
+    def fake_fit(model_key, model_config, data_ref, column_map, **kwargs):
+        calls["options"] = kwargs.get("options")
+        return {"params": {"G0": 1000.0}, "r_squared": 0.9}
+
+    step = NlsqStep(st, fit_fn=fake_fit)
+    qtbot.addWidget(step)
+    step._fit_options = {"multistart": True, "num_starts": 10, "ftol": 1e-10}
+
+    with qtbot.waitSignal(step.finished, timeout=2000):
+        step.run()
+
+    assert calls["options"] == {"ftol": 1e-10}
+    # self._fit_options (the dialog's stored state) must be untouched.
+    assert step._fit_options == {
+        "multistart": True,
+        "num_starts": 10,
+        "ftol": 1e-10,
+    }

--- a/tests/gui/workspace/fit/test_step3.py
+++ b/tests/gui/workspace/fit/test_step3.py
@@ -94,3 +94,61 @@ def test_nlsq_solver_failure_is_reported_without_escaping_qt_slot(qtbot):
     step.run()
     assert st.nlsq_result is None
     assert "optimizer failed" in step._result.text()
+
+
+def test_refresh_display_shows_chi2_mpe_and_fit_time_when_present(qtbot):
+    st = FitState(
+        protocol="oscillation", model_key="maxwell", data_ref="d", column_map={"x": 0}
+    )
+    st.nlsq_result = {
+        "params": {"G0": 1000.0},
+        "r_squared": 0.95,
+        "chi_squared": 12.3,
+        "mpe": 4.5,
+        "fit_time": 1.23,
+    }
+    step = NlsqStep(st)
+    qtbot.addWidget(step)
+
+    step.refresh_display()
+
+    text = step._result.text()
+    assert "R²=0.950" in text
+    assert "chi²=12.3" in text
+    assert "MPE=4.50%" in text
+    assert "time=1.23s" in text
+
+
+def test_refresh_display_shows_parameter_uncertainties_from_pcov(qtbot):
+    st = FitState(
+        protocol="oscillation", model_key="maxwell", data_ref="d", column_map={"x": 0}
+    )
+    st.nlsq_result = {
+        "params": {"G0": 1000.0, "eta": 50.0},
+        "r_squared": 0.95,
+        "pcov": [[4.0, 0.0], [0.0, 9.0]],
+    }
+    step = NlsqStep(st)
+    qtbot.addWidget(step)
+
+    step.refresh_display()
+
+    text = step._result.text()
+    assert "G0=±2" in text
+    assert "eta=±3" in text
+
+
+def test_refresh_display_omits_optional_fields_when_absent(qtbot):
+    # Regression: a result dict without chi_squared/mpe/fit_time/pcov (e.g.
+    # a bare test fake, as used throughout this test file) must not crash
+    # and must not show placeholder/garbage text for the missing fields.
+    st = FitState(
+        protocol="oscillation", model_key="maxwell", data_ref="d", column_map={"x": 0}
+    )
+    st.nlsq_result = {"params": {"G0": 1000.0}, "r_squared": 0.9}
+    step = NlsqStep(st)
+    qtbot.addWidget(step)
+
+    step.refresh_display()
+
+    assert step._result.text() == "R²=0.900"

--- a/tests/gui/workspace/fit/test_step3.py
+++ b/tests/gui/workspace/fit/test_step3.py
@@ -152,3 +152,68 @@ def test_refresh_display_omits_optional_fields_when_absent(qtbot):
     step.refresh_display()
 
     assert step._result.text() == "R²=0.900"
+
+
+def test_options_button_opens_dialog_and_stores_result(qtbot, monkeypatch):
+    from PySide6.QtWidgets import QDialog
+
+    from rheojax.gui.dialogs.fitting_options import FittingOptionsDialog
+
+    st = FitState(
+        protocol="oscillation", model_key="maxwell", data_ref="d", column_map={"x": 0}
+    )
+    step = NlsqStep(st)
+    qtbot.addWidget(step)
+
+    monkeypatch.setattr(
+        FittingOptionsDialog, "exec", lambda self: QDialog.DialogCode.Accepted
+    )
+    monkeypatch.setattr(
+        FittingOptionsDialog,
+        "get_options",
+        lambda self: {"algorithm": "L-BFGS-B", "ftol": 1e-10},
+    )
+
+    step._options_btn.click()
+
+    assert step.fit_options() == {"algorithm": "L-BFGS-B", "ftol": 1e-10}
+
+
+def test_options_dialog_cancelled_keeps_previous_options(qtbot, monkeypatch):
+    from PySide6.QtWidgets import QDialog
+
+    from rheojax.gui.dialogs.fitting_options import FittingOptionsDialog
+
+    st = FitState(
+        protocol="oscillation", model_key="maxwell", data_ref="d", column_map={"x": 0}
+    )
+    step = NlsqStep(st)
+    qtbot.addWidget(step)
+
+    monkeypatch.setattr(
+        FittingOptionsDialog, "exec", lambda self: QDialog.DialogCode.Rejected
+    )
+
+    step._options_btn.click()
+
+    assert step.fit_options() == {}
+
+
+def test_run_forwards_fit_options_to_fit_fn(qtbot):
+    st = FitState(
+        protocol="oscillation", model_key="maxwell", data_ref="d", column_map={"x": 0}
+    )
+    calls = {}
+
+    def fake_fit(model_key, model_config, data_ref, column_map, **kwargs):
+        calls["options"] = kwargs.get("options")
+        return {"params": {"G0": 1000.0}, "r_squared": 0.9}
+
+    step = NlsqStep(st, fit_fn=fake_fit)
+    qtbot.addWidget(step)
+    step._fit_options = {"ftol": 1e-10}
+
+    with qtbot.waitSignal(step.finished, timeout=2000):
+        step.run()
+
+    assert calls["options"] == {"ftol": 1e-10}

--- a/tests/gui/workspace/fit/test_step3_wiring.py
+++ b/tests/gui/workspace/fit/test_step3_wiring.py
@@ -187,6 +187,7 @@ def test_nlsq_step_loads_parameter_table_and_passes_bounds(monkeypatch):
         column_map,
         initial_params=None,
         multi_start=None,
+        options=None,
     ):
         captured["initial_params"] = initial_params
         return {"params": {"a": 1.0, "b": 2.0}, "r_squared": 0.5, "success": True}
@@ -226,6 +227,7 @@ def test_multistart_forwards_config_to_fit_fn():
         column_map,
         initial_params=None,
         multi_start=None,
+        options=None,
     ):
         captured["multi_start"] = multi_start
         return {"params": {"a": 1.0}, "r_squared": 0.9, "success": True}
@@ -389,6 +391,7 @@ def test_multistart_disabled_by_default():
         column_map,
         initial_params=None,
         multi_start=None,
+        options=None,
     ):
         captured["multi_start"] = multi_start
         return {"params": {"a": 1.0}, "r_squared": 0.9, "success": True}
@@ -397,3 +400,71 @@ def test_multistart_disabled_by_default():
     step = NlsqStep(st, fit_fn=fake_fit_fn)
     step.run()
     assert captured["multi_start"] == {"enabled": False, "count": 8}
+
+
+def test_make_fit_fn_threads_options_through_to_run_fit_isolated(monkeypatch):
+    calls = {}
+
+    def fake_run_fit_isolated(*args, **kwargs):
+        calls["options"] = kwargs.get("options")
+        return {"params": {"a": 1.0}, "r_squared": 0.9, "success": True}
+
+    monkeypatch.setattr(
+        "rheojax.gui.workspace.fit.fit_controller.run_fit_isolated",
+        fake_run_fit_isolated,
+    )
+
+    lib = DatasetLibrary()
+    lib.add(
+        DatasetRef(
+            id="d1",
+            name="d1",
+            protocol_type="flow_curve",
+            origin="imported",
+            units={},
+            row_count=2,
+            hash="h",
+            provenance={},
+            lineage=[],
+        )
+    )
+    lib.store_payload("d1", _RheoData([1.0, 2.0], [1.0, 2.0]))
+
+    fit_fn = _make_fit_fn(lib, FitState(protocol="flow_curve"))
+    fit_fn("power_law", {}, "d1", {"x": 0, "y": 1}, options={"ftol": 1e-10})
+    assert calls["options"] == {"ftol": 1e-10}
+
+
+def test_make_fit_fn_defaults_missing_options_to_empty_dict(monkeypatch):
+    # Regression-guard: options=None (the default when nothing is passed)
+    # must reach run_fit_isolated as {}, not None.
+    calls = {}
+
+    def fake_run_fit_isolated(*args, **kwargs):
+        calls["options"] = kwargs.get("options")
+        return {"params": {"a": 1.0}, "r_squared": 0.9, "success": True}
+
+    monkeypatch.setattr(
+        "rheojax.gui.workspace.fit.fit_controller.run_fit_isolated",
+        fake_run_fit_isolated,
+    )
+
+    lib = DatasetLibrary()
+    lib.add(
+        DatasetRef(
+            id="d1",
+            name="d1",
+            protocol_type="flow_curve",
+            origin="imported",
+            units={},
+            row_count=2,
+            hash="h",
+            provenance={},
+            lineage=[],
+        )
+    )
+    lib.store_payload("d1", _RheoData([1.0, 2.0], [1.0, 2.0]))
+
+    fit_fn = _make_fit_fn(lib, FitState(protocol="flow_curve"))
+    fit_fn("power_law", {}, "d1", {"x": 0, "y": 1})
+    assert calls["options"] == {}

--- a/tests/gui/workspace/test_window_import.py
+++ b/tests/gui/workspace/test_window_import.py
@@ -276,6 +276,36 @@ def test_import_failed_unparseable_file_skips_broken_column_mapper(
     assert len(messages) == 1
 
 
+def test_import_completed_dedupes_multi_segment_same_file_names(qtbot, tmp_path):
+    # Regression: multiple segments from one source file all got that file's
+    # bare stem as their name, producing indistinguishable duplicate entries
+    # in the rail/combo for a multi-segment import (e.g. a TRIOS file with
+    # more than one frequency-sweep segment).
+    state = AppState()
+    win = WorkspaceWindow(state)
+    qtbot.addWidget(win)
+
+    source = tmp_path / "multi.csv"
+    source.write_text("omega,g_prime\n1.0,2.0\n")
+    data_a = RheoData(
+        x=np.array([1.0, 2.0]),
+        y=np.array([2.0, 3.0]),
+        domain="frequency",
+        metadata={"_source_file": str(source)},
+    )
+    data_b = RheoData(
+        x=np.array([3.0, 4.0]),
+        y=np.array([4.0, 5.0]),
+        domain="frequency",
+        metadata={"_source_file": str(source)},
+    )
+
+    win._on_import_completed([data_a, data_b])
+
+    names = sorted(ref.name for ref in state.library.all())
+    assert names == ["multi_segment_1", "multi_segment_2"]
+
+
 def test_rail_dataset_selected_forwards_to_fit_data_step_when_in_fit_mode(
     qtbot, monkeypatch
 ):

--- a/tests/gui/workspace/test_window_import.py
+++ b/tests/gui/workspace/test_window_import.py
@@ -274,3 +274,37 @@ def test_import_failed_unparseable_file_skips_broken_column_mapper(
     assert exec_calls == []
     assert len(warnings_shown) == 1  # ColumnMapperDialog's own load-failure warning
     assert len(messages) == 1
+
+
+def test_rail_dataset_selected_forwards_to_fit_data_step_when_in_fit_mode(
+    qtbot, monkeypatch
+):
+    # Regression: LibraryRail.dataset_selected was defined and emitted but
+    # never connected to anything in WorkspaceWindow, so clicking a dataset
+    # in the rail had no effect on the Fit workflow's data selection.
+    state = AppState()
+    win = WorkspaceWindow(state)
+    qtbot.addWidget(win)
+    assert win._mode == "fit"
+
+    calls = []
+    monkeypatch.setattr(
+        win._fit_bodies[1], "select_dataset", lambda ds_id: calls.append(ds_id)
+    )
+
+    win._rail.dataset_selected.emit("abc123")
+
+    assert calls == ["abc123"]
+
+
+def test_rail_dataset_selected_ignored_outside_fit_mode(qtbot):
+    # Transform's SlotsStep manages multiple per-slot combos and Pipeline's
+    # PipelineConfigureRunStep selects datasets for batch execution -- neither
+    # has a single "make this the active dataset" concept to forward to.
+    # Verify the handler no-ops instead of raising in those modes.
+    state = AppState()
+    win = WorkspaceWindow(state)
+    qtbot.addWidget(win)
+    win.set_mode("transform")
+
+    win._rail.dataset_selected.emit("abc123")  # must not raise


### PR DESCRIPTION
## Summary

Starts from the original atomic-lock fix and adds Phase 1 + sub-phase 2a of a broader workspace-shell gap-closure effort (see `docs/superpowers/specs/2026-07-06-workspace-shell-gap-closure-design.md`, local-only per this repo's `.gitignore` convention for `docs/superpowers/`).

**Dataset lock (original)**
- `_commit_dataset()`'s `library.add()` + `library.store_payload()` now share one `with self._state.library.lock:` acquisition instead of two, closing a window where a concurrent reader could see a registered `DatasetRef` before its payload was written.

**Phase 1 — dead code / silent bugs**
- `4ec63181` — wire `LibraryRail.dataset_selected` (emitted, never connected) to the Fit workflow's `DataStep.select_dataset`
- `fb2af4ba` — dedupe dataset names for multi-segment single-file imports (previously all segments from one file shared an identical name)

**Sub-phase 2a — Fit (NLSQ): options + readout**
- `27d2d607` — NLSQ result readout now shows chi², MPE, fit time, and parameter uncertainty (±σ from pcov) — all already computed in production, previously undisplayed
- `a575beb5` — wire the existing `FittingOptionsDialog` into the workspace NLSQ step, replacing a hardcoded `options={}`
- `637fe29b` — fix a double multi-start bug caught by final review: the step's own multi-start widget and the Fit Options dialog's multi-start setting could both reach the backend, nesting two restart loops and silently multiplying fit time
- `b28099e7` — graphify knowledge graph rebuild

Each commit passed individual implementer + reviewer cycles (spec compliance + code quality) via `subagent-driven-development`, plus a final whole-branch review per phase/sub-phase.

## Test plan
- [x] `uv run pytest tests/gui/workspace/test_window_commit_dataset.py -q` — 8 passed (original fix)
- [x] `uv run pytest tests/gui/workspace/ -q` — 213 passed, 2 pre-existing failures confirmed unrelated (FreeType/matplotlib `raster overflow` rendering bug, reproduced identically on the pre-Phase-1 baseline)
- [x] `uv run pytest tests/gui/workspace/fit/ -v` — 79 passed after sub-phase 2a, same 2 pre-existing failures
- [x] `uv run ruff check rheojax/gui/workspace/window.py` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)