### PR TITLE
feat(cli): add rj/rj-gui short aliases

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -163,6 +163,8 @@ gpu_cuda12 = [
 [project.scripts]
 rheojax = "rheojax.cli.main:cli_entry"
 rheojax-gui = "rheojax.gui.main:main"
+rj = "rheojax.cli.main:cli_entry"
+rj-gui = "rheojax.gui.main:main"
 
 [project.urls]
 "Homepage" = "https://github.com/imewei/rheojax"


### PR DESCRIPTION
## Summary
- Add `rj` and `rj-gui` as short console-script aliases for `rheojax` and `rheojax-gui` in `[project.scripts]`.

## Test plan
- [x] `uv sync` picks up the new entry points
- [x] `uv run rj --help` runs the CLI
- [x] `uv run which rj-gui` resolves to the installed script

🤖 Generated with [Claude Code](https://claude.com/claude-code)