### PR TITLE
feat(gui): close Delete Dataset and Help menu parity gaps, deprecate --legacy

### DIFF
--- a/docs/superpowers/plans/gui-legacy-parity-gap-table.md
+++ b/docs/superpowers/plans/gui-legacy-parity-gap-table.md
@@ -1,0 +1,23 @@
+# GUI Legacy-Shell Parity Gap Table
+
+Source: `docs/superpowers/specs/2026-07-12-gui-legacy-parity-closure-design.md` §2.1.
+Every legacy menu/toolbar/dialog action was traced to its real handler (not just its
+menu declaration) in both `rheojax/gui/app/{menu_bar.py,toolbar.py,main_window.py}` and
+`rheojax/gui/workspace/{window.py,library_rail.py}`.
+
+| Feature | Legacy location | Workspace equivalent (Y/N) | Disposition | Notes |
+|---|---|---|---|---|
+| Delete Dataset | `app/menu_bar.py` Data menu, `main_window.py:_on_delete_dataset` | N | Implement | `LibraryRail`'s context menu only has "Preview…" (`library_rail.py:55-64`). Task 2/3. |
+| Help menu (Docs/Tutorials/Shortcuts/About) | `app/menu_bar.py` Help menu, `main_window.py:3445-3492` | N | Implement | Trivial handlers (open URL, static dialogs); `workspace/window.py` builds only File/View menus. Task 4. |
+| Undo/Redo | `app/menu_bar.py` Edit menu, `state/store.py` real undo/redo stack | N | Justified-drop (deferred to own future spec) | Real, working in legacy; workspace's plain-dataclass state has no history infrastructure — disproportionate to this spec's scope. |
+| New Dataset | `app/menu_bar.py` Data menu | Y | Not a gap | Legacy's own handler is `self._on_import()`; `LibraryRail`'s "+ Import data…" button covers it 1:1. |
+| Preferences | `app/menu_bar.py` Edit menu | Y | Not a gap | Same shared `PreferencesDialog`, already wired in `workspace/window.py:106`. |
+| Theme (Light/Dark/Auto) | `app/menu_bar.py` View menu | Y | Not a gap | Already in `workspace/window.py:173-190`. |
+| Log Panel toggle | `app/menu_bar.py` View menu | Y | Not a gap | Already in `workspace/window.py:164-171`. |
+| Models/Transforms/Analysis/Pipeline quick-launch | `app/menu_bar.py` | Y (different paradigm) | Not a gap | These are shortcuts into functionality that's the primary step-based UI in the workspace shell. |
+| Set Test Mode / Auto-detect Test Mode | `app/menu_bar.py` Data menu | Y | Not a gap | Test-mode detection happens automatically in the shared `DataService.load_file_multi()` path both shells use; confirmed by tracing `window._on_import_requested` → `_launch_import` → `ImportWorker.run()`. |
+| Zoom In/Out/Reset | `app/menu_bar.py`/`toolbar.py` | N | Justified-drop | Dead code in legacy itself — no page implements `zoom_in`/`zoom_out`/`reset_zoom`; the handler's `hasattr()` guard is always false. |
+| Recent Files | `app/menu_bar.py` File menu | N | Justified-drop | Legacy's own `_populate_recent_files()` is an explicit placeholder; always shows "No recent files." |
+| Cut/Copy/Paste | `app/menu_bar.py` Edit menu | N | Justified-drop | Generic passthrough to whatever native Qt widget has focus; no rheojax-specific logic, already free via Ctrl+C/right-click on any text field. |
+| Data Panel dock toggle | `app/menu_bar.py` View menu | N (architecture difference) | Justified-drop | Legacy toggles a closable dock; `LibraryRail` is an always-visible rail by design. |
+| Tools menu (Python Console/JAX Profiler/Memory Monitor) | `app/menu_bar.py` Tools menu | N | Justified-drop | All three are `setEnabled(False)` "(coming soon)" stubs in legacy itself. |

--- a/rheojax/gui/README.md
+++ b/rheojax/gui/README.md
@@ -8,7 +8,7 @@ RheoJAX GUI has two main implementations:
 
 1. **Workspace Shell** (Default, new): Modern mode-based interface with Fit, Transform, and Pipeline modes. Launched by `rheojax-gui` with no flags. Located in `foundation/` (core models) and `workspace/` (UI shell). Includes project save/load and batch pipeline execution.
 
-2. **Legacy Main Window** (Page-based, older): Original page-based navigation with sidebar pages. Launched with `rheojax-gui --legacy`. Located in `app/`, `pages/`, `state/`. Still fully functional but no longer the default.
+2. **Legacy Main Window** (Page-based, older, deprecated): Original page-based navigation with sidebar pages. Launched with `rheojax-gui --legacy`, which now prints a deprecation warning on startup. Located in `app/`, `pages/`, `state/`. Still fully functional during the current soak period; scheduled for removal in a future release.
 
 **This document describes the legacy architecture.** For the workspace shell, see `workspace/README.md`.
 

--- a/rheojax/gui/main.py
+++ b/rheojax/gui/main.py
@@ -70,6 +70,23 @@ def _create_workspace_window() -> "WorkspaceWindow":  # noqa: F821
     return WorkspaceWindow(AppState())
 
 
+def _warn_legacy_deprecated() -> None:
+    """Print/log the --legacy deprecation warning.
+
+    Extracted as a standalone function (rather than inlined like the
+    --workspace warning) so it's unit-testable without going through
+    main()'s blocking app.exec() call.
+    """
+    logger.warning(
+        "--legacy is deprecated and will be removed in a future release; "
+        "the workspace shell is now feature-complete for all supported workflows."
+    )
+    print(
+        "WARNING: --legacy is deprecated and will be removed in a future release.",
+        file=sys.stderr,
+    )
+
+
 def setup_logging(verbose: bool = False) -> None:
     """Configure application logging.
 
@@ -471,6 +488,8 @@ def main(argv: list[str] | None = None) -> int:
         except Exception:
             pass
         return exit_code
+
+    _warn_legacy_deprecated()
 
     # Import main window after Qt app is created
     logger.debug("Importing main window module")

--- a/rheojax/gui/workspace/README.md
+++ b/rheojax/gui/workspace/README.md
@@ -2,8 +2,8 @@
 
 The default GUI shell for RheoJAX (`rheojax-gui` with no flags). A mode-based
 interface — Fit, Transform, Pipeline — that replaces the legacy page-based
-window (`rheojax/gui/app/`, `pages/`, `state/`, still available via
-`rheojax-gui --legacy`) as the default entry point.
+window (`rheojax/gui/app/`, `pages/`, `state/` — deprecated, available via
+`rheojax-gui --legacy` during a soak period) as the default entry point.
 
 ## Relationship to `foundation/`
 

--- a/rheojax/gui/workspace/library_rail.py
+++ b/rheojax/gui/workspace/library_rail.py
@@ -17,6 +17,7 @@ from rheojax.gui.utils.layout_helpers import set_panel_margins
 class LibraryRail(QWidget):
     dataset_selected = Signal(str)
     dataset_preview_requested = Signal(str)
+    dataset_delete_requested = Signal(str)
     import_requested = Signal()
 
     def __init__(self, library: DatasetLibrary, parent: QWidget | None = None) -> None:
@@ -54,6 +55,7 @@ class LibraryRail(QWidget):
             return
         menu = QMenu(self)
         preview_action = menu.addAction("Preview…")
+        delete_action = menu.addAction("Delete…")
         # ponytail: call via QMenu.exec(menu, ...) rather than menu.exec(...) --
         # functionally identical, but PySide6 6.11's instance attribute lookup
         # bypasses Python-level monkeypatching of QMenu.exec (class-level
@@ -62,6 +64,8 @@ class LibraryRail(QWidget):
         chosen = QMenu.exec(menu, self._list.mapToGlobal(pos))
         if chosen is preview_action:
             self.dataset_preview_requested.emit(item.data(Qt.ItemDataRole.UserRole))
+        elif chosen is delete_action:
+            self.dataset_delete_requested.emit(item.data(Qt.ItemDataRole.UserRole))
 
     def count(self) -> int:
         return self._list.count()

--- a/rheojax/gui/workspace/window.py
+++ b/rheojax/gui/workspace/window.py
@@ -367,6 +367,7 @@ class WorkspaceWindow(QMainWindow):
             self._on_dataset_preview_requested
         )
         self._rail.dataset_selected.connect(self._on_rail_dataset_selected)
+        self._rail.dataset_delete_requested.connect(self._on_dataset_delete_requested)
         self._inspector = InspectorPanel(self)
         self._canvas = StepperCanvas(self._controllers[self._mode], self)
         self._wire_canvas(self._canvas)
@@ -488,6 +489,12 @@ class WorkspaceWindow(QMainWindow):
             pass
         try:
             self._rail.dataset_selected.disconnect(self._on_rail_dataset_selected)
+        except (RuntimeError, TypeError):
+            pass
+        try:
+            self._rail.dataset_delete_requested.disconnect(
+                self._on_dataset_delete_requested
+            )
         except (RuntimeError, TypeError):
             pass
         from rheojax.gui.compat import _is_qobject_alive
@@ -858,6 +865,56 @@ class WorkspaceWindow(QMainWindow):
         self._preview_dialog.show()
         self._preview_dialog.raise_()
         self._preview_dialog.activateWindow()
+
+    def _on_dataset_delete_requested(self, dataset_id: str) -> None:
+        from PySide6.QtWidgets import QMessageBox
+
+        with self._state.library.lock:
+            try:
+                ref = self._state.library.get(dataset_id)
+            except KeyError:
+                self.log_dock.append_record(
+                    logging.WARNING,
+                    f"Delete requested for unknown dataset id: {dataset_id}",
+                )
+                return
+
+        # Mirrors _blocked_by_active_jobs (used for Save/Close): a running fit
+        # or Pipeline batch job reads a dataset's payload via
+        # library.load_payload() from a worker thread. Deleting the dataset
+        # out from under that read would pop the payload mid-job instead of
+        # failing cleanly, so check ActiveJobsState (keyed by dataset id)
+        # before offering the confirm-delete prompt at all.
+        with self._state.active_jobs.lock:
+            has_active_job = dataset_id in self._state.active_jobs.by_id
+        if has_active_job:
+            QMessageBox.warning(
+                self,
+                "Delete Dataset",
+                "A job is currently running on this dataset. Wait for it to "
+                "finish (or cancel it) before deleting.",
+            )
+            return
+
+        choice = QMessageBox.question(
+            self,
+            "Delete Dataset",
+            f'Delete dataset "{ref.name}"? This cannot be undone.',
+            QMessageBox.StandardButton.Yes | QMessageBox.StandardButton.No,
+            QMessageBox.StandardButton.No,
+        )
+        if choice != QMessageBox.StandardButton.Yes:
+            return
+
+        with self._state.library.lock:
+            self._state.library.remove(dataset_id)
+        self._notifier.changed.emit()
+        self.log_dock.append_record(logging.INFO, f'Deleted dataset "{ref.name}"')
+        # ponytail: a derived dataset's DatasetRef.lineage may reference this
+        # id afterward -- lineage is provenance/display metadata only (never
+        # dereferenced at runtime, per DatasetLibrary's own field comment), so
+        # this is a known, accepted display-only gap, not a functional one.
+        # Clean up lineage entries if a future spec makes lineage load-bearing.
 
     def _commit_dataset(self, ref, payload=None, overwrite: bool = False) -> None:
         # Hold the library's lock across both calls so a concurrent reader never

--- a/rheojax/gui/workspace/window.py
+++ b/rheojax/gui/workspace/window.py
@@ -90,6 +90,7 @@ class WorkspaceWindow(QMainWindow):
         self.addDockWidget(Qt.DockWidgetArea.BottomDockWidgetArea, self.log_dock)
         self.log_dock.setVisible(False)
         self._build_view_menu()
+        self._build_help_menu()
 
         self._build_workspace(app_state)
         self._setup_os_theme_watcher()
@@ -188,6 +189,44 @@ class WorkspaceWindow(QMainWindow):
         theme_menu.addAction(self._theme_light_action)
         theme_menu.addAction(self._theme_dark_action)
         theme_menu.addAction(self._theme_system_action)
+
+    def _build_help_menu(self) -> None:
+        menu = self.menuBar().addMenu("&Help")
+        menu.addAction("&Documentation", self._on_open_docs)
+        menu.addAction("&Tutorials", self._on_open_tutorials)
+        menu.addAction("&Keyboard Shortcuts", self._on_show_shortcuts)
+        menu.addSeparator()
+        menu.addAction("&About RheoJAX", self._on_about)
+
+    def _on_open_docs(self) -> None:
+        import webbrowser
+
+        webbrowser.open("https://rheojax.readthedocs.io")
+
+    def _on_open_tutorials(self) -> None:
+        import webbrowser
+
+        webbrowser.open("https://rheojax.readthedocs.io/en/latest/tutorials/")
+
+    def _on_show_shortcuts(self) -> None:
+        from PySide6.QtWidgets import QMessageBox
+
+        shortcuts = """
+<h3>Keyboard Shortcuts</h3>
+<table>
+<tr><td><b>Ctrl+N</b></td><td>New Project</td></tr>
+<tr><td><b>Ctrl+O</b></td><td>Open Project</td></tr>
+<tr><td><b>Ctrl+S</b></td><td>Save Project</td></tr>
+<tr><td><b>Ctrl+Shift+S</b></td><td>Save Project As</td></tr>
+<tr><td><b>Ctrl+K</b></td><td>Command Palette</td></tr>
+</table>
+        """
+        QMessageBox.information(self, "Keyboard Shortcuts", shortcuts)
+
+    def _on_about(self) -> None:
+        from rheojax.gui.dialogs.about import AboutDialog
+
+        AboutDialog(self).exec()
 
     def _apply_theme(self, theme: str) -> None:
         """Apply a QSS theme to the QApplication and sync UI/state.

--- a/rheojax/gui/workspace/window.py
+++ b/rheojax/gui/workspace/window.py
@@ -924,6 +924,9 @@ class WorkspaceWindow(QMainWindow):
         # out from under that read would pop the payload mid-job instead of
         # failing cleanly, so check ActiveJobsState (keyed by dataset id)
         # before offering the confirm-delete prompt at all.
+        # NOTE: This guard only covers by_id entries keyed by dataset id; a
+        # future producer reading payload on a worker thread while registering
+        # under a different key (e.g. job id) would silently bypass this check.
         with self._state.active_jobs.lock:
             has_active_job = dataset_id in self._state.active_jobs.by_id
         if has_active_job:

--- a/tests/gui/test_gui_smoke.py
+++ b/tests/gui/test_gui_smoke.py
@@ -726,6 +726,16 @@ class TestQtIntegration:
         assert parse_args(["--workspace"]).workspace is True
 
     @pytest.mark.smoke
+    def test_legacy_deprecation_warning_prints_to_stderr(self, capsys) -> None:
+        """--legacy prints a deprecation warning, mirroring --workspace's."""
+        from rheojax.gui.main import _warn_legacy_deprecated
+
+        _warn_legacy_deprecated()
+
+        captured = capsys.readouterr()
+        assert "WARNING: --legacy is deprecated" in captured.err
+
+    @pytest.mark.smoke
     def test_create_workspace_window_reachable_from_entrypoint(self, qapp) -> None:
         """The exact function --workspace triggers must build a real WorkspaceWindow.
 

--- a/tests/gui/workspace/test_library_rail.py
+++ b/tests/gui/workspace/test_library_rail.py
@@ -100,3 +100,19 @@ def test_context_menu_targets_clicked_item_not_current_selection(qtbot, monkeypa
         rail._on_context_menu_requested(pos)
 
     assert blocker.args == ["d2"]
+
+
+def test_context_menu_delete_action_emits_dataset_delete_requested(qtbot, monkeypatch):
+    from PySide6.QtWidgets import QMenu
+
+    library = DatasetLibrary()
+    library.add(_ref("d1"))
+    rail = LibraryRail(library)
+    qtbot.addWidget(rail)
+    monkeypatch.setattr(QMenu, "exec", lambda self, *a, **k: self.actions()[1])
+    pos = rail._list.visualItemRect(rail._list.item(0)).center()
+
+    with qtbot.waitSignal(rail.dataset_delete_requested, timeout=1000) as blocker:
+        rail._on_context_menu_requested(pos)
+
+    assert blocker.args == ["d1"]

--- a/tests/gui/workspace/test_window_dataset_delete.py
+++ b/tests/gui/workspace/test_window_dataset_delete.py
@@ -1,0 +1,113 @@
+from __future__ import annotations
+
+import logging
+
+import pytest
+
+pytest.importorskip("PySide6")
+
+from rheojax.gui.foundation.library import DatasetRef
+from rheojax.gui.foundation.state import AppState
+from rheojax.gui.workspace.window import WorkspaceWindow
+
+
+def _ref(id_: str = "d1") -> DatasetRef:
+    return DatasetRef(
+        id=id_,
+        name=id_,
+        protocol_type="oscillation",
+        origin="imported",
+        units={},
+        row_count=1,
+        hash="h",
+        provenance={},
+        lineage=[],
+    )
+
+
+def test_delete_confirmed_removes_dataset_and_refreshes_rail(qtbot, monkeypatch):
+    from PySide6.QtWidgets import QMessageBox
+
+    state = AppState()
+    state.library.add(_ref("d1"))
+    win = WorkspaceWindow(state)
+    qtbot.addWidget(win)
+    assert win._rail.count() == 1
+    monkeypatch.setattr(
+        QMessageBox, "question", lambda *a, **k: QMessageBox.StandardButton.Yes
+    )
+
+    win._on_dataset_delete_requested("d1")
+
+    assert win._rail.count() == 0
+    with pytest.raises(KeyError):
+        state.library.get("d1")
+
+
+def test_delete_cancelled_keeps_dataset(qtbot, monkeypatch):
+    from PySide6.QtWidgets import QMessageBox
+
+    state = AppState()
+    state.library.add(_ref("d1"))
+    win = WorkspaceWindow(state)
+    qtbot.addWidget(win)
+    monkeypatch.setattr(
+        QMessageBox, "question", lambda *a, **k: QMessageBox.StandardButton.No
+    )
+
+    win._on_dataset_delete_requested("d1")
+
+    assert state.library.get("d1").id == "d1"
+    assert win._rail.count() == 1
+
+
+def test_delete_blocked_when_dataset_has_active_job(qtbot, monkeypatch):
+    from PySide6.QtWidgets import QMessageBox
+
+    state = AppState()
+    state.library.add(_ref("d1"))
+    state.active_jobs.by_id["d1"] = {"job_id": "j1", "step_type": "fit"}
+    win = WorkspaceWindow(state)
+    qtbot.addWidget(win)
+    prompted = []
+    monkeypatch.setattr(
+        QMessageBox,
+        "question",
+        lambda *a, **k: prompted.append(True) or QMessageBox.StandardButton.Yes,
+    )
+    warned = []
+    monkeypatch.setattr(
+        QMessageBox,
+        "warning",
+        lambda *a, **k: warned.append(True),
+    )
+
+    win._on_dataset_delete_requested("d1")
+
+    assert not prompted  # never got to the confirm-delete prompt
+    assert warned
+    assert state.library.get("d1").id == "d1"  # dataset untouched
+    assert win._rail.count() == 1
+
+
+def test_delete_unknown_dataset_id_logs_warning_and_does_not_prompt(qtbot, monkeypatch):
+    from PySide6.QtWidgets import QMessageBox
+
+    state = AppState()
+    win = WorkspaceWindow(state)
+    qtbot.addWidget(win)
+    logged = []
+    monkeypatch.setattr(
+        win.log_dock, "append_record", lambda level, msg: logged.append((level, msg))
+    )
+    prompted = []
+    monkeypatch.setattr(
+        QMessageBox,
+        "question",
+        lambda *a, **k: prompted.append(True) or QMessageBox.StandardButton.Yes,
+    )
+
+    win._on_dataset_delete_requested("does-not-exist")
+
+    assert not prompted
+    assert logged and logged[0][0] == logging.WARNING

--- a/tests/gui/workspace/test_window_help_menu.py
+++ b/tests/gui/workspace/test_window_help_menu.py
@@ -1,0 +1,68 @@
+from __future__ import annotations
+
+import pytest
+
+pytest.importorskip("PySide6")
+
+from rheojax.gui.foundation.state import AppState
+from rheojax.gui.workspace.window import WorkspaceWindow
+
+
+def _win(qtbot):
+    win = WorkspaceWindow(AppState())
+    qtbot.addWidget(win)
+    return win
+
+
+def test_help_menu_is_registered_on_menu_bar(qtbot):
+    win = _win(qtbot)
+    titles = [a.text() for a in win.menuBar().actions()]
+    assert "&Help" in titles
+
+
+def test_open_docs_opens_browser(qtbot, monkeypatch):
+    win = _win(qtbot)
+    opened = []
+    monkeypatch.setattr("webbrowser.open", lambda url: opened.append(url))
+
+    win._on_open_docs()
+
+    assert opened == ["https://rheojax.readthedocs.io"]
+
+
+def test_open_tutorials_opens_browser(qtbot, monkeypatch):
+    win = _win(qtbot)
+    opened = []
+    monkeypatch.setattr("webbrowser.open", lambda url: opened.append(url))
+
+    win._on_open_tutorials()
+
+    assert opened == ["https://rheojax.readthedocs.io/en/latest/tutorials/"]
+
+
+def test_show_shortcuts_displays_message_box(qtbot, monkeypatch):
+    from PySide6.QtWidgets import QMessageBox
+
+    win = _win(qtbot)
+    shown = []
+    monkeypatch.setattr(
+        QMessageBox,
+        "information",
+        lambda *a, **k: shown.append(a[1:]) or None,
+    )
+
+    win._on_show_shortcuts()
+
+    assert shown and shown[0][0] == "Keyboard Shortcuts"
+
+
+def test_about_shows_about_dialog(qtbot, monkeypatch):
+    from rheojax.gui.dialogs.about import AboutDialog
+
+    win = _win(qtbot)
+    shown = []
+    monkeypatch.setattr(AboutDialog, "exec", lambda self: shown.append(True))
+
+    win._on_about()
+
+    assert shown == [True]

--- a/tests/gui/workspace/test_window_help_menu.py
+++ b/tests/gui/workspace/test_window_help_menu.py
@@ -66,3 +66,23 @@ def test_about_shows_about_dialog(qtbot, monkeypatch):
     win._on_about()
 
     assert shown == [True]
+
+
+def test_documentation_action_trigger_reaches_open_docs_handler(qtbot, monkeypatch):
+    # Every other test in this file calls win._on_open_docs()/etc directly --
+    # a missing or mis-wired menu.addAction(text, handler) call (e.g. the
+    # wrong handler connected to the wrong label) would leave those tests
+    # passing while a real click on "Documentation" did nothing or opened
+    # the wrong page. This goes through the real QAction instead, matching
+    # test_library_rail.py's test_context_menu_signal_wiring_reaches_handler_through_real_emission.
+    win = _win(qtbot)
+    opened = []
+    monkeypatch.setattr("webbrowser.open", lambda url: opened.append(url))
+    help_action = next(a for a in win.menuBar().actions() if a.text() == "&Help")
+    doc_action = next(
+        a for a in help_action.menu().actions() if a.text() == "&Documentation"
+    )
+
+    doc_action.trigger()
+
+    assert opened == ["https://rheojax.readthedocs.io"]


### PR DESCRIPTION
## Summary

Spec A of a second two-spec legacy-retirement cutover (mirrors the 2026-07-02 workspace-default-flip spec). Closes the two real, confirmed feature-parity gaps between the legacy `--legacy` GUI shell and the default workspace shell, then starts the `--legacy` deprecation soak period. Actual legacy code deletion (Spec B) and `--workspace` flag removal are explicitly out of scope, deferred until after this soak period.

- **Delete Dataset**: `LibraryRail`'s context menu could only Preview, never remove, an imported dataset. Added a `dataset_delete_requested` signal and a `WorkspaceWindow` handler that confirms, checks for an active job on the dataset first (guards against a race with a running fit/Pipeline worker reading the payload), then removes it.
- **Help menu**: workspace shell had no Documentation/Tutorials/Shortcuts/About menu. Added one, reusing the existing `AboutDialog`.
- **`--legacy` deprecation warning**: mirrors the existing `--workspace` warning. READMEs updated to mark the legacy shell as sunsetting.
- A committed gap-table artifact (`docs/superpowers/plans/gui-legacy-parity-gap-table.md`, not tracked in this repo's git since `docs/superpowers/` is gitignored — kept in the branch's local history for reference) documents every other candidate gap considered and why it wasn't ported (already covered by the new workflow, dead code even in legacy today, or explicitly deferred — Undo/Redo).

Built via subagent-driven development: 5 tasks, each with an independent implementer + task-scoped reviewer, plus a final whole-branch review (Ready to merge: Yes, no Critical/Important issues).

## Test plan

- [x] `tests/gui/workspace/test_library_rail.py` — Delete action emits signal correctly, no regression to existing Preview tests
- [x] `tests/gui/workspace/test_window_dataset_delete.py` — confirmed/cancelled/active-job-blocked/unknown-id delete paths
- [x] `tests/gui/workspace/test_window_help_menu.py` — all 4 Help actions invoke real behavior (browser open, dialogs)
- [x] `tests/gui/test_gui_smoke.py` — `--legacy` deprecation warning prints to stderr
- [x] Full suite: `uv run pytest tests/gui/workspace/ tests/gui/test_gui_smoke.py` — 377 passed, 0 failed

🤖 Generated with [Claude Code](https://claude.com/claude-code)