### PR TITLE
fix(gui): 9th audit round — close real bugs in both default and legacy shells

### DIFF
--- a/rheojax/gui/app/main_window.py
+++ b/rheojax/gui/app/main_window.py
@@ -363,6 +363,11 @@ class RheoJAXMainWindow(QMainWindow):
         signals.dataset_added.connect(self._on_dataset_added_status)
         signals.dataset_added.connect(self._on_dataset_added)
         signals.dataset_added.connect(self.transform_page.refresh_dataset_checklist)
+        # store.py emits dataset_removed on delete, and DatasetTree.remove_dataset()
+        # exists to consume it, but nothing connected them: the tree kept a
+        # stale, still-clickable row after Remove/Delete Dataset, and clicking
+        # it fired dataset_selected(dead_id) for an id no longer in state.datasets.
+        signals.dataset_removed.connect(self.data_tree.remove_dataset)
         signals.pipeline_step_changed.connect(self._on_pipeline_step_changed)
 
         # GUI-016: keep selected pipeline step config in sync with page changes
@@ -842,6 +847,59 @@ class RheoJAXMainWindow(QMainWindow):
         """
         self.log_dock.append_record(logging.INFO, message)
 
+    def _confirm_unsaved_changes(self, action_desc: str) -> bool:
+        """Prompt to save/discard/cancel when there are unsaved changes.
+
+        Shared by every work-losing action (Exit/closeEvent, File>New,
+        File>Open, Open Recent) so each one gets the same GUI-P1-003
+        save-failure handling instead of re-implementing (and drifting
+        from) it independently. Previously only closeEvent checked
+        `_on_save_file()`'s return value; File>New ignored it (silently
+        wiping the project when "Save" failed since save isn't implemented
+        yet), and File>Open / Open Recent skipped the unsaved-changes
+        prompt entirely.
+
+        Returns
+        -------
+        bool
+            True if the caller should proceed (changes were saved,
+            discarded, or there were none). False if the action should be
+            aborted.
+        """
+        if not self._has_unsaved_changes:
+            return True
+        reply = QMessageBox.question(
+            self,
+            "Unsaved Changes",
+            f"You have unsaved changes. Do you want to save before {action_desc}?",
+            QMessageBox.StandardButton.Save
+            | QMessageBox.StandardButton.Discard
+            | QMessageBox.StandardButton.Cancel,
+            QMessageBox.StandardButton.Save,
+        )
+        if reply == QMessageBox.StandardButton.Save:
+            # _on_save_file() returns True when the save completes (or no
+            # changes needed) and False when the save is not implemented /
+            # failed.
+            if self._on_save_file():
+                return True
+            # Save failed or not implemented — give the user a second
+            # chance to explicitly discard or cancel, so data is never
+            # silently lost.
+            discard_reply = QMessageBox.question(
+                self,
+                "Save Failed",
+                "Save could not be completed.\n\n"
+                "Discard unsaved changes and continue anyway?",
+                QMessageBox.StandardButton.Discard
+                | QMessageBox.StandardButton.Cancel,
+                QMessageBox.StandardButton.Cancel,
+            )
+            return discard_reply == QMessageBox.StandardButton.Discard
+        if reply == QMessageBox.StandardButton.Discard:
+            return True
+        return False
+
     def closeEvent(self, event: QCloseEvent) -> None:
         """Handle window close event with cleanup.
 
@@ -851,50 +909,10 @@ class RheoJAXMainWindow(QMainWindow):
             Close event
         """
         logger.debug("Application shutting down")
-        # Check for unsaved changes
-        if self._has_unsaved_changes:
-            reply = QMessageBox.question(
-                self,
-                "Unsaved Changes",
-                "You have unsaved changes. Do you want to save before exiting?",
-                QMessageBox.StandardButton.Save
-                | QMessageBox.StandardButton.Discard
-                | QMessageBox.StandardButton.Cancel,
-                QMessageBox.StandardButton.Save,
-            )
-
-            if reply == QMessageBox.StandardButton.Save:
-                # GUI-P1-003 fix: only accept if save succeeds.  _on_save_file
-                # returns True when the save completes (or no changes needed)
-                # and False when the save is not implemented / failed.
-                saved = self._on_save_file()
-                if saved:
-                    event.accept()
-                else:
-                    # Save failed or not implemented — give the user a second
-                    # chance to explicitly discard or cancel, so data is never
-                    # silently lost.
-                    discard_reply = QMessageBox.question(
-                        self,
-                        "Save Failed",
-                        "Save could not be completed.\n\n"
-                        "Discard unsaved changes and close anyway?",
-                        QMessageBox.StandardButton.Discard
-                        | QMessageBox.StandardButton.Cancel,
-                        QMessageBox.StandardButton.Cancel,
-                    )
-                    if discard_reply == QMessageBox.StandardButton.Discard:
-                        event.accept()
-                    else:
-                        logger.debug("Shutdown cancelled after failed save")
-                        event.ignore()
-                        return
-            elif reply == QMessageBox.StandardButton.Discard:
-                event.accept()
-            else:
-                logger.debug("Shutdown cancelled by user")
-                event.ignore()
-                return
+        if not self._confirm_unsaved_changes("exiting"):
+            logger.debug("Shutdown cancelled")
+            event.ignore()
+            return
 
         # GUI-P1-006: flip the guard before any teardown so worker/relay
         # callbacks queued for delivery during the drain loop below (or that
@@ -983,6 +1001,7 @@ class RheoJAXMainWindow(QMainWindow):
                     ("dataset_added", self._on_dataset_added_status),
                     ("dataset_added", self._on_dataset_added),
                     ("dataset_added", self.transform_page.refresh_dataset_checklist),
+                    ("dataset_removed", self.data_tree.remove_dataset),
                     ("pipeline_step_changed", self._on_pipeline_step_changed),
                     # GUI-016 connections made in _connect_state_signals().
                     ("model_selected", self._sync_fit_step_config),
@@ -1045,6 +1064,16 @@ class RheoJAXMainWindow(QMainWindow):
         # Sync pipeline chips
         self._update_pipeline_chips_from_state(state)
 
+        # Sync Undo/Redo menu enablement -- both actions were set disabled at
+        # construction and nothing was re-enabling them (store.py fully
+        # supports undo/redo and can_undo()/can_redo() already existed as
+        # selectors), so a working feature was completely unreachable from
+        # the menu or its Ctrl+Z/Ctrl+Y shortcuts.
+        from rheojax.gui.state import selectors
+
+        self.menu_bar.undo_action.setEnabled(selectors.can_undo())
+        self.menu_bar.redo_action.setEnabled(selectors.can_redo())
+
         # Update workflow mode
         if state.workflow_mode != self._current_workflow_mode:
             previous_mode = self._current_workflow_mode
@@ -1065,19 +1094,8 @@ class RheoJAXMainWindow(QMainWindow):
     def _on_new_file(self) -> None:
         """Handle new file action."""
         logger.debug("New file action triggered")
-        if self._has_unsaved_changes:
-            reply = QMessageBox.question(
-                self,
-                "Unsaved Changes",
-                "You have unsaved changes. Do you want to save before creating a new project?",
-                QMessageBox.StandardButton.Save
-                | QMessageBox.StandardButton.Discard
-                | QMessageBox.StandardButton.Cancel,
-            )
-            if reply == QMessageBox.StandardButton.Save:
-                self._on_save_file()
-            elif reply == QMessageBox.StandardButton.Cancel:
-                return
+        if not self._confirm_unsaved_changes("creating a new project"):
+            return
 
         self.store.dispatch("NEW_PROJECT")
         self.log("Created new project")
@@ -1088,6 +1106,8 @@ class RheoJAXMainWindow(QMainWindow):
     def _on_open_file(self) -> None:
         """Handle open file action."""
         logger.debug("Open file action triggered")
+        if not self._confirm_unsaved_changes("opening another project"):
+            return
         file_path, _ = QFileDialog.getOpenFileName(
             self,
             "Open Project",
@@ -1170,6 +1190,8 @@ class RheoJAXMainWindow(QMainWindow):
                 "Project Not Found",
                 f"Recent project is missing:\n{path}",
             )
+            return
+        if not self._confirm_unsaved_changes("opening another project"):
             return
 
         self.log(f"Opening recent project: {path}")
@@ -2640,20 +2662,35 @@ class RheoJAXMainWindow(QMainWindow):
             from rheojax.gui.services.transform_service import TransformService
             from rheojax.gui.utils.rheodata import rheodata_from_dataset_state
 
-            # Mastercurve / SRFS need all loaded datasets, not just the active one.
+            # Mastercurve / SRFS need multiple datasets -- exactly the ones the
+            # user checked in TransformPage's "Datasets (select 2+)" checklist,
+            # not every loaded dataset. The checklist previously had no effect
+            # at all (checking only 2 of 3 still ran the transform on all 3);
+            # falling back to "all loaded datasets" only when the checklist
+            # itself isn't available (e.g. non-GUI callers / tests) preserves
+            # prior behavior for those callers.
             if transform_id in self._MULTI_DATASET_TRANSFORMS:
                 state = self.store.get_state()
                 all_datasets = state.datasets or {}
-                if len(all_datasets) < 2:
+                checked_ids = self.transform_page.get_checked_dataset_ids()
+                if checked_ids:
+                    selected_datasets = {
+                        ds_id: all_datasets[ds_id]
+                        for ds_id in checked_ids
+                        if ds_id in all_datasets
+                    }
+                else:
+                    selected_datasets = all_datasets
+                if len(selected_datasets) < 2:
                     self.status_bar.show_message(
                         f"{transform_id} requires at least 2 datasets "
-                        f"(loaded {len(all_datasets)})",
+                        f"(selected {len(selected_datasets)})",
                         5000,
                     )
                     return
                 rheo_data = [
                     rheodata_from_dataset_state(ds)
-                    for ds in all_datasets.values()
+                    for ds in selected_datasets.values()
                     if ds.x_data is not None and ds.y_data is not None
                 ]
             else:

--- a/rheojax/gui/app/main_window.py
+++ b/rheojax/gui/app/main_window.py
@@ -890,7 +890,7 @@ class RheoJAXMainWindow(QMainWindow):
                 self,
                 "Save Failed",
                 "Save could not be completed.\n\n"
-                "Discard unsaved changes and continue anyway?",
+                f"Discard unsaved changes and proceed with {action_desc}?",
                 QMessageBox.StandardButton.Discard
                 | QMessageBox.StandardButton.Cancel,
                 QMessageBox.StandardButton.Cancel,

--- a/rheojax/gui/app/main_window.py
+++ b/rheojax/gui/app/main_window.py
@@ -1115,10 +1115,24 @@ class RheoJAXMainWindow(QMainWindow):
             "RheoJAX Project (*.rheojax);;HDF5 Files (*.h5 *.hdf5);;All Files (*.*)",
         )
         if file_path:
-            self.log(f"Opening project: {file_path}")
-            logger.info("Opening project", file_path=file_path)
-            self.store.dispatch("LOAD_PROJECT", {"file_path": file_path})
-            self.status_bar.show_message(f"Opened: {file_path}", 3000)
+            # GUI-P1: LOAD_PROJECT's reducer only updates project_path/
+            # project_name/recents -- it never restores datasets/results
+            # (there is no codec bridging this legacy StateStore AppState to
+            # the versioned .rheojax v2 archive; that codec targets the
+            # workspace shell's foundation.state.AppState only). Dispatching
+            # it and reporting "Opened" would tell the user their project
+            # was restored when the previous/empty state is still active.
+            # Match the same not-implemented messaging as Save (see
+            # _on_save_file) until legacy project loading exists.
+            logger.warning("Open file action: not yet implemented", file_path=file_path)
+            QMessageBox.information(
+                self,
+                "Open Not Yet Implemented",
+                "Project open is not yet implemented in this legacy window.\n"
+                "Use 'Import Data' to load a dataset, or launch without "
+                "--legacy to use the workspace shell, which supports "
+                "opening .rheojax projects.",
+            )
 
     @Slot()
     def _on_save_file(self) -> bool:
@@ -1194,11 +1208,17 @@ class RheoJAXMainWindow(QMainWindow):
         if not self._confirm_unsaved_changes("opening another project"):
             return
 
-        self.log(f"Opening recent project: {path}")
-        logger.info("Opening recent project", file_path=str(path))
-        self.store.dispatch("LOAD_PROJECT", {"file_path": str(path)})
-        self.navigate_to("data")
-        self.status_bar.show_message(f"Opened: {path.name}", 3000)
+        # GUI-P1: same not-yet-implemented gap as _on_open_file -- LOAD_PROJECT
+        # does not actually restore project contents in this legacy window.
+        logger.warning("Open recent project: not yet implemented", file_path=str(path))
+        QMessageBox.information(
+            self,
+            "Open Not Yet Implemented",
+            "Project open is not yet implemented in this legacy window.\n"
+            "Use 'Import Data' to load a dataset, or launch without "
+            "--legacy to use the workspace shell, which supports "
+            "opening .rheojax projects.",
+        )
 
     @Slot()
     def _on_import(self) -> None:
@@ -1404,7 +1424,15 @@ class RheoJAXMainWindow(QMainWindow):
     def _on_preferences(self) -> None:
         """Handle preferences action."""
         logger.debug("Preferences action triggered")
-        dialog = PreferencesDialog(parent=self)
+        from rheojax.gui.jobs.process_adapter import get_worker_isolation_mode
+
+        state = self.store.get_state()
+        current_preferences = {
+            "theme": state.theme,
+            "autosave_enabled": state.auto_save_enabled,
+            "worker_isolation_mode": get_worker_isolation_mode(),
+        }
+        dialog = PreferencesDialog(current_preferences=current_preferences, parent=self)
         if dialog.exec():
             prefs = dialog.get_preferences()
             self.store.dispatch("UPDATE_PREFERENCES", prefs)
@@ -3498,8 +3526,17 @@ class RheoJAXMainWindow(QMainWindow):
             state = self.store.get_state()
             if state.auto_save_enabled and state.project_path:
                 project_path = state.project_path
-                logger.debug("Auto-saving project", path=str(project_path))
-                self.store.dispatch("SAVE_PROJECT", {"file_path": str(project_path)})
+                # GUI-P1: SAVE_PROJECT's reducer only clears is_modified -- it
+                # performs no serialization (project save is not yet
+                # implemented in this legacy window; see _on_save_file).
+                # Dispatching it here would mark unsaved work as "saved"
+                # without writing the project to disk. Skip it; the artifact
+                # exports below are real files but are not a project save.
+                logger.debug(
+                    "Auto-save: project serialization not yet implemented, "
+                    "exporting artifacts only",
+                    path=str(project_path),
+                )
 
                 # Export artifacts: parameters, plot, and Bayesian posterior if available
                 fit_result = self.store.get_active_fit_result()

--- a/rheojax/gui/app/status_bar.py
+++ b/rheojax/gui/app/status_bar.py
@@ -93,8 +93,12 @@ class StatusBar(QStatusBar):
         self.message_label.setText(message)
         self._message_token += 1
         if timeout > 0:
-            # Also show in Qt status bar for timeout support
-            super().showMessage(message, timeout)
+            # NOTE: deliberately NOT calling super().showMessage(message, timeout) --
+            # QStatusBar.showMessage() hides every non-permanent addWidget() item
+            # (message_label above, and progress_bar) for the whole timeout, which
+            # blanked the label we just set and hid an in-progress progress bar for
+            # the duration. message_label + this timer already provide the same
+            # "temporary message" behavior without that side effect.
             token = self._message_token
             QTimer.singleShot(
                 timeout, lambda: self._clear_timed_message(token, message)

--- a/rheojax/gui/dialogs/import_wizard.py
+++ b/rheojax/gui/dialogs/import_wizard.py
@@ -45,7 +45,7 @@ class _FileReadWorker(QRunnable):
     """
 
     class Signals(QObject):
-        completed = Signal(object)  # pandas.DataFrame
+        completed = Signal(object, str)  # pandas.DataFrame, source file path
         failed = Signal(str)  # error message
 
     def __init__(self, file_path: str, nrows: int) -> None:
@@ -69,7 +69,7 @@ class _FileReadWorker(QRunnable):
         except Exception as e:
             self.signals.failed.emit(str(e))
             return
-        self.signals.completed.emit(df)
+        self.signals.completed.emit(df, self._file_path)
 
 
 class FileSelectionPage(QWizardPage):
@@ -328,9 +328,15 @@ class ColumnMappingPage(QWizardPage):
         self, df: pd.DataFrame, file_path: str | None = None
     ) -> None:
         """Populate combo boxes/preview once the background read completes."""
+        current_path = str(self.field("file_path"))
+        if file_path is not None and file_path != current_path:
+            # The selected file changed while this worker was still reading;
+            # discard the stale result instead of caching it under the new path.
+            return
+
         wizard = self.wizard()
         wizard._cached_df = df
-        wizard._cached_file_path = file_path or str(self.field("file_path"))
+        wizard._cached_file_path = file_path or current_path
 
         columns = list(df.columns)
         logger.debug(
@@ -621,9 +627,15 @@ class PreviewConfirmPage(QWizardPage):
         self, df: pd.DataFrame, file_path: str | None = None
     ) -> None:
         """Populate the preview table once the background read completes."""
+        current_path = str(self.field("file_path"))
+        if file_path is not None and file_path != current_path:
+            # The selected file changed while this worker was still reading;
+            # discard the stale result instead of caching it under the new path.
+            return
+
         wizard = self.wizard()
         wizard._cached_preview_df = df
-        wizard._cached_preview_path = file_path or str(self.field("file_path"))
+        wizard._cached_preview_path = file_path or current_path
 
         x_col, y_col, y2_col = self._pending_preview_cols
 

--- a/rheojax/gui/foundation/priors.py
+++ b/rheojax/gui/foundation/priors.py
@@ -49,18 +49,25 @@ def map_centered_priors(map_estimate: dict[str, float]) -> dict[str, dict]:
     Returns
     -------
     dict
-        ``{param_name: {"type": "lognormal", "loc": log(|val|), "scale": 1.0}, ...,
-        "sigma": {"type": "halfnormal", "scale": 1.0}}``.
+        ``{param_name: {"type": "lognormal", "loc": log(val), "scale": 1.0}, ...,
+        "sigma": {"type": "halfnormal", "scale": 1.0}}`` for non-negative MAP
+        values. A strictly negative MAP value instead gets
+        ``{"type": "normal", "loc": val, "scale": max(|val|, 1.0)}``, since
+        LogNormal's support is ``(0, inf)`` and cannot represent a negative
+        value at all -- not even with the "wrong" ``loc``.
 
     Notes
     -----
-    ``loc = log(|val|)`` so the LogNormal median equals the MAP value.
+    ``loc = log(val)`` so the LogNormal median equals the MAP value.
     ``scale = 1.0`` is a broad default; callers may tighten it.
     Zero or None values fall back to ``loc = 0.0``.
     """
     priors: dict[str, dict] = {}
     for name, val in map_estimate.items():
-        loc = math.log(abs(val)) if val not in (0.0, None) else 0.0
-        priors[name] = {"type": "lognormal", "loc": loc, "scale": 1.0}
+        if val not in (0.0, None) and val < 0:
+            priors[name] = {"type": "normal", "loc": val, "scale": max(abs(val), 1.0)}
+        else:
+            loc = math.log(val) if val not in (0.0, None) else 0.0
+            priors[name] = {"type": "lognormal", "loc": loc, "scale": 1.0}
     priors["sigma"] = {"type": "halfnormal", "scale": 1.0}
     return priors

--- a/rheojax/gui/foundation/project_codec.py
+++ b/rheojax/gui/foundation/project_codec.py
@@ -199,7 +199,16 @@ def save_project_v2(state, path: Path) -> None:
         if raw_transform_result:
             for side in ("input", "output"):
                 payload = raw_transform_result.get(side)
-                if payload is None:
+                # "input" is a list[RheoData], not a single RheoData, for
+                # multi-slot/list-slot transforms (transform_controller.py's
+                # _run() -- see _resolve_slot_data()); save_hdf5() only
+                # accepts a single RheoData-like object and raises
+                # AttributeError on a list, which blocked Save entirely.
+                # Nothing is lost by skipping it here: transform_dict already
+                # persists `slots` (the source dataset ids/lineage), and
+                # step4_visualize.py's Input-vs-output overlay already
+                # tolerates a missing/list "input" the same way (no trace).
+                if payload is None or isinstance(payload, list):
                     continue
                 result_id = uuid.uuid4().hex
                 rel = f"transform_results/{result_id}.hdf5"

--- a/rheojax/gui/jobs/fit_worker.py
+++ b/rheojax/gui/jobs/fit_worker.py
@@ -77,7 +77,10 @@ class FitWorkerSignals(QObject):
         # GUI-P1-001: staging buffer for elapsed-timer messages posted via
         # QMetaObject.invokeMethod from a raw threading.Thread.  The buffer is
         # written by the timer thread before invokeMethod is called so the slot
-        # sees the latest message when it runs on the GUI thread.
+        # sees the latest message when it runs on the GUI thread. Guarded by a
+        # lock since the write happens on the timer thread while the read/clear
+        # happens on the GUI thread (mirrors BayesianWorkerSignals).
+        self._elapsed_lock = threading.Lock()
         self._pending_elapsed_msg: str = ""
 
     @Slot()
@@ -88,7 +91,8 @@ class FitWorkerSignals(QObject):
         from _elapsed_timer so that the progress signal is always emitted
         from the main Qt thread, regardless of which OS thread triggered it.
         """
-        msg = self._pending_elapsed_msg
+        with self._elapsed_lock:
+            msg = self._pending_elapsed_msg
         if msg:
             self.progress.emit(0, 0, msg)
 
@@ -266,7 +270,8 @@ class FitWorker(QRunnable):
                         if _use_invoke:
                             # Write buffer BEFORE invokeMethod to avoid race where
                             # the slot runs before the buffer is populated.
-                            self.signals._pending_elapsed_msg = msg
+                            with self.signals._elapsed_lock:
+                                self.signals._pending_elapsed_msg = msg
                             QMetaObject.invokeMethod(
                                 self.signals,
                                 "_emit_progress_elapsed",

--- a/rheojax/gui/pages/export_page.py
+++ b/rheojax/gui/pages/export_page.py
@@ -557,7 +557,11 @@ class ExportPage(QWidget):
             )
             file_path = output_dir / f"fit_{safe_name}.{data_ext}"
             try:
-                self._export_service.export_fit_result(fit_result, file_path, data_ext)
+                # ExportService has no export_fit_result method -- export_parameters()
+                # is the real API for writing a FitResult's parameters to disk. Every
+                # call here previously raised AttributeError (swallowed by the except
+                # below), so "Export All Fit Results" always reported "0 exported".
+                self._export_service.export_parameters(fit_result, file_path, data_ext)
                 exported.append(str(file_path))
             except Exception as exc:
                 logger.error(

--- a/rheojax/gui/pages/transform_page.py
+++ b/rheojax/gui/pages/transform_page.py
@@ -534,6 +534,25 @@ class TransformPage(QWidget):
         """Return list of available transforms with metadata."""
         return self._service.get_transform_metadata()
 
+    def get_checked_dataset_ids(self) -> list[str]:
+        """Return dataset ids checked in the multi-dataset checklist.
+
+        Regression: the "Datasets (select 2+)" checklist (shown for
+        requires_multiple transforms like Mastercurve/SRFS) had real
+        checkboxes, but nothing ever read their check state -- MainWindow
+        ran the transform over every loaded dataset regardless of which
+        ones were checked. Returns [] when the checklist isn't shown
+        (single-dataset transform, or nothing built yet).
+        """
+        if self._dataset_checklist is None:
+            return []
+        checked: list[str] = []
+        for i in range(self._dataset_checklist.count()):
+            item = self._dataset_checklist.item(i)
+            if item.checkState() == Qt.CheckState.Checked:
+                checked.append(item.data(Qt.UserRole))
+        return checked
+
     # ------------------------------------------------------------------
     # Helpers
     # ------------------------------------------------------------------

--- a/rheojax/gui/services/pipeline_execution_service.py
+++ b/rheojax/gui/services/pipeline_execution_service.py
@@ -762,6 +762,16 @@ class PipelineExecutionService(QObject):
             **fit_kwargs,
         )
 
+        # ModelService.fit() catches its own exceptions and returns
+        # FitResult(success=False, ...) rather than raising -- execute_all()/
+        # execute_single_step() only mark a step ERROR when _execute_step()
+        # raises, so an unraised failed fit was previously dispatched as
+        # StepStatus.COMPLETE and the pipeline reported success on a
+        # diverged/failed fit. Raise here so failure propagates the same way
+        # every other step type's failure already does.
+        if not fit_result.success:
+            raise RuntimeError(fit_result.message or "Fit failed")
+
         context["fit_result"] = fit_result
         context["model_name"] = model_name
         return fit_result

--- a/rheojax/gui/state/store.py
+++ b/rheojax/gui/state/store.py
@@ -783,11 +783,29 @@ class StateStore:
                     self.emit_signal("dataset_added", dataset_id)
                     self.emit_signal("dataset_selected", dataset_id)
 
+            elif action_type == "SET_ACTIVE_DATASET":
+                # Regression: this branch was missing entirely, so switching
+                # datasets via the tree (which dispatches SET_ACTIVE_DATASET)
+                # never emitted dataset_selected. FitPage subscribes only to
+                # that signal (no state_changed fallback), so it silently
+                # went stale on every dataset switch.
+                dataset_id = action.get("dataset_id") or (
+                    action.get("payload") or {}
+                ).get("dataset_id")
+                if dataset_id:
+                    self.emit_signal("dataset_selected", dataset_id)
+
             elif action_type == "DELETE_SELECTED_DATASET":
                 # STORE-001: Emit dataset_removed with the id that was active
                 # *before* the reducer ran (captured above).  Subscribers such
                 # as the data tree use this to purge the deleted entry.
                 self.emit_signal("dataset_removed", _pre_delete_dataset_id)
+                # The reducer auto-selects the next remaining dataset (or
+                # None) as active -- emit dataset_selected for it too, for
+                # the same reason as the SET_ACTIVE_DATASET branch above.
+                new_active = self._state.active_dataset_id
+                if new_active:
+                    self.emit_signal("dataset_selected", new_active)
 
             elif action_type == "IMPORT_DATA_FAILED":
                 error = action.get("error", "")

--- a/rheojax/gui/state/store.py
+++ b/rheojax/gui/state/store.py
@@ -789,9 +789,7 @@ class StateStore:
                 # never emitted dataset_selected. FitPage subscribes only to
                 # that signal (no state_changed fallback), so it silently
                 # went stale on every dataset switch.
-                dataset_id = action.get("dataset_id") or (
-                    action.get("payload") or {}
-                ).get("dataset_id")
+                dataset_id = action.get("dataset_id")
                 if dataset_id:
                     self.emit_signal("dataset_selected", dataset_id)
 

--- a/rheojax/gui/widgets/base_arviz_widget.py
+++ b/rheojax/gui/widgets/base_arviz_widget.py
@@ -154,13 +154,21 @@ class BaseArviZWidget(QWidget):
             if self._canvas is not None:
                 self._canvas.callbacks.callbacks.clear()
                 self._canvas.draw_idle = lambda: None
-            for fig in self._pending_cleanup:
-                plt.close(fig)
-            self._pending_cleanup.clear()
-            if self._figure is not None:
-                plt.close(self._figure)
         except RuntimeError:
-            pass  # C++ object already deleted
+            pass  # C++ canvas object already deleted
+
+        for fig in self._pending_cleanup:
+            try:
+                plt.close(fig)
+            except RuntimeError:
+                pass  # C++ object already deleted
+        self._pending_cleanup.clear()
+
+        if self._figure is not None:
+            try:
+                plt.close(self._figure)
+            except RuntimeError:
+                pass  # C++ object already deleted
 
     def closeEvent(self, event) -> None:  # noqa: N802
         """Cancel pending matplotlib draws before the widget is closed."""

--- a/rheojax/gui/widgets/log_dock.py
+++ b/rheojax/gui/widgets/log_dock.py
@@ -68,6 +68,12 @@ class LogDockWidget(QDockWidget):
         self.text_edit.setReadOnly(True)
         self.text_edit.setMaximumHeight(200)
         self.text_edit.setPlaceholderText("Application logs will appear here...")
+        # Without this, the document grows unboundedly (memory) even though
+        # `_records` is capped at _MAX_RECORDS -- and _rerender() (level-filter
+        # change) clears then replays only the capped deque, so a long session
+        # would visibly "shrink" on the next filter change. Qt trims oldest
+        # blocks automatically once the cap is hit, keeping the two in sync.
+        self.text_edit.document().setMaximumBlockCount(_MAX_RECORDS)
         layout.addWidget(self.text_edit)
 
         self.setWidget(container)

--- a/rheojax/gui/widgets/plot_canvas.py
+++ b/rheojax/gui/widgets/plot_canvas.py
@@ -112,6 +112,13 @@ class PlotCanvas(QWidget):
                 self.canvas.callbacks.callbacks.clear()
                 # Neuter the timer-based draw_idle so it becomes a no-op.
                 self.canvas.draw_idle = lambda: None
+        except RuntimeError:
+            pass  # C++ object already deleted
+
+        # Independent try/except: a RuntimeError above (deleted C++ canvas)
+        # must not skip figure cleanup, or the Figure leaks (matplotlib
+        # keeps every unclosed Figure alive in its global registry).
+        try:
             if hasattr(self, "figure") and self.figure is not None:
                 plt.close(self.figure)
         except RuntimeError:

--- a/rheojax/gui/widgets/pyqtgraph_canvas.py
+++ b/rheojax/gui/widgets/pyqtgraph_canvas.py
@@ -426,7 +426,10 @@ class PyQtGraphCanvas(QWidget):
             "PNG Image (*.png);;SVG Vector (*.svg);;All Files (*)",
         )
         if file_path:
-            exporter = pg.exporters.ImageExporter(self._plot_item)
+            if file_path.lower().endswith(".svg"):
+                exporter = pg.exporters.SVGExporter(self._plot_item)
+            else:
+                exporter = pg.exporters.ImageExporter(self._plot_item)
             exporter.export(file_path)
             logger.info("Plot exported", path=file_path)
 

--- a/rheojax/gui/workspace/fit/fit_controller.py
+++ b/rheojax/gui/workspace/fit/fit_controller.py
@@ -2,9 +2,10 @@ from __future__ import annotations
 
 import math
 import multiprocessing
+import queue
 
 import numpy as np
-from PySide6.QtCore import QEventLoop, QObject, QRunnable, QThreadPool, Signal
+from PySide6.QtCore import QEventLoop, QObject, QRunnable, QThreadPool, QTimer, Signal
 
 from rheojax.gui.foundation.invalidation import invalidate_downstream
 from rheojax.gui.foundation.state import AppState
@@ -68,7 +69,7 @@ class _CallableWorker(QRunnable):
             self.signals.completed.emit(result)
 
 
-def _run_on_thread(fn):
+def _run_on_thread(fn, *, progress_queue=None, on_progress=None):
     """Run *fn* on a QThreadPool thread while pumping a local QEventLoop, so
     the GUI stays responsive -- mirrors transform_controller.py's
     _make_run_fn. The calling function still returns synchronously (or
@@ -76,6 +77,14 @@ def _run_on_thread(fn):
     NLSQ/NUTS computation no longer blocks the GUI thread directly, which
     used to freeze the entire app (repaints, Cancel, everything) for the
     full duration of every real fit/sample run.
+
+    If *progress_queue* is given, it is drained on a QTimer (on the GUI
+    thread, alongside the nested QEventLoop above) and each message is
+    forwarded to *on_progress*. Without this, messages that
+    subprocess_fit.py/subprocess_bayesian.py put on the queue during the
+    run just accumulate unread until the caller closes the queue after
+    the run finishes -- intermediate fit/sample progress never reaches
+    the UI.
     """
     worker = _CallableWorker(fn)
     loop = QEventLoop()
@@ -91,12 +100,50 @@ def _run_on_thread(fn):
 
     worker.signals.completed.connect(_on_completed)
     worker.signals.failed.connect(_on_failed)
+
+    drain_timer = None
+    if progress_queue is not None:
+
+        def _drain() -> None:
+            while True:
+                try:
+                    msg = progress_queue.get_nowait()
+                except queue.Empty:
+                    return
+                if on_progress is not None:
+                    on_progress(msg)
+
+        drain_timer = QTimer()
+        drain_timer.timeout.connect(_drain)
+        drain_timer.start(100)
+
     QThreadPool.globalInstance().start(worker)
     loop.exec()
+
+    if drain_timer is not None:
+        drain_timer.stop()
+        _drain()  # final drain: catch messages put right before completion
 
     if "error" in outcome:
         raise outcome["error"]
     return outcome["result"]
+
+
+def _make_progress_reporter(active_jobs, job_id):
+    """Build an on_progress callback that stashes the latest progress
+    message on the job's active_jobs.by_id entry, so anything reading
+    active_jobs (e.g. a future status-bar/progress widget) can see it.
+    GUI-thread only -- no lock needed, see ActiveJobsState.lock's docstring.
+    """
+
+    def _on_progress(msg) -> None:
+        if active_jobs is None:
+            return
+        job = active_jobs.by_id.get(job_id)
+        if job is not None:
+            job["progress"] = msg
+
+    return _on_progress
 
 
 def _make_fit_fn(library, fit_state, active_jobs=None):
@@ -136,6 +183,7 @@ def _make_fit_fn(library, fit_state, active_jobs=None):
                 multi_start,
                 options,
                 token.event,
+                active_jobs,
             )
         finally:
             if active_jobs is not None:
@@ -154,6 +202,7 @@ def _fit_fn_body(
     multi_start,
     options,
     cancel_event,
+    active_jobs=None,
 ):
     rheo_data = library.load_payload(data_ref)
     # ponytail: Step 1's protocol combo uses the same vocabulary as
@@ -201,7 +250,9 @@ def _fit_fn_body(
                     dataset_id=data_ref,
                     model_config=model_config,
                     metadata=metadata,
-                )
+                ),
+                progress_queue=progress_queue,
+                on_progress=_make_progress_reporter(active_jobs, data_ref),
             )
         finally:
             # Release the queue's feeder thread/fds/semaphore -- mirrors
@@ -270,7 +321,9 @@ def _make_sample_fn(library, fit_state, active_jobs=None):
                     model_config=fit_state.model_config,
                     metadata=getattr(rheo_data, "metadata", None),
                     max_tree_depth=config.get("max_tree_depth"),
-                )
+                ),
+                progress_queue=progress_queue,
+                on_progress=_make_progress_reporter(active_jobs, fit_state.data_ref),
             )
         finally:
             # Release the queue's feeder thread/fds/semaphore -- mirrors

--- a/rheojax/gui/workspace/pipeline/batch_runner.py
+++ b/rheojax/gui/workspace/pipeline/batch_runner.py
@@ -27,6 +27,7 @@ class PipelineBatchRunner(QRunnable):
         library,
         stop_requested,
         app_state=None,
+        batch_job_id: str | None = None,
     ) -> None:
         super().__init__()
         self._service = service
@@ -35,54 +36,70 @@ class PipelineBatchRunner(QRunnable):
         self._library = library
         self._stop_requested = stop_requested
         self._app_state = app_state
+        # Caller (WorkspaceWindow._on_pipeline_run_requested) pre-registers this key in
+        # active_jobs synchronously on the GUI thread, before QThreadPool.start()
+        # returns, so a double-click "Run All" sees a non-empty active_jobs even before
+        # this thread reaches its first per-dataset registration below. We own clearing
+        # it once the batch reaches a terminal state.
+        self._batch_job_id = batch_job_id
 
     def run(self) -> None:
         from rheojax.gui.services.pipeline_execution_service import (
             WorkerIsolationRequiredError,
         )
 
-        for dataset_id in self._selected_dataset_ids:
-            if self._stop_requested.is_set():
-                break
-            # Register synchronously (plain dict write, not via the Qt signal)
-            # before execute() can start mutating the library. dataset_run_started
-            # is Qt.AutoConnection, which resolves to a queued cross-thread
-            # connection when run() executes on a QThreadPool worker thread --
-            # relying on it alone leaves a window where Save can see an empty
-            # active_jobs and serialize the library while this thread is
-            # concurrently writing to it. `app_state` is optional so tests that
-            # construct this runner directly (with no AppState) are unaffected.
-            if self._app_state is not None:
+        try:
+            for dataset_id in self._selected_dataset_ids:
+                if self._stop_requested.is_set():
+                    break
+                # Register synchronously (plain dict write, not via the Qt signal)
+                # before execute() can start mutating the library. dataset_run_started
+                # is Qt.AutoConnection, which resolves to a queued cross-thread
+                # connection when run() executes on a QThreadPool worker thread --
+                # relying on it alone leaves a window where Save can see an empty
+                # active_jobs and serialize the library while this thread is
+                # concurrently writing to it. `app_state` is optional so tests that
+                # construct this runner directly (with no AppState) are unaffected.
+                if self._app_state is not None:
+                    with self._app_state.active_jobs.lock:
+                        self._app_state.active_jobs.by_id[dataset_id] = {
+                            "status": "running"
+                        }
+                self._service.dataset_run_started.emit(dataset_id)
+                ctx = pipeline_context_from_library(self._library, [dataset_id])
+                steps_for_dataset = self._substitute_dataset_id(self._steps, dataset_id)
+                fatal = False
+                try:
+                    result = self._service.execute(
+                        steps=steps_for_dataset,
+                        initial_context=ctx,
+                        library=self._library,
+                        stop_requested=self._stop_requested,
+                    )
+                    record = self._prepare_job_record(dataset_id, result)
+                except WorkerIsolationRequiredError as exc:
+                    # Misconfigured environment -- would fail identically for every
+                    # remaining dataset, so this is the batch's last iteration too.
+                    record = self._failed_record(dataset_id, str(exc))
+                    fatal = True
+                except Exception as exc:  # pragma: no cover - defensive backstop
+                    # execute() already converts ordinary step failures into a
+                    # status="failed" PipelineRunResult internally; this only catches an
+                    # unexpected bug elsewhere in the call chain (e.g. context/record
+                    # construction). Without this, such an exception would propagate out
+                    # of run() with dataset_run_finished never emitted, leaving this
+                    # dataset's active_jobs entry stuck forever (nothing else clears it).
+                    record = self._failed_record(dataset_id, str(exc))
+                self._service.dataset_run_finished.emit(dataset_id, record)
+                if fatal:
+                    break
+        finally:
+            # Runs on every exit path (normal completion, stop_requested break, fatal
+            # break, empty selected_dataset_ids) so the pre-registered sentinel never
+            # outlives the batch, regardless of how it ends.
+            if self._app_state is not None and self._batch_job_id is not None:
                 with self._app_state.active_jobs.lock:
-                    self._app_state.active_jobs.by_id[dataset_id] = {"status": "running"}
-            self._service.dataset_run_started.emit(dataset_id)
-            ctx = pipeline_context_from_library(self._library, [dataset_id])
-            steps_for_dataset = self._substitute_dataset_id(self._steps, dataset_id)
-            fatal = False
-            try:
-                result = self._service.execute(
-                    steps=steps_for_dataset,
-                    initial_context=ctx,
-                    library=self._library,
-                    stop_requested=self._stop_requested,
-                )
-                record = self._prepare_job_record(dataset_id, result)
-            except WorkerIsolationRequiredError as exc:
-                # Misconfigured environment -- would fail identically for every
-                # remaining dataset, so this is the batch's last iteration too.
-                record = self._failed_record(dataset_id, str(exc))
-                fatal = True
-            except Exception as exc:  # pragma: no cover - defensive backstop
-                # execute() already converts ordinary step failures into a
-                # status="failed" PipelineRunResult internally; this only catches an
-                # unexpected bug elsewhere in the call chain (e.g. context/record
-                # construction). Without this, such an exception would propagate out
-                # of run() with dataset_run_finished never emitted, leaving this
-                # dataset's active_jobs entry stuck forever (nothing else clears it).
-                record = self._failed_record(dataset_id, str(exc))
-            self._service.dataset_run_finished.emit(dataset_id, record)
-            if fatal:
-                break
+                    self._app_state.active_jobs.by_id.pop(self._batch_job_id, None)
 
     @staticmethod
     def _failed_record(dataset_id: str, error: str) -> dict:

--- a/rheojax/gui/workspace/transform/step5_export.py
+++ b/rheojax/gui/workspace/transform/step5_export.py
@@ -6,6 +6,7 @@ from pathlib import Path
 from PySide6.QtCore import Signal
 from PySide6.QtWidgets import QLabel, QPushButton, QVBoxLayout, QWidget
 
+from rheojax.gui.compat import QFileDialog
 from rheojax.gui.foundation.library import DatasetLibrary, DatasetRef
 from rheojax.gui.foundation.state import TransformState
 from rheojax.gui.resources.styles.tokens import field_label_style
@@ -30,14 +31,31 @@ class TransformExportStep(QWidget):
         self._export_service = ExportService()
         self._save_btn = QPushButton("＋ Save output → library", self)
         self._export_btn = QPushButton("⤓ Export", self)
+        self._export_status = QLabel("", self)
         lay = QVBoxLayout(self)
         set_panel_margins(lay)
         caption = QLabel("Export")
         caption.setStyleSheet(field_label_style())
-        for w in (caption, self._save_btn, self._export_btn):
+        for w in (caption, self._save_btn, self._export_btn, self._export_status):
             lay.addWidget(w)
         self._save_btn.clicked.connect(self.save_to_library)
-        self._export_btn.clicked.connect(lambda: self.export_bundle(Path.cwd()))
+        self._export_btn.clicked.connect(self._on_export_clicked)
+
+    def _on_export_clicked(self) -> None:
+        """Prompt for a destination directory rather than silently writing
+        to Path.cwd() -- the user previously had no way to know or choose
+        where the bundle landed."""
+        chosen = QFileDialog.getExistingDirectory(
+            self, "Export bundle to...", str(Path.cwd())
+        )
+        if not chosen:
+            return
+        try:
+            self.export_bundle(Path(chosen))
+        except OSError as exc:
+            self._export_status.setText(f"Export failed: {exc}")
+            return
+        self._export_status.setText(f"Exported to {Path(chosen)}")
 
     def bundle_manifest(self) -> list[str]:
         return ["output", "result", "provenance"]

--- a/rheojax/gui/workspace/transform/transform_controller.py
+++ b/rheojax/gui/workspace/transform/transform_controller.py
@@ -6,6 +6,7 @@ from PySide6.QtCore import QEventLoop, QThreadPool
 
 from rheojax.core.registry import TransformRegistry
 from rheojax.gui.foundation.state import AppState
+from rheojax.gui.jobs.cancellation import CancellationToken
 from rheojax.gui.jobs.transform_worker import TransformWorker
 from rheojax.gui.workspace.controller import Step, TransformController
 from rheojax.gui.workspace.transform.slots_spec import transform_slots
@@ -68,7 +69,10 @@ def infer_output_protocol(library, transform_key, slots) -> str:
     return library.get(first).protocol_type
 
 
-def _make_run_fn(library):
+_TRANSFORM_JOB_KEY = "transform"
+
+
+def _make_run_fn(library, active_jobs=None):
     def _run(transform_key, slots, config):
         # Snapshot slots up front: the caller's dict is the live, mutable
         # FitState/TransformState.slots object, and loop.exec() below pumps
@@ -78,7 +82,24 @@ def _make_run_fn(library):
         # one `data` was actually resolved from.
         slots = dict(slots)
         data = _resolve_slot_data(library, transform_key, slots)
-        worker = TransformWorker(transform_key, data, params=config)
+        # A real, cancellable token registered in active_jobs -- mirrors
+        # fit_controller.py's _make_fit_fn/_make_sample_fn. Without this,
+        # window.py's _maybe_confirm_active_jobs (Close/New/Open) and
+        # _blocked_by_active_jobs (Save) never see a Transform run as
+        # "active" (active_jobs.by_id stayed empty for this mode), so they
+        # would rebuild/replace the workspace's AppState -- discarding the
+        # very `library`/TransformState this closure still writes into --
+        # while the run is still in flight, or let Save race a torn
+        # snapshot against it.
+        cancel_token = CancellationToken(job_id=_TRANSFORM_JOB_KEY)
+        worker = TransformWorker(
+            transform_key, data, params=config, cancel_token=cancel_token
+        )
+        if active_jobs is not None:
+            active_jobs.by_id[_TRANSFORM_JOB_KEY] = {
+                "status": "running",
+                "worker": cancel_token,
+            }
         loop = QEventLoop()
         outcome: dict = {}
 
@@ -98,7 +119,11 @@ def _make_run_fn(library):
         worker.signals.failed.connect(_on_failed)
         worker.signals.cancelled.connect(_on_cancelled)
         QThreadPool.globalInstance().start(worker)
-        loop.exec()
+        try:
+            loop.exec()
+        finally:
+            if active_jobs is not None:
+                active_jobs.by_id.pop(_TRANSFORM_JOB_KEY, None)
 
         if "error" in outcome:
             raise RuntimeError(outcome["error"])
@@ -126,7 +151,7 @@ def build_transform_controller(app_state: AppState):
     bodies = [
         TransformPickStep(st),
         SlotsStep(st, app_state.library),
-        RunStep(st, run_fn=_make_run_fn(app_state.library)),
+        RunStep(st, run_fn=_make_run_fn(app_state.library, app_state.active_jobs)),
         TransformVisualizeStep(st),
         TransformExportStep(st, app_state.library),
     ]

--- a/rheojax/gui/workspace/window.py
+++ b/rheojax/gui/workspace/window.py
@@ -1160,12 +1160,25 @@ class WorkspaceWindow(QMainWindow):
             # stop event and race active_jobs/DatasetLibrary from two worker threads.
             return
 
+        import uuid
+
         from PySide6.QtCore import QThreadPool
 
         from rheojax.gui.workspace.pipeline.batch_runner import PipelineBatchRunner
 
         pipeline_state = self._state.pipeline
         self._pipeline_stop_event = threading.Event()
+        # Register a batch sentinel synchronously on the GUI thread, under the same
+        # lock the above guard reads, before QThreadPool.start() can even schedule the
+        # runner -- PipelineBatchRunner.run() only writes its first per-dataset
+        # active_jobs entry once it actually starts executing on a worker thread,
+        # which QThreadPool.start() does not guarantee happens before it returns. Without
+        # this, a second "Run All" click landing in that gap would see an empty
+        # active_jobs and start a second runner. PipelineBatchRunner pops this key
+        # itself once the batch reaches a terminal state (batch_runner.py's run()).
+        batch_job_id = f"pipeline_batch:{uuid.uuid4().hex}"
+        with self._state.active_jobs.lock:
+            self._state.active_jobs.by_id[batch_job_id] = {"status": "starting"}
         runner = PipelineBatchRunner(
             service=self._pipeline_service,
             steps=pipeline_state.steps,
@@ -1173,5 +1186,6 @@ class WorkspaceWindow(QMainWindow):
             library=self._state.library,
             stop_requested=self._pipeline_stop_event,
             app_state=self._state,
+            batch_job_id=batch_job_id,
         )
         QThreadPool.globalInstance().start(runner)

--- a/tests/gui/foundation/test_priors.py
+++ b/tests/gui/foundation/test_priors.py
@@ -100,9 +100,18 @@ def test_map_centered_priors_zero_value_fallback():
 
 
 def test_map_centered_priors_negative_value():
-    """Negative MAP value uses abs() so loc = log(|val|)."""
+    """Negative MAP value gets a Normal prior, not LogNormal.
+
+    Regression: LogNormal's support is (0, inf), so a LogNormal prior with
+    loc=log(|val|) places zero density at the true negative MAP value
+    (dropping the sign didn't just get `loc` wrong -- the whole distribution
+    family can't represent a negative value). A Normal prior centered on the
+    actual value can.
+    """
     pri = map_centered_priors({"x": -50.0})
-    assert abs(pri["x"]["loc"] - math.log(50.0)) < 1e-12
+    assert pri["x"]["type"] == "normal"
+    assert pri["x"]["loc"] == -50.0
+    assert pri["x"]["scale"] == 50.0
 
 
 def test_map_centered_priors_empty():

--- a/tests/gui/foundation/test_project_codec.py
+++ b/tests/gui/foundation/test_project_codec.py
@@ -337,6 +337,34 @@ def test_round_trip_full_state(tmp_path):
     np.testing.assert_array_equal(loaded.transform.result["output"].x, payload.x)
 
 
+def test_save_project_with_list_valued_transform_input_does_not_crash(tmp_path):
+    # Multi-slot/list-slot transforms (e.g. cox_merz, or any is_list slot) store a
+    # list[RheoData] under transform.result["input"] (transform_controller.py's
+    # _run()/_resolve_slot_data()), not a single RheoData. save_hdf5() only accepts a
+    # single RheoData-like object and raised AttributeError: 'list' object has no
+    # attribute 'x' here, blocking Save entirely after any such transform. The fix
+    # skips persisting a list-valued side instead of crashing -- "output" (always a
+    # single RheoData) still round-trips normally.
+    state = AppState()
+    payload_a = RheoData(x=[1.0, 2.0], y=[1.0, 2.0], initial_test_mode="oscillation")
+    payload_b = RheoData(x=[3.0, 4.0], y=[3.0, 4.0], initial_test_mode="flow_curve")
+    output_payload = RheoData(
+        x=[5.0, 6.0], y=[5.0, 6.0], initial_test_mode="oscillation"
+    )
+    state.transform.result = {
+        "input": [payload_a, payload_b],
+        "output": output_payload,
+        "protocol_type": "oscillation",
+    }
+
+    path = tmp_path / "project.rheojax"
+    save_project_v2(state, path)  # must not raise
+    loaded = load_project_v2(path)
+
+    assert loaded.transform.result.get("input") is None
+    np.testing.assert_array_equal(loaded.transform.result["output"].x, output_payload.x)
+
+
 def test_round_trip_job_history_with_fit_phase_results(tmp_path):
     state = AppState()
     state.job_history.by_id["job1"] = {

--- a/tests/gui/test_base_arviz_widget_cleanup.py
+++ b/tests/gui/test_base_arviz_widget_cleanup.py
@@ -1,0 +1,31 @@
+"""Regression test: cleanup() must still close figures when the canvas's
+C++ object has already been deleted (RuntimeError on attribute access).
+"""
+
+import matplotlib.pyplot as plt
+
+from rheojax.gui.widgets.base_arviz_widget import BaseArviZWidget
+
+
+class _DeadCanvas:
+    """Stand-in for a FigureCanvasQTAgg whose C++ object was already freed."""
+
+    @property
+    def callbacks(self):
+        raise RuntimeError("wrapped C/C++ object of type FigureCanvasQTAgg has been deleted")
+
+
+def test_cleanup_closes_figures_when_canvas_is_dead(qapp):
+    widget = BaseArviZWidget()
+    fig = plt.figure()
+    pending_fig = plt.figure()
+
+    widget._figure = fig
+    widget._pending_cleanup = [pending_fig]
+    widget._canvas = _DeadCanvas()
+
+    widget.cleanup()
+
+    assert not plt.fignum_exists(fig.number)
+    assert not plt.fignum_exists(pending_fig.number)
+    assert widget._pending_cleanup == []

--- a/tests/gui/test_dataset_removed_wiring.py
+++ b/tests/gui/test_dataset_removed_wiring.py
@@ -1,0 +1,38 @@
+"""Regression: dataset_removed was emitted by the store but never connected.
+
+DatasetTree.remove_dataset() existed to consume it, but nothing wired the
+signal to the slot, so deleting a dataset left a stale, still-clickable row
+in the tree (clicking it fired dataset_selected(dead_id) for an id no longer
+in state.datasets).
+"""
+
+from unittest.mock import patch
+
+import pytest
+
+pytestmark = pytest.mark.gui
+
+try:
+    from PySide6.QtWidgets import QApplication
+
+    HAS_PYSIDE6 = True
+except ImportError:
+    HAS_PYSIDE6 = False
+
+
+@pytest.mark.skipif(not HAS_PYSIDE6, reason="PySide6 required")
+def test_dataset_removed_signal_calls_remove_dataset(qtbot, qapp) -> None:
+    from rheojax.gui.app.main_window import RheoJAXMainWindow
+    from rheojax.gui.widgets.dataset_tree import DatasetTree
+
+    with patch.object(DatasetTree, "remove_dataset") as mock_remove:
+        window = RheoJAXMainWindow()
+        qtbot.addWidget(window)
+
+        window.store._signals.dataset_removed.emit("dataset-123")
+
+    # patch.object replaces the class attribute with a plain Mock, which
+    # (unlike a real function) isn't a descriptor -- so `self` is not bound
+    # automatically when accessed off the instance, and the emitted signal's
+    # single str argument is all `mock_remove` sees.
+    mock_remove.assert_called_with("dataset-123")

--- a/tests/gui/test_dataset_selected_signal.py
+++ b/tests/gui/test_dataset_selected_signal.py
@@ -1,0 +1,58 @@
+"""Regression: SET_ACTIVE_DATASET / DELETE_SELECTED_DATASET never emitted
+dataset_selected, so pages subscribed only to that signal (FitPage has no
+state_changed fallback) went stale on every dataset switch made via the tree.
+"""
+
+from rheojax.gui.state.store import AppState, DatasetState, StateStore
+
+
+def setup_function() -> None:
+    StateStore.reset()
+
+
+def test_set_active_dataset_emits_dataset_selected() -> None:
+    store = StateStore()
+    ds1 = DatasetState(id="d1", name="ds1", file_path=None, test_mode="oscillation")
+    ds2 = DatasetState(id="d2", name="ds2", file_path=None, test_mode="oscillation")
+    store._state = AppState(datasets={"d1": ds1, "d2": ds2}, active_dataset_id="d1")
+
+    selected: list[str] = []
+    store.signals.dataset_selected.connect(selected.append)
+
+    store.dispatch("SET_ACTIVE_DATASET", {"dataset_id": "d2"})
+
+    assert selected == ["d2"]
+    assert store.get_state().active_dataset_id == "d2"
+
+
+def test_delete_selected_dataset_emits_dataset_selected_for_new_active() -> None:
+    store = StateStore()
+    ds1 = DatasetState(id="d1", name="ds1", file_path=None, test_mode="oscillation")
+    ds2 = DatasetState(id="d2", name="ds2", file_path=None, test_mode="oscillation")
+    store._state = AppState(datasets={"d1": ds1, "d2": ds2}, active_dataset_id="d1")
+
+    removed: list[str] = []
+    selected: list[str] = []
+    store.signals.dataset_removed.connect(removed.append)
+    store.signals.dataset_selected.connect(selected.append)
+
+    store.dispatch("DELETE_SELECTED_DATASET")
+
+    assert removed == ["d1"]
+    assert selected == ["d2"]
+    assert store.get_state().active_dataset_id == "d2"
+
+
+def test_delete_last_dataset_does_not_emit_dataset_selected() -> None:
+    """No datasets remain -> no dataset to select, so no emission."""
+    store = StateStore()
+    ds1 = DatasetState(id="d1", name="ds1", file_path=None, test_mode="oscillation")
+    store._state = AppState(datasets={"d1": ds1}, active_dataset_id="d1")
+
+    selected: list[str] = []
+    store.signals.dataset_selected.connect(selected.append)
+
+    store.dispatch("DELETE_SELECTED_DATASET")
+
+    assert selected == []
+    assert store.get_state().active_dataset_id is None

--- a/tests/gui/test_import_wizard.py
+++ b/tests/gui/test_import_wizard.py
@@ -4,6 +4,7 @@ import os
 
 os.environ.setdefault("QT_QPA_PLATFORM", "offscreen")
 
+import pandas as pd
 import pytest
 
 pytest.importorskip("PySide6")
@@ -46,5 +47,30 @@ def test_column_mapping_populates_after_background_worker_completes(qapp, tmp_pa
     assert page.x_combo.count() == 3
     assert page.x_combo.itemText(0) == "freq"
     assert wizard._cached_df is not None
+
+    wizard.deleteLater()
+
+
+def test_stale_column_load_result_is_discarded_after_path_change(qapp, tmp_path):
+    """A `_on_columns_loaded` callback carrying a file_path that no longer
+    matches the current `file_path` field (because the user picked a
+    different file before the background read finished) must not populate
+    the combos or overwrite the wizard's cache.
+    """
+    csv_path = tmp_path / "data.csv"
+    csv_path.write_text("freq,G_prime\n1.0,100.0\n")
+
+    wizard = ImportWizard()
+    wizard.file_page.file_path_edit.setText(str(csv_path))
+
+    page = wizard.column_page
+    stale_df = pd.DataFrame({"old_col": [1, 2]})
+
+    # Simulate a worker for a *previous* path completing after the field
+    # already moved on to csv_path.
+    page._on_columns_loaded(stale_df, str(tmp_path / "other.csv"))
+
+    assert page.x_combo.count() == 0
+    assert not hasattr(wizard, "_cached_df")
 
     wizard.deleteLater()

--- a/tests/gui/test_menu_actions.py
+++ b/tests/gui/test_menu_actions.py
@@ -419,6 +419,34 @@ class TestDialogIntegration:
 
     @pytest.mark.smoke
     @pytest.mark.skipif(not HAS_PYSIDE6, reason="PySide6 required")
+    def test_preferences_dialog_seeded_with_current_state(self, qtbot, qapp) -> None:
+        """_on_preferences must pass the StateStore's current settings into
+        PreferencesDialog -- an empty current_preferences dict makes the
+        dialog fall back to hardcoded defaults (e.g. Light theme), and
+        saving it then overwrites the user's real settings (GUI-P1)."""
+        from dataclasses import replace
+        from unittest.mock import patch
+
+        from rheojax.gui.app.main_window import RheoJAXMainWindow
+
+        window = RheoJAXMainWindow()
+        qtbot.addWidget(window)
+        dark_state = replace(window.store.get_state(), theme="dark")
+
+        with (
+            patch.object(window.store, "get_state", return_value=dark_state),
+            patch(
+                "rheojax.gui.app.main_window.PreferencesDialog"
+            ) as mock_dialog_cls,
+        ):
+            mock_dialog_cls.return_value.exec.return_value = False
+            window._on_preferences()
+
+        _, kwargs = mock_dialog_cls.call_args
+        assert kwargs.get("current_preferences", {}).get("theme") == "dark"
+
+    @pytest.mark.smoke
+    @pytest.mark.skipif(not HAS_PYSIDE6, reason="PySide6 required")
     def test_about_dialog_accessible(self, qtbot, qapp) -> None:
         """Verify AboutDialog can be imported and instantiated."""
         from rheojax.gui.dialogs.about import AboutDialog

--- a/tests/gui/test_menu_actions.py
+++ b/tests/gui/test_menu_actions.py
@@ -470,3 +470,52 @@ class TestActionCountConsistency:
         assert len(unconnected) == 0, (
             f"Found {len(unconnected)} unconnected menu actions: {unconnected}"
         )
+
+
+class TestUndoRedoEnablement:
+    """Regression: Undo/Redo were permanently disabled despite full store support.
+
+    Both QActions were constructed with setEnabled(False) and nothing ever
+    re-enabled them, so a working undo/redo feature (store.py's undo()/redo()
+    plus the can_undo()/can_redo() selectors) was completely unreachable from
+    the Edit menu or its Ctrl+Z/Ctrl+Y shortcuts.
+    """
+
+    @pytest.mark.skipif(not HAS_PYSIDE6, reason="PySide6 required")
+    def test_undo_redo_disabled_with_empty_history(self, qtbot, qapp) -> None:
+        from rheojax.gui.app.main_window import RheoJAXMainWindow
+
+        window = RheoJAXMainWindow()
+        qtbot.addWidget(window)
+
+        assert window.menu_bar.undo_action.isEnabled() is False
+        assert window.menu_bar.redo_action.isEnabled() is False
+
+    @pytest.mark.skipif(not HAS_PYSIDE6, reason="PySide6 required")
+    def test_undo_action_enables_after_undoable_dispatch(self, qtbot, qapp) -> None:
+        # Exercises _on_state_changed's enable-state sync directly rather
+        # than via a real dispatch: SET_THEME (or any theme-changing action)
+        # also fires signals.theme_changed -> _apply_theme, which applies a
+        # real app-wide stylesheet and triggers a full relayout -- harmless
+        # alone, but when this file's earlier tests have left matplotlib
+        # canvas widgets (bayesian_page/diagnostics_page) alive, that
+        # relayout can drive a pre-existing matplotlib Qt-backend
+        # sizeHint/minimumSizeHint mutual-recursion bug into a 120s hang.
+        # can_undo()/can_redo() are unrelated to theme state, so a direct
+        # call is both a tighter unit test and side-effect-free.
+        from unittest.mock import patch
+
+        from rheojax.gui.app.main_window import RheoJAXMainWindow
+
+        window = RheoJAXMainWindow()
+        qtbot.addWidget(window)
+
+        assert window.menu_bar.undo_action.isEnabled() is False
+
+        with (
+            patch("rheojax.gui.state.selectors.can_undo", return_value=True),
+            patch("rheojax.gui.state.selectors.can_redo", return_value=False),
+        ):
+            window._on_state_changed(window.store.get_state())
+
+        assert window.menu_bar.undo_action.isEnabled() is True

--- a/tests/gui/test_pipeline_execution_service.py
+++ b/tests/gui/test_pipeline_execution_service.py
@@ -209,6 +209,41 @@ class TestPipelineExecutionService:
         with pytest.raises(ValueError, match="'model'"):
             service._execute_fit(config={}, context={"data": mock_data})
 
+    def test_execute_fit_raises_on_unsuccessful_fit_result(self, service):
+        """_execute_fit must raise when ModelService.fit() reports success=False.
+
+        Regression: ModelService.fit() catches its own exceptions and returns
+        FitResult(success=False, ...) instead of raising. execute_all()/
+        execute_single_step() only mark a step ERROR when the handler raises,
+        so a diverged/failed fit was silently dispatched as StepStatus.COMPLETE
+        and the pipeline reported success.
+        """
+        mock_data = MagicMock()
+        failed_result = MagicMock(success=False, message="Fit diverged")
+        service._model_service = MagicMock()
+        service._model_service.fit.return_value = failed_result
+
+        with pytest.raises(RuntimeError, match="Fit diverged"):
+            service._execute_fit(
+                config={"model": "Maxwell"}, context={"data": mock_data}
+            )
+
+    def test_execute_single_step_marks_error_on_failed_fit(self, service):
+        """A failed fit step must land on StepStatus.ERROR, not COMPLETE."""
+        step_id = _add_fit_step()
+        step = get_pipeline_step_by_id(step_id)
+
+        mock_data = MagicMock()
+        failed_result = MagicMock(success=False, message="Fit diverged")
+        service._model_service = MagicMock()
+        service._model_service.fit.return_value = failed_result
+
+        with pytest.raises(RuntimeError, match="Fit diverged"):
+            service.execute_single_step(step, {"data": mock_data})
+
+        final_step = get_pipeline_step_by_id(step_id)
+        assert final_step.status == StepStatus.ERROR
+
     def test_execute_bayesian_requires_data_in_context(self, service):
         """_execute_bayesian must raise ValueError when context has no 'data'."""
         with pytest.raises(ValueError, match="prior load step"):

--- a/tests/gui/test_process_worker.py
+++ b/tests/gui/test_process_worker.py
@@ -679,6 +679,54 @@ class TestResultReconstruction:
 # ===========================================================================
 
 
+class TestFitWorkerSignalsElapsedMsgLock:
+    """GUI-P1-001 regression: _pending_elapsed_msg must be lock-guarded.
+
+    Written from the elapsed-timer thread, read/cleared on the GUI thread
+    inside _emit_progress_elapsed. Without a lock this is a data race
+    (unlike BayesianWorkerSignals, which already uses _elapsed_lock).
+    """
+
+    def test_has_elapsed_lock(self):
+        import threading
+
+        from rheojax.gui.jobs.fit_worker import FitWorkerSignals
+
+        signals = FitWorkerSignals()
+        assert isinstance(signals._elapsed_lock, type(threading.Lock()))
+
+    def test_concurrent_writes_and_reads_are_race_free(self):
+        import threading
+
+        from rheojax.gui.jobs.fit_worker import FitWorkerSignals
+
+        signals = FitWorkerSignals()
+        errors = []
+        stop = threading.Event()
+
+        def writer():
+            i = 0
+            while not stop.is_set():
+                with signals._elapsed_lock:
+                    signals._pending_elapsed_msg = f"elapsed {i}s"
+                i += 1
+
+        def reader():
+            try:
+                for _ in range(2000):
+                    with signals._elapsed_lock:
+                        _ = signals._pending_elapsed_msg
+            except Exception as exc:  # pragma: no cover - defensive
+                errors.append(exc)
+
+        t = threading.Thread(target=writer, daemon=True)
+        t.start()
+        reader()
+        stop.set()
+        t.join(timeout=1.0)
+        assert errors == []
+
+
 class TestMakeFitWorker:
     """make_fit_worker returns FitWorker in thread mode, ProcessWorkerAdapter otherwise."""
 

--- a/tests/gui/test_regressions_stability.py
+++ b/tests/gui/test_regressions_stability.py
@@ -1,3 +1,5 @@
+from datetime import datetime
+
 import numpy as np
 import pytest
 
@@ -7,6 +9,7 @@ from rheojax.gui.state.actions import update_dataset
 from rheojax.gui.state.store import (
     AppState,
     DatasetState,
+    FitResult,
     PipelineState,
     PipelineStep,
     StateStore,
@@ -102,6 +105,39 @@ def test_export_raw_data_converts_dataset(qtbot, tmp_path):
     out = tmp_path / "data.csv"
     page._export_service.export_data(rheojax, out, "csv")
     assert out.exists()
+
+
+def test_export_all_fit_results_writes_real_files(qtbot, tmp_path, monkeypatch):
+    """Regression: ExportPage called a nonexistent ExportService.export_fit_result,
+    so every export raised AttributeError (swallowed per-result) and "Export All
+    Fit Results" always reported "0 exported" with no file ever written.
+    """
+    from rheojax.gui.compat import QMessageBox
+
+    monkeypatch.setattr(QMessageBox, "information", staticmethod(lambda *a, **k: None))
+
+    page = ExportPage()
+    qtbot.addWidget(page)
+
+    fit_result = FitResult(
+        model_name="maxwell",
+        parameters={"G0": 1000.0, "eta": 50.0},
+        chi_squared=0.01,
+        success=True,
+        message="ok",
+        timestamp=datetime.now(),
+        dataset_id="d1",
+    )
+    store = page._store
+    store._state = AppState(fit_results={"maxwell:d1": fit_result})
+
+    page._output_dir_edit.setText(str(tmp_path))
+    page._data_format_combo.setCurrentText("CSV")
+
+    page._export_all_fit_results()
+
+    written = list(tmp_path.glob("fit_*.csv"))
+    assert len(written) == 1
 
 
 def test_export_page_prepare_for_close_cancels_and_guards_callbacks(qtbot):

--- a/tests/gui/test_transform_checklist_selection.py
+++ b/tests/gui/test_transform_checklist_selection.py
@@ -1,0 +1,93 @@
+"""Regression: TransformPage's "Datasets (select 2+)" checklist had real
+checkboxes, but nothing ever read their check state -- checking only 2 of 3
+loaded datasets still ran the (mastercurve/srfs/cox_merz) transform over all
+3. TransformPage.get_checked_dataset_ids() now exposes the checked subset,
+and MainWindow._on_apply_transform() uses it to filter which datasets run.
+"""
+
+from unittest.mock import patch
+
+import pytest
+
+pytestmark = pytest.mark.gui
+
+try:
+    from PySide6.QtCore import Qt
+    from PySide6.QtWidgets import QApplication, QListWidgetItem
+
+    HAS_PYSIDE6 = True
+except ImportError:
+    HAS_PYSIDE6 = False
+
+
+@pytest.mark.skipif(not HAS_PYSIDE6, reason="PySide6 required")
+def test_get_checked_dataset_ids_returns_only_checked_items(qtbot):
+    from rheojax.gui.pages.transform_page import TransformPage
+    from rheojax.gui.state.store import StateStore
+
+    StateStore.reset()
+    page = TransformPage()
+    qtbot.addWidget(page)
+
+    assert page.get_checked_dataset_ids() == []
+
+    from PySide6.QtWidgets import QListWidget
+
+    page._dataset_checklist = QListWidget()
+    for ds_id, checked in [("d1", True), ("d2", False), ("d3", True)]:
+        item = QListWidgetItem(ds_id)
+        item.setData(Qt.UserRole, ds_id)
+        item.setCheckState(
+            Qt.CheckState.Checked if checked else Qt.CheckState.Unchecked
+        )
+        page._dataset_checklist.addItem(item)
+
+    assert page.get_checked_dataset_ids() == ["d1", "d3"]
+
+
+@pytest.mark.skipif(not HAS_PYSIDE6, reason="PySide6 required")
+def test_apply_transform_uses_checked_subset_not_all_datasets(qtbot):
+    import numpy as np
+
+    from rheojax.gui.app.main_window import RheoJAXMainWindow
+    from rheojax.gui.state.store import AppState, DatasetState, StateStore
+
+    StateStore.reset()
+    window = RheoJAXMainWindow()
+    qtbot.addWidget(window)
+
+    datasets = {
+        ds_id: DatasetState(
+            id=ds_id,
+            name=ds_id,
+            file_path=None,
+            test_mode="oscillation",
+            x_data=np.array([1.0, 2.0]),
+            y_data=np.array([3.0, 4.0]),
+        )
+        for ds_id in ("d1", "d2", "d3")
+    }
+    window.store._state = AppState(datasets=datasets, active_dataset_id="d1")
+
+    converted_ids: list[str] = []
+
+    def fake_rheodata_from_dataset_state(ds):
+        converted_ids.append(ds.id)
+        return ds
+
+    with (
+        patch.object(
+            window.transform_page,
+            "get_checked_dataset_ids",
+            return_value=["d1", "d3"],
+        ),
+        patch(
+            "rheojax.gui.utils.rheodata.rheodata_from_dataset_state",
+            side_effect=fake_rheodata_from_dataset_state,
+        ),
+        patch.object(window, "_run_transform_sync"),
+        patch.object(window, "worker_pool", None),
+    ):
+        window._on_apply_transform("mastercurve", params={})
+
+    assert sorted(converted_ids) == ["d1", "d3"]

--- a/tests/gui/test_unsaved_changes_guard.py
+++ b/tests/gui/test_unsaved_changes_guard.py
@@ -110,3 +110,52 @@ def test_open_recent_project_guards_unsaved_changes(qtbot, qapp, tmp_path) -> No
         window._on_open_recent_project(recent_project)
 
     mock_dispatch.assert_not_called()
+
+
+@pytest.mark.skipif(not HAS_PYSIDE6, reason="PySide6 required")
+def test_open_file_does_not_dispatch_load_project(qtbot, qapp, tmp_path) -> None:
+    """LOAD_PROJECT's reducer never restores datasets/results in this legacy
+    window (no codec bridges its AppState to the .rheojax v2 archive), so
+    picking a file must not dispatch LOAD_PROJECT nor claim success -- it
+    must show a not-yet-implemented message instead (GUI-P1)."""
+    from rheojax.gui.app.main_window import RheoJAXMainWindow
+    from rheojax.gui.compat import QFileDialog
+
+    window = RheoJAXMainWindow()
+    qtbot.addWidget(window)
+
+    picked = tmp_path / "project.rheojax"
+    picked.write_text("placeholder")
+
+    with (
+        patch.object(
+            QFileDialog, "getOpenFileName", return_value=(str(picked), "")
+        ),
+        patch.object(QMessageBox, "information") as mock_info,
+        patch.object(window.store, "dispatch") as mock_dispatch,
+    ):
+        window._on_open_file()
+
+    mock_dispatch.assert_not_called()
+    mock_info.assert_called_once()
+
+
+@pytest.mark.skipif(not HAS_PYSIDE6, reason="PySide6 required")
+def test_auto_save_does_not_dispatch_save_project(qtbot, qapp, tmp_path) -> None:
+    """SAVE_PROJECT's reducer only clears is_modified -- it writes nothing to
+    disk in this legacy window. Auto-save must not dispatch it (that would
+    mark unsaved work as saved without persisting it) (GUI-P1)."""
+    from rheojax.gui.app.main_window import RheoJAXMainWindow
+
+    window = RheoJAXMainWindow()
+    qtbot.addWidget(window)
+
+    project_path = tmp_path / "project.rheojax"
+    window.store.dispatch("LOAD_PROJECT", {"file_path": str(project_path)})
+    assert window.store.get_state().auto_save_enabled is True
+
+    with patch.object(window.store, "dispatch") as mock_dispatch:
+        window._do_auto_save()
+
+    for call in mock_dispatch.call_args_list:
+        assert call.args[0] != "SAVE_PROJECT"

--- a/tests/gui/test_unsaved_changes_guard.py
+++ b/tests/gui/test_unsaved_changes_guard.py
@@ -1,0 +1,112 @@
+"""Regression tests for the shared unsaved-changes guard on File>New/Open/Open Recent.
+
+Prior to this fix, File>New ignored `_on_save_file()`'s return value (so
+choosing "Save" silently wiped the project when save wasn't implemented),
+and File>Open / Open Recent skipped the unsaved-changes prompt entirely,
+silently discarding the current project. All three now route through
+`RheoJAXMainWindow._confirm_unsaved_changes`, the same guard `closeEvent`
+already used correctly.
+"""
+
+from unittest.mock import patch
+
+import pytest
+
+pytestmark = pytest.mark.gui
+
+try:
+    from PySide6.QtWidgets import QApplication, QMessageBox
+
+    HAS_PYSIDE6 = True
+except ImportError:
+    HAS_PYSIDE6 = False
+
+
+@pytest.mark.skipif(not HAS_PYSIDE6, reason="PySide6 required")
+def test_new_file_does_not_wipe_project_when_save_fails(qtbot, qapp) -> None:
+    """File>New must NOT dispatch NEW_PROJECT if the user picks Save and it fails."""
+    from rheojax.gui.app.main_window import RheoJAXMainWindow
+
+    window = RheoJAXMainWindow()
+    qtbot.addWidget(window)
+    window._has_unsaved_changes = True
+
+    with (
+        patch.object(
+            QMessageBox, "question", return_value=QMessageBox.StandardButton.Save
+        ),
+        patch.object(window, "_on_save_file", return_value=False),
+        patch.object(window.store, "dispatch") as mock_dispatch,
+    ):
+        window._on_new_file()
+
+    mock_dispatch.assert_not_called()
+
+
+@pytest.mark.skipif(not HAS_PYSIDE6, reason="PySide6 required")
+def test_new_file_proceeds_when_save_succeeds(qtbot, qapp) -> None:
+    """File>New dispatches NEW_PROJECT once the chosen Save actually succeeds."""
+    from rheojax.gui.app.main_window import RheoJAXMainWindow
+
+    window = RheoJAXMainWindow()
+    qtbot.addWidget(window)
+    window._has_unsaved_changes = True
+
+    with (
+        patch.object(
+            QMessageBox, "question", return_value=QMessageBox.StandardButton.Save
+        ),
+        patch.object(window, "_on_save_file", return_value=True),
+        patch.object(window.store, "dispatch") as mock_dispatch,
+    ):
+        window._on_new_file()
+
+    mock_dispatch.assert_any_call("NEW_PROJECT")
+
+
+@pytest.mark.skipif(not HAS_PYSIDE6, reason="PySide6 required")
+def test_open_file_guards_unsaved_changes(qtbot, qapp) -> None:
+    """File>Open must prompt for unsaved changes before replacing the project."""
+    from rheojax.gui.app.main_window import RheoJAXMainWindow
+    from rheojax.gui.compat import QFileDialog
+
+    window = RheoJAXMainWindow()
+    qtbot.addWidget(window)
+    window._has_unsaved_changes = True
+
+    with (
+        patch.object(
+            QMessageBox, "question", return_value=QMessageBox.StandardButton.Cancel
+        ),
+        patch.object(QFileDialog, "getOpenFileName") as mock_dialog,
+        patch.object(window.store, "dispatch") as mock_dispatch,
+    ):
+        window._on_open_file()
+
+    # Cancelling the unsaved-changes prompt must abort before the file picker
+    # even opens, and LOAD_PROJECT must never be dispatched.
+    mock_dialog.assert_not_called()
+    mock_dispatch.assert_not_called()
+
+
+@pytest.mark.skipif(not HAS_PYSIDE6, reason="PySide6 required")
+def test_open_recent_project_guards_unsaved_changes(qtbot, qapp, tmp_path) -> None:
+    """Open Recent must prompt for unsaved changes before replacing the project."""
+    from rheojax.gui.app.main_window import RheoJAXMainWindow
+
+    window = RheoJAXMainWindow()
+    qtbot.addWidget(window)
+    window._has_unsaved_changes = True
+
+    recent_project = tmp_path / "project.rheojax"
+    recent_project.write_text("placeholder")
+
+    with (
+        patch.object(
+            QMessageBox, "question", return_value=QMessageBox.StandardButton.Cancel
+        ),
+        patch.object(window.store, "dispatch") as mock_dispatch,
+    ):
+        window._on_open_recent_project(recent_project)
+
+    mock_dispatch.assert_not_called()

--- a/tests/gui/test_visual_regression.py
+++ b/tests/gui/test_visual_regression.py
@@ -203,6 +203,39 @@ class TestPlotCanvasVisual:
 
         canvas.close()
 
+    def test_plot_canvas_cleanup_closes_figure_despite_dead_canvas(
+        self,
+        qapp: QApplication,
+        qtbot: Any,
+        monkeypatch: Any,
+    ) -> None:
+        """cleanup() must still close the Figure when the C++ canvas widget
+        is already gone (RuntimeError from accessing canvas.callbacks) —
+        otherwise the Figure leaks via matplotlib's global registry."""
+        import matplotlib.pyplot as plt
+
+        from rheojax.gui.widgets.plot_canvas import PlotCanvas
+
+        canvas = PlotCanvas()
+        qtbot.addWidget(canvas)
+        fig = canvas.figure
+
+        closed_figs = []
+        monkeypatch.setattr(plt, "close", lambda f: closed_figs.append(f))
+
+        # Simulate the real failure: accessing .callbacks on a deleted C++
+        # canvas widget raises RuntimeError (Qt/PySide6 wrapped-object error).
+        def _dead_callbacks(self: Any) -> None:
+            raise RuntimeError("wrapped C/C++ object has been deleted")
+
+        monkeypatch.setattr(
+            type(canvas.canvas), "callbacks", property(_dead_callbacks)
+        )
+
+        canvas.cleanup()
+
+        assert closed_figs == [fig], "plt.close(figure) was skipped after RuntimeError"
+
     def test_plot_canvas_scatter_plot(
         self,
         qapp: QApplication,

--- a/tests/gui/widgets/test_pyqtgraph_canvas.py
+++ b/tests/gui/widgets/test_pyqtgraph_canvas.py
@@ -1,0 +1,88 @@
+"""Regression tests for PyQtGraphCanvas export behavior."""
+
+from __future__ import annotations
+
+import pytest
+
+pytest.importorskip("pyqtgraph")
+
+from rheojax.gui.widgets.pyqtgraph_canvas import (  # noqa: E402
+    PYQTGRAPH_AVAILABLE,
+    PyQtGraphCanvas,
+)
+
+pytestmark = pytest.mark.skipif(
+    not PYQTGRAPH_AVAILABLE, reason="pyqtgraph not available"
+)
+
+
+def test_on_export_uses_svg_exporter_for_svg_path(qtbot, monkeypatch, tmp_path):
+    """Regression: _on_export used ImageExporter (PNG) unconditionally, even
+    when the user chose the SVG filter and a .svg path, corrupting the file.
+    """
+    import pyqtgraph as pg
+
+    from rheojax.gui.compat import QFileDialog
+
+    canvas = PyQtGraphCanvas()
+    qtbot.addWidget(canvas)
+    canvas.plot_data([1, 2, 3], [1, 4, 9], name="test")
+
+    svg_path = str(tmp_path / "plot.svg")
+    monkeypatch.setattr(
+        QFileDialog, "getSaveFileName", lambda *a, **k: (svg_path, "SVG Vector (*.svg)")
+    )
+
+    used_exporter_types = []
+    for exporter_cls_name in ("SVGExporter", "ImageExporter"):
+        orig_cls = getattr(pg.exporters, exporter_cls_name)
+
+        def make_tracker(cls, name=exporter_cls_name):
+            def _tracker(item):
+                used_exporter_types.append(name)
+                instance = cls(item)
+                instance.export = lambda path: None  # avoid touching disk twice
+                return instance
+
+            return _tracker
+
+        monkeypatch.setattr(pg.exporters, exporter_cls_name, make_tracker(orig_cls))
+
+    canvas._on_export()
+
+    assert used_exporter_types == ["SVGExporter"]
+
+
+def test_on_export_uses_image_exporter_for_png_path(qtbot, monkeypatch, tmp_path):
+    """Non-SVG paths (e.g. .png) must still use ImageExporter."""
+    import pyqtgraph as pg
+
+    from rheojax.gui.compat import QFileDialog
+
+    canvas = PyQtGraphCanvas()
+    qtbot.addWidget(canvas)
+    canvas.plot_data([1, 2, 3], [1, 4, 9], name="test")
+
+    png_path = str(tmp_path / "plot.png")
+    monkeypatch.setattr(
+        QFileDialog, "getSaveFileName", lambda *a, **k: (png_path, "PNG Image (*.png)")
+    )
+
+    used_exporter_types = []
+    for exporter_cls_name in ("SVGExporter", "ImageExporter"):
+        orig_cls = getattr(pg.exporters, exporter_cls_name)
+
+        def make_tracker(cls, name=exporter_cls_name):
+            def _tracker(item):
+                used_exporter_types.append(name)
+                instance = cls(item)
+                instance.export = lambda path: None
+                return instance
+
+            return _tracker
+
+        monkeypatch.setattr(pg.exporters, exporter_cls_name, make_tracker(orig_cls))
+
+    canvas._on_export()
+
+    assert used_exporter_types == ["ImageExporter"]

--- a/tests/gui/workspace/fit/test_fit_controller.py
+++ b/tests/gui/workspace/fit/test_fit_controller.py
@@ -1,3 +1,6 @@
+import queue
+import time
+
 import numpy as np
 import pytest
 
@@ -5,7 +8,7 @@ pytest.importorskip("PySide6")
 import rheojax.models  # noqa
 from rheojax.gui.foundation.library import DatasetRef
 from rheojax.gui.foundation.state import AppState
-from rheojax.gui.workspace.fit.fit_controller import build_fit_controller
+from rheojax.gui.workspace.fit.fit_controller import _run_on_thread, build_fit_controller
 from rheojax.gui.workspace.window import WorkspaceWindow
 
 
@@ -13,6 +16,31 @@ class _RheoData:
     def __init__(self, x, y):
         self.x = np.asarray(x)
         self.y = np.asarray(y)
+
+
+def test_run_on_thread_drains_progress_queue(qtbot):
+    # Regression: progress_queue was created in _fit_fn_body/_sample_fn and
+    # handed to run_fit_isolated/run_bayesian_isolated, but _run_on_thread
+    # never read from it -- every progress_callback() message piled up
+    # unread and never reached the UI. _run_on_thread must poll and forward
+    # messages (via on_progress) while the worker runs, not just discard
+    # them.
+    q = queue.Queue()
+    seen = []
+
+    def fn():
+        q.put({"type": "progress", "percent": 1})
+        time.sleep(0.05)
+        q.put({"type": "progress", "percent": 50})
+        time.sleep(0.25)  # spans multiple QTimer drain ticks (100ms each)
+        q.put({"type": "progress", "percent": 100})
+        return "done"
+
+    result = _run_on_thread(fn, progress_queue=q, on_progress=seen.append)
+
+    assert result == "done"
+    assert [m["percent"] for m in seen] == [1, 50, 100]
+    assert q.empty()
 
 
 def test_controller_gating_and_invalidation(qtbot):

--- a/tests/gui/workspace/test_window_pipeline_mode.py
+++ b/tests/gui/workspace/test_window_pipeline_mode.py
@@ -95,3 +95,31 @@ def test_run_all_ignored_while_batch_already_running(qtbot, monkeypatch):
     win._on_pipeline_run_requested()
 
     assert start_calls == []
+
+
+def test_run_all_double_click_starts_only_one_runner(qtbot, monkeypatch):
+    # Regression test: PipelineBatchRunner.run() only writes its first per-dataset
+    # active_jobs entry once it actually executes on a worker thread -- QThreadPool.start()
+    # doesn't guarantee that happens before it returns. Mocking start() as a no-op
+    # (like test_run_all_ignored_while_batch_already_running above) simulates exactly
+    # that gap: active_jobs stays whatever _on_pipeline_run_requested itself wrote,
+    # since the runner body never runs. A second call in that gap must still be
+    # ignored, not start a second runner.
+    from PySide6.QtCore import QThreadPool
+
+    state = AppState()
+    win = WorkspaceWindow(state)
+    qtbot.addWidget(win)
+    win.set_mode("pipeline")
+
+    start_calls = []
+    monkeypatch.setattr(
+        QThreadPool.globalInstance(),
+        "start",
+        lambda *a, **kw: start_calls.append((a, kw)),
+    )
+
+    win._on_pipeline_run_requested()
+    win._on_pipeline_run_requested()
+
+    assert len(start_calls) == 1

--- a/tests/gui/workspace/transform/test_run_step_wiring.py
+++ b/tests/gui/workspace/transform/test_run_step_wiring.py
@@ -62,6 +62,43 @@ def test_build_transform_controller_injects_real_run_fn(qapp, monkeypatch):
     assert app.transform.result["input"].x[0] == 0.0
 
 
+def test_run_fn_registers_active_job_during_run(qapp, monkeypatch):
+    # Regression: _make_run_fn never registered the in-flight TransformWorker
+    # in app_state.active_jobs, unlike fit_controller.py's _make_fit_fn/
+    # _make_sample_fn -- so window.py's Close/New/Open active-jobs guard
+    # never saw a running Transform and would rebuild the workspace (discard
+    # `library`/TransformState) out from under it. Assert the job is visible
+    # while the (synchronous, from this thread's perspective) worker signal
+    # fires, and cleared once run() returns.
+    seen_during_run = {}
+
+    def fake_apply_transform(self, name, data, params):
+        seen_during_run["job_count"] = len(app.active_jobs.by_id)
+        seen_during_run["has_worker"] = "worker" in next(
+            iter(app.active_jobs.by_id.values()), {}
+        )
+        return _RheoData([1.0], [2.0])
+
+    monkeypatch.setattr(
+        "rheojax.gui.services.transform_service.TransformService.apply_transform",
+        fake_apply_transform,
+    )
+
+    app = AppState()
+    app.library.add(_ref("d1", "flow_curve"))
+    app.library.store_payload("d1", _RheoData([0.0], [0.0]))
+    app.transform.transform_key = "smooth_derivative"
+    app.transform.slots = {"input": "d1"}
+
+    ctl, bodies = build_transform_controller(app)
+    run_step = bodies[2]
+    run_step.run()
+
+    assert seen_during_run["job_count"] == 1
+    assert seen_during_run["has_worker"] is True
+    assert app.active_jobs.by_id == {}
+
+
 def test_run_fn_raises_on_worker_failure(qapp, monkeypatch):
     def fake_apply_transform(self, name, data, params):
         raise ValueError("bad params")

--- a/tests/gui/workspace/transform/test_step5_writers.py
+++ b/tests/gui/workspace/transform/test_step5_writers.py
@@ -4,6 +4,7 @@ import pytest
 
 pytest.importorskip("PySide6")
 
+from rheojax.gui.compat import QFileDialog
 from rheojax.gui.foundation.library import DatasetLibrary
 from rheojax.gui.foundation.state import TransformState
 from rheojax.gui.workspace.transform.step5_export import TransformExportStep
@@ -48,3 +49,49 @@ def test_export_bundle_skips_output_when_no_result(qtbot, tmp_path):
     assert "output" not in written
     assert "result" not in written
     assert written["provenance"].exists()
+
+
+def test_export_button_prompts_for_directory_instead_of_using_cwd(
+    qtbot, monkeypatch, tmp_path
+):
+    """Regression: the Export button used to be wired directly to
+    export_bundle(Path.cwd()), silently writing files into the process's
+    working directory with no dialog and no feedback."""
+    st = TransformState(
+        transform_key="derivative",
+        slots={"input": "d1"},
+        result={"result": {"n": 2}, "protocol_type": "flow_curve"},
+    )
+    lib = DatasetLibrary()
+    step = TransformExportStep(st, lib)
+    qtbot.addWidget(step)
+
+    monkeypatch.setattr(
+        QFileDialog, "getExistingDirectory", lambda *a, **k: str(tmp_path)
+    )
+
+    step._on_export_clicked()
+
+    assert (tmp_path / "provenance.json").exists()
+    assert str(tmp_path) in step._export_status.text()
+
+
+def test_export_button_reports_failure_instead_of_raising(qtbot, monkeypatch):
+    """Export errors (e.g. an unwritable directory) must surface in the
+    status label, not propagate uncaught out of the Qt slot."""
+    st = TransformState(transform_key="derivative", slots={"input": "d1"}, result=None)
+    lib = DatasetLibrary()
+    step = TransformExportStep(st, lib)
+    qtbot.addWidget(step)
+
+    monkeypatch.setattr(
+        QFileDialog, "getExistingDirectory", lambda *a, **k: "/nonexistent/path"
+    )
+
+    def _raise(_directory):
+        raise OSError("disk full")
+
+    monkeypatch.setattr(step, "export_bundle", _raise)
+
+    step._on_export_clicked()  # must not raise
+    assert "failed" in step._export_status.text().lower()


### PR DESCRIPTION
## Summary

Requested: use `/dev-suite:smart-debug` and `/superpowers:systematic-debugging` to review and debug the completeness/accuracy of the GUI implementation and fix all issues found.

5 parallel audit agents reviewed pages, state/jobs, dialogs, services/foundation, and app-shell/widgets end-to-end. Unlike the prior 8 audit rounds (see `docs` in project memory), which focused almost exclusively on the default `WorkspaceWindow` shell, this pass deliberately covered the legacy `--legacy` `RheoJAXMainWindow` shell too — it turned out to have several real, previously-unaudited P1s.

### Default (`WorkspaceWindow`) shell fixes
- Transform-mode runs never registered in `active_jobs`, so Close/New/Open couldn't detect or wait for an in-flight transform (Fit mode already did this correctly).
- `status_bar.py`'s `show_message()` redundantly called `super().showMessage()`, which hides the message label *and* the progress bar for the whole timeout.
- `log_dock.py`'s `QTextEdit` grew unbounded, desyncing from the capped record deque on filter changes.
- `map_centered_priors()` used `log(abs(val))` for negative MAP estimates — LogNormal's `(0, ∞)` support can't represent a negative value at all (not just a wrong `loc`); switched to a `Normal` prior for that case.

### Legacy (`--legacy`) shell fixes
- A failed NLSQ fit inside the visual-pipeline builder (`execute_all`) was dispatched as `StepStatus.COMPLETE`, since `ModelService.fit()` returns `success=False` instead of raising.
- Undo/Redo menu actions were permanently disabled at construction despite full store support; nothing ever re-enabled them.
- File>New ignored `_on_save_file()`'s return value — the exact `GUI-P1-003` class already fixed in `closeEvent`, never ported to this sibling handler.
- File>Open and Open Recent skipped the unsaved-changes guard entirely.
- `store.py` emitted `dataset_removed` but nothing connected it to `DatasetTree.remove_dataset()`, leaving a stale, still-clickable tree row after deleting a dataset.
- `SET_ACTIVE_DATASET`'s dispatch had no signal-emission branch at all, so `dataset_selected` never fired and `FitPage` went stale on every tree-driven dataset switch (`DELETE_SELECTED_DATASET` had the same gap for the auto-selected next dataset).
- `ExportPage` called a nonexistent `ExportService.export_fit_result` (real method is `export_parameters`), so "Export All Fit Results" always silently exported 0 files.
- `TransformPage`'s "Datasets (select 2+)" checklist had real checkboxes whose state nothing ever read — multi-dataset transforms (mastercurve/srfs/cox_merz) always ran over every loaded dataset regardless of which were checked.

Introduced one shared helper (`_confirm_unsaved_changes`) so `closeEvent`/File>New/File>Open/Open Recent all route through the same guard instead of each reimplementing it.

### Correction to a reported finding
The shell/widgets audit reported the toolbar Stop button as "permanently disabled, no way to cancel a running job." Verified this did **not** hold up: `app/toolbar.py`'s `MainToolBar` is never actually instantiated by either shell (confirmed via `grep addToolBar`/`MainToolBar(`) — it's unreachable dead code, not a reachable disabled-button bug. Left as-is.

### Still open (documented, not fixed this round — lower confidence or lower impact)
- `bayesian_page.py`'s preset-dataset auto-load branch is dead code (unreachable due to an earlier `return`); its `.h5` export filter path writes no file.
- `RheoJAXMainWindow`'s Preferences dialog and the legacy Bayesian "Edit priors" dialog both fail to seed current settings, so opening either resets to constructor defaults on accept.
- `pipeline_chips.py`'s "✔" checkmark is never cleared by `reset()`/an `ACTIVE`/`ERROR` transition.
- Column mapper accepts `X == Y`.
- A few P2 numerical/data-integrity items in `services/foundation` (CLI import skips unit conversion the GUI path applies; `ModelService.predict()`'s `TypeError` retry can swallow a genuine math error; filename-based temperature fallback can fabricate a value; `export_service.py::generate_report` crashes on array-valued params).
- `VisualPipelineState.clone()` deep-copies `step_results` on every snapshot (perf, not correctness).

## Test plan

- [x] 23 new/updated regression tests, one per fixed bug, each demonstrating the failure mode before the fix
- [x] `tests/gui/` (legacy shell, 600 tests): 588 passed, 12 skipped (pre-existing, reasoned), 0 failed
- [x] `tests/gui/workspace/` (default shell, 300 tests): 300 passed, 1 pre-existing Qt-teardown-order flake in an untouched file (`test_step2_selectors.py`, passes cleanly in isolation)
- [x] `ruff check` clean on all changed files

🤖 Generated with [Claude Code](https://claude.com/claude-code)