### PR TITLE
test(sgr): raise sgr_generic coverage 74%→93%

### DIFF
--- a/tests/models/sgr/test_sgr_generic.py
+++ b/tests/models/sgr/test_sgr_generic.py
@@ -420,3 +420,378 @@ class TestSGRGenericFitting:
 
         with pytest.raises(ValueError, match="Unsupported test_mode"):
             model.fit(omega, G_star, test_mode="invalid_mode")
+
+
+def _make_model(x=1.5, G0=1000.0, tau0=1e-3):
+    """Helper: SGRGeneric with power-law-fluid parameters."""
+    m = SGRGeneric()
+    m.parameters.set_value("x", x)
+    m.parameters.set_value("G0", G0)
+    m.parameters.set_value("tau0", tau0)
+    return m
+
+
+class TestSGRGenericAdditionalFitModes:
+    """Fitting in creep, steady-shear, and startup protocols (noiseless data)."""
+
+    def test_creep_fit_and_predict_roundtrip(self):
+        model_true = _make_model()
+        model_true._test_mode = "creep"
+        t = np.logspace(-3, 2, 40)
+        J = model_true.predict(t)
+
+        # J(t) ~ (1 + t/tau0)^(x-1): positive, monotonically increasing, finite
+        assert np.all(J > 0)
+        assert np.all(np.diff(J) >= 0)
+        assert np.all(np.isfinite(J))
+
+        model_fit = _make_model(x=1.2, G0=500.0, tau0=1e-2)
+        model_fit.fit(t, J, test_mode="creep")
+        assert model_fit.fitted_ is True
+        assert model_fit._test_mode == "creep"
+        np.testing.assert_allclose(model_fit.predict(t), J, rtol=1e-3, atol=1e-8)
+
+    def test_steady_shear_fit_and_predict_roundtrip(self):
+        model_true = _make_model()
+        model_true._test_mode = "steady_shear"
+        gamma_dot = np.logspace(-2, 2, 40)
+        sigma = model_true.predict(gamma_dot)
+
+        # Returns real stress (not complex), sigma ~ gamma_dot^(x-1) increasing for x>1
+        assert not np.iscomplexobj(sigma)
+        assert np.all(sigma > 0)
+        assert np.all(np.diff(sigma) >= 0)
+
+        model_fit = _make_model(x=1.2, G0=500.0, tau0=1e-2)
+        model_fit.fit(gamma_dot, sigma, test_mode="steady_shear")
+        assert model_fit.fitted_ is True
+        np.testing.assert_allclose(
+            model_fit.predict(gamma_dot), sigma, rtol=1e-3, atol=1e-8
+        )
+
+    def test_flow_curve_alias_routes_to_steady_shear(self):
+        model = _make_model()
+        gamma_dot = np.logspace(-2, 2, 20)
+        model._test_mode = "steady_shear"
+        sigma = model.predict(gamma_dot)
+
+        model_fit = _make_model()
+        model_fit.fit(gamma_dot, sigma, test_mode="flow_curve")
+        assert model_fit.fitted_ is True
+
+    def test_startup_fit_and_predict_roundtrip(self):
+        model_true = _make_model()
+        model_true._startup_gamma_dot = 1.0
+        model_true._test_mode = "startup"
+        t = np.logspace(-3, 2, 40)
+        eta_plus = model_true.predict(t)
+
+        assert np.all(np.isfinite(eta_plus))
+        assert np.all(eta_plus >= 0)
+
+        model_fit = _make_model()
+        model_fit.fit(t, eta_plus, test_mode="startup", gamma_dot=1.0)
+        assert model_fit.fitted_ is True
+        assert model_fit._startup_gamma_dot == 1.0
+        np.testing.assert_allclose(
+            model_fit.predict(t), eta_plus, rtol=1e-3, atol=1e-8
+        )
+
+    def test_startup_fit_from_stress_input(self):
+        """is_stress=True divides applied stress by gamma_dot before fitting."""
+        model_true = _make_model()
+        model_true._startup_gamma_dot = 2.0
+        model_true._test_mode = "startup"
+        t = np.logspace(-3, 1, 30)
+        eta_plus = model_true.predict(t)
+        stress = eta_plus * 2.0  # sigma = eta_plus * gamma_dot
+
+        model_fit = _make_model()
+        model_fit.fit(t, stress, test_mode="startup", gamma_dot=2.0, is_stress=True)
+        assert model_fit.fitted_ is True
+
+
+class TestSGRGenericFitValidation:
+    """Input validation raised before optimization begins."""
+
+    def test_oscillation_bad_gstar_shape_raises(self):
+        model = SGRGeneric()
+        with pytest.raises(ValueError, match="G_star must be complex"):
+            model.fit(np.logspace(0, 2, 10), np.ones((10, 3)), test_mode="oscillation")
+
+    def test_laos_fit_requires_gamma0_and_omega(self):
+        model = SGRGeneric()
+        t = np.linspace(0, 4 * np.pi, 100)
+        with pytest.raises(ValueError, match="requires gamma_0 and omega"):
+            model.fit(t, np.sin(t), test_mode="laos")
+
+    def test_laos_fit_rejects_nonpositive_gamma0(self):
+        model = SGRGeneric()
+        t = np.linspace(0, 4 * np.pi, 100)
+        with pytest.raises(ValueError, match="must be positive"):
+            model.fit(t, np.sin(t), test_mode="laos", gamma_0=-1.0, omega=1.0)
+
+
+class TestSGRGenericLAOSFitBugs:
+    """LAOS fitting via the public fit() API is currently broken (bug report).
+
+    Both branches of _fit_laos_mode forward **kwargs that still contain the
+    positional argument names (omega / gamma_0 / n_particles), so the inner
+    call raises TypeError('got multiple values for argument ...').
+    """
+
+    @pytest.mark.xfail(
+        reason="_fit_laos_mode passes omega in **kwargs to _fit_oscillation_mode "
+        "(positional collision); small-amplitude LAOS fit is broken.",
+        strict=True,
+    )
+    def test_laos_saos_branch_small_amplitude(self):
+        model = _make_model()
+        model._test_mode = "oscillation"
+        omega = 1.0
+        gamma_0 = 0.05  # < 0.1 -> SAOS branch
+        t = np.linspace(0, 4 * np.pi, 400)
+        strain = gamma_0 * np.sin(omega * t)
+        stress = 500.0 * strain
+        model.fit(t, stress, test_mode="laos", gamma_0=gamma_0, omega=omega)
+        assert model.fitted_ is True
+
+    @pytest.mark.xfail(
+        reason="_fit_laos_mode passes gamma_0/omega/n_particles in **kwargs to "
+        "_fit_laos_mc (positional collision); MC LAOS fit is broken.",
+        strict=True,
+    )
+    def test_laos_mc_branch_large_amplitude(self):
+        model = _make_model()
+        omega = 2.0
+        gamma_0 = 0.5  # >= 0.1 -> MC branch
+        t = np.linspace(0, 2 * 2 * np.pi / omega, 200)
+        stress = 500.0 * gamma_0 * np.sin(omega * t)
+        model.fit(
+            t, stress, test_mode="laos", gamma_0=gamma_0, omega=omega,
+            n_particles=50, max_iter=1,
+        )
+        assert model.fitted_ is True
+
+
+class TestSGRGenericPredictJIT:
+    """Direct JIT predictors and the LAOS predict route."""
+
+    def test_predict_viscosity_jit_shear_thinning(self):
+        model = _make_model()
+        gamma_dot = np.logspace(-2, 2, 20)
+        from rheojax.core.jax_config import safe_import_jax
+
+        _, jnp = safe_import_jax()
+        eta = np.asarray(
+            model._predict_viscosity_jit(jnp.asarray(gamma_dot), 1.5, 1000.0, 1e-3)
+        )
+        # x=1.5 < 2 -> shear-thinning: eta decreases with gamma_dot
+        assert np.all(np.isfinite(eta))
+        assert np.all(eta > 0)
+        assert np.all(np.diff(eta) <= 0)
+
+    def test_predict_laos_mode_via_predict(self):
+        model = _make_model()
+        model._test_mode = "laos"
+        model._gamma_0 = 0.2
+        model._omega_laos = 1.0
+        X = np.linspace(0, 4 * np.pi, 50)
+        stress = model.predict(X)
+        assert stress.shape == (50,)
+        assert np.all(np.isfinite(stress))
+
+
+class TestSGRGenericModelFunction:
+    """model_function() routing for Bayesian inference across modes."""
+
+    @pytest.mark.parametrize("mode", ["oscillation", "relaxation", "steady_shear", "creep"])
+    def test_model_function_basic_modes(self, mode):
+        model = SGRGeneric()
+        params = np.array([1.5, 1000.0, 1e-3])
+        X = np.logspace(-2, 2, 25)
+        out = np.asarray(model.model_function(X, params, test_mode=mode))
+        assert np.all(np.isfinite(out))
+        if mode == "oscillation":
+            assert out.shape == (25, 2)
+        else:
+            assert out.shape == (25,)
+
+    def test_model_function_defaults_to_oscillation(self):
+        model = SGRGeneric()
+        assert model._test_mode is None
+        params = np.array([1.5, 1000.0, 1e-3])
+        out = np.asarray(model.model_function(np.logspace(0, 2, 10), params))
+        assert out.shape == (10, 2)
+
+    def test_model_function_startup_requires_gamma_dot(self):
+        model = SGRGeneric()
+        params = np.array([1.5, 1000.0, 1e-3])
+        with pytest.raises(RuntimeError, match="gamma_dot not provided"):
+            model.model_function(np.logspace(-2, 1, 10), params, test_mode="startup")
+
+    def test_model_function_startup_with_gamma_dot(self):
+        model = SGRGeneric()
+        params = np.array([1.5, 1000.0, 1e-3])
+        out = np.asarray(
+            model.model_function(
+                np.logspace(-2, 1, 10), params, test_mode="startup", gamma_dot=2.0
+            )
+        )
+        assert out.shape == (10,)
+        assert np.all(np.isfinite(out))
+
+    def test_model_function_laos_not_implemented(self):
+        model = SGRGeneric()
+        params = np.array([1.5, 1000.0, 1e-3])
+        with pytest.raises(NotImplementedError, match="LAOS"):
+            model.model_function(np.logspace(0, 2, 10), params, test_mode="laos")
+
+    def test_model_function_unsupported_mode_raises(self):
+        model = SGRGeneric()
+        params = np.array([1.5, 1000.0, 1e-3])
+        with pytest.raises(ValueError, match="Unsupported test mode"):
+            model.model_function(np.logspace(0, 2, 10), params, test_mode="nope")
+
+
+class TestSGRGenericPredictErrors:
+    """Prediction-side error handling."""
+
+    def test_predict_without_test_mode_raises(self):
+        model = SGRGeneric()
+        with pytest.raises(ValueError, match="test_mode must be specified"):
+            model.predict(np.array([1.0, 2.0]))
+
+    def test_predict_unknown_test_mode_raises(self):
+        model = _make_model()
+        model._test_mode = "not_a_real_mode"
+        with pytest.raises(ValueError, match="Unknown test_mode"):
+            model.predict(np.logspace(0, 2, 10))
+
+    def test_predict_startup_unfitted_raises(self):
+        model = _make_model()
+        model._test_mode = "startup"  # but no _startup_gamma_dot cached
+        with pytest.raises(RuntimeError, match="_startup_gamma_dot"):
+            model.predict(np.logspace(-2, 1, 10))
+
+
+class TestSGRGenericPhaseRegime:
+    """Phase-regime classification from noise temperature x."""
+
+    @pytest.mark.parametrize(
+        "x,expected",
+        [(0.8, "glass"), (1.0, "power-law"), (1.5, "power-law"), (2.0, "newtonian"), (2.5, "newtonian")],
+    )
+    def test_phase_regime(self, x, expected):
+        model = SGRGeneric()
+        model.parameters.set_value("x", x)
+        assert model.get_phase_regime() == expected
+
+
+class TestSGRGenericDynamicsSplit:
+    """Reversible / irreversible / full GENERIC dynamics."""
+
+    def test_dynamics_components_finite(self):
+        model = _make_model()
+        for state in (np.array([100.0, 0.5]), np.array([-500.0, 0.2]), np.array([0.0, 0.9])):
+            rev = model.reversible_dynamics(state)
+            irr = model.irreversible_dynamics(state)
+            full = model.full_dynamics(state)
+            assert np.all(np.isfinite(rev))
+            assert np.all(np.isfinite(irr))
+            np.testing.assert_allclose(full, rev + irr, rtol=1e-12, atol=1e-12)
+
+    def test_entropy_production_rate_nonnegative(self):
+        model = _make_model()
+        for state in (np.array([100.0, 0.5]), np.array([500.0, 0.3])):
+            assert model.entropy_production_rate(state) >= -1e-12
+
+
+class TestSGRGenericThixotropyEdgeCases:
+    """Error paths and re-configuration for thixotropy."""
+
+    def test_enable_thixotropy_twice_updates_values(self):
+        model = SGRGeneric()
+        model.enable_thixotropy(k_build=0.1, k_break=0.5, n_struct=2.0)
+        # Second call must overwrite existing parameter values (else-branches)
+        model.enable_thixotropy(k_build=0.2, k_break=0.6, n_struct=1.5)
+        assert model.parameters.get_value("k_build") == 0.2
+        assert model.parameters.get_value("k_break") == 0.6
+        assert model.parameters.get_value("n_struct") == 1.5
+
+    def test_evolve_lambda_requires_enabled(self):
+        model = SGRGeneric()
+        with pytest.raises(ValueError, match="Thixotropy not enabled"):
+            model.evolve_lambda(np.array([0.0, 1.0]), np.array([0.0, 1.0]))
+
+    def test_evolve_lambda_shape_mismatch(self):
+        model = SGRGeneric()
+        model.enable_thixotropy()
+        with pytest.raises(ValueError, match="same shape"):
+            model.evolve_lambda(np.array([0.0, 1.0, 2.0]), np.array([0.0, 1.0]))
+
+    def test_predict_thixotropic_stress_requires_enabled(self):
+        model = SGRGeneric()
+        with pytest.raises(ValueError, match="Thixotropy not enabled"):
+            model.predict_thixotropic_stress(
+                np.array([0.0, 1.0]), np.array([0.0, 1.0])
+            )
+
+
+class TestSGRGenericDynamicXErrors:
+    """Error paths for dynamic noise-temperature evolution."""
+
+    def test_evolve_x_requires_dynamic_x(self):
+        model = SGRGeneric()  # dynamic_x=False
+        with pytest.raises(ValueError, match="Dynamic x not enabled"):
+            model.evolve_x(np.array([0.0, 1.0]), np.array([0.0, 1.0]))
+
+    def test_evolve_x_shape_mismatch(self):
+        model = SGRGeneric(dynamic_x=True)
+        with pytest.raises(ValueError, match="same shape"):
+            model.evolve_x(np.array([0.0, 1.0, 2.0]), np.array([0.0, 1.0]))
+
+
+class TestSGRGenericLAOSAnalysisEdgeCases:
+    """Edge branches in harmonic / Chebyshev decomposition."""
+
+    def test_harmonics_small_window_zeros_high_harmonics(self):
+        """Window too short to resolve 5th/7th harmonics -> zeroed out."""
+        model = _make_model()
+        model._test_mode = "oscillation"
+        _, stress = model.simulate_laos(
+            gamma_0=0.5, omega=1.0, n_cycles=2, n_points_per_cycle=10
+        )
+        harmonics = model.extract_laos_harmonics(stress, n_points_per_cycle=10)
+        # n=10 -> n//2=5, so idx_5=5 and idx_7=7 are not < 5 -> else-branch
+        assert harmonics["I_5"] == 0.0
+        assert harmonics["I_7"] == 0.0
+
+    def test_harmonics_tiny_window_zeros_third_harmonic(self):
+        """n_points_per_cycle=4 -> n//2=2 so even idx_3=3 is unresolved."""
+        model = _make_model()
+        model._test_mode = "oscillation"
+        _, stress = model.simulate_laos(
+            gamma_0=0.5, omega=1.0, n_cycles=2, n_points_per_cycle=4
+        )
+        harmonics = model.extract_laos_harmonics(stress, n_points_per_cycle=4)
+        assert harmonics["I_3"] == 0.0
+
+    def test_harmonics_zero_stress_zero_ratios(self):
+        model = _make_model()
+        harmonics = model.extract_laos_harmonics(np.zeros(256))
+        # I_1 == 0 triggers the ratio else-branch
+        assert harmonics["I_3_I_1"] == 0.0
+        assert harmonics["I_5_I_1"] == 0.0
+        assert harmonics["I_7_I_1"] == 0.0
+
+    def test_chebyshev_zero_stress_zero_ratios(self):
+        model = _make_model()
+        strain = np.zeros(256)
+        stress = np.zeros(256)
+        cheb = model.compute_chebyshev_coefficients(strain, stress, gamma_0=0.5, omega=1.0)
+        # e_1 and v_1 near zero trigger the else-branches
+        assert cheb["e_3_e_1"] == 0.0
+        assert cheb["e_5_e_1"] == 0.0
+        assert cheb["v_3_v_1"] == 0.0
+        assert cheb["v_5_v_1"] == 0.0


### PR DESCRIPTION
## Summary
Closes a test-coverage gap in `rheojax/models/sgr/sgr_generic.py` (SGR GENERIC model), raising line coverage from **74% → 93%**. Tests only — the source file is unchanged.

## What's covered (new tests in `tests/models/sgr/test_sgr_generic.py`)
- **Fitting modes** (round-trip fit + predict on noiseless synthetic data): creep, steady-shear (+`flow_curve` alias), startup (incl. `is_stress=True` path)
- **`model_function`** routing for oscillation/relaxation/steady-shear/creep, default-to-oscillation, startup `gamma_dot` handling (required vs. supplied), LAOS `NotImplementedError`, unsupported-mode `ValueError`
- **Prediction error paths**: missing `test_mode`, unknown `test_mode`, unfitted startup
- **JIT predictors**: `_predict_viscosity_jit` shear-thinning; LAOS predict route
- **Phase-regime** classification (glass / power-law / newtonian)
- **GENERIC dynamics** split (reversible + irreversible = full) and entropy-production rate
- **Thixotropy / dynamic-x error paths**: not-enabled guards, shape mismatches, `enable_thixotropy` re-configuration
- **Fit input validation**: bad `G_star` shape, LAOS missing / non-positive amplitude
- **LAOS analysis edge branches**: harmonic zeroing for short/tiny windows and zero stress, Chebyshev near-zero denominators

Scientific conventions: `numpy.testing.assert_allclose` with explicit tolerances, physically-meaningful checks (monotonicity, sign, shear-thinning), and no-NaN/Inf assertions.

## Bugs found (documented, not fixed — 2 `strict` xfail tests)
`_fit_laos_mode` is broken through the public `fit(..., test_mode="laos", ...)` API. Both branches forward `**kwargs` that still contain the positional argument names, so the inner call raises `TypeError: got multiple values for argument ...`:
- **Small-amplitude (SAOS) branch**: `omega` in `**kwargs` collides with `_fit_oscillation_mode(omega, ...)` (sgr_generic.py:1034)
- **Large-amplitude (MC) branch**: `gamma_0`/`omega`/`n_particles` collide with `_fit_laos_mc(..., gamma_0, omega, n_particles, ...)` (sgr_generic.py:1037)

The MC-LAOS body (lines 1066–1178) is consequently unreachable via `fit()` and remains uncovered.

## Verification
`ruff check` clean; `pytest -n0 tests/models/sgr/test_sgr_generic.py` → **51 passed, 2 xfailed**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)