### PR TITLE
docs: fix stale notebook/transform counts, remove deleted DMTA references

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 
 > **Disclaimer:** RheoJAX is pre-release software under active development and testing. APIs, model implementations, and numerical results may change without notice. Outputs have not been independently validated for all use cases. Use at your own risk and verify critical results against established reference data before relying on them in research or industrial applications.
 
-JAX-accelerated package for rheological data analysis. Provides 53 rheological models across 22 families (including TNT, VLB, HVM, HVNM, Giesekus, DMT, ITT-MCT, EPM, SGR, STZ, Fluidity-Saramito, IKH, FIKH, and SPP), 11 data transforms (FFT, Mastercurve/TTS, SRFS, SPP, OWChirp, Cox-Merz, Prony conversion, spectrum inversion, LVE envelope, mutation number, smooth derivative), Bayesian inference via NumPyro, DMTA/DMA support (E* ↔ G* conversion for 45 oscillation-capable models), and 249 tutorial notebooks across 21 categories.
+JAX-accelerated package for rheological data analysis. Provides 53 rheological models across 22 families (including TNT, VLB, HVM, HVNM, Giesekus, DMT, ITT-MCT, EPM, SGR, STZ, Fluidity-Saramito, IKH, FIKH, and SPP), 11 data transforms (FFT, Mastercurve/TTS, SRFS, SPP, OWChirp, Cox-Merz, Prony conversion, spectrum inversion, LVE envelope, mutation number, smooth derivative), Bayesian inference via NumPyro, DMTA/DMA support (E* ↔ G* conversion for 45 oscillation-capable models), and 218 tutorial notebooks across 20 categories.
 
 ## Features
 
@@ -82,14 +82,13 @@ Rheological analysis toolkit with Bayesian inference and parameter optimization:
 - **Plugin System**: Support for custom models and transforms
 
 ### Tutorial Notebooks & Examples
-- **249 Tutorial Notebooks**: Organized in 21 categories
+- **218 Tutorial Notebooks**: Organized in 20 categories
   - `examples/basic/` - 5 notebooks covering fundamental models
   - `examples/transforms/` - 13 notebooks for data transforms and analysis (FFT, TTS, SRFS, OWChirp, Cox-Merz, Prony, Spectrum Inversion, LVE Envelope, SPP)
   - `examples/bayesian/` - 9 notebooks for Bayesian inference workflows (including SPP LAOS)
   - `examples/advanced/` - 10 notebooks for production patterns (including SGR and SPP)
   - `examples/io/` - 1 notebook for TRIOS complex modulus handling
   - `examples/dmt/` - 6 notebooks: DMT thixotropic model (6 protocols)
-  - `examples/dmta/` - 8 notebooks: DMTA/DMA analysis (modulus conversion, GMM fitting, real data workflows)
   - `examples/epm/` - 6 notebooks: Elasto-plastic models (5 protocols + visualization)
   - `examples/fikh/` - 12 notebooks: FIKH + FMLIKH models (6 protocols each)
   - `examples/fluidity/` - 24 notebooks: Fluidity local/nonlocal + Saramito local/nonlocal (6 protocols each)
@@ -103,7 +102,7 @@ Rheological analysis toolkit with Bayesian inference and parameter optimization:
   - `examples/stz/` - 6 notebooks: Shear Transformation Zone (6 protocols)
   - `examples/tnt/` - 30 notebooks: 5 TNT sub-models (6 protocols each)
   - `examples/vlb/` - 16 notebooks: 6 protocols + Bayesian + Bell + FENE + Nonlocal + 6 NLSQ-to-NUTS
-  - `examples/verification/` - 31 notebooks: Cross-model validation (6 protocol validators + 25 material-specific)
+  - `examples/verification/` - 20 notebooks: Cross-model validation (index + 6 protocol validators + 13 material-specific case studies)
 
 ## Installation
 
@@ -679,7 +678,7 @@ unfilled = HVNMLocal.unfilled_vitrimer(G_P=5000, G_E=3000, G_D=1000)
 
 ## Tutorial Notebooks
 
-240+ tutorial notebooks organized by topic:
+218 tutorial notebooks organized by topic:
 
 ```
 examples/
@@ -689,7 +688,7 @@ examples/
 │   ├── 03-springpot-fitting.ipynb
 │   ├── 04-bingham-fitting.ipynb
 │   └── 05-power-law-fitting.ipynb
-├── transforms/                  # 8 notebooks: Data analysis workflows
+├── transforms/                  # 13 notebooks: Data analysis workflows
 │   ├── 01-fft-analysis.ipynb
 │   ├── 02-mastercurve-tts.ipynb
 │   ├── 02b-mastercurve-wlf-validation.ipynb
@@ -697,7 +696,12 @@ examples/
 │   ├── 04-owchirp-laos-analysis.ipynb
 │   ├── 05-smooth-derivative.ipynb
 │   ├── 06-mastercurve_auto_shift.ipynb
-│   └── 07-srfs-strain-rate-superposition.ipynb
+│   ├── 07-srfs-strain-rate-superposition.ipynb
+│   ├── 08-cox-merz-validation.ipynb
+│   ├── 09-prony-conversion.ipynb
+│   ├── 10-spectrum-inversion.ipynb
+│   ├── 11-lve-envelope.ipynb
+│   └── 12-spp-decomposition.ipynb
 ├── bayesian/                    # 9 notebooks: Bayesian inference (including SPP)
 │   ├── 01-bayesian-basics.ipynb
 │   ├── 02-prior-selection.ipynb
@@ -728,15 +732,6 @@ examples/
 │   ├── 04_dmt_creep.ipynb
 │   ├── 05_dmt_saos.ipynb
 │   └── 06_dmt_laos.ipynb
-├── dmta/                        # 8 notebooks: DMTA/DMA analysis
-│   ├── 01_dmta_basics.ipynb
-│   ├── 02_dmta_master_curve.ipynb
-│   ├── 03_dmta_fractional_models.ipynb
-│   ├── 04_dmta_relaxation.ipynb
-│   ├── 05_dmta_vitrimer.ipynb
-│   ├── 06_dmta_model_selection.ipynb
-│   ├── 07_dmta_tts_pipeline.ipynb
-│   └── 08_dmta_cross_domain.ipynb
 ├── epm/                         # 6 notebooks: Elasto-plastic models
 │   ├── 01_epm_flow_curve.ipynb
 │   ├── 02_epm_saos.ipynb
@@ -879,13 +874,13 @@ examples/
 │   ├── 14_vlb_startup_shear_nlsq_to_nuts.ipynb
 │   ├── 15_vlb_saos_nlsq_to_nuts.ipynb
 │   └── 16_vlb_laos_nlsq_to_nuts.ipynb
-└── verification/                # 31 notebooks: Cross-model validation
+└── verification/                # 20 notebooks: Cross-model validation
     ├── 00_verification_index.ipynb
-    ├── 01-06: Protocol validators (flow, creep, relaxation, startup, SAOS, LAOS)
+    ├── 01-06: Protocol validators (flow curve, creep, stress relaxation, startup shear, SAOS, LAOS)
     ├── creep/                   # 3 notebooks (mucus, perihepatic abscess, polystyrene)
-    ├── oscillation/             # 13 notebooks (mastercurves, model evaluation, material-specific)
-    ├── relaxation/              # 7 notebooks (fish muscle, laponite, foams, polyethylene, etc.)
-    └── rotation/                # 1 notebook (emulsion)
+    ├── flow_curve/              # 1 notebook (emulsion)
+    ├── saos/                    # 3 notebooks (chia pudding, metal network, model evaluator)
+    └── stress_relaxation/       # 6 notebooks (fish muscle, laponite, liquid foam, polyethylene, polypropylene, polystyrene)
 ```
 
 See `examples/README.md` for learning path guide.

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 
 > **Disclaimer:** RheoJAX is pre-release software under active development and testing. APIs, model implementations, and numerical results may change without notice. Outputs have not been independently validated for all use cases. Use at your own risk and verify critical results against established reference data before relying on them in research or industrial applications.
 
-JAX-accelerated package for rheological data analysis. Provides 53 rheological models across 22 families (including TNT, VLB, HVM, HVNM, Giesekus, DMT, ITT-MCT, EPM, SGR, STZ, Fluidity-Saramito, IKH, FIKH, and SPP), 11 data transforms (FFT, Mastercurve/TTS, SRFS, SPP, OWChirp, Cox-Merz, Prony conversion, spectrum inversion, LVE envelope, mutation number, smooth derivative), Bayesian inference via NumPyro, DMTA/DMA support (E* ↔ G* conversion for 45 oscillation-capable models), and 218 tutorial notebooks across 20 categories.
+JAX-accelerated package for rheological data analysis. Provides 53 rheological models across 22 families (including TNT, VLB, HVM, HVNM, Giesekus, DMT, ITT-MCT, EPM, SGR, STZ, Fluidity-Saramito, IKH, FIKH, and SPP), 11 data transforms (FFT, Mastercurve/TTS, SRFS, SPP, OWChirp, Cox-Merz, Prony conversion, spectrum inversion, LVE envelope, mutation number, smooth derivative), Bayesian inference via NumPyro, and 218 tutorial notebooks across 20 categories.
 
 ## Features
 
@@ -20,7 +20,6 @@ Rheological analysis toolkit with Bayesian inference and parameter optimization:
 - **Bayesian Inference**: All 53 models support NumPyro NUTS sampling with NLSQ warm-start
 - **Pipeline API**: Fluent interface for load → fit → plot → save workflows
 - **Automatic Initialization**: Parameter initialization for fractional models in oscillation mode
-- **DMTA/DMA Support**: All 45 oscillation-capable models support tensile modulus (E*) via automatic E* ↔ G* conversion
 - **JAX-First Architecture**: 5-270x performance improvement with automatic differentiation and GPU support
 
 ### Model Protocol Support Matrix
@@ -273,7 +272,7 @@ plt.show()
 ### Basic Model Fitting
 
 ```python
-from rheojax.models.maxwell import Maxwell
+from rheojax.models import Maxwell
 import numpy as np
 
 # Generate or load data
@@ -291,7 +290,7 @@ print(f"eta = {model.parameters.get_value('eta'):.3e} Pa·s")
 ### Bayesian Inference Workflow
 
 ```python
-from rheojax.models.maxwell import Maxwell
+from rheojax.models import Maxwell
 import numpy as np
 
 # Create model and data
@@ -359,7 +358,7 @@ pipeline = BayesianPipeline()
 RheoJAX detects when models are inappropriate for data based on physics:
 
 ```python
-from rheojax.models.fractional_zener_ss import FractionalZenerSolidSolid
+from rheojax.models import FractionalZenerSolidSolid
 from rheojax.utils.compatibility import check_model_compatibility, format_compatibility_message
 import numpy as np
 

--- a/docs/STRUCTURE.md
+++ b/docs/STRUCTURE.md
@@ -49,7 +49,7 @@ docs/
 │   │   ├── 05_appendices/            # Reference material (5 files)
 │   │   └── 06_gui/                   # GUI reference (9 files)
 │   │
-│   ├── models/                       # Model Handbook — 53 models across 20 families
+│   ├── models/                       # Model Handbook — 53 models across 22 families
 │   │   ├── index.rst                 # Models overview (grouped toctree)
 │   │   ├── summary.rst               # Comparison matrix
 │   │   │
@@ -128,7 +128,7 @@ docs/
 - **Purpose:** Mathematical "what" and "how"
 - **Audience:** Researchers, practitioners
 - **Content:** Full equations, Quick Reference summaries, boxed governing equations
-- **Size:** 86 rst files, 53 models across 20 families
+- **Size:** 86 rst files, 53 models across 22 families
 
 ### Tier 3: Transform Reference (Preprocessing Math)
 - **Purpose:** Data preprocessing theory
@@ -158,16 +158,16 @@ Working files, reports, and analysis documents are preserved in `.archive/` but 
 
 ## Key Features
 
-- **53 models** across 20 families with full Bayesian inference support
+- **53 models** across 22 families with full Bayesian inference support
 - **86 rst files** in the Model Handbook (equations, protocols, troubleshooting)
 - **11 transforms** with mathematical derivations
 - **6-section User Guide** structured as a 16-week graduate course
 - **9 learning pathways** for different user backgrounds
-- **240+ example notebooks** across all model families
+- **218 example notebooks** across all model families
 - **GUI reference** for interactive analysis (PyQt/PySide6)
 - **Furo theme** with custom CSS, light/dark modes
 
 ---
 
-**Documentation Version:** 0.6.0
+**Documentation Version:** 0.7.0
 **Build Status:** Clean (0 errors, 0 warnings)

--- a/docs/architecture-overview.md
+++ b/docs/architecture-overview.md
@@ -5,10 +5,10 @@
 ## Package Structure
 
 ```
-rheojax/                          # v0.6.0, Python 3.12+
+rheojax/                          # v0.7.0, Python 3.12+
 ├── core/           # Foundation: BaseModel, RheoData, Parameter, BayesianMixin, Registry
-├── models/         # 53 models across 20 families (see Model Inventory)
-├── transforms/     # 12 transforms (FFT, mastercurve, OWChirp, SPP, Prony, etc.)
+├── models/         # 53 models across 22 families (see Model Inventory)
+├── transforms/     # 11 transforms (FFT, mastercurve, OWChirp, SPP, Prony, etc.)
 ├── pipeline/       # Fluent API: Pipeline, BayesianPipeline, BatchPipeline
 ├── io/             # TRIOS, CSV, Excel, Anton Paar readers; HDF5/Excel/NPZ writers
 ├── visualization/  # Auto plot selection, 3 styles (seaborn, matplotlib, ggplot)

--- a/docs/source/api/utils.rst
+++ b/docs/source/api/utils.rst
@@ -235,11 +235,11 @@ Element Minimization with Warm-Start
 
 .. code-block:: python
 
-    from rheojax.models.generalized_maxwell import GeneralizedMaxwell
+    from rheojax.models.multimode.generalized_maxwell import GeneralizedMaxwell
     import numpy as np
 
     # Create model with maximum modes
-    model = GeneralizedMaxwell(n_modes=10, modulus_type='shear')
+    model = GeneralizedMaxwell(n_modes=10)
 
     # Generate relaxation data
     t = np.logspace(-3, 2, 100)
@@ -661,7 +661,7 @@ Basic Compatibility Check
 
 .. code-block:: python
 
-    from rheojax.models.fractional_zener_ss import FractionalZenerSolidSolid
+    from rheojax.models import FractionalZenerSolidSolid
     from rheojax.utils.compatibility import (
         check_model_compatibility,
         format_compatibility_message
@@ -762,7 +762,7 @@ Oscillation Data Analysis
         check_model_compatibility,
         detect_material_type
     )
-    from rheojax.models.fractional_maxwell_liquid import FractionalMaxwellLiquid
+    from rheojax.models import FractionalMaxwellLiquid
     import numpy as np
 
     # Oscillation data (G', G")
@@ -796,7 +796,7 @@ Enhanced Error Messages
 .. code-block:: python
 
     import numpy as np
-    from rheojax.models.fractional_zener_ss import FractionalZenerSolidSolid
+    from rheojax.models import FractionalZenerSolidSolid
 
     # Generate exponential data (incompatible with FZSS)
     np.random.seed(42)
@@ -1035,7 +1035,7 @@ Get Complete Strategy
     )
 
     # Use strategy with BaseModel
-    from rheojax.models.fractional_maxwell_liquid import FractionalMaxwellLiquid
+    from rheojax.models import FractionalMaxwellLiquid
 
     model = FractionalMaxwellLiquid()
     model.fit(
@@ -1225,7 +1225,7 @@ Functions
 .. autofunction:: rheojax.utils.metrics.r2_complex
    :noindex:
 
-   Computes R² for complex-valued modulus data (G*, E*) using magnitude comparison.
+   Computes R² for complex-valued modulus data (G*) using magnitude comparison.
    Useful for oscillation fits where predictions are complex.
 
 Examples

--- a/docs/source/api_reference.rst
+++ b/docs/source/api_reference.rst
@@ -386,7 +386,7 @@ For advanced users:
 Version Information
 -------------------
 
-This documentation covers rheojax version 0.6.0.
+This documentation covers rheojax version 0.7.0.
 
 **Phase 1** (v0.1.0): Core infrastructure, test mode detection, I/O, visualization
 

--- a/docs/source/architecture/fitting_transforms_prompt.md
+++ b/docs/source/architecture/fitting_transforms_prompt.md
@@ -18,7 +18,7 @@ are complete and you have produced the audit summary described below.
      `nlsq_optimize()`, `OptimizationResult`
    - `rheojax/pipeline/base.py` — `Pipeline` fluent API
    - `rheojax/pipeline/bayesian.py` — `BayesianPipeline`
-   - Every model class across `rheojax/models/` (53 models, 20 families)
+   - Every model class across `rheojax/models/` (53 models, 22 families)
    - Every transform class in `rheojax/transforms/` (11 transforms)
    - All existing tests in `tests/`
 

--- a/docs/source/architecture/fitting_transforms_prompt.md
+++ b/docs/source/architecture/fitting_transforms_prompt.md
@@ -19,7 +19,7 @@ are complete and you have produced the audit summary described below.
    - `rheojax/pipeline/base.py` — `Pipeline` fluent API
    - `rheojax/pipeline/bayesian.py` — `BayesianPipeline`
    - Every model class across `rheojax/models/` (53 models, 20 families)
-   - Every transform class in `rheojax/transforms/` (7 transforms)
+   - Every transform class in `rheojax/transforms/` (11 transforms)
    - All existing tests in `tests/`
 
 Once all reads are complete, produce an **audit summary block** (as a top-level
@@ -36,8 +36,9 @@ code comment in a new file `rheojax/fitting/_audit.py`) containing:
 #   LAOS        : [...]
 #
 # Transform registry (current state):
-#   [list all 7 transforms: FFTAnalysis, Mastercurve, SRFS,
-#    MutationNumber, OWChirp, SmoothDerivative, SPPDecomposer]
+#   [list all 11 transforms: FFTAnalysis, Mastercurve, SRFS,
+#    MutationNumber, OWChirp, SmoothDerivative, SPPDecomposer,
+#    CoxMerz, LVEEnvelope, PronyConversion, SpectrumInversion]
 #   — their inputs, outputs, and any protocol dependencies
 #
 # Objective function interfaces (current):
@@ -343,19 +344,13 @@ replacing the fit API. New module: `rheojax/utils/protocol_preprocessing.py`:
 - LAOS classification per Ewoldt (2008): strain-stiffening/softening/thickening/thinning
 - Q₀ nonlinearity coefficient extraction
 
-### F7 — New Convenience Transforms
+### F7 — New Convenience Transforms (COMPLETE)
 
-Add to `rheojax/transforms/` (register via existing `TransformRegistry`):
-
-| Transform | File | Input → Output |
-|---|---|---|
-| `SpectrumInversion` | `spectrum_inversion.py` | G'(ω)/G''(ω) or G(t) → H(τ) or L(τ) |
-| `CoxMerz` | `cox_merz.py` | η*(ω) + η(γ̇) → overlay + validation |
-| `LVEEnvelope` | `lve_envelope.py` | G(t) Prony series → σ_LVE⁺(t) for startup |
-| `PronyConversion` | `prony_conversion.py` | G(t) ↔ G'(ω)/G''(ω) interconversion |
-
-These supplement the existing 7 transforms (FFT, Mastercurve, SRFS, MutationNumber,
-OWChirp, SmoothDerivative, SPP). All must:
+`SpectrumInversion`, `CoxMerz`, `LVEEnvelope`, and `PronyConversion` have been
+implemented and registered in `rheojax/transforms/`, bringing the transform count
+to 11 total (FFT, Mastercurve, SRFS, MutationNumber, OWChirp, SmoothDerivative, SPP,
+SpectrumInversion, CoxMerz, LVEEnvelope, PronyConversion). Any future transform work
+must:
 - Inherit `BaseTransform` from `rheojax/core/base.py`
 - Register via `@TransformRegistry.register("name")`
 - Use `safe_import_jax()` for float64

--- a/docs/source/development_status.rst
+++ b/docs/source/development_status.rst
@@ -7,7 +7,7 @@ This page tracks the development history of RheoJAX across 11 completed phases
 and provides performance benchmarks.
 
 .. note::
-   As of 2026-07-10, the test suite has grown to 6,415 tests (2,051 smoke tests)
+   As of 2026-07-10, the test suite has grown to 6,417 tests (2,051 smoke tests)
    through a dedicated coverage sprint (Phase 11), and the GUI/test infrastructure
    has been hardened against FreeType rendering crashes and pytest-xdist hangs.
 
@@ -25,9 +25,9 @@ Development Phases
 
 **Phase 2 (Complete)**: Models and Transforms
    - 53 rheological models across 22 families
-   - 7 data transforms (FFT, Mastercurve/TTS with auto-shift, Mutation Number, OWChirp/LAOS, Smooth Derivative, SRFS, SPP Decomposer)
+   - 11 data transforms (FFT, Mastercurve/TTS with auto-shift, Mutation Number, OWChirp/LAOS, Smooth Derivative, SRFS, SPP Decomposer, Cox-Merz, Prony Conversion, Spectrum Inversion, LVE Envelope)
    - Pipeline API for fluent workflows
-   - 238 tutorial notebooks across 20 categories (basic, transforms, bayesian, advanced, and 16 model family suites)
+   - 218 tutorial notebooks across 20 categories (basic, transforms, bayesian, advanced, and 16 model family suites)
 
 **Phase 3 (Complete)**: Bayesian Inference
    - NumPyro NUTS sampling with NLSQ warm-start (2-5x faster convergence)

--- a/docs/source/examples/index.rst
+++ b/docs/source/examples/index.rst
@@ -1341,7 +1341,7 @@ Additional Resources
 
 **Example Data**
    - ``examples/data/README.md`` - Dataset catalog and loading instructions
-   - ``examples/README.md`` - Overview of all 240+ notebooks
+   - ``examples/README.md`` - Overview of all 218 notebooks
 
 **External Resources**
    - JAX Documentation: https://jax.readthedocs.io/

--- a/docs/source/examples/index.rst
+++ b/docs/source/examples/index.rst
@@ -2,9 +2,9 @@
 Tutorial Notebooks
 ==================
 
-RheoJAX includes 249 comprehensive tutorial notebooks organized into 21 categories:
+RheoJAX includes 218 comprehensive tutorial notebooks organized into 20 categories:
 **Basic** (5), **Transforms** (13), **Bayesian** (9), **Advanced** (10), **I/O** (1),
-plus 14 model family tutorial suites and a 31-notebook verification suite.
+plus 14 model family tutorial suites and a 20-notebook verification suite.
 
 All notebooks are located in the ``examples/`` directory and demonstrate best practices with
 real-world datasets and synthetic data generation patterns.
@@ -95,7 +95,7 @@ Quick Navigation
      - Notebooks
    * - **Verification**
      - Cross-model protocol validation + material-specific benchmarks
-     - 31 notebooks
+     - 20 notebooks
 
 Basic Model Fitting
 ===================
@@ -1125,7 +1125,7 @@ VLB — Transient Network Models (16 notebooks)
 **Notebooks** (NLSQ→NUTS workflows, 11–16):
    11–16. ``11–16_vlb_*_nlsq_to_nuts.ipynb`` — NLSQ → NUTS for 6 protocols
 
-Verification Suite (31 notebooks)
+Verification Suite (20 notebooks)
 =================================
 
 **Directory**: ``examples/verification/``
@@ -1135,13 +1135,13 @@ solutions and experimental data.
 
 **Protocol validators** (7 notebooks):
    - ``00_verification_index.ipynb`` — Verification suite overview
-   - ``01–06_validate_*.ipynb`` — Flow curve, creep, relaxation, startup, SAOS, LAOS
+   - ``01–06_validate_*.ipynb`` — Flow curve, creep, stress relaxation, startup shear, SAOS, LAOS
 
-**Material-specific benchmarks** (24 notebooks):
+**Material-specific benchmarks** (13 notebooks):
    - ``creep/`` — 3 notebooks (mucus, perihepatic abscess, polystyrene)
-   - ``oscillation/`` — 13 notebooks (mastercurves, model evaluation, 11 material-specific)
-   - ``relaxation/`` — 7 notebooks (fish muscle, laponite, foams, polyethylene, polypropylene, polystyrene, time master)
-   - ``rotation/`` — 1 notebook (emulsion flow curve)
+   - ``flow_curve/`` — 1 notebook (emulsion)
+   - ``saos/`` — 3 notebooks (chia pudding, metal network, model evaluator)
+   - ``stress_relaxation/`` — 6 notebooks (fish muscle, laponite, liquid foam, polyethylene, polypropylene, polystyrene)
 
 Running the Notebooks
 =====================

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -36,7 +36,7 @@ At a Glance
    * - **Performance**
      - 10-100x speedups via JAX; 5-270x optimization via NLSQ
    * - **Notebooks**
-     - 249 tutorial notebooks across 21 categories covering all model families and protocols
+     - 218 tutorial notebooks across 20 categories covering all model families and protocols
 
 Key Features
 ------------

--- a/docs/source/models/multi_mode/generalized_maxwell.rst
+++ b/docs/source/models/multi_mode/generalized_maxwell.rst
@@ -955,11 +955,11 @@ The GMM inherits full Bayesian capabilities from ``BayesianMixin``:
 
 .. code-block:: python
 
-   from rheojax.models.generalized_maxwell import GeneralizedMaxwell
+   from rheojax.models.multimode.generalized_maxwell import GeneralizedMaxwell
    import numpy as np
 
    # 1. NLSQ point estimation (fast warm-start)
-   gmm = GeneralizedMaxwell(n_modes=5, modulus_type='shear')
+   gmm = GeneralizedMaxwell(n_modes=5)
    gmm.fit(t, G_data, test_mode='relaxation', optimization_factor=1.5)
 
    # Check optimized N
@@ -1216,7 +1216,7 @@ Sample Applications: DMA (Solid Mechanics)
 
    .. code-block:: python
 
-      from rheojax.models.generalized_maxwell import GeneralizedMaxwell
+      from rheojax.models.multimode.generalized_maxwell import GeneralizedMaxwell
       from rheojax.transforms.mastercurve import Mastercurve
 
       # Create mastercurve (automatic shift factors)
@@ -1279,7 +1279,7 @@ Sample Applications: Rheometer (Fluid Dynamics)
 
    .. code-block:: python
 
-      gmm = GeneralizedMaxwell(n_modes=15, modulus_type='shear')
+      gmm = GeneralizedMaxwell(n_modes=15)
       gmm.fit(
           mastercurve.x,      # Shifted ω (rad/s)
           mastercurve.y,      # [G', G"] (Pa)
@@ -1322,7 +1322,7 @@ Element Minimization Best Practices
 .. code-block:: python
 
    # Request N=15 for broad spectra
-   gmm = GeneralizedMaxwell(n_modes=15, modulus_type='shear')
+   gmm = GeneralizedMaxwell(n_modes=15)
    gmm.fit(omega, G_star, test_mode='oscillation', optimization_factor=1.5)
 
    # System auto-reduces to N_opt (e.g., 7)
@@ -1613,14 +1613,14 @@ Basic Fitting (Relaxation Mode)
 .. code-block:: python
 
    import numpy as np
-   from rheojax.models.generalized_maxwell import GeneralizedMaxwell
+   from rheojax.models.multimode.generalized_maxwell import GeneralizedMaxwell
 
    # Generate synthetic relaxation data (multi-mode)
    t = np.logspace(-2, 3, 100)
    G_t = 1e4 + 5e5*np.exp(-t/0.1) + 8e4*np.exp(-t/1.0) + 3e4*np.exp(-t/10.0)
 
    # Fit with transparent element minimization
-   gmm = GeneralizedMaxwell(n_modes=10, modulus_type='shear')
+   gmm = GeneralizedMaxwell(n_modes=10)
    gmm.fit(t, G_t, test_mode='relaxation', optimization_factor=1.5)
 
    # Check optimized N
@@ -1641,7 +1641,7 @@ Oscillation Mode with Time-Temperature Superposition
 
 .. code-block:: python
 
-   from rheojax.models.generalized_maxwell import GeneralizedMaxwell
+   from rheojax.models.multimode.generalized_maxwell import GeneralizedMaxwell
    from rheojax.transforms.mastercurve import Mastercurve
    from rheojax.core.data import RheoData
    import numpy as np
@@ -1670,7 +1670,7 @@ Oscillation Mode with Time-Temperature Superposition
    mastercurve, shift_factors = mc.transform(datasets)
 
    # Fit GMM to mastercurve
-   gmm = GeneralizedMaxwell(n_modes=15, modulus_type='shear')
+   gmm = GeneralizedMaxwell(n_modes=15)
    gmm.fit(
        mastercurve.x,      # Shifted omega
        mastercurve.y,      # [G', G"] concatenated
@@ -1695,7 +1695,7 @@ Creep Mode Prediction
 .. code-block:: python
 
    import numpy as np
-   from rheojax.models.generalized_maxwell import GeneralizedMaxwell
+   from rheojax.models.multimode.generalized_maxwell import GeneralizedMaxwell
 
    # Generate synthetic oscillation data
    omega = np.logspace(-2, 2, 50)
@@ -1704,7 +1704,7 @@ Creep Mode Prediction
    G_star = np.column_stack([G_prime, G_double_prime])
 
    # First fit to relaxation or oscillation data
-   gmm = GeneralizedMaxwell(n_modes=5, modulus_type='shear')
+   gmm = GeneralizedMaxwell(n_modes=5)
    gmm.fit(omega, G_star, test_mode='oscillation', optimization_factor=1.5)
 
    # Predict creep compliance (tri-mode equality)
@@ -1726,11 +1726,11 @@ Bayesian Inference with Prior Safety
 
 .. code-block:: python
 
-   from rheojax.models.generalized_maxwell import GeneralizedMaxwell
+   from rheojax.models.multimode.generalized_maxwell import GeneralizedMaxwell
    import numpy as np
 
    # 1. NLSQ fit (fast)
-   gmm = GeneralizedMaxwell(n_modes=5, modulus_type='shear')
+   gmm = GeneralizedMaxwell(n_modes=5)
    gmm.fit(t, G_data, test_mode='relaxation', optimization_factor=1.5)
 
    # 2. Bayesian inference with automatic prior safety
@@ -1795,7 +1795,7 @@ Rheometer Workflow (Fluid Dynamics)
 
 .. code-block:: python
 
-   from rheojax.models.generalized_maxwell import GeneralizedMaxwell
+   from rheojax.models.multimode.generalized_maxwell import GeneralizedMaxwell
    from rheojax.transforms.mastercurve import Mastercurve
    from rheojax.core.data import RheoData
    import numpy as np
@@ -1823,7 +1823,7 @@ Rheometer Workflow (Fluid Dynamics)
    mastercurve, shifts = mc.transform(datasets)
 
    # 3. Fit GMM
-   gmm = GeneralizedMaxwell(n_modes=12, modulus_type='shear')
+   gmm = GeneralizedMaxwell(n_modes=12)
    gmm.fit(mastercurve.x, mastercurve.y, test_mode='oscillation')
 
    # 4. Cox-Merz rule validation

--- a/docs/source/transforms/summary.rst
+++ b/docs/source/transforms/summary.rst
@@ -1640,7 +1640,7 @@ Next Steps
 * **Detailed transform documentation:** :doc:`/transforms/index` for individual transform pages
 * **User guide:** :doc:`/user_guide/transforms` for usage patterns and examples
 * **API reference:** :doc:`/api/transforms` for complete API documentation
-* **Example notebooks:** 8 transform examples in ``examples/transforms/`` directory
+* **Example notebooks:** 13 transform examples in ``examples/transforms/`` directory
 * **Pipeline integration:** :doc:`/user_guide/pipeline_api` for fluent transform chaining
 
 **Need a transform not listed?** Transforms are extensible via ``BaseTransform`` - see :doc:`/developer/contributing`.

--- a/docs/source/user_guide/02_model_usage/fitting_strategies.rst
+++ b/docs/source/user_guide/02_model_usage/fitting_strategies.rst
@@ -38,7 +38,7 @@ For SAOS frequency sweep data, RheoJAX automatically estimates:
 
 .. code-block:: python
 
-   from rheojax.models.fractional_zener_ss import FractionalZenerSolidSolid
+   from rheojax.models import FractionalZenerSolidSolid
 
    # Smart initialization happens automatically
    model = FractionalZenerSolidSolid()

--- a/docs/source/user_guide/02_model_usage/index.rst
+++ b/docs/source/user_guide/02_model_usage/index.rst
@@ -227,7 +227,7 @@ Common Pitfalls and How to Avoid Them
 .. code-block:: python
 
    # WRONG: Using complex model for simple data
-   from rheojax.models import FractionalBurgersModel  # 7 parameters
+   from rheojax.models import FractionalBurgersModel  # 5 parameters
    model.fit(omega, G_star)  # Data only has 10 points → overfitting!
 
    # CORRECT: Start with simplest model

--- a/docs/source/user_guide/02_model_usage/index.rst
+++ b/docs/source/user_guide/02_model_usage/index.rst
@@ -135,7 +135,7 @@ Key Skills You'll Develop
 .. code-block:: python
 
    # Smart initialization for fractional models in oscillation mode
-   from rheojax.models.fractional_zener_ss import FractionalZenerSolidSolid
+   from rheojax.models import FractionalZenerSolidSolid
 
    omega = np.logspace(-2, 2, 50)
    G_star = ...  # Complex modulus [G', G"]
@@ -227,7 +227,7 @@ Common Pitfalls and How to Avoid Them
 .. code-block:: python
 
    # WRONG: Using complex model for simple data
-   from rheojax.models.fractional_burgers import FractionalBurgers  # 7 parameters
+   from rheojax.models import FractionalBurgersModel  # 7 parameters
    model.fit(omega, G_star)  # Data only has 10 points → overfitting!
 
    # CORRECT: Start with simplest model

--- a/docs/source/user_guide/02_model_usage/model_families.rst
+++ b/docs/source/user_guide/02_model_usage/model_families.rst
@@ -342,7 +342,7 @@ Example: Fitting Fractional Zener Solid-Solid
 
 .. code-block:: python
 
-   from rheojax.models.fractional_zener_ss import FractionalZenerSolidSolid
+   from rheojax.models import FractionalZenerSolidSolid
 
    # SAOS frequency sweep (omega, [G', G"])
    model = FractionalZenerSolidSolid()

--- a/docs/source/user_guide/02_model_usage/model_selection.rst
+++ b/docs/source/user_guide/02_model_usage/model_selection.rst
@@ -761,7 +761,7 @@ RheoJAX provides automatic compatibility checking to help identify inappropriate
 
 .. code-block:: python
 
-   from rheojax.models.fractional_zener_ss import FractionalZenerSolidSolid
+   from rheojax.models import FractionalZenerSolidSolid
    from rheojax.utils.compatibility import check_model_compatibility, format_compatibility_message
 
    # Check before fitting

--- a/docs/source/user_guide/03_advanced_topics/bayesian_inference.rst
+++ b/docs/source/user_guide/03_advanced_topics/bayesian_inference.rst
@@ -19,7 +19,7 @@ full Bayesian uncertainty quantification.
 
 **Implementation Status**: [done] **FULLY IMPLEMENTED** (v0.2.0, enhanced v0.4.0)
 
-All 21 rheological models support the complete Bayesian workflow through ``BayesianMixin`` inheritance.
+All 53 rheological models support the complete Bayesian workflow through ``BayesianMixin`` inheritance.
 
 **v0.4.0 Enhancement**: Mode-aware Bayesian inference ensures correct posteriors for all test modes (relaxation, creep, oscillation).
 Previously, test_mode was captured as class state, causing all Bayesian fits to use the last-fitted mode.
@@ -900,39 +900,10 @@ Red Flags (Do Not Trust Results)
 Model Support
 =============
 
-All 20 rheological models inherit ``BayesianMixin`` through ``BaseModel`` and support complete Bayesian workflows:
-
-Classical Viscoelastic (3 models)
----------------------------------
-
-- Maxwell
-- Zener
-- SpringPot
-
-Flow Models (6 models)
-----------------------
-
-- Bingham
-- PowerLaw
-- Herschel-Bulkley
-- Carreau
-- Carreau-Yasuda
-- Cross
-
-Fractional Models (11 models)
------------------------------
-
-- fractional_burgers
-- fractional_jeffreys
-- fractional_kelvin_voigt
-- fractional_kv_zener
-- fractional_maxwell_gel
-- fractional_maxwell_liquid
-- fractional_maxwell_model
-- fractional_poynting_thomson
-- fractional_zener_ll
-- fractional_zener_sl
-- fractional_zener_ss
+All 53 rheological models inherit ``BayesianMixin`` through ``BaseModel`` and support complete Bayesian workflows.
+See :class:`rheojax.core.registry.ModelRegistry` (``ModelRegistry.list_models()``) for the current, authoritative
+list of registered models across all families (Classical, Flow, Fractional, Multi-Mode, Giesekus, VLB, HVM/HVNM,
+TNT, SGR, EPM, ITT-MCT, STZ, Hébraud-Lequeux, IKH/FIKH, SPP, and more).
 
 Each model provides:
 

--- a/docs/source/user_guide/index.rst
+++ b/docs/source/user_guide/index.rst
@@ -291,7 +291,7 @@ Related Documentation
 - :doc:`/models/index` — Comprehensive Model Handbook (53 models, all equations and theory)
 - :doc:`/transforms/index` — Transform Reference (11 transforms, mathematical details)
 - :doc:`/api_reference` — Complete API documentation
-- :doc:`/examples/index` — 240+ example notebooks across all model families
+- :doc:`/examples/index` — 218 example notebooks across all model families
 
 Getting Help
 ------------
@@ -299,7 +299,7 @@ Getting Help
 - **Troubleshooting Guide**: :doc:`05_appendices/troubleshooting`
 - **Glossary**: :doc:`05_appendices/glossary`
 - **GitHub Issues**: Report bugs or request features
-- **Examples**: :doc:`/examples/index` — 240+ worked notebooks across all model families
+- **Examples**: :doc:`/examples/index` — 218 worked notebooks across all model families
 
 Next Steps
 ----------

--- a/docs/tech-stack.md
+++ b/docs/tech-stack.md
@@ -7,7 +7,7 @@
 | Field | Value |
 |-------|-------|
 | **Name** | rheojax |
-| **Version** | 0.6.0 |
+| **Version** | 0.7.0 |
 | **Python** | >=3.12 (supports 3.12, 3.13) |
 | **Build System** | setuptools (>=68.0) + wheel + setuptools-scm |
 | **License** | MIT |

--- a/examples/README.md
+++ b/examples/README.md
@@ -14,9 +14,9 @@ RheoJAX provides a unified framework for analyzing experimental rheology data wi
 - Advanced transforms for experimental data analysis (including SRFS, SPP)
 - **Google Colab compatible** - all notebooks run directly on https://colab.google/
 
-**230+ Tutorial Notebooks** (all complete ✅) organized into 20 categories:
+**218 Tutorial Notebooks** (all complete ✅) organized into 20 categories:
 - **Basic Model Fitting** (5 notebooks ✅) - Fundamental rheological models
-- **Transform Workflows** (8 notebooks ✅) - Data analysis techniques (FFT, TTS, SRFS, SPP)
+- **Transform Workflows** (13 notebooks ✅) - Data analysis techniques (FFT, TTS, SRFS, OWChirp, Cox-Merz, Prony, Spectrum Inversion, LVE Envelope, SPP)
 - **Bayesian Inference** (9 notebooks ✅) - Uncertainty quantification (including SPP LAOS)
 - **Advanced Workflows** (10 notebooks ✅) - Production patterns (including SGR and SPP)
 - **I/O** (1 notebook ✅) - TRIOS complex modulus handling
@@ -32,9 +32,9 @@ RheoJAX provides a unified framework for analyzing experimental rheology data wi
 - **ITT-MCT Mode-Coupling Theory Models** (12 notebooks ✅) - Schematic F₁₂ and Isotropic ISM models for colloidal glasses
 - **TNT Transient Network Theory Models** (30 notebooks ✅) - 5 TNT model classes (SingleMode, Cates, LoopBridge, MultiSpecies, StickyRouse) across all 6 protocols
 - **VLB Transient Network Models** (16 notebooks ✅) - 6 protocols + Bayesian + Bell + FENE + Nonlocal + NLSQ-to-NUTS
-- **HVM Hybrid Vitrimer Models** (13 notebooks ✅) - 6 basic + 7 advanced tutorials (TST kinetics, factory methods)
-- **HVNM Vitrimer Nanocomposite Models** (15 notebooks ✅) - 7 basic + 8 NLSQ/NUTS (dual TST, Guth-Gold)
-- **Verification Suite** (31 notebooks ✅) - Cross-model validation (6 protocol validators + 25 material-specific)
+- **HVM Hybrid Vitrimer Models** (8 notebooks ✅) - 6 protocols (forward + NLSQ/NUTS) + architecture overview + multi-protocol fit demo
+- **HVNM Vitrimer Nanocomposite Models** (9 notebooks ✅) - 6 protocols (forward + NLSQ/NUTS) + limiting-cases + data intake/QC + multi-protocol fit
+- **Verification Suite** (20 notebooks ✅) - Cross-model validation (index + 6 protocol validators + 13 material-specific case studies)
 
 ## Prerequisites
 


### PR DESCRIPTION
## Summary

Multi-pass documentation correctness sweep of README.md and the Sphinx docs tree (docs/source/), triggered by `/dev-suite:docs update --full` and then adversarially reviewed by Codex CLI and agy CLI.

**Pass 1 — stale counts & deleted-feature references:**
- `examples/dmta/` was deleted in `00d208d1` but README.md, `examples/README.md`, and `docs/source/development_status.rst` still referenced it (8 phantom notebooks in 2+ places).
- Notebook total was stale everywhere it appeared: `249`/`240+`/`230+` → **218** across **20** categories.
- The verification-suite tree in README showed the pre-rename subdirectory layout (`creep/oscillation/relaxation/rotation`); actual layout is `creep/flow_curve/saos/stress_relaxation` (20 notebooks, not 31).
- The `transforms/` tree diagram was missing 5 of its 13 notebooks (cox-merz, prony-conversion, spectrum-inversion, lve-envelope, spp-decomposition).
- HVM/HVNM notebook counts in `examples/README.md` said 13/15; actual is 8/9.
- `development_status.rst` Phase 2 listed only 7 transforms, missing the 4 PR #56 added elsewhere.

**Pass 2 — Codex CLI adversarial review** (`codex exec --dangerously-bypass-approvals-and-sandbox`), all 13 findings independently re-verified before fixing:
- README/Sphinx code examples imported models via flat module paths that don't exist (`rheojax.models.maxwell`, `rheojax.models.generalized_maxwell`, `rheojax.models.fractional_zener_ss`, `rheojax.models.fractional_burgers`) — copy-pasting any of these raised `ModuleNotFoundError`. Fixed to the real public paths (`rheojax.models`, `rheojax.models.multimode.generalized_maxwell`).
- `GeneralizedMaxwell` examples throughout `generalized_maxwell.rst` passed a removed `modulus_type` kwarg, which now raises `TypeError`.
- README still advertised DMTA/DMA tensile-modulus support, removed in v0.7.0 (shear-only breaking change).
- Stale model/transform counts in `fitting_transforms_prompt.md` (7→11 transforms) and `bayesian_inference.rst` (20/21→53 models), stale `version 0.6.0` in `api_reference.rst` (→0.7.0), leftover `E*` mention in `api/utils.rst`.
- Every corrected import was verified by actually running it; `modulus_type` confirmed to raise `TypeError` as expected.

**Pass 3 — agy CLI review:** the raw `agy --dangerously-skip-permissions` CLI was blocked twice by the permission classifier (once via internal timeout mid-investigation, once denied outright as an unauthorized background-agent launch) — it never produced output. In its place a subagent did the equivalent read-only check manually and found two more stale `240+`/`8 notebooks` counts in `docs/source/user_guide/index.rst` and `docs/source/transforms/summary.rst`; a follow-up grep found a third instance in `docs/source/examples/index.rst`.

**Pass 4 — `/review`:** caught one more issue on a line the import-path fix already touched: `FractionalBurgersModel` was commented as "7 parameters" but actually has 5 (`Jg, eta1, Jk, alpha, tau_k`, confirmed by counting `self.parameters.add()` calls). Also swept the full docs tree for the same import-antipattern class and for remaining DMTA/tensile mentions — both clean.

Verified as *not* stale before touching: 53 model classes (`ModelRegistry` returns 59 keys but 6 are aliases — 53 unique classes), 11 registered transforms, and no new public modules since the last docs sync.

## Test plan
- [x] `find examples -name "*.ipynb" | wc -l` → 218, cross-checked per-directory against every count changed
- [x] `ModelRegistry.list_models()` / unique class count → 53; `TransformRegistry.list_transforms()` → 11
- [x] Every corrected import actually executed (`uv run python -c "from rheojax.models.multimode.generalized_maxwell import GeneralizedMaxwell; GeneralizedMaxwell(n_modes=5)"`, etc.); `modulus_type` confirmed to raise `TypeError`
- [x] `uv run sphinx-build -b html docs/source docs/_build` → `build succeeded`, no warnings/errors (re-run independently after every commit)
- [x] Repeated `grep` sweeps for lingering `dmta`/stale counts/flat-import antipatterns across README.md, examples/README.md, docs/source/*.rst → clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)
