### PR TITLE
fix(gui): main window cannot be maximized after start

### DIFF
--- a/rheojax/gui/workspace/stepper_canvas.py
+++ b/rheojax/gui/workspace/stepper_canvas.py
@@ -13,6 +13,30 @@ from rheojax.gui.utils.layout_helpers import set_toolbar_margins, set_zero_margi
 from rheojax.gui.workspace.controller import WorkflowController
 
 
+class _CurrentPageStack(QStackedWidget):
+    """QStackedWidget whose size hints reflect only the current page.
+
+    Qt's default QStackedWidget sizes itself to the largest of ALL pages
+    it holds, even hidden ones (documented behavior), so the tallest step
+    (e.g. NUTS diagnostics) permanently forces every other step's minimum
+    window size -- on a real display this can exceed the screen's usable
+    area and make the window impossible to maximize.
+    """
+
+    def sizeHint(self):  # noqa: N802 - Qt override
+        current = self.currentWidget()
+        return current.sizeHint() if current is not None else super().sizeHint()
+
+    def minimumSizeHint(self):  # noqa: N802 - Qt override
+        current = self.currentWidget()
+        if current is None:
+            return super().minimumSizeHint()
+        # Match Qt's own QWidgetItem::minimumSize() formula so a page that
+        # calls setMinimumSize() directly (not just via child layout
+        # constraints) is still honored.
+        return current.minimumSizeHint().expandedTo(current.minimumSize())
+
+
 class StepperCanvas(QWidget):
     step_clicked = Signal(int)
 
@@ -23,7 +47,8 @@ class StepperCanvas(QWidget):
         self._ctl = controller
         self._rail = QHBoxLayout()
         self._buttons: list[QPushButton] = []
-        self._stack = QStackedWidget(self)
+        self._stack = _CurrentPageStack(self)
+        self._stack.currentChanged.connect(lambda _: self._stack.updateGeometry())
         for i, step in enumerate(controller.steps):
             b = QPushButton(f"{i + 1} {step.title}", self)
             b.setCheckable(True)
@@ -44,6 +69,8 @@ class StepperCanvas(QWidget):
         self._stack.removeWidget(old)
         if old is not None:
             old.deleteLater()
+        if index == self._stack.currentIndex():
+            self._stack.updateGeometry()
 
     def is_enabled(self, index: int) -> bool:
         return self._buttons[index].isEnabled()

--- a/rheojax/gui/workspace/stepper_canvas.py
+++ b/rheojax/gui/workspace/stepper_canvas.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from PySide6.QtCore import Signal
+from PySide6.QtCore import QSize, Signal
 from PySide6.QtWidgets import (
     QHBoxLayout,
     QPushButton,
@@ -23,11 +23,15 @@ class _CurrentPageStack(QStackedWidget):
     area and make the window impossible to maximize.
     """
 
-    def sizeHint(self):  # noqa: N802 - Qt override
+    def sizeHint(self) -> QSize:  # noqa: N802 - Qt override
         current = self.currentWidget()
-        return current.sizeHint() if current is not None else super().sizeHint()
+        if current is None:
+            return super().sizeHint()
+        # Match Qt's own QWidgetItem::sizeHint() formula (expandedTo minimumSize)
+        # so this never reports a preferred size smaller than the minimum below.
+        return current.sizeHint().expandedTo(current.minimumSize())
 
-    def minimumSizeHint(self):  # noqa: N802 - Qt override
+    def minimumSizeHint(self) -> QSize:  # noqa: N802 - Qt override
         current = self.currentWidget()
         if current is None:
             return super().minimumSizeHint()

--- a/tests/gui/workspace/test_stepper_canvas.py
+++ b/tests/gui/workspace/test_stepper_canvas.py
@@ -1,0 +1,40 @@
+import pytest
+
+pytest.importorskip("PySide6")
+
+from PySide6.QtWidgets import QWidget
+
+from rheojax.gui.workspace.controller import Step, WorkflowController
+from rheojax.gui.workspace.stepper_canvas import StepperCanvas
+
+
+def _ctl():
+    steps = [
+        Step(id=str(i), title=str(i), is_ready=(lambda: True), validate=(lambda: True))
+        for i in range(2)
+    ]
+    return WorkflowController(steps)
+
+
+def test_size_hint_tracks_current_page_only(qapp):
+    # A QStackedWidget sizes itself to the largest of ALL pages by default
+    # (Qt's documented behavior), so a single oversized step would forever
+    # inflate the window's minimum size -- even while a small step is shown.
+    canvas = StepperCanvas(_ctl(), None)
+
+    small = QWidget()
+    small.setMinimumSize(100, 100)
+    tall = QWidget()
+    tall.setMinimumSize(100, 900)
+
+    canvas.set_body(0, small)
+    canvas.set_body(1, tall)
+    canvas._stack.setCurrentIndex(0)
+
+    assert canvas._stack.minimumSizeHint().height() == 100
+
+    canvas._stack.setCurrentIndex(1)
+    assert canvas._stack.minimumSizeHint().height() == 900
+
+    canvas._stack.setCurrentIndex(0)
+    assert canvas._stack.minimumSizeHint().height() == 100


### PR DESCRIPTION
## Summary
- `StepperCanvas`'s internal `QStackedWidget` was sizing itself to the *largest* of all six step pages (Qt's documented default: hidden pages still count toward `minimumSizeHint()`), not just the currently visible one.
- On a real display this forced the window's minimum size (observed: 2389x2518px) above the screen's usable work area (2480px tall), so the window manager could not satisfy a maximize request — the window was already pinned larger than its own maximize target.
- Fixed by subclassing `QStackedWidget` so `sizeHint()`/`minimumSizeHint()` reflect only the current page, invalidated via `updateGeometry()` on step/mode switches.

## Root cause verification
Reproduced live against a real X11/Cinnamon session (not just offscreen):
- Before: `WM_NORMAL_HINTS` reported `program specified minimum size: 2389 by 2518`; `wmctrl -b add,maximized_vert,maximized_horz` was silently ignored.
- After: minimum size dropped to `2389 by 939`; the same wmctrl maximize request actually resizes the window to fill the screen (`_NET_WM_STATE` shows `MAXIMIZED_HORZ`/`MAXIMIZED_VERT`, geometry matches the workarea).

## Test plan
- [x] New regression test `tests/gui/workspace/test_stepper_canvas.py` verifies the stack's minimum size hint tracks only whichever page is current.
- [x] Targeted subset of workspace GUI tests pass (`test_stepper_canvas.py`, `test_controller.py`, `test_widgets.py`, `test_window_chrome.py`, `test_window_rebuild.py`, `test_window_pipeline_mode.py`) run with `-n0` to sidestep the known unrelated xdist+FreeType hang documented from PR #52.
- [x] Live end-to-end verification on a real X11 display via `wmctrl`/`xprop`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)