### PR TITLE
fix(gui): File>Close now actually closes the window

### DIFF
--- a/rheojax/gui/workspace/window.py
+++ b/rheojax/gui/workspace/window.py
@@ -439,6 +439,9 @@ class WorkspaceWindow(QMainWindow):
         )
 
     def _confirmed_close(self) -> None:
+        # ponytail: assumes WorkspaceWindow is top-level (its only construction site is
+        # _create_workspace_window() in rheojax/gui/main.py); self.close() semantics
+        # would need reconsidering if it's ever embedded as a child widget instead.
         self._close_confirmed = True
         self.close()
 

--- a/rheojax/gui/workspace/window.py
+++ b/rheojax/gui/workspace/window.py
@@ -412,10 +412,12 @@ class WorkspaceWindow(QMainWindow):
             self._state.project.dirty = False
 
     def _on_close(self) -> None:
+        # Actually close the window (same chain closeEvent uses for the OS ✕
+        # button), not a workspace reset -- this used to call
+        # self._rebuild(AppState()), copy-pasted from _on_new, which just
+        # blanked the project instead of closing anything.
         self._maybe_confirm_active_jobs(
-            lambda: self._maybe_confirm_unsaved_changes(
-                lambda: self._rebuild(AppState())
-            )
+            lambda: self._maybe_confirm_unsaved_changes(self._confirmed_close)
         )
 
     def closeEvent(self, event: QCloseEvent) -> None:

--- a/tests/gui/workspace/test_window_active_jobs_dialog.py
+++ b/tests/gui/workspace/test_window_active_jobs_dialog.py
@@ -122,6 +122,30 @@ def test_on_close_actually_closes_window_not_reset(qtbot, monkeypatch):
     assert rebuild_calls == []
 
 
+def test_on_close_declines_active_jobs_cancel_does_not_close(qtbot, monkeypatch):
+    # Coverage gap flagged in review: the test above only exercises _on_close's
+    # trivial fast path (no jobs, not dirty). This exercises the active-jobs branch
+    # specifically -- user declines to cancel running jobs, so _confirmed_close must
+    # never fire and the window must stay open.
+    win = WorkspaceWindow(AppState())
+    qtbot.addWidget(win)
+    win._state.active_jobs.by_id["d1"] = {"status": "running"}
+
+    from PySide6.QtWidgets import QMessageBox
+
+    monkeypatch.setattr(
+        QMessageBox, "question", lambda *a, **k: QMessageBox.StandardButton.Cancel
+    )
+    confirmed_close_calls = []
+    monkeypatch.setattr(
+        win, "_confirmed_close", lambda: confirmed_close_calls.append(1)
+    )
+
+    win._on_close()
+
+    assert confirmed_close_calls == []
+
+
 @pytest.mark.parametrize("trigger", ["_on_save", "_on_save_as"])
 def test_save_and_save_as_blocked_while_jobs_active(
     qtbot, monkeypatch, trigger, tmp_path

--- a/tests/gui/workspace/test_window_active_jobs_dialog.py
+++ b/tests/gui/workspace/test_window_active_jobs_dialog.py
@@ -101,6 +101,27 @@ def test_on_new_and_close_do_not_rebuild_while_jobs_active(qtbot, monkeypatch, t
     assert rebuild_calls == []
 
 
+def test_on_close_actually_closes_window_not_reset(qtbot, monkeypatch):
+    # Regression: _on_close used to call self._rebuild(AppState()) (copy-pasted from
+    # _on_new), which just blanked the project instead of closing the window -- File>Close
+    # appeared to do nothing. It must route through the same _confirmed_close chain
+    # closeEvent uses for the OS window controls.
+    win = WorkspaceWindow(AppState())
+    qtbot.addWidget(win)
+
+    confirmed_close_calls = []
+    monkeypatch.setattr(
+        win, "_confirmed_close", lambda: confirmed_close_calls.append(1)
+    )
+    rebuild_calls = []
+    monkeypatch.setattr(win, "_rebuild", lambda *a, **k: rebuild_calls.append(1))
+
+    win._on_close()
+
+    assert confirmed_close_calls == [1]
+    assert rebuild_calls == []
+
+
 @pytest.mark.parametrize("trigger", ["_on_save", "_on_save_as"])
 def test_save_and_save_as_blocked_while_jobs_active(
     qtbot, monkeypatch, trigger, tmp_path

--- a/tests/gui/workspace/test_window_file_menu.py
+++ b/tests/gui/workspace/test_window_file_menu.py
@@ -94,6 +94,28 @@ def test_maybe_confirm_unsaved_clean_state_proceeds_without_dialog(qtbot, monkey
     assert calls == [1]
 
 
+def test_on_close_reaches_confirmed_close_after_discarding_unsaved_changes(
+    qtbot, monkeypatch
+):
+    # Coverage gap flagged in review: the _on_close regression test in
+    # test_window_active_jobs_dialog.py only covers the clean-state fast path. This
+    # exercises _on_close's unsaved-changes branch specifically -- user discards
+    # pending edits, so _confirmed_close must still fire.
+    win = _win(qtbot)
+    win._state.project.dirty = True
+    monkeypatch.setattr(
+        QMessageBox, "question", lambda *a, **k: QMessageBox.StandardButton.Discard
+    )
+    confirmed_close_calls = []
+    monkeypatch.setattr(
+        win, "_confirmed_close", lambda: confirmed_close_calls.append(1)
+    )
+
+    win._on_close()
+
+    assert confirmed_close_calls == [1]
+
+
 def test_on_save_shows_critical_dialog_on_value_error(qtbot, monkeypatch):
     win = _win(qtbot)
     win._state.project.path = "/tmp/whatever.rheojax"


### PR DESCRIPTION
## Summary
- `WorkspaceWindow._on_close` (wired to the File>Close menu action) called `self._rebuild(AppState())` — copy-pasted from `_on_new` — instead of closing anything, so File>Close silently reset the project instead of shutting down the app.
- Routes it through the same `_confirmed_close` chain `closeEvent` already uses for the OS window controls (✕ button / Alt+F4).

## Root cause
Found via systematic debugging: `_on_close` and `_on_new` had identical bodies. The real close path only existed in `closeEvent`, which the File menu action never reached.

## Test plan
- [x] Added regression test asserting `_on_close` calls `_confirmed_close`, not `_rebuild`
- [x] `uv run pytest tests/gui/workspace/test_window_active_jobs_dialog.py -q` — 10 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)