### PR TITLE
docs: fix stale test counts and document 4 missing transforms

### DIFF
--- a/README.md
+++ b/README.md
@@ -1003,10 +1003,10 @@ uv sync
 # Install pre-commit hooks
 pre-commit install
 
-# Run smoke tests (CI gate, ~1838 tests)
+# Run smoke tests (CI gate, ~2051 tests)
 uv run pytest -n 4 -m "smoke"
 
-# Run full test suite (~4963 tests)
+# Run full test suite (~6415 tests)
 uv run pytest -n 4
 
 # Format and lint

--- a/docs/README.md
+++ b/docs/README.md
@@ -145,7 +145,7 @@ Complete API documentation with autodoc:
 
 - **[Core](source/api/core.rst)** - BaseModel, RheoData, ParameterSet, BayesianMixin
 - **[Models](source/api/models.rst)** - All 53 rheological models
-- **[Transforms](source/api/transforms.rst)** - All 7 data transforms
+- **[Transforms](source/api/transforms.rst)** - All 11 data transforms
 - **[Pipeline](source/api/pipeline.rst)** - Pipeline, BayesianPipeline, BatchPipeline
 - **[Visualization](source/api/visualization.rst)** - Plotter, BayesianPlotter, templates
 - **[Utilities](source/api/utils.rst)** - Optimization, initialization, compatibility

--- a/docs/STRUCTURE.md
+++ b/docs/STRUCTURE.md
@@ -88,7 +88,7 @@ docs/
 │   │   │  # LAOS Analysis
 │   │   └── spp/                      # 1 model: SPPYieldStress + SPPDecomposer (3 rst)
 │   │
-│   ├── transforms/                   # Transform Reference — 7 transforms (9 rst)
+│   ├── transforms/                   # Transform Reference — 11 transforms (13 rst)
 │   │   ├── index.rst
 │   │   ├── summary.rst               # Application guide
 │   │   ├── fft.rst                   # FFT analysis
@@ -97,7 +97,11 @@ docs/
 │   │   ├── owchirp.rst              # Fast rheometry
 │   │   ├── smooth_derivative.rst     # Noise-robust differentiation
 │   │   ├── spp.rst                   # SPP decomposition transform
-│   │   └── srfs.rst                  # Strain-rate frequency superposition
+│   │   ├── srfs.rst                  # Strain-rate frequency superposition
+│   │   ├── cox_merz.rst              # Cox-Merz rule validation
+│   │   ├── prony_conversion.rst      # Prony series time<->frequency conversion
+│   │   ├── spectrum_inversion.rst    # Relaxation spectrum H(tau) recovery
+│   │   └── lve_envelope.rst          # Linear viscoelastic startup envelope
 │   │
 │   ├── api/                          # API Reference (auto-generated, 9 files)
 │   ├── developer/                    # Contributing guides (2 files)
@@ -129,8 +133,9 @@ docs/
 ### Tier 3: Transform Reference (Preprocessing Math)
 - **Purpose:** Data preprocessing theory
 - **Audience:** Advanced practitioners
-- **Content:** FFT, WLF/TTS, SRFS, SPP, mutation number, OWChirp, derivatives
-- **Size:** 9 rst files covering 7 transforms
+- **Content:** FFT, WLF/TTS, SRFS, SPP, mutation number, OWChirp, derivatives, Cox-Merz,
+  Prony conversion, spectrum inversion, LVE envelope
+- **Size:** 13 rst files covering 11 transforms
 
 ## Building Documentation
 
@@ -155,7 +160,7 @@ Working files, reports, and analysis documents are preserved in `.archive/` but 
 
 - **53 models** across 20 families with full Bayesian inference support
 - **86 rst files** in the Model Handbook (equations, protocols, troubleshooting)
-- **7 transforms** with mathematical derivations
+- **11 transforms** with mathematical derivations
 - **6-section User Guide** structured as a 16-week graduate course
 - **9 learning pathways** for different user backgrounds
 - **240+ example notebooks** across all model families

--- a/docs/source/api/transforms.rst
+++ b/docs/source/api/transforms.rst
@@ -185,3 +185,113 @@ and nonlinearity metrics using the Sequence of Physical Processes framework.
    :members:
    :undoc-members:
    :show-inheritance:
+
+CoxMerz
+~~~~~~~
+
+:class:`rheojax.transforms.cox_merz.CoxMerz` | Handbook: :doc:`/transforms/cox_merz`
+Validates the Cox-Merz rule by comparing complex viscosity |η*(ω)| from oscillation data
+with steady-shear viscosity η(γ̇) from flow curve data on a common grid.
+
+.. list-table:: Parameters
+   :header-rows: 1
+   :widths: 28 72
+
+   * - Parameter (default)
+     - Description
+   * - ``tolerance`` (``0.1``)
+     - Maximum mean relative deviation for the rule to "pass" (10%).
+   * - ``n_points`` (``50``)
+     - Number of interpolation points on the common grid.
+
+.. autoclass:: rheojax.transforms.cox_merz.CoxMerz
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+PronyConversion
+~~~~~~~~~~~~~~~
+
+:class:`rheojax.transforms.prony_conversion.PronyConversion` | Handbook: :doc:`/transforms/prony_conversion`
+Converts between time-domain and frequency-domain viscoelastic representations via a
+Prony series, using the fitting utilities in ``rheojax.utils.prony``.
+
+.. list-table:: Parameters
+   :header-rows: 1
+   :widths: 28 72
+
+   * - Parameter (default)
+     - Description
+   * - ``n_modes`` (``None``)
+     - Number of Prony modes; auto-selected when ``None``.
+   * - ``direction`` (``'time_to_freq'``)
+     - Conversion direction: ``'time_to_freq'`` or ``'freq_to_time'``.
+   * - ``omega_out`` (``None``)
+     - Target frequency array for time→freq conversion.
+   * - ``t_out`` (``None``)
+     - Target time array for freq→time conversion.
+
+.. autoclass:: rheojax.transforms.prony_conversion.PronyConversion
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+SpectrumInversion
+~~~~~~~~~~~~~~~~~
+
+:class:`rheojax.transforms.spectrum_inversion.SpectrumInversion` | Handbook: :doc:`/transforms/spectrum_inversion`
+Recovers the continuous relaxation spectrum H(τ) from oscillation or relaxation data via
+regularized inversion (Tikhonov with L-curve/GCV selection, or maximum entropy).
+
+.. list-table:: Parameters
+   :header-rows: 1
+   :widths: 28 72
+
+   * - Parameter (default)
+     - Description
+   * - ``method`` (``'tikhonov'``)
+     - Inversion method: ``'tikhonov'`` or ``'max_entropy'``.
+   * - ``n_tau`` (``100``)
+     - Number of τ points in the recovered spectrum.
+   * - ``tau_range`` (``None``)
+     - ``(tau_min, tau_max)``; auto-detected from data when ``None``.
+   * - ``regularization`` (``None``)
+     - Manual regularization parameter λ; auto-selected when ``None``.
+   * - ``source`` (``'oscillation'``)
+     - Input data type: ``'oscillation'`` or ``'relaxation'``.
+   * - ``G_e`` (``0.0``)
+     - Equilibrium modulus (Pa); estimated from data when ``None``.
+
+.. autoclass:: rheojax.transforms.spectrum_inversion.SpectrumInversion
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+LVEEnvelope
+~~~~~~~~~~~
+
+:class:`rheojax.transforms.lve_envelope.LVEEnvelope` | Handbook: :doc:`/transforms/lve_envelope`
+Computes the theoretical linear-viscoelastic startup stress envelope from Prony modes, for
+comparison against experimental startup data to reveal nonlinear strain hardening/softening.
+
+.. list-table:: Parameters
+   :header-rows: 1
+   :widths: 28 72
+
+   * - Parameter (default)
+     - Description
+   * - ``shear_rate`` (``1.0``)
+     - Applied shear rate γ̇₀ (s⁻¹).
+   * - ``G_i`` (``None``)
+     - Prony mode strengths (Pa); read from data metadata when ``None``.
+   * - ``tau_i`` (``None``)
+     - Prony relaxation times (s); read from data metadata when ``None``.
+   * - ``G_e`` (``0.0``)
+     - Equilibrium modulus (Pa).
+   * - ``t_out`` (``None``)
+     - Output time array; auto-generated when ``None``.
+
+.. autoclass:: rheojax.transforms.lve_envelope.LVEEnvelope
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/source/api_reference.rst
+++ b/docs/source/api_reference.rst
@@ -31,7 +31,7 @@ Quick Links
 **Phase 2 (Models and Transforms)**:
 
 - :doc:`api/models` - All 53 rheological models (classical, fractional, flow, multi-mode, SGR, STZ, EPM, fluidity, Saramito, DMT, IKH, FIKH, HL, Giesekus, ITT-MCT, TNT, VLB, HVM, HVNM, SPP)
-- :doc:`api/transforms` - All 7 data transforms (FFT, mastercurve, mutation, OWChirp, smoothing, SRFS, SPP)
+- :doc:`api/transforms` - All 11 data transforms (FFT, mastercurve, mutation, OWChirp, smoothing, SRFS, SPP, Cox-Merz, Prony conversion, spectrum inversion, LVE envelope)
 - :doc:`api/pipeline` - Pipeline API for high-level workflows
 
 **Phase 4 (Complete)**: Performance & Correctness [done - v0.3.0-v0.4.0]
@@ -204,8 +204,8 @@ Models (53 total)
 
 - :class:`rheojax.models.HVNMLocal` - Hybrid vitrimer nanocomposite (4 sub-networks)
 
-Transforms (7 total)
-~~~~~~~~~~~~~~~~~~~~
+Transforms (11 total)
+~~~~~~~~~~~~~~~~~~~~~
 
 - :class:`rheojax.transforms.FFTAnalysis` - Time -> frequency domain (FFT)
 - :class:`rheojax.transforms.Mastercurve` - Time-temperature superposition (WLF/Arrhenius)
@@ -214,6 +214,10 @@ Transforms (7 total)
 - :class:`rheojax.transforms.SmoothDerivative` - Noise-robust differentiation
 - :class:`rheojax.transforms.SRFS` - Strain-rate frequency superposition
 - :class:`rheojax.transforms.SPPDecomposer` - Sequence of Physical Processes decomposition
+- :class:`rheojax.transforms.CoxMerz` - Cox-Merz rule validation (|η*| vs η)
+- :class:`rheojax.transforms.PronyConversion` - Prony series time<->frequency conversion
+- :class:`rheojax.transforms.SpectrumInversion` - Relaxation spectrum H(τ) recovery
+- :class:`rheojax.transforms.LVEEnvelope` - Linear viscoelastic startup envelope
 
 Pipeline API
 ~~~~~~~~~~~~

--- a/docs/source/developer/architecture.rst
+++ b/docs/source/developer/architecture.rst
@@ -93,14 +93,18 @@ Module Structure
     |   |--- vlb/            # Local, MultiNetwork, Variant, Nonlocal
     |   |--- hvm/            # HVMLocal (vitrimer, 3 subnetworks)
     |   \--- hvnm/           # HVNMLocal (nanocomposite, 4 subnetworks)
-    |--- transforms/         # 7 data transforms
-    |   |--- fft.py          # FFT spectral analysis
-    |   |--- mastercurve.py  # TTS + auto shift factors
-    |   |--- owchirp.py      # OWChirp LAOS analysis
-    |   |--- srfs.py         # Strain-Rate Frequency Superposition
-    |   |--- spp.py          # SPP decomposition
+    |--- transforms/         # 11 data transforms
+    |   |--- fft_analysis.py     # FFT spectral analysis
+    |   |--- mastercurve.py      # TTS + auto shift factors
+    |   |--- owchirp.py          # OWChirp LAOS analysis
+    |   |--- srfs.py             # Strain-Rate Frequency Superposition
+    |   |--- spp_decomposer.py   # SPP decomposition
     |   |--- mutation_number.py  # Mutation number
-    |   \--- smooth_derivative.py  # Savitzky-Golay derivatives
+    |   |--- smooth_derivative.py  # Savitzky-Golay derivatives
+    |   |--- cox_merz.py         # Cox-Merz rule validation
+    |   |--- prony_conversion.py # Prony series time<->frequency conversion
+    |   |--- spectrum_inversion.py  # Relaxation spectrum H(tau) recovery
+    |   \--- lve_envelope.py     # Linear viscoelastic startup envelope
     |--- utils/              # Utilities
     |   |--- optimization.py     # NLSQ interface (5-270x vs scipy)
     |   |--- prony.py            # Prony series decomposition

--- a/docs/source/developer/contributing.rst
+++ b/docs/source/developer/contributing.rst
@@ -49,13 +49,13 @@ Development Setup
 
    .. code-block:: bash
 
-       # Run smoke tests (~1838 tests, ~2-6 min)
+       # Run smoke tests (~2051 tests, ~2-6 min)
        uv run pytest -n 4 -m "smoke"
 
        # Run standard tests (~4714 tests, ~10-20 min)
        uv run pytest -n 4 -m "not slow"
 
-       # Run full suite (~4963 tests, includes slow Bayesian)
+       # Run full suite (~6415 tests, includes slow Bayesian)
        uv run pytest -n 4
 
        # Quick format + lint + smoke
@@ -304,13 +304,13 @@ RheoJAX uses a **tiered testing strategy** with pytest markers:
 
 .. code-block:: bash
 
-    # Tier 1: Smoke tests (~1838 tests, ~2-6 min) — CI gate
+    # Tier 1: Smoke tests (~2051 tests, ~2-6 min) — CI gate
     uv run pytest -n 4 -m "smoke"
 
     # Tier 2: Standard tests (~4714 tests, ~10-20 min)
     uv run pytest -n 4 -m "not slow"
 
-    # Tier 3: Full suite (~4963 tests, includes slow Bayesian)
+    # Tier 3: Full suite (~6415 tests, includes slow Bayesian)
     uv run pytest -n 4
 
     # Quick format + lint + smoke

--- a/docs/source/development_status.rst
+++ b/docs/source/development_status.rst
@@ -6,6 +6,11 @@ Development Status & Performance
 This page tracks the development history of RheoJAX across 11 completed phases
 and provides performance benchmarks.
 
+.. note::
+   As of 2026-07-10, the test suite has grown to 6,415 tests (2,051 smoke tests)
+   through a dedicated coverage sprint (Phase 11), and the GUI/test infrastructure
+   has been hardened against FreeType rendering crashes and pytest-xdist hangs.
+
 Development Phases
 ------------------
 

--- a/docs/source/user_guide/02_model_usage/model_families.rst
+++ b/docs/source/user_guide/02_model_usage/model_families.rst
@@ -997,7 +997,7 @@ Further Reading
 - :doc:`../03_advanced_topics/dense_suspensions_glasses` — ITT-MCT
 - :doc:`../03_advanced_topics/polymer_network_models` — TNT and VLB
 - :doc:`../03_advanced_topics/vitrimer_models` — HVM and HVNM
-- :doc:`../03_advanced_topics/transforms_complete` — All 7 data transforms
+- :doc:`../03_advanced_topics/transforms_complete` — All 11 data transforms
 
 Summary
 -------

--- a/docs/source/user_guide/03_advanced_topics/index.rst
+++ b/docs/source/user_guide/03_advanced_topics/index.rst
@@ -28,7 +28,7 @@ By completing this section, you will be able to:
 10. Apply transient polymer network models (TNT, VLB)
 11. Model vitrimer and nanocomposite rheology (HVM, HVNM)
 12. Understand dense suspension dynamics via mode-coupling theory (ITT-MCT)
-13. Apply all 7 data transforms to experimental data
+13. Apply all 11 data transforms to experimental data
 
 ----
 

--- a/docs/source/user_guide/03_advanced_topics/transforms_complete.rst
+++ b/docs/source/user_guide/03_advanced_topics/transforms_complete.rst
@@ -846,8 +846,9 @@ them within a tolerance (default 10% mean relative deviation).
    from rheojax.transforms import CoxMerz
 
    cm = CoxMerz(tolerance=0.1, n_points=50)
-   result = cm.transform(oscillation_data, flow_curve_data)
-   print(f"Cox-Merz holds: {result.holds}, mean deviation: {result.mean_deviation:.3f}")
+   result_data, meta = cm.transform([oscillation_data, flow_curve_data])
+   cmr = meta["cox_merz_result"]
+   print(f"Cox-Merz holds: {cmr.passes}, mean deviation: {cmr.mean_deviation:.3f}")
 
 See :doc:`../../transforms/cox_merz` for the full parameter reference and theory.
 
@@ -867,7 +868,8 @@ other domain, using the fitting utilities in ``rheojax.utils.prony``.
    from rheojax.transforms import PronyConversion
 
    pc = PronyConversion(direction="time_to_freq", omega_out=omega_grid)
-   freq_data = pc.transform(relaxation_data)
+   freq_data, meta = pc.transform(relaxation_data)
+   prony_result = meta["prony_result"]
 
 See :doc:`../../transforms/prony_conversion` for the full parameter reference and theory.
 
@@ -887,7 +889,8 @@ inversion (Tikhonov with L-curve/GCV selection, or maximum entropy).
    from rheojax.transforms import SpectrumInversion
 
    si = SpectrumInversion(method="tikhonov", n_tau=100, source="oscillation")
-   spectrum = si.transform(data)
+   spectrum_data, meta = si.transform(data)
+   spectrum_result = meta["spectrum_result"]
 
 See :doc:`../../transforms/spectrum_inversion` for the full parameter reference and theory.
 
@@ -906,8 +909,10 @@ against this envelope reveals nonlinear effects such as strain hardening or soft
 
    from rheojax.transforms import LVEEnvelope
 
+   # G_i/tau_i supplied directly, so no input data is required
    env = LVEEnvelope(shear_rate=1.0, G_i=G_i, tau_i=tau_i)
-   envelope = env.transform(startup_data)
+   envelope_data, meta = env.transform(None)
+   lve_result = meta["lve_result"]
 
 See :doc:`../../transforms/lve_envelope` for the full parameter reference and theory.
 

--- a/docs/source/user_guide/03_advanced_topics/transforms_complete.rst
+++ b/docs/source/user_guide/03_advanced_topics/transforms_complete.rst
@@ -9,7 +9,7 @@ Complete Guide to Data Transforms
 Overview
 ========
 
-RheoJAX provides **7 specialized data transforms** that process raw rheological measurements
+RheoJAX provides **11 specialized data transforms** that process raw rheological measurements
 into derived quantities. These transforms operate on ``RheoData`` objects or raw NumPy/JAX
 arrays and extract physically meaningful information for material characterization, nonlinearity
 quantification, and data quality assessment.
@@ -61,6 +61,18 @@ When to Use Transforms
    * - Chirp oscillatory data
      - :math:`G'(\omega)`, :math:`G''(\omega)` from single test
      - :ref:`OWChirp <owchirp_transform>`
+   * - Oscillation + flow curve data
+     - Check if Cox-Merz rule holds (|η*| vs η)
+     - :doc:`CoxMerz <../../transforms/cox_merz>`
+   * - Modulus data in one domain
+     - Convert time <-> frequency domain via Prony series
+     - :doc:`PronyConversion <../../transforms/prony_conversion>`
+   * - Oscillation or relaxation data
+     - Continuous relaxation spectrum :math:`H(\tau)`
+     - :doc:`SpectrumInversion <../../transforms/spectrum_inversion>`
+   * - Startup data + Prony modes
+     - Theoretical LVE startup envelope for nonlinearity check
+     - :doc:`LVEEnvelope <../../transforms/lve_envelope>`
 
 .. _fft_transform:
 
@@ -817,6 +829,88 @@ Usage
    **Nonlinearity**: Chirp data analysis assumes **linear viscoelasticity** (SAOS regime).
    For LAOS, use discrete frequency sweeps with FFT/SPP instead.
 
+.. _cox_merz_transform:
+
+8. Cox-Merz (Rule Validation)
+==============================
+
+**Comparing Oscillatory and Steady-Shear Viscosity**
+
+:class:`CoxMerz <rheojax.transforms.CoxMerz>` checks whether the empirical Cox-Merz rule,
+:math:`|\eta^*(\omega)| \approx \eta(\dot{\gamma})` at :math:`\omega = \dot{\gamma}`, holds for
+a material by interpolating oscillation and flow-curve data onto a common grid and comparing
+them within a tolerance (default 10% mean relative deviation).
+
+.. code-block:: python
+
+   from rheojax.transforms import CoxMerz
+
+   cm = CoxMerz(tolerance=0.1, n_points=50)
+   result = cm.transform(oscillation_data, flow_curve_data)
+   print(f"Cox-Merz holds: {result.holds}, mean deviation: {result.mean_deviation:.3f}")
+
+See :doc:`../../transforms/cox_merz` for the full parameter reference and theory.
+
+.. _prony_conversion_transform:
+
+9. Prony Conversion (Time <-> Frequency Domain)
+==================================================
+
+**Converting Between Relaxation and Oscillation Representations**
+
+:class:`PronyConversion <rheojax.transforms.PronyConversion>` fits a Prony series to
+time-domain or frequency-domain viscoelastic data and evaluates it on a target grid in the
+other domain, using the fitting utilities in ``rheojax.utils.prony``.
+
+.. code-block:: python
+
+   from rheojax.transforms import PronyConversion
+
+   pc = PronyConversion(direction="time_to_freq", omega_out=omega_grid)
+   freq_data = pc.transform(relaxation_data)
+
+See :doc:`../../transforms/prony_conversion` for the full parameter reference and theory.
+
+.. _spectrum_inversion_transform:
+
+10. Spectrum Inversion (Relaxation Spectrum Recovery)
+========================================================
+
+**Recovering the Continuous Relaxation Spectrum**
+
+:class:`SpectrumInversion <rheojax.transforms.SpectrumInversion>` recovers the continuous
+relaxation spectrum :math:`H(\tau)` from oscillation or relaxation data via regularized
+inversion (Tikhonov with L-curve/GCV selection, or maximum entropy).
+
+.. code-block:: python
+
+   from rheojax.transforms import SpectrumInversion
+
+   si = SpectrumInversion(method="tikhonov", n_tau=100, source="oscillation")
+   spectrum = si.transform(data)
+
+See :doc:`../../transforms/spectrum_inversion` for the full parameter reference and theory.
+
+.. _lve_envelope_transform:
+
+11. LVE Envelope (Startup Nonlinearity Check)
+================================================
+
+**Theoretical Linear-Viscoelastic Startup Envelope**
+
+:class:`LVEEnvelope <rheojax.transforms.LVEEnvelope>` computes the theoretical stress growth
+response assuming linear viscoelasticity from Prony modes. Comparing experimental startup data
+against this envelope reveals nonlinear effects such as strain hardening or softening.
+
+.. code-block:: python
+
+   from rheojax.transforms import LVEEnvelope
+
+   env = LVEEnvelope(shear_rate=1.0, G_i=G_i, tau_i=tau_i)
+   envelope = env.transform(startup_data)
+
+See :doc:`../../transforms/lve_envelope` for the full parameter reference and theory.
+
 Combining Transforms
 ====================
 
@@ -1053,13 +1147,18 @@ See Also
 
 **Transform API Reference:**
 
-- :doc:`../../api_reference/transforms/fft_analysis` — FFTAnalysis class
-- :doc:`../../api_reference/transforms/mastercurve` — Mastercurve class
-- :doc:`../../api_reference/transforms/srfs` — SRFS class
-- :doc:`../../api_reference/transforms/spp_decomposer` — SPPDecomposer class
-- :doc:`../../api_reference/transforms/smooth_derivative` — SmoothDerivative class
-- :doc:`../../api_reference/transforms/mutation_number` — MutationNumber class
-- :doc:`../../api_reference/transforms/owchirp` — OWChirp class
+- :doc:`../../api/transforms` — Full API reference for all 11 transforms
+- :doc:`../../transforms/fft` — FFTAnalysis handbook page
+- :doc:`../../transforms/mastercurve` — Mastercurve handbook page
+- :doc:`../../transforms/srfs` — SRFS handbook page
+- :doc:`../../transforms/spp` — SPPDecomposer handbook page
+- :doc:`../../transforms/smooth_derivative` — SmoothDerivative handbook page
+- :doc:`../../transforms/mutation_number` — MutationNumber handbook page
+- :doc:`../../transforms/owchirp` — OWChirp handbook page
+- :doc:`../../transforms/cox_merz` — CoxMerz handbook page
+- :doc:`../../transforms/prony_conversion` — PronyConversion handbook page
+- :doc:`../../transforms/spectrum_inversion` — SpectrumInversion handbook page
+- :doc:`../../transforms/lve_envelope` — LVEEnvelope handbook page
 
 **Example Notebooks:**
 

--- a/docs/source/user_guide/04_practical_guides/data_formats.rst
+++ b/docs/source/user_guide/04_practical_guides/data_formats.rst
@@ -10,7 +10,7 @@ Data Format Reference
    fitting analyses and transforms. Use this as a technical specification when
    preparing data for analysis.
 
-   **Version**: v0.6.0 — 53 models | 7 transforms | 5 readers | 3 writers
+   **Version**: v0.7.0 — 53 models | 11 transforms | 5 readers | 3 writers
 
 .. contents:: On this page
    :local:

--- a/docs/tech-stack.md
+++ b/docs/tech-stack.md
@@ -150,8 +150,8 @@ Install with: `make install-jax-gpu` (auto-detects CUDA version) or `uv sync --e
 | `make install` | `uv sync` | Editable install |
 | `make install-dev` | `uv sync --all-extras` | + development deps |
 | `make install-jax-gpu` | Auto-detect CUDA | GPU JAX backend |
-| `make test` | `pytest` | Full test suite (~4963 tests) |
-| `make test-smoke` | `pytest -m smoke` | Critical tests (~1838, CI gate) |
+| `make test` | `pytest` | Full test suite (~6415 tests) |
+| `make test-smoke` | `pytest -m smoke` | Critical tests (~2051, CI gate) |
 | `make test-fast` | `pytest -m "not slow..."` | Exclude slow Bayesian (~4714) |
 | `make test-parallel` | `pytest -n $XDIST_WORKERS` | Parallel (default 4 workers) |
 | `make test-ci` | `pytest -m smoke` | CI gate (matches GitHub Actions) |
@@ -178,7 +178,7 @@ addopts = [
 ```
 
 **Test Markers:**
-- **Tiers:** `smoke` (~1838 tests, <6 min), `unit`, `integration`, `validation`, `benchmark`
+- **Tiers:** `smoke` (~2051 tests, <6 min), `unit`, `integration`, `validation`, `benchmark`
 - **Execution:** `slow` (>30s), `gpu`, `macos_only`, `crash_test`
 - **Content:** `notebook_smoke`, `notebook_comprehensive`, `io`, `visual`, `sgr`, `spp`, `gui`
 
@@ -215,7 +215,7 @@ Overrides: `rheojax.models.*` (relaxed name-defined/any-return), `rheojax.gui.*`
   - `release.yml` — tag-triggered PyPI publish with build provenance attestation, SBOM, GitHub Release (reuses CI via `workflow_call`)
   - `security.yml` — CodeQL, Semgrep SAST, Gitleaks, Trivy (push/PR + weekly schedule)
   - `dependabot-auto-merge.yml` — auto-squash-merge minor/patch dependency updates
-- **CI gate:** Smoke tests (~1838 tests) on 3 OS × 2 Python versions
+- **CI gate:** Smoke tests (~2051 tests) on 3 OS × 2 Python versions
 - **Local CI:** `make quick` (format + lint + smoke)
 
 ---


### PR DESCRIPTION
## Summary
- API reference and user-guide transform docs only listed 7 of the 11 transforms — `CoxMerz`, `PronyConversion`, `SpectrumInversion`, and `LVEEnvelope` existed in the registry but were never added to `docs/source/api/transforms.rst`, `api_reference.rst`, or the `transforms_complete.rst` handbook, so the "7 transforms" count was stale in 8 files.
- Fixed dead `:doc:` links in `transforms_complete.rst` pointing to a nonexistent `api_reference/transforms/` path — silently unreported because `ref.doc` warnings are suppressed in `conf.py`.
- Updated stale test-suite counts (4963→6415 full, 1838→2051 smoke) reflecting the recent coverage sprint (PR #51/#52).
- Added a note in `development_status.rst` covering the post-Phase-10 test-coverage/hardening work, resolving the "11 completed phases" vs. 10-listed-phases mismatch.
- Fixed stale transform filenames in `developer/architecture.rst` (`fft.py`/`spp.py` → `fft_analysis.py`/`spp_decomposer.py`).

## Test plan
- [x] `uv run sphinx-build -b html docs/source docs/_build/html -W --keep-going` — build succeeds, no new warnings
- [x] Verified transform count (11) and test counts (6415 total / 2051 smoke) against `TransformRegistry` and `pytest --collect-only`
- [x] Confirmed all new `:doc:`/`:class:` references resolve (handbook pages already existed for the 4 newly-documented transforms)

🤖 Generated with [Claude Code](https://claude.com/claude-code)