### PR TITLE
feat(gui): add dataset preview & inspection dialog

### DIFF
--- a/rheojax/gui/dialogs/__init__.py
+++ b/rheojax/gui/dialogs/__init__.py
@@ -8,6 +8,7 @@ Modal dialogs for wizards and configuration.
 from rheojax.gui.dialogs.about import About, AboutDialog
 from rheojax.gui.dialogs.bayesian_options import BayesianOptions, BayesianOptionsDialog
 from rheojax.gui.dialogs.column_mapper import ColumnMapper, ColumnMapperDialog
+from rheojax.gui.dialogs.dataset_preview import DatasetPreviewDialog
 from rheojax.gui.dialogs.export_options import ExportOptions, ExportOptionsDialog
 from rheojax.gui.dialogs.fitting_options import FittingOptions, FittingOptionsDialog
 from rheojax.gui.dialogs.import_wizard import ImportWizard
@@ -19,6 +20,7 @@ __all__ = [
     "PipelineTemplateDialog",
     "ColumnMapper",
     "ColumnMapperDialog",
+    "DatasetPreviewDialog",
     "FittingOptions",
     "FittingOptionsDialog",
     "BayesianOptions",

--- a/rheojax/gui/dialogs/dataset_preview.py
+++ b/rheojax/gui/dialogs/dataset_preview.py
@@ -136,6 +136,8 @@ class DatasetPreviewDialog(QDialog):
         # sections (i.e. before the first set_dataset() call). Force one
         # placeholder section into existence so the mode sticks immediately;
         # set_dataset()/the no-data path reset it back to empty as normal.
+        # Until then, columnCount()==1 with headerData(0)=="" (not the true
+        # 0-column x=None state) — required for the workaround, not a bug.
         self._model.set_data(np.array([]), np.array([]), "", [])
 
         layout = QVBoxLayout(self)

--- a/rheojax/gui/dialogs/dataset_preview.py
+++ b/rheojax/gui/dialogs/dataset_preview.py
@@ -10,7 +10,19 @@ from __future__ import annotations
 
 import numpy as np
 
-from rheojax.gui.compat import Qt, QtCore
+from rheojax.core.data import RheoData
+from rheojax.gui.compat import (
+    QDialog,
+    QFormLayout,
+    QHeaderView,
+    QLabel,
+    Qt,
+    QtCore,
+    QtWidgets,
+    QVBoxLayout,
+    QWidget,
+)
+from rheojax.gui.foundation.library import DatasetRef
 
 
 class RheoDataTableModel(QtCore.QAbstractTableModel):
@@ -85,3 +97,94 @@ class RheoDataTableModel(QtCore.QAbstractTableModel):
         if section < 0 or section >= len(self._headers):
             return None
         return self._headers[section]
+
+
+class DatasetPreviewDialog(QDialog):
+    """Non-modal preview of a single dataset's table, summary, and warnings."""
+
+    def __init__(self, parent: QWidget | None = None) -> None:
+        super().__init__(parent)
+        self.setWindowTitle("Dataset Preview")
+        self.setModal(False)
+
+        self._name_label = QLabel(self)
+        self._protocol_label = QLabel(self)
+        self._origin_label = QLabel(self)
+        self._domain_label = QLabel(self)
+        self._row_count_label = QLabel(self)
+        summary_form = QFormLayout()
+        summary_form.addRow("Name:", self._name_label)
+        summary_form.addRow("Protocol:", self._protocol_label)
+        summary_form.addRow("Origin:", self._origin_label)
+        summary_form.addRow("Domain:", self._domain_label)
+        summary_form.addRow("Rows:", self._row_count_label)
+
+        self._no_data_label = QLabel("No data available for this dataset", self)
+
+        self._warnings_layout = QVBoxLayout()
+        self._warnings_container = QWidget(self)
+        self._warnings_container.setLayout(self._warnings_layout)
+
+        self._model = RheoDataTableModel(self)
+        self._table_view = QtWidgets.QTableView(self)
+        self._table_view.setModel(self._model)
+        self._table_view.horizontalHeader().setSectionResizeMode(
+            QHeaderView.ResizeMode.ResizeToContents
+        )
+        # ponytail: PySide6 6.11's QHeaderView.sectionResizeMode(0) reports
+        # Fixed instead of the mode set above when the header has zero
+        # sections (i.e. before the first set_dataset() call). Force one
+        # placeholder section into existence so the mode sticks immediately;
+        # set_dataset()/the no-data path reset it back to empty as normal.
+        self._model.set_data(np.array([]), np.array([]), "", [])
+
+        layout = QVBoxLayout(self)
+        layout.addLayout(summary_form)
+        layout.addWidget(self._no_data_label)
+        layout.addWidget(self._warnings_container)
+        layout.addWidget(self._table_view)
+
+    def set_dataset(
+        self, ref: DatasetRef, data: RheoData | None, warnings: list[str]
+    ) -> None:
+        """Populate the dialog for ref/data (data is None for the no-data state)."""
+        self._name_label.setText(ref.name)
+        self._protocol_label.setText(ref.protocol_type or "(none)")
+        self._origin_label.setText(ref.origin)
+
+        has_data = data is not None
+        self._domain_label.setText(data.domain if has_data else "unknown")
+        self._row_count_label.setText(str(len(data.x) if has_data else ref.row_count))
+
+        self._no_data_label.setVisible(not has_data)
+        self._warnings_container.setVisible(has_data and bool(warnings))
+        self._table_view.setVisible(has_data)
+
+        self._set_warnings(warnings if has_data else [])
+
+        if not has_data:
+            self._model.set_data(None, None, "", [])
+            return
+
+        is_complex = np.iscomplexobj(data.y)
+        x_unit = ref.units.get("x") or data.x_units
+        y_unit = ref.units.get("y") or data.y_units
+        x_header = f"x [{x_unit}]" if x_unit else "x"
+        if is_complex:
+            if ref.protocol_type == "oscillation":
+                y_names = ["G'", "G''"]
+            else:
+                y_names = ["Re(y)", "Im(y)"]
+        else:
+            y_names = ["y"]
+        y_headers = [f"{name} [{y_unit}]" if y_unit else name for name in y_names]
+        self._model.set_data(data.x, data.y, x_header, y_headers)
+
+    def _set_warnings(self, warnings: list[str]) -> None:
+        while self._warnings_layout.count():
+            item = self._warnings_layout.takeAt(0)
+            widget = item.widget()
+            if widget is not None:
+                widget.deleteLater()
+        for message in warnings:
+            self._warnings_layout.addWidget(QLabel(message, self._warnings_container))

--- a/rheojax/gui/dialogs/dataset_preview.py
+++ b/rheojax/gui/dialogs/dataset_preview.py
@@ -1,0 +1,87 @@
+"""
+Dataset Preview Dialog
+=======================
+
+Non-modal dialog for inspecting a dataset's raw table, summary, and
+data-quality warnings from the workspace LibraryRail.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+
+from rheojax.gui.compat import Qt, QtCore
+
+
+class RheoDataTableModel(QtCore.QAbstractTableModel):
+    """Read-only table model over a dataset's x/y arrays.
+
+    `y` may be real-valued (one data column) or complex-valued (two
+    columns: real then imaginary). Which is which, and what the columns
+    are labeled, is entirely the caller's decision (see `set_data`) --
+    this model only decides *how many cells* to read off `y`, based on
+    `np.iscomplexobj(y)`.
+    """
+
+    def __init__(self, parent=None) -> None:
+        super().__init__(parent)
+        self._x: np.ndarray | None = None
+        self._y: np.ndarray | None = None
+        self._headers: list[str] = []
+
+    def set_data(
+        self,
+        x: np.ndarray | None,
+        y: np.ndarray | None,
+        x_header: str,
+        y_headers: list[str],
+    ) -> None:
+        """Replace the model's data, safely notifying attached views.
+
+        Pass `x=None, y=None, x_header="", y_headers=[]` to reset the
+        model to an empty (0-row, 0-column) state.
+        """
+        self.beginResetModel()
+        self._x = x
+        self._y = y
+        self._headers = [x_header, *y_headers] if x is not None else []
+        self.endResetModel()
+
+    def rowCount(self, parent=QtCore.QModelIndex()) -> int:
+        if parent.isValid():
+            return 0
+        return 0 if self._x is None else len(self._x)
+
+    def columnCount(self, parent=QtCore.QModelIndex()) -> int:
+        if parent.isValid():
+            return 0
+        return len(self._headers)
+
+    def data(self, index, role=Qt.ItemDataRole.DisplayRole):
+        if not index.isValid() or self._x is None:
+            return None
+        if role != Qt.ItemDataRole.DisplayRole:
+            return None
+        col = index.column()
+        row = index.row()
+        if col == 0:
+            value = self._x[row]
+        elif np.iscomplexobj(self._y):
+            value = self._y[row].real if col == 1 else self._y[row].imag
+        else:
+            value = self._y[row]
+        try:
+            return f"{value:.6g}"
+        except (TypeError, ValueError):
+            # Non-numeric values can slip past shape-only validation
+            # upstream -- render as plain text instead of crashing the view.
+            return str(value)
+
+    def headerData(self, section, orientation, role=Qt.ItemDataRole.DisplayRole):
+        if role != Qt.ItemDataRole.DisplayRole:
+            return None
+        if orientation != Qt.Orientation.Horizontal:
+            return None
+        if section < 0 or section >= len(self._headers):
+            return None
+        return self._headers[section]

--- a/rheojax/gui/workspace/library_rail.py
+++ b/rheojax/gui/workspace/library_rail.py
@@ -4,6 +4,7 @@ from PySide6.QtCore import Qt, Signal
 from PySide6.QtWidgets import (
     QListWidget,
     QListWidgetItem,
+    QMenu,
     QPushButton,
     QVBoxLayout,
     QWidget,
@@ -15,6 +16,7 @@ from rheojax.gui.utils.layout_helpers import set_panel_margins
 
 class LibraryRail(QWidget):
     dataset_selected = Signal(str)
+    dataset_preview_requested = Signal(str)
     import_requested = Signal()
 
     def __init__(self, library: DatasetLibrary, parent: QWidget | None = None) -> None:
@@ -29,6 +31,13 @@ class LibraryRail(QWidget):
         self._list.itemClicked.connect(
             lambda it: self.dataset_selected.emit(it.data(Qt.ItemDataRole.UserRole))
         )
+        self._list.itemDoubleClicked.connect(
+            lambda it: self.dataset_preview_requested.emit(
+                it.data(Qt.ItemDataRole.UserRole)
+            )
+        )
+        self._list.setContextMenuPolicy(Qt.ContextMenuPolicy.CustomContextMenu)
+        self._list.customContextMenuRequested.connect(self._on_context_menu_requested)
         self._import.clicked.connect(self.import_requested.emit)
         self.refresh()
 
@@ -38,6 +47,21 @@ class LibraryRail(QWidget):
             it = QListWidgetItem(f"{ref.name}   [{ref.protocol_type}]")
             it.setData(Qt.ItemDataRole.UserRole, ref.id)
             self._list.addItem(it)
+
+    def _on_context_menu_requested(self, pos) -> None:
+        item = self._list.itemAt(pos)
+        if item is None:
+            return
+        menu = QMenu(self)
+        preview_action = menu.addAction("Preview…")
+        # ponytail: call via QMenu.exec(menu, ...) rather than menu.exec(...) --
+        # functionally identical, but PySide6 6.11's instance attribute lookup
+        # bypasses Python-level monkeypatching of QMenu.exec (class-level
+        # override only takes effect through the unbound call). This keeps
+        # QMenu.exec mockable in tests without changing runtime behavior.
+        chosen = QMenu.exec(menu, self._list.mapToGlobal(pos))
+        if chosen is preview_action:
+            self.dataset_preview_requested.emit(item.data(Qt.ItemDataRole.UserRole))
 
     def count(self) -> int:
         return self._list.count()

--- a/rheojax/gui/workspace/window.py
+++ b/rheojax/gui/workspace/window.py
@@ -41,6 +41,7 @@ class WorkspaceWindow(QMainWindow):
         self._pipeline_stop_event: threading.Event | None = None
         self._active_jobs_action_pending = False
         self._close_confirmed = False
+        self._preview_dialog = None
         # Keyed by job_id, not a single scalar -- a second concurrent import
         # launched before the first one finishes must not drop the only
         # Python reference to the first ImportWorker/ImportWorkerSignals
@@ -166,6 +167,9 @@ class WorkspaceWindow(QMainWindow):
         self._notifier.changed.connect(self._transform_bodies[1].refresh)
         self._notifier.changed.connect(self._pipeline_bodies[0].refresh)
         self._rail.import_requested.connect(self._on_import_requested)
+        self._rail.dataset_preview_requested.connect(
+            self._on_dataset_preview_requested
+        )
         self._inspector = InspectorPanel(self)
         self._canvas = StepperCanvas(self._controllers[self._mode], self)
         self._wire_canvas(self._canvas)
@@ -279,6 +283,19 @@ class WorkspaceWindow(QMainWindow):
             self._rail.import_requested.disconnect(self._on_import_requested)
         except (RuntimeError, TypeError):
             pass
+        try:
+            self._rail.dataset_preview_requested.disconnect(
+                self._on_dataset_preview_requested
+            )
+        except (RuntimeError, TypeError):
+            pass
+        from rheojax.gui.compat import _is_qobject_alive
+
+        if self._preview_dialog is not None:
+            if _is_qobject_alive(self._preview_dialog):
+                self._preview_dialog.close()
+                self._preview_dialog.deleteLater()
+            self._preview_dialog = None
         for widget in (self._canvas, self._rail, self._inspector, self._splitter):
             widget.deleteLater()
         self._controllers = {}
@@ -566,6 +583,56 @@ class WorkspaceWindow(QMainWindow):
 
     def _mark_dirty(self) -> None:
         self._state.project.dirty = True
+
+    def _on_dataset_preview_requested(self, dataset_id: str) -> None:
+        from rheojax.gui.compat import _is_qobject_alive
+        from rheojax.gui.dialogs.dataset_preview import DatasetPreviewDialog
+        from rheojax.gui.services.data_service import DataService
+        from rheojax.gui.utils.rheodata import rheodata_from_any
+
+        with self._state.library.lock:
+            try:
+                ref = self._state.library.get(dataset_id)
+            except KeyError:
+                self.log_dock.append_record(
+                    logging.WARNING,
+                    f"Preview requested for unknown dataset id: {dataset_id}",
+                )
+                return
+            try:
+                payload = self._state.library.load_payload(dataset_id)
+            except KeyError:
+                payload = None
+
+        data = None
+        if payload is not None:
+            try:
+                candidate = rheodata_from_any(payload).to_numpy()
+                if candidate.x.ndim == 1 and candidate.y.ndim == 1:
+                    data = candidate
+            except (TypeError, ValueError, IndexError):
+                data = None
+
+        warnings: list[str] = []
+        if data is not None:
+            if len(data.x) == 0:
+                warnings = ["Dataset contains no rows"]
+            else:
+                try:
+                    warnings = DataService().validate_data(data)
+                except Exception as exc:
+                    # Object-dtype/non-numeric values can pass the shape checks
+                    # above but still trip validate_data()'s numeric operations
+                    # (np.isfinite, np.ptp, percentiles) -- surface that as a
+                    # warning instead of crashing the preview.
+                    warnings = [f"Validation check failed: {exc}"]
+
+        if self._preview_dialog is None or not _is_qobject_alive(self._preview_dialog):
+            self._preview_dialog = DatasetPreviewDialog(self)
+        self._preview_dialog.set_dataset(ref, data, warnings)
+        self._preview_dialog.show()
+        self._preview_dialog.raise_()
+        self._preview_dialog.activateWindow()
 
     def _commit_dataset(self, ref, payload=None, overwrite: bool = False) -> None:
         self._state.library.add(ref, overwrite=overwrite)

--- a/tests/gui/test_dataset_preview.py
+++ b/tests/gui/test_dataset_preview.py
@@ -89,3 +89,191 @@ def test_data_falls_back_to_str_for_non_numeric_values():
     model.set_data(x, y, "x", ["y"])
     assert model.data(model.index(0, 0)) == "a"
     assert model.data(model.index(0, 1)) == "c"
+
+
+from rheojax.core.data import RheoData
+from rheojax.gui.dialogs.dataset_preview import DatasetPreviewDialog
+from rheojax.gui.foundation.library import DatasetRef
+
+
+def _ref(protocol_type="oscillation", units=None, row_count=0):
+    return DatasetRef(
+        id="d1",
+        name="d1",
+        protocol_type=protocol_type,
+        origin="imported",
+        units=units or {},
+        row_count=row_count,
+        hash="h",
+        provenance={},
+        lineage=[],
+    )
+
+
+def test_dialog_is_non_modal(qtbot):
+    dialog = DatasetPreviewDialog()
+    qtbot.addWidget(dialog)
+    assert dialog.isModal() is False
+
+
+def test_table_view_resizes_columns_to_contents(qtbot):
+    from PySide6.QtWidgets import QHeaderView
+
+    dialog = DatasetPreviewDialog()
+    qtbot.addWidget(dialog)
+    mode = dialog._table_view.horizontalHeader().sectionResizeMode(0)
+    assert mode == QHeaderView.ResizeMode.ResizeToContents
+
+
+def test_set_dataset_shows_table_and_hides_no_data_label(qtbot):
+    # isVisible() reflects the whole ancestor chain, not just this widget's
+    # own setVisible() flag -- the dialog itself must actually be shown for
+    # these assertions to mean anything (qtbot.addWidget() alone doesn't).
+    dialog = DatasetPreviewDialog()
+    qtbot.addWidget(dialog)
+    dialog.show()
+    data = RheoData(x=np.array([1.0, 2.0]), y=np.array([3.0, 4.0]), validate=False)
+
+    dialog.set_dataset(_ref(), data, [])
+
+    assert dialog._no_data_label.isVisible() is False
+    assert dialog._table_view.isVisible() is True
+    assert dialog._model.rowCount() == 2
+
+
+def test_set_dataset_with_none_shows_no_data_label(qtbot):
+    dialog = DatasetPreviewDialog()
+    qtbot.addWidget(dialog)
+    dialog.show()
+
+    dialog.set_dataset(_ref(row_count=7), None, [])
+
+    assert dialog._no_data_label.isVisible() is True
+    assert dialog._table_view.isVisible() is False
+    assert dialog._model.rowCount() == 0
+    # Summary header must stay populated/visible in the no-data state too --
+    # only the warnings/table region should change.
+    assert dialog._name_label.text() == "d1"
+    assert dialog._protocol_label.text() == "oscillation"
+    assert dialog._origin_label.text() == "imported"
+    assert dialog._domain_label.text() == "unknown"
+    assert dialog._row_count_label.text() == "7"
+
+
+def test_set_dataset_uses_len_x_for_row_count_not_ref_row_count(qtbot):
+    dialog = DatasetPreviewDialog()
+    qtbot.addWidget(dialog)
+    data = RheoData(
+        x=np.array([1.0, 2.0, 3.0, 4.0, 5.0]),
+        y=np.array([1.0, 2.0, 3.0, 4.0, 5.0]),
+        validate=False,
+    )
+
+    dialog.set_dataset(_ref(row_count=0), data, [])
+
+    assert dialog._row_count_label.text() == "5"
+
+
+def test_set_dataset_with_simplenamespace_derived_payload(qtbot):
+    from types import SimpleNamespace
+
+    from rheojax.gui.utils.rheodata import rheodata_from_any
+
+    dialog = DatasetPreviewDialog()
+    qtbot.addWidget(dialog)
+    payload = SimpleNamespace(x=np.array([1.0, 2.0]), y=np.array([3.0, 4.0]))
+    data = rheodata_from_any(payload).to_numpy()
+
+    dialog.set_dataset(_ref(row_count=0), data, [])
+
+    assert dialog._domain_label.text() == "time"
+    assert dialog._row_count_label.text() == "2"
+
+
+def test_warnings_banner_replaces_labels_on_reuse(qtbot):
+    dialog = DatasetPreviewDialog()
+    qtbot.addWidget(dialog)
+    data = RheoData(x=np.array([1.0, 2.0]), y=np.array([3.0, 4.0]), validate=False)
+
+    dialog.set_dataset(_ref(), data, ["one", "two", "three"])
+    assert dialog._warnings_layout.count() == 3
+
+    dialog.set_dataset(_ref(), data, ["only one now"])
+    assert dialog._warnings_layout.count() == 1
+    assert dialog._warnings_layout.itemAt(0).widget().text() == "only one now"
+
+
+def test_warnings_container_hidden_when_no_warnings(qtbot):
+    dialog = DatasetPreviewDialog()
+    qtbot.addWidget(dialog)
+    dialog.show()
+    data = RheoData(x=np.array([1.0]), y=np.array([2.0]), validate=False)
+
+    dialog.set_dataset(_ref(), data, [])
+
+    assert dialog._warnings_container.isVisible() is False
+
+
+def test_set_dataset_reuse_updates_columns_and_values(qtbot):
+    # Spec-level reuse test through the dialog's own set_dataset(), which
+    # also recomputes headers/visibility -- a superset of Task 1's raw
+    # model-level reuse test.
+    dialog = DatasetPreviewDialog()
+    qtbot.addWidget(dialog)
+    complex_data = RheoData(
+        x=np.array([1.0, 2.0]), y=np.array([1.0 + 1.0j, 2.0 + 2.0j]), validate=False
+    )
+    dialog.set_dataset(_ref(protocol_type="oscillation"), complex_data, [])
+    assert dialog._model.columnCount() == 3
+
+    real_data = RheoData(x=np.array([9.0]), y=np.array([42.0]), validate=False)
+    dialog.set_dataset(_ref(protocol_type="creep"), real_data, [])
+
+    assert dialog._model.columnCount() == 2
+    assert dialog._model.rowCount() == 1
+    assert dialog._model.data(dialog._model.index(0, 1)) == f"{42.0:.6g}"
+
+
+def test_column_headers_include_units(qtbot):
+    from PySide6.QtCore import Qt as QtQt
+
+    dialog = DatasetPreviewDialog()
+    qtbot.addWidget(dialog)
+    data = RheoData(
+        x=np.array([1.0, 2.0]),
+        y=np.array([3.0, 4.0]),
+        x_units="s",
+        y_units="Pa",
+        validate=False,
+    )
+
+    dialog.set_dataset(_ref(units={"x": "s", "y": "Pa"}), data, [])
+
+    assert dialog._model.headerData(0, QtQt.Orientation.Horizontal) == "x [s]"
+    assert dialog._model.headerData(1, QtQt.Orientation.Horizontal) == "y [Pa]"
+
+
+def test_complex_columns_labeled_gprime_for_oscillation_protocol(qtbot):
+    from PySide6.QtCore import Qt as QtQt
+
+    dialog = DatasetPreviewDialog()
+    qtbot.addWidget(dialog)
+    data = RheoData(x=np.array([1.0]), y=np.array([1.0 + 2.0j]), validate=False)
+
+    dialog.set_dataset(_ref(protocol_type="oscillation"), data, [])
+
+    assert dialog._model.headerData(1, QtQt.Orientation.Horizontal) == "G'"
+    assert dialog._model.headerData(2, QtQt.Orientation.Horizontal) == "G''"
+
+
+def test_complex_columns_labeled_re_im_for_non_oscillation_protocol(qtbot):
+    from PySide6.QtCore import Qt as QtQt
+
+    dialog = DatasetPreviewDialog()
+    qtbot.addWidget(dialog)
+    data = RheoData(x=np.array([1.0]), y=np.array([1.0 + 2.0j]), validate=False)
+
+    dialog.set_dataset(_ref(protocol_type="creep"), data, [])
+
+    assert dialog._model.headerData(1, QtQt.Orientation.Horizontal) == "Re(y)"
+    assert dialog._model.headerData(2, QtQt.Orientation.Horizontal) == "Im(y)"

--- a/tests/gui/test_dataset_preview.py
+++ b/tests/gui/test_dataset_preview.py
@@ -1,0 +1,91 @@
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+pytest.importorskip("PySide6")
+
+from PySide6.QtCore import Qt
+
+from rheojax.gui.dialogs.dataset_preview import RheoDataTableModel
+
+
+def test_empty_model_reports_zero_rows_and_columns():
+    model = RheoDataTableModel()
+    assert model.rowCount() == 0
+    assert model.columnCount() == 0
+
+
+def test_real_valued_data_has_two_columns():
+    model = RheoDataTableModel()
+    x = np.array([1.0, 2.0, 3.0])
+    y = np.array([10.0, 20.0, 30.0])
+    model.set_data(x, y, "x", ["y"])
+    assert model.rowCount() == 3
+    assert model.columnCount() == 2
+    assert model.headerData(0, Qt.Orientation.Horizontal) == "x"
+    assert model.headerData(1, Qt.Orientation.Horizontal) == "y"
+
+
+def test_complex_valued_data_has_three_columns():
+    model = RheoDataTableModel()
+    x = np.array([1.0, 2.0])
+    y = np.array([1.0 + 2.0j, 3.0 + 4.0j])
+    model.set_data(x, y, "x", ["G'", "G''"])
+    assert model.columnCount() == 3
+    assert model.headerData(1, Qt.Orientation.Horizontal) == "G'"
+    assert model.headerData(2, Qt.Orientation.Horizontal) == "G''"
+
+
+def test_cell_values_are_formatted_with_6g():
+    model = RheoDataTableModel()
+    x = np.array([0.00012345])
+    y = np.array([98765.4321])
+    model.set_data(x, y, "x", ["y"])
+    assert model.data(model.index(0, 0)) == f"{0.00012345:.6g}"
+    assert model.data(model.index(0, 1)) == f"{98765.4321:.6g}"
+
+
+def test_complex_cell_splits_into_real_and_imag_columns():
+    model = RheoDataTableModel()
+    x = np.array([1.0])
+    y = np.array([3.0 + 4.0j])
+    model.set_data(x, y, "x", ["Re(y)", "Im(y)"])
+    assert model.data(model.index(0, 1)) == f"{3.0:.6g}"
+    assert model.data(model.index(0, 2)) == f"{4.0:.6g}"
+
+
+def test_set_data_resets_model_shape_on_reuse():
+    model = RheoDataTableModel()
+    model.set_data(
+        np.array([1.0, 2.0, 3.0]),
+        np.array([1.0 + 1.0j, 2.0 + 2.0j, 3.0 + 3.0j]),
+        "x",
+        ["G'", "G''"],
+    )
+    assert model.columnCount() == 3
+    model.set_data(np.array([1.0]), np.array([5.0]), "x", ["y"])
+    assert model.columnCount() == 2
+    assert model.rowCount() == 1
+    assert model.data(model.index(0, 1)) == f"{5.0:.6g}"
+
+
+def test_set_data_none_resets_to_empty():
+    model = RheoDataTableModel()
+    model.set_data(np.array([1.0]), np.array([5.0]), "x", ["y"])
+    model.set_data(None, None, "", [])
+    assert model.rowCount() == 0
+    assert model.columnCount() == 0
+
+
+def test_data_falls_back_to_str_for_non_numeric_values():
+    # Non-numeric (e.g. object-dtype/string) values can pass shape-only
+    # validation upstream (Task 4's handler only checks ndim/length, not
+    # dtype) -- the model must not crash Qt's paint/scroll machinery when
+    # it eventually reads such a cell.
+    model = RheoDataTableModel()
+    x = np.array(["a", "b"], dtype=object)
+    y = np.array(["c", "d"], dtype=object)
+    model.set_data(x, y, "x", ["y"])
+    assert model.data(model.index(0, 0)) == "a"
+    assert model.data(model.index(0, 1)) == "c"

--- a/tests/gui/workspace/test_library_rail.py
+++ b/tests/gui/workspace/test_library_rail.py
@@ -1,0 +1,79 @@
+from __future__ import annotations
+
+import pytest
+
+pytest.importorskip("PySide6")
+
+from rheojax.gui.foundation.library import DatasetLibrary, DatasetRef
+from rheojax.gui.workspace.library_rail import LibraryRail
+
+
+def _ref(id_: str) -> DatasetRef:
+    return DatasetRef(
+        id=id_,
+        name=id_,
+        protocol_type="oscillation",
+        origin="imported",
+        units={},
+        row_count=1,
+        hash="h",
+        provenance={},
+        lineage=[],
+    )
+
+
+def test_double_click_emits_dataset_preview_requested(qtbot):
+    library = DatasetLibrary()
+    library.add(_ref("d1"))
+    rail = LibraryRail(library)
+    qtbot.addWidget(rail)
+    item = rail._list.item(0)
+
+    with qtbot.waitSignal(rail.dataset_preview_requested, timeout=1000) as blocker:
+        rail._list.itemDoubleClicked.emit(item)
+
+    assert blocker.args == ["d1"]
+
+
+def test_context_menu_on_item_emits_dataset_preview_requested(qtbot, monkeypatch):
+    from PySide6.QtWidgets import QMenu
+
+    library = DatasetLibrary()
+    library.add(_ref("d1"))
+    rail = LibraryRail(library)
+    qtbot.addWidget(rail)
+    monkeypatch.setattr(QMenu, "exec", lambda self, *a, **k: self.actions()[0])
+    pos = rail._list.visualItemRect(rail._list.item(0)).center()
+
+    with qtbot.waitSignal(rail.dataset_preview_requested, timeout=1000) as blocker:
+        rail._on_context_menu_requested(pos)
+
+    assert blocker.args == ["d1"]
+
+
+def test_context_menu_on_empty_space_does_nothing(qtbot):
+    library = DatasetLibrary()
+    rail = LibraryRail(library)
+    qtbot.addWidget(rail)
+
+    # No items in the list -- itemAt() at any position returns None, so this
+    # must not raise and must not show a menu.
+    rail._on_context_menu_requested(rail._list.rect().center())
+
+
+def test_context_menu_targets_clicked_item_not_current_selection(qtbot, monkeypatch):
+    from PySide6.QtWidgets import QMenu
+
+    library = DatasetLibrary()
+    library.add(_ref("d1"))
+    library.add(_ref("d2"))
+    rail = LibraryRail(library)
+    qtbot.addWidget(rail)
+    rail._list.setCurrentRow(0)  # "d1" is the current selection
+    monkeypatch.setattr(QMenu, "exec", lambda self, *a, **k: self.actions()[0])
+    pos = rail._list.visualItemRect(rail._list.item(1)).center()  # right-click on "d2"
+
+    with qtbot.waitSignal(rail.dataset_preview_requested, timeout=1000) as blocker:
+        rail._on_context_menu_requested(pos)
+
+    assert blocker.args == ["d2"]

--- a/tests/gui/workspace/test_library_rail.py
+++ b/tests/gui/workspace/test_library_rail.py
@@ -51,6 +51,29 @@ def test_context_menu_on_item_emits_dataset_preview_requested(qtbot, monkeypatch
     assert blocker.args == ["d1"]
 
 
+def test_context_menu_signal_wiring_reaches_handler_through_real_emission(
+    qtbot, monkeypatch
+):
+    # Every other context-menu test calls rail._on_context_menu_requested(pos)
+    # directly. A missing or broken setContextMenuPolicy()/
+    # customContextMenuRequested.connect(...) in __init__ would leave those
+    # tests passing while a real right-click did nothing -- this test goes
+    # through the real Qt signal instead of calling the handler.
+    from PySide6.QtWidgets import QMenu
+
+    library = DatasetLibrary()
+    library.add(_ref("d1"))
+    rail = LibraryRail(library)
+    qtbot.addWidget(rail)
+    monkeypatch.setattr(QMenu, "exec", lambda self, *a, **k: self.actions()[0])
+    pos = rail._list.visualItemRect(rail._list.item(0)).center()
+
+    with qtbot.waitSignal(rail.dataset_preview_requested, timeout=1000) as blocker:
+        rail._list.customContextMenuRequested.emit(pos)
+
+    assert blocker.args == ["d1"]
+
+
 def test_context_menu_on_empty_space_does_nothing(qtbot):
     library = DatasetLibrary()
     rail = LibraryRail(library)

--- a/tests/gui/workspace/test_window_dataset_preview.py
+++ b/tests/gui/workspace/test_window_dataset_preview.py
@@ -1,0 +1,377 @@
+from __future__ import annotations
+
+import logging
+from types import SimpleNamespace
+
+import numpy as np
+import pytest
+
+pytest.importorskip("PySide6")
+
+from rheojax.core.data import RheoData
+from rheojax.gui.foundation.library import DatasetRef
+from rheojax.gui.foundation.state import AppState
+from rheojax.gui.workspace.window import WorkspaceWindow
+
+
+def _ref(id_: str = "d1", row_count: int = 0) -> DatasetRef:
+    return DatasetRef(
+        id=id_,
+        name=id_,
+        protocol_type="oscillation",
+        origin="derived",
+        units={},
+        row_count=row_count,
+        hash="h",
+        provenance={},
+        lineage=[],
+    )
+
+
+def test_preview_unknown_dataset_id_leaves_dialog_none(qtbot):
+    state = AppState()
+    win = WorkspaceWindow(state)
+    qtbot.addWidget(win)
+
+    win._on_dataset_preview_requested("does-not-exist")
+
+    assert win._preview_dialog is None
+
+
+def test_preview_unknown_dataset_id_leaves_existing_dialog_untouched(qtbot):
+    # Distinct from the test above: here a dialog is already open showing a
+    # real dataset, and a stale/unknown id must not clear or replace it.
+    state = AppState()
+    win = WorkspaceWindow(state)
+    qtbot.addWidget(win)
+    state.library.add(_ref("d1"))
+    state.library.store_payload(
+        "d1", RheoData(x=np.array([1.0, 2.0]), y=np.array([3.0, 4.0]), validate=False)
+    )
+    win._on_dataset_preview_requested("d1")
+    existing_dialog = win._preview_dialog
+    assert existing_dialog is not None
+
+    win._on_dataset_preview_requested("does-not-exist")
+
+    assert win._preview_dialog is existing_dialog
+    assert win._preview_dialog._model.rowCount() == 2
+
+
+def test_preview_unknown_dataset_id_logs_warning(qtbot, monkeypatch):
+    state = AppState()
+    win = WorkspaceWindow(state)
+    qtbot.addWidget(win)
+    logged = []
+    monkeypatch.setattr(
+        win.log_dock, "append_record", lambda level, msg: logged.append((level, msg))
+    )
+
+    win._on_dataset_preview_requested("does-not-exist")
+
+    assert len(logged) == 1
+    level, message = logged[0]
+    assert level == logging.WARNING
+    assert "does-not-exist" in message
+
+
+def test_preview_known_dataset_opens_dialog_with_table(qtbot):
+    state = AppState()
+    win = WorkspaceWindow(state)
+    qtbot.addWidget(win)
+    state.library.add(_ref("d1"))
+    state.library.store_payload(
+        "d1", RheoData(x=np.array([1.0, 2.0]), y=np.array([3.0, 4.0]), validate=False)
+    )
+
+    win._on_dataset_preview_requested("d1")
+
+    assert win._preview_dialog is not None
+    assert win._preview_dialog.isVisible()
+    assert win._preview_dialog._model.rowCount() == 2
+
+
+def test_rail_signal_emission_reaches_handler_through_real_wiring(qtbot):
+    # Every other test in this file calls _on_dataset_preview_requested()
+    # directly. A missing or broken
+    # `_rail.dataset_preview_requested.connect(...)` in _build_workspace
+    # would leave all of them passing while the actual user-facing feature
+    # (double-click/right-click in LibraryRail) silently did nothing -- this
+    # test goes through the real signal instead of calling the handler.
+    state = AppState()
+    win = WorkspaceWindow(state)
+    qtbot.addWidget(win)
+    state.library.add(_ref("d1"))
+    state.library.store_payload(
+        "d1", RheoData(x=np.array([1.0, 2.0]), y=np.array([3.0, 4.0]), validate=False)
+    )
+
+    win._rail.dataset_preview_requested.emit("d1")
+
+    assert win._preview_dialog is not None
+    assert win._preview_dialog._model.rowCount() == 2
+
+
+def test_preview_ref_with_no_payload_shows_no_data_state(qtbot):
+    state = AppState()
+    win = WorkspaceWindow(state)
+    qtbot.addWidget(win)
+    state.library.add(_ref("d1"))  # never store_payload()'d
+
+    win._on_dataset_preview_requested("d1")
+
+    assert win._preview_dialog._no_data_label.isVisible() is True
+
+
+def test_preview_simplenamespace_payload_normalizes_without_crashing(qtbot):
+    state = AppState()
+    win = WorkspaceWindow(state)
+    qtbot.addWidget(win)
+    state.library.add(_ref("d1"))
+    state.library.store_payload(
+        "d1", SimpleNamespace(x=np.array([1.0, 2.0]), y=np.array([5.0, 6.0]))
+    )
+
+    win._on_dataset_preview_requested("d1")
+
+    assert win._preview_dialog._model.rowCount() == 2
+    assert win._preview_dialog._domain_label.text() == "time"
+
+
+def test_preview_mismatched_length_payload_shows_no_data_state(qtbot):
+    state = AppState()
+    win = WorkspaceWindow(state)
+    qtbot.addWidget(win)
+    state.library.add(_ref("d1"))
+    state.library.store_payload(
+        "d1", SimpleNamespace(x=np.array([1.0, 2.0, 3.0]), y=np.array([5.0]))
+    )
+
+    win._on_dataset_preview_requested("d1")
+
+    assert win._preview_dialog._no_data_label.isVisible() is True
+
+
+def test_preview_2d_y_payload_shows_no_data_state(qtbot):
+    # Round-2/3 review: RheoData's own shape validation tolerates a real-valued
+    # (N,2) `y` (e.g. a hand-crafted/restored payload), but no interactive
+    # import/transform/fit path in this codebase produces it -- this design
+    # treats it as unsupported rather than claiming it can't occur.
+    state = AppState()
+    win = WorkspaceWindow(state)
+    qtbot.addWidget(win)
+    state.library.add(_ref("d1"))
+    state.library.store_payload(
+        "d1",
+        RheoData(
+            x=np.array([1.0, 2.0, 3.0]),
+            y=np.array([[1.0, 2.0], [3.0, 4.0], [5.0, 6.0]]),
+            validate=False,
+        ),
+    )
+
+    win._on_dataset_preview_requested("d1")
+
+    assert win._preview_dialog._no_data_label.isVisible() is True
+
+
+def test_preview_nan_dataset_surfaces_real_validation_warning(qtbot):
+    # End-to-end with the REAL DataService.validate_data() (not mocked), to
+    # prove the full pipeline surfaces an actual validation warning, not just
+    # that the dialog can render whatever warnings list it's handed.
+    state = AppState()
+    win = WorkspaceWindow(state)
+    qtbot.addWidget(win)
+    state.library.add(_ref("d1"))
+    state.library.store_payload(
+        "d1",
+        RheoData(
+            x=np.array([1.0, 2.0, 3.0]),
+            y=np.array([1.0, np.nan, 3.0]),
+            validate=False,
+        ),
+    )
+
+    win._on_dataset_preview_requested("d1")
+
+    warnings_shown = [
+        win._preview_dialog._warnings_layout.itemAt(i).widget().text()
+        for i in range(win._preview_dialog._warnings_layout.count())
+    ]
+    assert "Y-axis contains NaN or Inf values" in warnings_shown
+
+
+def test_preview_object_dtype_payload_does_not_crash_rendering(qtbot):
+    # Non-numeric values can pass the shape/length/ndim checks (they're 1-D,
+    # matching length) but must still render without crashing -- exercises
+    # the real validate_data() AND the real table model, no mocking.
+    state = AppState()
+    win = WorkspaceWindow(state)
+    qtbot.addWidget(win)
+    state.library.add(_ref("d1"))
+    state.library.store_payload(
+        "d1",
+        RheoData(
+            x=np.array([1.0, 2.0]),
+            y=np.array(["not", "numeric"], dtype=object),
+            validate=False,
+        ),
+    )
+
+    win._on_dataset_preview_requested("d1")  # must not raise
+
+    dialog = win._preview_dialog
+    assert dialog._model.data(dialog._model.index(0, 1)) == "not"
+    warnings_shown = [
+        dialog._warnings_layout.itemAt(i).widget().text()
+        for i in range(dialog._warnings_layout.count())
+    ]
+    assert len(warnings_shown) == 1
+    assert warnings_shown[0].startswith("Validation check failed:")
+
+
+def test_preview_zero_row_dataset_skips_validate_data(qtbot, monkeypatch):
+    from rheojax.gui.services.data_service import DataService
+
+    state = AppState()
+    win = WorkspaceWindow(state)
+    qtbot.addWidget(win)
+    state.library.add(_ref("d1"))
+    state.library.store_payload(
+        "d1", RheoData(x=np.array([]), y=np.array([]), validate=False)
+    )
+    calls = {"n": 0}
+
+    def fake_validate(self, data):
+        calls["n"] += 1
+        return []
+
+    monkeypatch.setattr(DataService, "validate_data", fake_validate)
+
+    win._on_dataset_preview_requested("d1")
+
+    assert calls["n"] == 0
+    assert win._preview_dialog._warnings_layout.count() == 1
+    assert (
+        win._preview_dialog._warnings_layout.itemAt(0).widget().text()
+        == "Dataset contains no rows"
+    )
+
+
+def test_preview_validate_data_exception_becomes_warning_not_crash(qtbot, monkeypatch):
+    from rheojax.gui.services.data_service import DataService
+
+    state = AppState()
+    win = WorkspaceWindow(state)
+    qtbot.addWidget(win)
+    state.library.add(_ref("d1"))
+    state.library.store_payload(
+        "d1", RheoData(x=np.array([1.0, 2.0]), y=np.array([3.0, 4.0]), validate=False)
+    )
+
+    def broken_validate(self, data):
+        raise TypeError("boom")
+
+    monkeypatch.setattr(DataService, "validate_data", broken_validate)
+
+    win._on_dataset_preview_requested("d1")  # must not raise
+
+    assert win._preview_dialog._warnings_layout.count() == 1
+
+
+def test_preview_reuses_same_dialog_instance_after_closing(qtbot):
+    state = AppState()
+    win = WorkspaceWindow(state)
+    qtbot.addWidget(win)
+    state.library.add(_ref("d1"))
+    state.library.store_payload(
+        "d1", RheoData(x=np.array([1.0]), y=np.array([2.0]), validate=False)
+    )
+
+    win._on_dataset_preview_requested("d1")
+    first_dialog = win._preview_dialog
+    first_dialog.close()
+    assert first_dialog.isVisible() is False
+
+    win._on_dataset_preview_requested("d1")
+
+    assert win._preview_dialog is first_dialog
+    assert win._preview_dialog.isVisible() is True
+
+
+def test_preview_holds_library_lock_across_get_and_load_payload(qtbot):
+    # A shallow "was library.lock entered at all" check would still pass if
+    # get()/load_payload() were accidentally moved outside the `with` block
+    # -- DatasetLibrary.get()/load_payload() acquire the SAME RLock via the
+    # private `_lock` attribute (`.lock` is just a public alias to it).
+    # Recording depth inside __enter__ itself (rather than in a wrapper
+    # called *before* the wrapped method reacquires the lock) captures every
+    # acquisition, including the reentrant ones -- proving the outer
+    # `with library.lock:` in the handler is still held when get()/
+    # load_payload() acquire it internally, not merely that it was entered
+    # at some point.
+    state = AppState()
+    win = WorkspaceWindow(state)
+    qtbot.addWidget(win)
+    state.library.add(_ref("d1"))
+    state.library.store_payload(
+        "d1", RheoData(x=np.array([1.0]), y=np.array([2.0]), validate=False)
+    )
+    depths_seen = []
+
+    class ReentrantSpyLock:
+        def __init__(self, real_lock):
+            self._real_lock = real_lock
+            self.depth = 0
+
+        def __enter__(self):
+            self._real_lock.__enter__()
+            self.depth += 1
+            depths_seen.append(self.depth)
+            return self
+
+        def __exit__(self, *exc):
+            self.depth -= 1
+            return self._real_lock.__exit__(*exc)
+
+    spy = ReentrantSpyLock(state.library.lock)
+    state.library.lock = spy
+    state.library._lock = spy
+
+    win._on_dataset_preview_requested("d1")
+
+    # [1, 2, 2]: the handler's outer scope acquires first (depth 1), then
+    # get() and load_payload() each reacquire the SAME lock from inside it
+    # (depth 2 each), one after the other.
+    assert depths_seen == [1, 2, 2]
+
+
+def test_rebuild_closes_and_clears_open_preview_dialog(qtbot):
+    state = AppState()
+    win = WorkspaceWindow(state)
+    qtbot.addWidget(win)
+    state.library.add(_ref("d1"))
+    state.library.store_payload(
+        "d1", RheoData(x=np.array([1.0]), y=np.array([2.0]), validate=False)
+    )
+    win._on_dataset_preview_requested("d1")
+    old_dialog = win._preview_dialog
+    assert old_dialog is not None
+
+    win._rebuild(AppState())
+
+    # Not just "the attribute was cleared" -- the old dialog itself must
+    # actually be closed, not merely dereferenced while still on screen.
+    assert win._preview_dialog is None
+    assert old_dialog.isVisible() is False
+
+
+def test_rebuild_with_no_preview_ever_opened_does_not_raise(qtbot):
+    state = AppState()
+    win = WorkspaceWindow(state)
+    qtbot.addWidget(win)
+    assert win._preview_dialog is None
+
+    win._rebuild(AppState())  # must not raise AttributeError
+
+    assert win._preview_dialog is None


### PR DESCRIPTION
## Summary
- Adds a non-modal Dataset Preview dialog to the workspace `LibraryRail`: double-click (or right-click → "Preview…") any dataset to see its raw data table, a summary (name/protocol/origin/domain/row count), and data-quality warnings.
- Closes the gap where there was no way to see the numeric contents of a dataset anywhere in the workspace shell.

## Changes
- `RheoDataTableModel` (`rheojax/gui/dialogs/dataset_preview.py`) — read-only `QAbstractTableModel` over a dataset's x/y arrays, real or complex-valued.
- `DatasetPreviewDialog` (same file) — summary fields, warnings banner, and the table view; re-exported from `rheojax/gui/dialogs/__init__.py`.
- `LibraryRail.dataset_preview_requested(str)` signal — double-click and right-click "Preview…" triggers.
- `WorkspaceWindow` wiring — resolves the dataset (holding `DatasetLibrary`'s lock across `get()`+`load_payload()`), normalizes any payload shape via `rheodata_from_any(...).to_numpy()`, validates it, and shows/reuses a lazily-created dialog; tears it down on workspace rebuild (New/Open project).

Implemented and reviewed task-by-task via subagent-driven-development (4 tasks, each with an independent spec+quality review and one fix round on Task 2's Qt-quirk workaround), plus a final whole-branch review. See `docs/superpowers/plans/2026-07-06-dataset-preview-inspection.md` for the full plan (gitignored, not in this diff).

## Test plan
- [x] 41 new tests across the 4 tasks, all passing (`tests/gui/test_dataset_preview.py`, `tests/gui/workspace/test_library_rail.py`, `tests/gui/workspace/test_window_dataset_preview.py`)
- [x] Full `tests/gui/` suite: 545 passed; 10 pre-existing failures (matplotlib/FreeType font rendering + one MemoryError in unrelated Bayesian-parity/visual-regression tests) and one pre-existing order-dependent segfault, both verified via git-stash comparison to reproduce identically on pre-branch code
- [x] `ruff check` clean on all changed files
- [ ] Manual smoke test in a running GUI session (double-click + right-click preview, New/Open project teardown)

🤖 Generated with [Claude Code](https://claude.com/claude-code)