### PR TITLE
fix(gui): QMenu.exec crash, active-jobs SIGABRT, worker-lock race, dropped pipeline signals

### DIFF
--- a/rheojax/gui/workspace/library_rail.py
+++ b/rheojax/gui/workspace/library_rail.py
@@ -56,16 +56,19 @@ class LibraryRail(QWidget):
         menu = QMenu(self)
         preview_action = menu.addAction("Preview…")
         delete_action = menu.addAction("Delete…")
-        # ponytail: call via QMenu.exec(menu, ...) rather than menu.exec(...) --
-        # functionally identical, but PySide6 6.11's instance attribute lookup
-        # bypasses Python-level monkeypatching of QMenu.exec (class-level
-        # override only takes effect through the unbound call). This keeps
-        # QMenu.exec mockable in tests without changing runtime behavior.
-        chosen = QMenu.exec(menu, self._list.mapToGlobal(pos))
+        chosen = self._exec_context_menu(menu, self._list.mapToGlobal(pos))
         if chosen is preview_action:
             self.dataset_preview_requested.emit(item.data(Qt.ItemDataRole.UserRole))
         elif chosen is delete_action:
             self.dataset_delete_requested.emit(item.data(Qt.ItemDataRole.UserRole))
+
+    def _exec_context_menu(self, menu: QMenu, global_pos):
+        # ponytail: seam for tests to monkeypatch instead of QMenu.exec directly --
+        # PySide6 6.11's bound-method lookup for QMenu.exec bypasses class-level
+        # Python monkeypatching, so patching Qt's own class silently falls through
+        # to the real (blocking) exec(). Patching this plain-Python method instead
+        # behaves like normal Python attribute lookup.
+        return menu.exec(global_pos)
 
     def count(self) -> int:
         return self._list.count()

--- a/rheojax/gui/workspace/window.py
+++ b/rheojax/gui/workspace/window.py
@@ -92,6 +92,42 @@ class WorkspaceWindow(QMainWindow):
         self._build_view_menu()
         self._build_help_menu()
 
+        # These fire ~20 times through a real pipeline run but had no
+        # listener anywhere -- real per-step/per-phase progress was computed
+        # and silently discarded, with no user-visible feedback beyond the
+        # coarse per-dataset start/finish. Route them to the log dock (the
+        # existing mechanism for this kind of event, see log_dock.append_record
+        # elsewhere in this file) rather than building new progress UI.
+        # QueuedConnection: PipelineExecutionService documents that it runs
+        # off the GUI thread, same as phase_worker_ready above.
+        self._pipeline_service.pipeline_started.connect(
+            self._on_pipeline_started, Qt.ConnectionType.QueuedConnection
+        )
+        self._pipeline_service.pipeline_completed.connect(
+            self._on_pipeline_completed, Qt.ConnectionType.QueuedConnection
+        )
+        self._pipeline_service.pipeline_failed.connect(
+            self._on_pipeline_failed, Qt.ConnectionType.QueuedConnection
+        )
+        self._pipeline_service.step_started.connect(
+            self._on_pipeline_step_started, Qt.ConnectionType.QueuedConnection
+        )
+        self._pipeline_service.step_completed.connect(
+            self._on_pipeline_step_completed, Qt.ConnectionType.QueuedConnection
+        )
+        self._pipeline_service.step_failed.connect(
+            self._on_pipeline_step_failed, Qt.ConnectionType.QueuedConnection
+        )
+        self._pipeline_service.step_phase_started.connect(
+            self._on_pipeline_step_phase_started, Qt.ConnectionType.QueuedConnection
+        )
+        self._pipeline_service.step_phase_completed.connect(
+            self._on_pipeline_step_phase_completed, Qt.ConnectionType.QueuedConnection
+        )
+        self._pipeline_service.step_phase_failed.connect(
+            self._on_pipeline_step_phase_failed, Qt.ConnectionType.QueuedConnection
+        )
+
         self._build_workspace(app_state)
         self._setup_os_theme_watcher()
         QShortcut(QKeySequence("Ctrl+K"), self, self._open_command_palette)
@@ -755,14 +791,30 @@ class WorkspaceWindow(QMainWindow):
             # do NOT proceed(): that would rebuild/replace self._state while a
             # worker is still mutating the project it belonged to. Tell the
             # user and let them retry once cancellation actually finishes.
-            from PySide6.QtWidgets import QMessageBox
+            #
+            # Only show that warning if this window is actually visible.
+            # _is_qobject_alive above only catches the case where self's C++
+            # object has already been destroyed -- it does NOT catch a
+            # window that is still fully alive but orphaned (e.g. a stale
+            # instance from a previous test that was never shown, still
+            # ticking down this same 250ms/30s chain). A real user always
+            # has this window visible for the entire duration of a close/new
+            # confirmation, so gating on isVisible() costs nothing for real
+            # usage while preventing this modal from firing into whatever
+            # unrelated context happens to be running when a stale chain's
+            # timer finally elapses -- that reentrant QMessageBox.warning()
+            # call is what caused a reproducible Fatal Python error: Aborted
+            # crash under the full GUI test suite.
+            if self.isVisible():
+                from PySide6.QtWidgets import QMessageBox
 
-            QMessageBox.warning(
-                self,
-                "Jobs Still Running",
-                "Some jobs did not finish cancelling in time. This action was "
-                "cancelled -- try again once they've stopped.",
-            )
+                QMessageBox.warning(
+                    self,
+                    "Jobs Still Running",
+                    "Some jobs did not finish cancelling in time. This "
+                    "action was cancelled -- try again once they've "
+                    "stopped.",
+                )
             self._active_jobs_action_pending = False
             return
         from PySide6.QtCore import QTimer
@@ -782,9 +834,53 @@ class WorkspaceWindow(QMainWindow):
     def _on_phase_worker_ready(
         self, dataset_id: str, step_id: str, phase: str, worker
     ) -> None:
-        job = self._state.active_jobs.by_id.get(dataset_id)
-        if job is not None:
-            job["worker"] = worker
+        # Every other active_jobs.by_id access in this file takes this lock --
+        # PipelineBatchRunner mutates the same dict from a worker thread, so
+        # skipping it here left a TOCTOU gap where a job could be evicted
+        # between the .get() and the assignment, silently dropping the worker
+        # reference the cancel-on-close path (_maybe_confirm_active_jobs)
+        # needs to actually cancel a still-running job.
+        with self._state.active_jobs.lock:
+            job = self._state.active_jobs.by_id.get(dataset_id)
+            if job is not None:
+                job["worker"] = worker
+
+    def _on_pipeline_started(self) -> None:
+        self.log_dock.append_record(logging.INFO, "Pipeline run started")
+
+    def _on_pipeline_completed(self) -> None:
+        self.log_dock.append_record(logging.INFO, "Pipeline run completed")
+
+    def _on_pipeline_failed(self, error: str) -> None:
+        self.log_dock.append_record(logging.ERROR, f"Pipeline run failed: {error}")
+
+    def _on_pipeline_step_started(self, step_id: str) -> None:
+        self.log_dock.append_record(logging.INFO, f"Step {step_id} started")
+
+    def _on_pipeline_step_completed(self, step_id: str) -> None:
+        self.log_dock.append_record(logging.INFO, f"Step {step_id} completed")
+
+    def _on_pipeline_step_failed(self, step_id: str, error: str) -> None:
+        self.log_dock.append_record(
+            logging.ERROR, f"Step {step_id} failed: {error}"
+        )
+
+    def _on_pipeline_step_phase_started(self, step_id: str, phase: str) -> None:
+        self.log_dock.append_record(
+            logging.INFO, f"Step {step_id}: {phase} phase started"
+        )
+
+    def _on_pipeline_step_phase_completed(self, step_id: str, phase: str) -> None:
+        self.log_dock.append_record(
+            logging.INFO, f"Step {step_id}: {phase} phase completed"
+        )
+
+    def _on_pipeline_step_phase_failed(
+        self, step_id: str, phase: str, error: str
+    ) -> None:
+        self.log_dock.append_record(
+            logging.ERROR, f"Step {step_id}: {phase} phase failed: {error}"
+        )
 
     def _maybe_confirm_unsaved_changes(self, proceed) -> None:
         if not self._state.project.dirty:

--- a/tests/gui/workspace/test_library_rail.py
+++ b/tests/gui/workspace/test_library_rail.py
@@ -36,13 +36,13 @@ def test_double_click_emits_dataset_preview_requested(qtbot):
 
 
 def test_context_menu_on_item_emits_dataset_preview_requested(qtbot, monkeypatch):
-    from PySide6.QtWidgets import QMenu
-
     library = DatasetLibrary()
     library.add(_ref("d1"))
     rail = LibraryRail(library)
     qtbot.addWidget(rail)
-    monkeypatch.setattr(QMenu, "exec", lambda self, *a, **k: self.actions()[0])
+    monkeypatch.setattr(
+        LibraryRail, "_exec_context_menu", lambda self, menu, pos: menu.actions()[0]
+    )
     pos = rail._list.visualItemRect(rail._list.item(0)).center()
 
     with qtbot.waitSignal(rail.dataset_preview_requested, timeout=1000) as blocker:
@@ -59,13 +59,13 @@ def test_context_menu_signal_wiring_reaches_handler_through_real_emission(
     # customContextMenuRequested.connect(...) in __init__ would leave those
     # tests passing while a real right-click did nothing -- this test goes
     # through the real Qt signal instead of calling the handler.
-    from PySide6.QtWidgets import QMenu
-
     library = DatasetLibrary()
     library.add(_ref("d1"))
     rail = LibraryRail(library)
     qtbot.addWidget(rail)
-    monkeypatch.setattr(QMenu, "exec", lambda self, *a, **k: self.actions()[0])
+    monkeypatch.setattr(
+        LibraryRail, "_exec_context_menu", lambda self, menu, pos: menu.actions()[0]
+    )
     pos = rail._list.visualItemRect(rail._list.item(0)).center()
 
     with qtbot.waitSignal(rail.dataset_preview_requested, timeout=1000) as blocker:
@@ -85,15 +85,15 @@ def test_context_menu_on_empty_space_does_nothing(qtbot):
 
 
 def test_context_menu_targets_clicked_item_not_current_selection(qtbot, monkeypatch):
-    from PySide6.QtWidgets import QMenu
-
     library = DatasetLibrary()
     library.add(_ref("d1"))
     library.add(_ref("d2"))
     rail = LibraryRail(library)
     qtbot.addWidget(rail)
     rail._list.setCurrentRow(0)  # "d1" is the current selection
-    monkeypatch.setattr(QMenu, "exec", lambda self, *a, **k: self.actions()[0])
+    monkeypatch.setattr(
+        LibraryRail, "_exec_context_menu", lambda self, menu, pos: menu.actions()[0]
+    )
     pos = rail._list.visualItemRect(rail._list.item(1)).center()  # right-click on "d2"
 
     with qtbot.waitSignal(rail.dataset_preview_requested, timeout=1000) as blocker:
@@ -103,13 +103,13 @@ def test_context_menu_targets_clicked_item_not_current_selection(qtbot, monkeypa
 
 
 def test_context_menu_delete_action_emits_dataset_delete_requested(qtbot, monkeypatch):
-    from PySide6.QtWidgets import QMenu
-
     library = DatasetLibrary()
     library.add(_ref("d1"))
     rail = LibraryRail(library)
     qtbot.addWidget(rail)
-    monkeypatch.setattr(QMenu, "exec", lambda self, *a, **k: self.actions()[1])
+    monkeypatch.setattr(
+        LibraryRail, "_exec_context_menu", lambda self, menu, pos: menu.actions()[1]
+    )
     pos = rail._list.visualItemRect(rail._list.item(0)).center()
 
     with qtbot.waitSignal(rail.dataset_delete_requested, timeout=1000) as blocker:

--- a/tests/gui/workspace/test_window_active_jobs_dialog.py
+++ b/tests/gui/workspace/test_window_active_jobs_dialog.py
@@ -97,6 +97,85 @@ def test_stale_poll_chain_timer_is_parented_to_window(qtbot):
     )
 
 
+def test_poll_timeout_does_not_show_modal_when_window_not_visible(qtbot, monkeypatch):
+    # Regression: a stale/orphaned WorkspaceWindow (never shown, or already
+    # closed -- e.g. left behind by a previous test whose poll chain never
+    # resolved) must not pop a real modal QMessageBox.warning() once its 30s
+    # budget expires. _is_qobject_alive only catches the case where the C++
+    # object is already destroyed; it does NOT catch a window that is still
+    # fully alive but orphaned. Showing a modal from an orphaned window's
+    # timer callback, reentrant into whatever unrelated test happens to be
+    # running at that moment, is exactly what caused a reproducible
+    # Fatal Python error: Aborted crash under the full GUI test suite.
+    win = WorkspaceWindow(AppState())
+    qtbot.addWidget(win)
+    assert not win.isVisible()  # never shown -- the orphaned-window case
+
+    from PySide6.QtWidgets import QMessageBox
+
+    warned = []
+    monkeypatch.setattr(QMessageBox, "warning", lambda *a, **k: warned.append(1))
+
+    win._state.active_jobs.by_id["d1"] = {"status": "running"}
+    win._active_jobs_action_pending = True
+    win._poll_active_jobs_then(lambda: None, remaining_polls=0)
+
+    assert warned == []
+    assert win._active_jobs_action_pending is False
+
+
+def test_poll_timeout_shows_modal_when_window_visible(qtbot, monkeypatch):
+    # Complement to the test above: a real, visible window (the only case
+    # that occurs in actual usage -- a user closing/starting-new always has
+    # this window shown) must still get the warning.
+    win = WorkspaceWindow(AppState())
+    qtbot.addWidget(win)
+    win.show()
+    qtbot.waitExposed(win)
+
+    from PySide6.QtWidgets import QMessageBox
+
+    warned = []
+    monkeypatch.setattr(QMessageBox, "warning", lambda *a, **k: warned.append(1))
+
+    win._state.active_jobs.by_id["d1"] = {"status": "running"}
+    win._active_jobs_action_pending = True
+    win._poll_active_jobs_then(lambda: None, remaining_polls=0)
+
+    assert warned == [1]
+
+
+def test_phase_worker_ready_takes_active_jobs_lock(qtbot, monkeypatch):
+    # Regression: _on_phase_worker_ready used to read/write
+    # active_jobs.by_id without taking active_jobs.lock, unlike every other
+    # call site in this file -- a real TOCTOU gap against
+    # PipelineBatchRunner, which mutates the same dict from a worker thread.
+    win = WorkspaceWindow(AppState())
+    qtbot.addWidget(win)
+    win._state.active_jobs.by_id["d1"] = {"status": "running"}
+
+    acquired = []
+    real_lock = win._state.active_jobs.lock
+
+    class _SpyLock:
+        def __enter__(self):
+            acquired.append(1)
+            return real_lock.__enter__()
+
+        def __exit__(self, *exc):
+            return real_lock.__exit__(*exc)
+
+    monkeypatch.setattr(win._state.active_jobs, "lock", _SpyLock())
+
+    class _FakeWorker:
+        pass
+
+    win._on_phase_worker_ready("d1", "s1", "nlsq", _FakeWorker())
+
+    assert acquired == [1]
+    assert win._state.active_jobs.by_id["d1"].get("worker") is not None
+
+
 def test_phase_worker_ready_updates_only_its_own_dataset(qtbot):
     win = WorkspaceWindow(AppState())
     qtbot.addWidget(win)

--- a/tests/gui/workspace/test_window_pipeline_mode.py
+++ b/tests/gui/workspace/test_window_pipeline_mode.py
@@ -123,3 +123,36 @@ def test_run_all_double_click_starts_only_one_runner(qtbot, monkeypatch):
     win._on_pipeline_run_requested()
 
     assert len(start_calls) == 1
+
+
+def test_pipeline_progress_signals_are_wired_to_log_dock(qtbot):
+    # Regression: step_started/step_completed/step_failed, pipeline_started/
+    # completed/failed, and step_phase_started/completed/failed used to have
+    # zero listeners anywhere -- real per-step/per-phase progress was
+    # computed and silently discarded during a pipeline run, with no
+    # user-visible feedback beyond the coarse per-dataset start/finish.
+    win = WorkspaceWindow(AppState())
+    qtbot.addWidget(win)
+    service = win._pipeline_service
+
+    service.pipeline_started.emit()
+    service.step_started.emit("s1")
+    service.step_phase_started.emit("s1", "nlsq")
+    service.step_phase_completed.emit("s1", "nlsq")
+    service.step_completed.emit("s1")
+    service.step_failed.emit("s2", "boom")
+    service.step_phase_failed.emit("s3", "nuts", "kaboom")
+    service.pipeline_failed.emit("fatal")
+    service.pipeline_completed.emit()
+    qtbot.wait(50)  # these connections are QueuedConnection
+
+    messages = [msg for _, msg in win.log_dock._records]
+    assert any("Pipeline run started" in m for m in messages)
+    assert any("Step s1 started" in m for m in messages)
+    assert any("s1: nlsq phase started" in m for m in messages)
+    assert any("s1: nlsq phase completed" in m for m in messages)
+    assert any("Step s1 completed" in m for m in messages)
+    assert any("Step s2 failed: boom" in m for m in messages)
+    assert any("s3: nuts phase failed: kaboom" in m for m in messages)
+    assert any("Pipeline run failed: fatal" in m for m in messages)
+    assert any("Pipeline run completed" in m for m in messages)


### PR DESCRIPTION
## Summary

Fixes four bugs found while diagnosing a reported `QMenu.exec` crash and doing a follow-up GUI wiring/security/performance double-check:

- **`library_rail.py`**: `QMenu.exec(menu, pos)` (unbound classmethod-style call) doesn't bind `self` correctly in PySide6 6.11 — this crashed every dataset context-menu with a `TypeError`. Fixed to `menu.exec(pos)`, with a small `_exec_context_menu` seam tests can monkeypatch (patching Qt's own `QMenu` class silently doesn't take effect for bound-instance calls in this PySide6 version).
- **`window.py` — active-jobs SIGABRT**: the active-jobs poll timeout could show a real modal `QMessageBox.warning()` from a stale/orphaned window (e.g. one left over from a previous test whose poll chain never resolved), reentrant into an unrelated later test's teardown — reproduced as `Fatal Python error: Aborted` under the full GUI test suite, despite an earlier fix (`ec65cc33`) that only guarded against the object being fully C++-destroyed. Fixed by gating the modal on `self.isVisible()` (always true for a real user's close/new flow, false for an orphaned instance).
- **`window.py` — worker-lock race**: `_on_phase_worker_ready` read/wrote `active_jobs.by_id` without the lock every other call site takes — a real TOCTOU gap against `PipelineBatchRunner` mutating the same dict from a worker thread.
- **`window.py` — dropped pipeline progress signals**: `PipelineExecutionService`'s per-step/per-phase/pipeline-level signals had zero listeners anywhere — real progress was computed and silently discarded. Wired to the existing log dock.

## Test plan

- [x] `tests/gui/workspace/test_library_rail.py` — 6/6 pass (QMenu fix)
- [x] `tests/gui/workspace/test_window_active_jobs_dialog.py` — 21/21 pass, including new regression tests for the visibility-gated modal and the lock fix
- [x] `tests/gui/workspace/test_window_pipeline_mode.py` — new test confirming all 9 pipeline signals reach the log dock
- [x] Full `tests/gui/workspace/` suite: **321 passed, 0 failed** (18 min run, no coverage overhead) — confirms the SIGABRT no longer reproduces
- [x] `ruff check` / `mypy` clean on all changed files

🤖 Generated with [Claude Code](https://claude.com/claude-code)