### PR TITLE
fix(core): audit and fix 42 completeness/accuracy bugs across rheojax/core

### DIFF
--- a/rheojax/core/arviz_utils.py
+++ b/rheojax/core/arviz_utils.py
@@ -31,8 +31,8 @@ def import_arviz(*, required: Iterable[str] | None = None) -> ModuleType:
             ArviZ module (e.g., "plot_pair", "plot_forest", "from_numpyro").
 
     Raises:
-        ImportError: When ArviZ itself cannot be imported or has been disabled.
-        RuntimeError: When ArviZ imports but is missing required helpers.
+        ImportError: When ArviZ itself cannot be imported or has been disabled,
+            or when ArviZ imports but is missing required helpers.
     """
 
     if sys.modules.get("arviz", object()) is None:
@@ -52,10 +52,12 @@ def import_arviz(*, required: Iterable[str] | None = None) -> ModuleType:
         missing = sorted(name for name in required if not hasattr(arviz, name))
         if missing:
             missing_csv = ", ".join(missing)
-            raise RuntimeError(
+            raise ImportError(
                 "ArviZ is installed but missing required component(s) "
-                f"[{missing_csv}]. Reinstall ArviZ with optional plotting extras "
-                "(`pip install arviz[plots]`) to enable Bayesian diagnostics."
+                f"[{missing_csv}]. This usually means an incompatible ArviZ "
+                "version or a partial install -- try `pip install -U "
+                '"arviz>=0.23.4,<2.0.0"`, or `pip install arviz[matplotlib]` '
+                "if this is a plotting-backend gap."
             )
 
     return arviz

--- a/rheojax/core/base.py
+++ b/rheojax/core/base.py
@@ -176,7 +176,12 @@ class BaseModel(BayesianMixin, ABC):
             if hasattr(resolved_test_mode, "name")
             else str(resolved_test_mode)
         )
-        data_shape = (int(x_np.shape[0]),) if hasattr(x_np, "shape") else None
+        # x_np is always an ndarray (np.asarray above), so hasattr(shape) is
+        # always True; a 0-d array (scalar X) has shape == () and shape[0]
+        # raises IndexError. Guard on ndim instead, matching the (1,)
+        # scalar-fallback used by the sibling data_shape computations in
+        # predict()/fit_predict()/fit_bayesian().
+        data_shape = (int(x_np.shape[0]),) if x_np.ndim > 0 else (1,)
 
         x_data = jnp.array(x_np)
         y_data = jnp.array(y_np)
@@ -232,7 +237,8 @@ class BaseModel(BayesianMixin, ABC):
 
             # --- 4. Validate ---
             if not result.success:
-                if not np.isfinite(result.fun) or result.fun > 1e6 * len(x_np):
+                _n_points = int(x_np.shape[0]) if x_np.ndim > 0 else 1
+                if not np.isfinite(result.fun) or result.fun > 1e6 * _n_points:
                     logger.error(
                         "Optimization failed",
                         message=result.message,

--- a/rheojax/core/base.py
+++ b/rheojax/core/base.py
@@ -41,10 +41,21 @@ class BaseModel(BayesianMixin, ABC):
     supporting JAX arrays, scikit-learn style APIs,
     and Bayesian inference via NumPyro NUTS.
 
-    All models inherit Bayesian capabilities from BayesianMixin, including:
+    Every subclass must implement ``_fit()`` and ``_predict()``. All subclasses
+    additionally inherit the Bayesian *methods* from BayesianMixin, including:
     - fit_bayesian(): Bayesian parameter estimation using NUTS
     - sample_prior(): Sample from prior distributions
     - get_credible_intervals(): Compute highest density intervals
+
+    However, calling ``fit_bayesian()`` only works if the subclass *also*
+    defines a ``model_function(X, params, **kwargs)`` method (not enforced as
+    an abstractmethod here to avoid forcing every model, including ones that
+    only ever do point-estimation, to implement it). Without ``model_function``,
+    ``fit_bayesian()`` raises ``AttributeError`` at call time
+    (see ``BayesianMixin._validate_bayesian_requirements``). Check
+    ``hasattr(instance, 'model_function')`` — not ``hasattr(instance, 'fit_bayesian')``,
+    which is always ``True`` — to determine whether a given model actually
+    supports Bayesian fitting.
 
     The fit() method uses NLSQ optimization by default for fast point estimation,
     which can be used to warm-start Bayesian inference.
@@ -135,7 +146,10 @@ class BaseModel(BayesianMixin, ABC):
                 y_np = y_raw.astype(np.complex128)
             else:
                 y_np = y_raw.astype(float)
-            resolved_test_mode = rheo_data.test_mode
+            supplied = test_mode if test_mode is not None else kwargs.get("test_mode")
+            resolved_test_mode = (
+                supplied if supplied is not None else rheo_data.test_mode
+            )
         else:
             x_np = np.asarray(X, dtype=float)
             y_raw = np.asarray(y)
@@ -550,6 +564,7 @@ class BaseModel(BayesianMixin, ABC):
             name: self.parameters.get_value(name) for name in self.parameters
         }
         saved_fitted = self.fitted_
+        saved_nlsq_result = self._nlsq_result
         _had_test_mode = hasattr(self, "_test_mode")  # BASE-003: track if attr existed
         saved_test_mode = getattr(self, "_test_mode", None)
         _raw = getattr(self, "_last_fit_kwargs", None)
@@ -581,6 +596,7 @@ class BaseModel(BayesianMixin, ABC):
             else:
                 self.parameters._parameters[name].value = None
         self.fitted_ = saved_fitted
+        self._nlsq_result = saved_nlsq_result
         # BASE-003: only restore _test_mode if the attribute existed before
         if _had_test_mode:
             self._test_mode = saved_test_mode
@@ -782,7 +798,10 @@ class BaseModel(BayesianMixin, ABC):
             Model predictions
         """
         reject_removed_options(kwargs)
-        x_shape = getattr(X, "shape", None) or (len(X),)
+        _shape = getattr(X, "shape", None)
+        x_shape = (
+            _shape if _shape is not None else (len(X) if hasattr(X, "__len__") else (1,))
+        )
         logger.debug(
             "Predict called",
             model=self.__class__.__name__,
@@ -790,18 +809,6 @@ class BaseModel(BayesianMixin, ABC):
             test_mode=test_mode,
             kwargs=kwargs,
         )
-
-        # Check if parameters are set manually (allow predict without fit)
-        # but do NOT permanently mutate self.fitted_ — predict() must be read-only
-        _effectively_fitted = self.fitted_
-        if not _effectively_fitted and len(self.parameters) > 0:
-            if not any(p.value is None for p in self.parameters._parameters.values()):
-                _effectively_fitted = True
-                logger.debug(
-                    "Parameters set manually — proceeding with predict "
-                    "(model not marked as fitted)",
-                    model=self.__class__.__name__,
-                )
 
         # Preserve the test mode declared on a RheoData container. predict()
         # unpacks X.x below, which strips the metadata that _predict() relies
@@ -878,10 +885,14 @@ class BaseModel(BayesianMixin, ABC):
         Returns:
             Model predictions on training data
         """
+        _shape = getattr(X, "shape", None)
+        data_shape = (
+            _shape if _shape is not None else (len(X) if hasattr(X, "__len__") else (1,))
+        )
         logger.debug(
             "fit_predict called",
             model=self.__class__.__name__,
-            data_shape=getattr(X, "shape", None) or (len(X),),
+            data_shape=data_shape,
         )
         self.fit(X, y, **kwargs)
         return self.predict(X)
@@ -1319,17 +1330,26 @@ class TransformPipeline(BaseTransform):
             Transformed data after all transforms
         """
         result = data
+        n_steps = len(self.transforms)
         for i, transform in enumerate(self.transforms):
             logger.debug(
-                f"Pipeline step {i + 1}/{len(self.transforms)}",
+                f"Pipeline step {i + 1}/{n_steps}",
                 transform="TransformPipeline",
                 step=i + 1,
-                total_steps=len(self.transforms),
+                total_steps=n_steps,
                 current_transform=transform.__class__.__name__,
             )
             step_result = transform.transform(result)
-            # Handle tuple returns (data, extras) from mid-pipeline steps
-            result = step_result[0] if isinstance(step_result, tuple) else step_result
+            is_last = i == n_steps - 1
+            # Mid-pipeline steps must unwrap (data, extras) tuples since the
+            # next step's .transform() expects only the data. The final
+            # step's extras are propagated to the caller instead of dropped.
+            if is_last:
+                result = step_result
+            else:
+                result = (
+                    step_result[0] if isinstance(step_result, tuple) else step_result
+                )
         return result
 
     def _inverse_transform(self, data):

--- a/rheojax/core/bayesian.py
+++ b/rheojax/core/bayesian.py
@@ -38,6 +38,14 @@ logger = get_logger(__name__)
 # Safe JAX import (verifies NLSQ was imported first)
 jax, jnp = safe_import_jax()
 
+# Canonical R-hat convergence threshold (see fit_bayesian docstring).
+R_HAT_THRESHOLD = 1.01
+
+# Canonical minimum bulk-ESS threshold (Vehtari/Stan/ArviZ rule of thumb):
+# below this, chains produced too few effective independent samples to trust
+# even if R-hat looks converged (see fit_bayesian docstring).
+ESS_THRESHOLD = 400
+
 
 def _import_numpyro():
     """Lazy-import NumPyro and its submodules.
@@ -336,6 +344,60 @@ class BayesianMixin:
             "scale_info": scale_info,
         }
 
+    def _validate_finite_inputs(self, X_jax: Array, y_jax: Array) -> None:
+        """Reject NaN/Inf in X or y before they reach NUTS.
+
+        Shared by fit_bayesian() and precompile_bayesian() (both build the
+        NumPyro model and call _run_nuts_sampling on the same X/y) so bad
+        input produces a clear error instead of silent divergences or an
+        opaque sampler failure downstream. isfinite (not isnan) also catches
+        +/-Inf. y_jax is always real-valued (complex y is split into
+        concatenated real/imag parts by _prepare_jax_data), so a single
+        isfinite check covers both the real and complex paths.
+        """
+        if bool(jnp.any(~jnp.isfinite(X_jax))):
+            raise ValueError("Input X contains NaN or Inf values.")
+        if bool(jnp.any(~jnp.isfinite(y_jax))):
+            raise ValueError("Input y contains NaN or Inf values.")
+
+    @staticmethod
+    def _validate_xy_shapes(X_array: ArrayLike, y_array: ArrayLike) -> None:
+        """Reject shape-mismatched or ambiguous-shaped y before JAX prep.
+
+        Must run on the raw X_array/y_array *before* _prepare_jax_data's
+        complex real/imag split (which concatenates y into length 2N while
+        X stays length N — a raw-shape check after that split would reject
+        every legitimate complex/oscillation fit).
+
+        A plain length-N check (``y.shape[0] == X.shape[0]``) is not enough:
+        a caller-supplied y of shape (N, 1) (e.g. from
+        ``df['col'].values.reshape(-1, 1)``) also has shape[0] == N but
+        broadcasts silently against an (N,)-shaped prediction inside
+        NumPyro's Normal likelihood, corrupting the log-likelihood instead
+        of raising. So y must be exactly 1-D, with the single exception of
+        the (N, 2) real/imag-columns convention that numpyro_model_builder
+        and RheoData both already support for oscillation data (G', G'').
+        """
+        x_arr = np.asarray(X_array)
+        y_arr = np.asarray(y_array)
+        n = x_arr.shape[0] if x_arr.ndim > 0 else None
+
+        if y_arr.ndim == 1:
+            pass
+        elif y_arr.ndim == 2 and y_arr.shape[1] == 2:
+            pass
+        else:
+            raise ValueError(
+                "y must be 1-dimensional (or shape (N, 2) for the real/imag "
+                f"-columns convention), got shape {y_arr.shape}"
+            )
+
+        if n is not None and y_arr.shape[0] != n:
+            raise ValueError(
+                "X and y must have the same length. "
+                f"Got X: {x_arr.shape}, y: {y_arr.shape}"
+            )
+
     def _get_parameter_bounds(
         self,
         X_array: np.ndarray,
@@ -424,6 +486,8 @@ class BayesianMixin:
             for name in param_names
         }
 
+        clamped_params: list[str] = []
+
         def sanitize_value(name: str, raw_value: float | None) -> float:
             lower_raw, upper_raw = param_bounds[name]
             safe_lower, safe_upper = init_intervals[name]
@@ -443,6 +507,15 @@ class BayesianMixin:
                     clamped=value,
                     interval=(float(safe_lower), float(safe_upper)),
                 )
+                # Only a caller-supplied initial_values entry outside bounds
+                # is worth a user-visible warning — the same clamp logic also
+                # runs on the synthesized default midpoint (which is
+                # constructed from the same bounds and can never be out of
+                # range), so gate on raw_value to avoid false positives there.
+                if raw_value is not None and np.isfinite(raw_value):
+                    clamped_params.append(
+                        f"{name}={original!r} -> {value!r}"
+                    )
             return float(value)
 
         warm_start: dict[str, float] = {}
@@ -462,6 +535,15 @@ class BayesianMixin:
                         parameter=name,
                     )
             warm_start[name] = sanitize_value(name, candidate)
+
+        if clamped_params:
+            warnings.warn(
+                "initial_values contained value(s) outside parameter bounds; "
+                "clamped to the nearest valid bound: "
+                f"{', '.join(clamped_params)}",
+                RuntimeWarning,
+                stacklevel=3,
+            )
 
         # Add noise scale initial values.
         # Use explicit None-check (not or-sentinel) so that a legitimately zero
@@ -501,11 +583,20 @@ class BayesianMixin:
         num_chains: int,
         nuts_kwargs: dict[str, Any],
         seed: int | None = None,
+        has_explicit_warm_start: bool = False,
     ) -> MCMC:
         """Run NUTS sampling with fallback to uniform initialization.
 
         Args:
             seed: Random seed for reproducibility. If None, uses 0.
+            has_explicit_warm_start: Whether the caller has a genuine warm
+                start (either caller-supplied `initial_values` or a prior
+                `.fit()` call), as opposed to `warm_start_values` merely being
+                non-empty because `_build_warm_start_values` always fills in
+                bounds-midpoint fallbacks. Computed by the caller from the raw
+                `initial_values`/`fitted_` state, not re-derived here, since
+                `bool(warm_start_values)` is always True in practice and
+                cannot distinguish a genuine warm start from a synthesized one.
         """
         _, _, _, MCMC, NUTS, init_to_uniform, init_to_value = _import_numpyro()
 
@@ -559,10 +650,10 @@ class BayesianMixin:
         # Use provided seed or default to 0 for reproducibility
         rng_seed = seed if seed is not None else 0
 
-        # Warm-start-aware NUTS defaults
-        has_warm_start = (
-            bool(warm_start_values) and hasattr(self, "fitted_") and self.fitted_
-        )
+        # Warm-start-aware NUTS defaults. Gated on the caller-computed
+        # has_explicit_warm_start flag (not re-derived from warm_start_values,
+        # which is always non-empty — see docstring above).
+        has_warm_start = has_explicit_warm_start
         if has_warm_start:
             nuts_kwargs.setdefault("target_accept_prob", 0.90)
             nuts_kwargs.setdefault("max_tree_depth", 8)
@@ -615,8 +706,14 @@ class BayesianMixin:
             rng_key = jax.random.PRNGKey(rng_seed)
             # R12-B-009: include "diverging" so _process_mcmc_results can report
             # per-transition divergence counts without a second MCMC.get_extra_fields() call.
+            # "energy" is the true Hamiltonian (potential + kinetic) NumPyro already
+            # computes every step; requesting it is free and lets bayesian_result.py
+            # report a correct BFMI instead of approximating from potential_energy alone.
             sampler.run(
-                rng_key, X_jax, y_jax, extra_fields=("potential_energy", "diverging")
+                rng_key,
+                X_jax,
+                y_jax,
+                extra_fields=("potential_energy", "energy", "diverging"),
             )
             return sampler
 
@@ -624,7 +721,10 @@ class BayesianMixin:
             logger.debug("Running MCMC sampling")
             result = run_mcmc(init_strategy)
             logger.debug("MCMC sampling completed successfully")
-            self._nuts_init_strategy = "warm_start"
+            # Do NOT unconditionally reset to "warm_start" here: if the
+            # `init_to_value` construction above already failed and downgraded
+            # this to "uniform_fallback", that is what actually ran and must
+            # be preserved for _process_mcmc_results()'s diagnostics.
             return result
         except RuntimeError as e:
             if "Cannot find valid initial parameters" in str(e):
@@ -685,6 +785,16 @@ class BayesianMixin:
             samples_grouped = None
             samples = mcmc.get_samples()
 
+        # Surface the NaN-guard's per-draw activity (numpyro.deterministic
+        # "num_nonfinite" in build_numpyro_model) so a model that is quietly
+        # hitting the ODE NaN guard on a meaningful fraction of draws is
+        # visible in diagnostics instead of silently dropped by the
+        # param_names/sigma-prefix filtering below. Not every model defines
+        # this site, so default to 0 when absent.
+        nonfinite_draws = (
+            int(np.sum(samples["num_nonfinite"])) if "num_nonfinite" in samples else 0
+        )
+
         # Convert to numpy arrays (model parameters only)
         posterior_samples = {}
         for name in param_names:
@@ -743,6 +853,7 @@ class BayesianMixin:
         diagnostics["init_strategy"] = init_strategy
         if init_strategy == "uniform_fallback":
             diagnostics["warm_start_failed"] = True
+        diagnostics["nonfinite_draws"] = nonfinite_draws
 
         return BayesianResult(
             posterior_samples=posterior_samples,
@@ -759,9 +870,14 @@ class BayesianMixin:
     ) -> dict[str, np.ndarray]:
         """Sample from prior distributions over parameter bounds.
 
-        Samples from uniform prior distributions defined by parameter bounds.
-        This is useful for prior predictive checks and understanding the prior's
-        influence on the posterior.
+        Mirrors the exact prior-selection order used by the NUTS model builder
+        (numpyro_model_builder.build_numpyro_model): bayesian_prior_factory
+        override -> Parameter.prior dict (via prior_dict_to_dist) -> alpha-suffixed
+        Beta(2,2) for bounded fractional-order parameters -> Uniform(lower, upper)
+        fallback -> constant for near-degenerate bounds. This guarantees
+        sample_prior() draws from the same distribution NUTS actually samples,
+        which is useful for prior predictive checks and understanding the
+        prior's influence on the posterior.
 
         Args:
             num_samples: Number of samples to draw from prior (default: 1000)
@@ -787,7 +903,9 @@ class BayesianMixin:
                 "Class must have 'parameters' attribute (ParameterSet)"
             )
 
-        rng = np.random.default_rng(seed)
+        _, dist, dist_transforms, *_ = _import_numpyro()
+        key = jax.random.PRNGKey(seed if seed is not None else 0)
+        prior_factory = getattr(self, "bayesian_prior_factory", None)
         prior_samples = {}
 
         for param_name in self.parameters:
@@ -805,16 +923,44 @@ class BayesianMixin:
             lower = float(lower) if lower is not None else -1e10
             upper = float(upper) if upper is not None else 1e10
 
-            # Respect user-specified prior distribution if available
-            prior = getattr(param, "prior", None)
-            if isinstance(prior, dict) and prior.get("type") == "beta":
-                a_val = float(prior.get("a", 2.0))
-                b_val = float(prior.get("b", 2.0))
-                unit_samples = rng.beta(a=a_val, b=b_val, size=num_samples)
-                samples = (lower + unit_samples * (upper - lower)).astype(np.float64)
+            key, subkey = jax.random.split(key)
+
+            # Same selection order as build_numpyro_model's numpyro_model():
+            # 1) bayesian_prior_factory override, 2) Parameter.prior dict,
+            # 3) alpha-suffix Beta(2,2), 4) Uniform fallback (or constant for
+            # near-degenerate bounds).
+            custom_dist = None
+            if callable(prior_factory):
+                custom_dist = prior_factory(param_name, lower, upper)
+
+            if custom_dist is None:
+                param_prior = getattr(param, "prior", None)
+                if isinstance(param_prior, dict):
+                    custom_dist = prior_dict_to_dist(param_prior, dist)
+
+            if custom_dist is not None:
+                samples = np.asarray(
+                    custom_dist.sample(subkey, (num_samples,)), dtype=np.float64
+                )
+            elif param_name.lower().endswith("alpha") and 0.0 <= lower < upper <= 1.0:
+                beta_base = dist.Beta(concentration1=2.0, concentration0=2.0)
+                if lower == 0.0 and upper == 1.0:
+                    beta_dist = beta_base
+                else:
+                    scale = upper - lower
+                    beta_trans = dist_transforms.AffineTransform(loc=lower, scale=scale)
+                    beta_dist = dist.TransformedDistribution(beta_base, beta_trans)
+                samples = np.asarray(
+                    beta_dist.sample(subkey, (num_samples,)), dtype=np.float64
+                )
+            elif abs(upper - lower) < 1e-10 * max(abs(lower), 1.0):
+                # PARAMS-001: near-degenerate bounds — NUTS uses a deterministic
+                # constant rather than sampling, so mirror that here.
+                samples = np.full(num_samples, lower, dtype=np.float64)
             else:
-                samples = rng.uniform(low=lower, high=upper, size=num_samples).astype(
-                    np.float64
+                uniform_dist = dist.Uniform(low=lower, high=upper)
+                samples = np.asarray(
+                    uniform_dist.sample(subkey, (num_samples,)), dtype=np.float64
                 )
 
             prior_samples[param_name] = samples
@@ -910,6 +1056,7 @@ class BayesianMixin:
         y: np.ndarray | None = None,
         test_mode: str | TestMode | None = None,
         num_chains: int = 4,
+        **protocol_kwargs,
     ) -> float:
         """Precompile NUTS kernel to eliminate JIT overhead in subsequent calls.
 
@@ -926,6 +1073,12 @@ class BayesianMixin:
             Sample output data. If None, generates dummy data.
         test_mode : str or TestMode, optional
             Test mode to precompile for. If None, defaults to 'relaxation'.
+        **protocol_kwargs
+            Protocol-specific kwargs (e.g. strain, omega_laos, lam_init) to
+            forward to the model builder. Must match the kwargs the real
+            fit_bayesian() call will use, otherwise the closure cache key
+            computed here will not match the real call's key and the warmed
+            closure will be a cache miss.
 
         Returns
         -------
@@ -971,9 +1124,18 @@ class BayesianMixin:
             self._validate_bayesian_requirements()
             self._validate_parameter_bounds()
 
+            # I/O boundary validation: same check fit_bayesian() enforces —
+            # reject shape-mismatched/ambiguous y before it reaches JAX prep.
+            self._validate_xy_shapes(X_array, y_array)
+
             # Prepare JAX data
             jax_data = self._prepare_jax_data(X_array, y_array)
             is_complex_data = jax_data["is_complex"]
+
+            # I/O boundary validation: same check fit_bayesian() enforces —
+            # callers are expected to pass their real X/y here to warm the
+            # JIT cache (see docstring), so bad input must fail the same way.
+            self._validate_finite_inputs(jax_data["X_jax"], jax_data["y_jax"])
 
             # Get parameter info
             param_names = list(self.parameters)
@@ -986,6 +1148,7 @@ class BayesianMixin:
                 test_mode=test_mode,
                 is_complex_data=is_complex_data,
                 scale_info=jax_data["scale_info"],
+                **protocol_kwargs,
             )
 
             # Build warm-start values
@@ -1013,6 +1176,8 @@ class BayesianMixin:
                     num_chains=num_chains,
                     nuts_kwargs={"progress_bar": False, "target_accept_prob": 0.5},
                     seed=0,
+                    has_explicit_warm_start=hasattr(self, "fitted_")
+                    and self.fitted_,
                 )
             except Exception as e:
                 logger.warning(
@@ -1168,6 +1333,21 @@ class BayesianMixin:
                 self._validate_bayesian_requirements()
                 self._validate_parameter_bounds()
 
+                # Reject initial_values keys that don't match a real parameter
+                # name (typo, stale key from a renamed/dropped parameter) here,
+                # before any warm-start construction. Silently dropping them
+                # would fall back to a midpoint init for that parameter while
+                # has_explicit_warm_start (below) still reports a genuine warm
+                # start, defeating the warm-start contract with no diagnostic.
+                if initial_values:
+                    unknown = set(initial_values) - set(self.parameters)
+                    if unknown:
+                        raise ValueError(
+                            "initial_values contains unrecognized parameter "
+                            f"name(s): {sorted(unknown)}; expected one of "
+                            f"{sorted(self.parameters)}"
+                        )
+
                 # Phase 2: Resolve test_mode and extract data
                 X_array, y_from_rheo, test_mode = self._resolve_test_mode(X, test_mode)
                 y_array = y_from_rheo if y_from_rheo is not None else y
@@ -1176,6 +1356,11 @@ class BayesianMixin:
                         "fit_bayesian() requires `y` when `X` is not a RheoData "
                         "instance (no observations to fit)."
                     )
+
+                # I/O boundary validation: reject shape-mismatched/ambiguous y
+                # (e.g. an accidental (N, 1) column vector) before it reaches
+                # _prepare_jax_data's complex real/imag split.
+                self._validate_xy_shapes(X_array, y_array)
 
                 # R12-B-004: On success, _test_mode is permanently updated.
                 self._test_mode = test_mode
@@ -1204,6 +1389,13 @@ class BayesianMixin:
                 y_jax = jax_data["y_jax"]
                 is_complex_data = jax_data["is_complex"]
                 scale_info = jax_data["scale_info"]
+
+                # I/O boundary validation: reject NaN/Inf in X or y before they
+                # reach NUTS (see _validate_finite_inputs), where they'd
+                # otherwise produce silent divergences or opaque sampler
+                # failures instead of a clear error. The y<=0 check below does
+                # not catch +/-Inf on its own (Inf > 0 is True).
+                self._validate_finite_inputs(X_jax, y_jax)
 
                 # Log-space likelihood requires real, strictly positive data
                 # (LogNormal support is (0, ∞)). Fail loudly rather than produce
@@ -1252,6 +1444,9 @@ class BayesianMixin:
                 )
 
                 # Phase 8: Run NUTS sampling with multi-chain parallelization
+                has_explicit_warm_start = bool(initial_values) or (
+                    hasattr(self, "fitted_") and self.fitted_
+                )
                 mcmc = self._run_nuts_sampling(
                     numpyro_model=numpyro_model,
                     X_jax=X_jax,
@@ -1262,6 +1457,7 @@ class BayesianMixin:
                     num_chains=num_chains,
                     nuts_kwargs=nuts_kwargs,
                     seed=seed,
+                    has_explicit_warm_start=has_explicit_warm_start,
                 )
 
                 # Phase 9: Process results
@@ -1270,7 +1466,9 @@ class BayesianMixin:
                 )
 
                 # Add diagnostics to log context
-                log_ctx["divergences"] = result.diagnostics.get("divergences", 0)
+                divergences = result.diagnostics.get("divergences", 0)
+                diagnostics_valid = result.diagnostics.get("diagnostics_valid", True)
+                log_ctx["divergences"] = divergences
                 r_hat_vals = result.diagnostics.get("r_hat", {}).values()
                 ess_vals = result.diagnostics.get("ess", {}).values()
                 _finite_r_hats = [v for v in r_hat_vals if np.isfinite(v)]
@@ -1283,10 +1481,33 @@ class BayesianMixin:
                 logger.info(
                     "Bayesian inference completed",
                     model=model_name,
-                    divergences=result.diagnostics.get("divergences", 0),
+                    divergences=divergences,
                     r_hat_max=max_r_hat,
                     ess_min=min_ess,
                 )
+
+                # Fail loudly (not just via logger, which may have no handler
+                # configured — see NullHandler default) when diagnostics
+                # indicate the posterior may not be trustworthy: divergences,
+                # an R-hat above the canonical convergence threshold, or
+                # compute_diagnostics itself flagging diagnostics_valid=False.
+                if (
+                    (np.isfinite(max_r_hat) and max_r_hat > R_HAT_THRESHOLD)
+                    or divergences > 0
+                    or not diagnostics_valid
+                    or (np.isfinite(min_ess) and min_ess < ESS_THRESHOLD)
+                ):
+                    warnings.warn(
+                        "Bayesian fit has questionable convergence diagnostics: "
+                        f"max R-hat={max_r_hat:.4f} (threshold {R_HAT_THRESHOLD}), "
+                        f"divergences={divergences}, "
+                        f"min ESS={min_ess:.1f} (threshold {ESS_THRESHOLD}), "
+                        f"diagnostics_valid={diagnostics_valid}. Inspect "
+                        "result.diagnostics and trace plots before trusting "
+                        "the posterior.",
+                        RuntimeWarning,
+                        stacklevel=2,
+                    )
 
                 _fit_bayesian_succeeded = True
                 return result

--- a/rheojax/core/bayesian_diagnostics.py
+++ b/rheojax/core/bayesian_diagnostics.py
@@ -17,6 +17,10 @@ from rheojax.logging import get_logger
 
 logger = get_logger(__name__)
 
+# E-BFMI below this threshold indicates poor HMC/NUTS mixing even when
+# R-hat/ESS look fine (Betancourt 2017 rule of thumb).
+BFMI_THRESHOLD = 0.3
+
 if TYPE_CHECKING:
     from numpyro.infer import MCMC
 
@@ -37,8 +41,10 @@ def compute_per_param_diagnostic(
 ) -> tuple[dict[str, float], bool]:
     """Compute a per-parameter diagnostic (R-hat or ESS).
 
-    Reshapes flat posterior samples to (num_chains, num_samples) and applies
-    the given NumPyro diagnostic function to each parameter.
+    Reshapes flat posterior samples to (num_chains, -1), inferring per-chain
+    length rather than using num_samples directly (see inline comment below —
+    accounts for thinning/warmup/early-stopping), and applies the given
+    NumPyro diagnostic function to each parameter.
 
     Args:
         posterior_samples: Parameter name -> flat samples array.
@@ -66,6 +72,11 @@ def compute_per_param_diagnostic(
             else:
                 samples_shaped = samples_arr.reshape(1, -1)
             result_dict[name] = float(diagnostic_fn(samples_shaped))
+            if not np.isfinite(result_dict[name]):
+                # A degenerate/stuck chain makes numpyro's diagnostic_fn return
+                # NaN/Inf *without* raising — must be flagged here too, not just
+                # in the except branch below, or diagnostics_valid stays True.
+                all_succeeded = False
         except Exception as exc:
             # R12-B-008: log array size and chain count to help diagnose
             # reshape failures caused by unexpected sample counts (e.g., thinning
@@ -91,6 +102,64 @@ def compute_per_param_diagnostic(
     return result_dict, all_succeeded
 
 
+def compute_bfmi(mcmc: MCMC, num_chains: int = 1) -> float:
+    """Compute the worst-chain E-BFMI (energy Bayesian fraction of missing info).
+
+    Formula: ``mean(diff(energy)**2) / var(energy)``, evaluated per chain and
+    reduced to the minimum (worst-mixing chain). Values below ~0.3 indicate
+    poor HMC/NUTS mixing even when R-hat/ESS look fine. Matches the formula
+    in rheojax.gui.foundation.metrics.bfmi.
+
+    Args:
+        mcmc: NumPyro MCMC object after sampling.
+        num_chains: Number of MCMC chains, used only on the legacy fallback
+            path (get_extra_fields() without group_by_chain support) to
+            reshape the flat concatenated energy trace back into per-chain
+            rows. Mirrors the reshape-with-fallback pattern already used in
+            bayesian_result.py for the same TypeError branch.
+
+    Returns NaN if the "energy" extra field is unavailable (e.g. mcmc.run()
+    was not called with extra_fields including "energy").
+    """
+    try:
+        try:
+            extra = mcmc.get_extra_fields(group_by_chain=True)
+        except TypeError:
+            extra = mcmc.get_extra_fields()
+        energy = np.asarray(extra["energy"], dtype=float)
+    except Exception:
+        return float("nan")
+
+    if energy.ndim == 1:
+        if num_chains > 1:
+            try:
+                energy = energy.reshape(num_chains, -1)
+            except ValueError:
+                energy = energy[None, :]
+        else:
+            energy = energy[None, :]
+    chain_bfmis = []
+    for chain_energy in energy:
+        denom = np.var(chain_energy)
+        chain_bfmis.append(
+            0.0 if denom == 0.0 else float(np.mean(np.diff(chain_energy) ** 2) / denom)
+        )
+    if not chain_bfmis:
+        return float("nan")
+    arr = np.asarray(chain_bfmis, dtype=float)
+    n_nan = int(np.isnan(arr).sum())
+    if n_nan == arr.size:
+        return float("nan")
+    if n_nan > 0:
+        logger.warning(
+            "BFMI: chains had non-finite energy trace, excluded from "
+            "worst-chain reduction",
+            excluded_chains=n_nan,
+            total_chains=int(arr.size),
+        )
+    return float(np.nanmin(arr))
+
+
 def compute_diagnostics(
     mcmc: MCMC,
     posterior_samples: dict[str, np.ndarray],
@@ -110,6 +179,7 @@ def compute_diagnostics(
             - r_hat: R-hat (Gelman-Rubin) statistic per parameter (NaN if failed)
             - ess: Effective sample size per parameter (NaN if failed)
             - divergences: Number of divergent transitions (-1 if unknown)
+            - bfmi: Worst-chain E-BFMI (NaN if the energy extra field is unavailable)
             - diagnostics_valid: Whether all diagnostics computed successfully
     """
     numpyro_diag = _import_numpyro_diagnostics()
@@ -144,7 +214,13 @@ def compute_diagnostics(
             except TypeError:
                 divergences = mcmc.get_extra_fields()["diverging"]
             num_divergences = int(np.sum(divergences))
-        except (KeyError, AttributeError):
+        except Exception:
+            # Broad catch (matches compute_per_param_diagnostic's pattern, R12-B-010):
+            # r_hat/ess above may have already succeeded and are stored in
+            # `diagnostics`. A narrower clause here would let an unrelated
+            # divergence-counting failure (e.g. RuntimeError/ValueError/IndexError
+            # from a numpyro version mismatch) propagate to the outer handler,
+            # which would then discard those already-successful results.
             logger.warning(
                 "Divergence information not available from MCMC extra fields. "
                 "Divergence count is unknown — inspect trace plots manually."
@@ -156,6 +232,16 @@ def compute_diagnostics(
         diagnostics["total_samples"] = int(num_samples * num_chains)
         diagnostics["num_chains"] = int(num_chains)
         diagnostics["num_samples_per_chain"] = int(num_samples)
+        # R12-B-0xx: BFMI catches energy-transition pathologies that R-hat/ESS
+        # can miss entirely. NaN (energy field not requested) is not treated
+        # as a diagnostics failure — it's a normal "unavailable" state, same
+        # as the divergences=-1 convention above. A *finite* BFMI below
+        # BFMI_THRESHOLD, however, is a genuine pathology and must gate
+        # diagnostics_valid the same way a bad r_hat/ess does.
+        bfmi = compute_bfmi(mcmc, num_chains)
+        diagnostics["bfmi"] = bfmi
+        if np.isfinite(bfmi) and bfmi < BFMI_THRESHOLD:
+            all_valid = False
 
     except Exception as e:
         logger.error(
@@ -176,6 +262,7 @@ def compute_diagnostics(
         diagnostics["total_samples"] = int(num_samples * num_chains)
         diagnostics["num_chains"] = int(num_chains)
         diagnostics["num_samples_per_chain"] = int(num_samples)
+        diagnostics["bfmi"] = float("nan")
         diagnostics["error"] = str(e)
         all_valid = False
 
@@ -194,6 +281,8 @@ def compute_diagnostics(
 
 
 __all__ = [
+    "BFMI_THRESHOLD",
+    "compute_bfmi",
     "compute_diagnostics",
     "compute_per_param_diagnostic",
 ]

--- a/rheojax/core/bayesian_result.py
+++ b/rheojax/core/bayesian_result.py
@@ -32,9 +32,11 @@ class DiagnosticsDict(TypedDict, total=False):
     error: str
     init_strategy: str
     warm_start_failed: bool
+    bfmi: float
+    nonfinite_draws: int
 
 
-@dataclass
+@dataclass(eq=False)
 class BayesianResult:
     """Results from Bayesian inference with NUTS sampling.
 
@@ -97,6 +99,32 @@ class BayesianResult:
         logger.debug(
             "BayesianResult initialized",
             parameter_names=list(self.posterior_samples.keys()),
+        )
+
+    def __eq__(self, other: object) -> bool:
+        """Compare results by value, using np.array_equal for posterior_samples.
+
+        The default dataclass __eq__ would crash (ValueError) whenever any
+        posterior_samples array has more than one element, because tuple/dict
+        equality forces bool() on the ndarray comparison result. mcmc and the
+        cached InferenceData objects are excluded as not meaningfully
+        comparable via value equality.
+        """
+        if not isinstance(other, BayesianResult):
+            return NotImplemented
+        if self.posterior_samples.keys() != other.posterior_samples.keys():
+            return False
+        if not all(
+            np.array_equal(self.posterior_samples[k], other.posterior_samples[k])
+            for k in self.posterior_samples
+        ):
+            return False
+        return (
+            self.summary == other.summary
+            and self.diagnostics == other.diagnostics
+            and self.num_samples == other.num_samples
+            and self.num_chains == other.num_chains
+            and self.model_comparison == other.model_comparison
         )
 
     def to_inference_data(self, log_likelihood: bool = False) -> Any:
@@ -245,8 +273,14 @@ class BayesianResult:
                         shaped = np_arr[np.newaxis, :]
                     posterior_dict[name] = xr.DataArray(shaped, dims=("chain", "draw"))
         except Exception as exc:
-            # Fall back to posterior_samples (already numpy, already on host)
-            logger.debug(
+            # Fall back to posterior_samples (already numpy, already on host).
+            # Reset any partially-populated entries so a mid-loop failure
+            # can't leave an internally-inconsistent subset of fields
+            # silently attached, and log at WARNING (not DEBUG) so the drop
+            # is visible at normal verbosity instead of only in debug logs
+            # (mirrors the sample_stats fallback below).
+            posterior_dict = {}
+            logger.warning(
                 "get_samples(group_by_chain=True) failed, using posterior_samples",
                 error=str(exc),
             )
@@ -277,6 +311,11 @@ class BayesianResult:
             if isinstance(extra_fields, dict):
                 for stat, value in extra_fields.items():
                     if isinstance(value, (dict, tuple)):
+                        logger.debug(
+                            "Skipping sample_stats field: unsupported container type",
+                            stat=stat,
+                            value_type=type(value).__name__,
+                        )
                         continue
                     arr = np.asarray(value)
                     # Ensure (chain, draw) shape
@@ -286,24 +325,54 @@ class BayesianResult:
                         except ValueError:
                             arr = arr[np.newaxis, :]
                     elif arr.ndim != 2:
+                        logger.debug(
+                            "Skipping sample_stats field: unexpected ndim",
+                            stat=stat,
+                            ndim=arr.ndim,
+                        )
                         continue  # Skip unexpected shapes
 
-                    # Match ArviZ's NumPyroConverter: potential_energy → negated "lp".
-                    # Also synthesise "energy" from potential_energy so that
-                    # ArviZ's plot_energy() works out of the box.  True HMC
-                    # energy = potential + kinetic, but potential_energy alone is
-                    # the standard proxy when kinetic energy is not stored.
+                    # Match ArviZ's real NumPyroConverter.sample_stats_to_xarray():
+                    # potential_energy -> "lp" verbatim, no sign flip. "energy" (the
+                    # true Hamiltonian = potential + kinetic) is passed through as-is
+                    # when NumPyro provided it via extra_fields; see fallback below
+                    # for older MCMC objects that only requested potential_energy.
                     if stat == "potential_energy":
-                        stats_dict["lp"] = xr.DataArray(-arr, dims=("chain", "draw"))
+                        stats_dict["lp"] = xr.DataArray(arr, dims=("chain", "draw"))
+                    elif stat == "energy":
                         stats_dict["energy"] = xr.DataArray(arr, dims=("chain", "draw"))
                     else:
                         dest_name = _stat_rename.get(stat, stat)
                         stats_dict[dest_name] = xr.DataArray(
                             arr, dims=("chain", "draw")
                         )
+
+                # Fallback only: older MCMC objects that never requested the real
+                # "energy" extra field. Approximate it from potential_energy alone
+                # and say so — this proxy omits kinetic energy, so BFMI computed
+                # from it is approximate, not the exact E-BFMI statistic.
+                if "energy" not in stats_dict and "lp" in stats_dict:
+                    logger.warning(
+                        "NumPyro extra_fields did not include 'energy' (true "
+                        "Hamiltonian); approximating sample_stats['energy'] from "
+                        "potential_energy alone. BFMI computed from this proxy "
+                        "will be approximate.",
+                    )
+                    stats_dict["energy"] = xr.DataArray(
+                        stats_dict["lp"].values, dims=("chain", "draw")
+                    )
         except Exception as exc:
-            logger.debug(
-                "Failed to extract sample_stats from MCMC extra fields",
+            # sample_stats is a best-effort group here (posterior-only callers,
+            # e.g. WAIC/LOO consumers, must not break on an unrelated failure
+            # in this block). Reset any partially-populated stats so a
+            # mid-loop failure can't leave an internally-inconsistent subset
+            # of fields silently attached, and log at WARNING (not DEBUG) so
+            # the drop is visible at normal verbosity instead of only in
+            # debug logs.
+            stats_dict = {}
+            logger.warning(
+                "Failed to extract sample_stats from MCMC extra fields; "
+                "sample_stats group will be absent from InferenceData",
                 error=str(exc),
             )
 

--- a/rheojax/core/data.py
+++ b/rheojax/core/data.py
@@ -55,6 +55,20 @@ def _coerce_ndarray(data: ArrayLike | jnp_typing.ndarray | None) -> np.ndarray:
     return np.asarray(data)
 
 
+def _check_dtype(arr: np.ndarray, name: str, *, allow_complex: bool = False) -> None:
+    """Raise if arr's dtype is not numeric.
+
+    Rejects bool and object dtypes (e.g. an accidental 0/1 mask array),
+    which would otherwise silently pass NaN/finite checks and be treated
+    as real physical data.
+    """
+    kind = arr.dtype.kind
+    allowed_kinds = "fiu" + ("c" if allow_complex else "")
+    if kind not in allowed_kinds:
+        kinds_desc = "floating/integer" + (" or complex" if allow_complex else "")
+        raise ValueError(f"{name} data must be {kinds_desc}, got dtype {arr.dtype}")
+
+
 @dataclass
 class RheoData:
     """JAX-native container for rheological data with NumPy/JAX array support.
@@ -96,9 +110,9 @@ class RheoData:
         )
 
         # Normalize metadata container (defensive — callers may pass None explicitly,
-        # bypassing the type checker since dataclasses do not validate at runtime).
-        if self.metadata is None:
-            self.metadata = {}  # type: ignore[unreachable]
+        # bypassing the type checker since dataclasses do not validate at runtime)
+        # and always copy so two RheoData instances never alias the same dict.
+        self.metadata = dict(self.metadata) if self.metadata else {}
 
         # Persist explicitly provided test mode into metadata and internal cache
         if initial_test_mode is not None:
@@ -133,7 +147,30 @@ class RheoData:
             y_dtype=str(y_array.dtype),
         )
 
-        # Validate shapes — allow (N,) x with (N,2) y for DMTA/GMM complex data
+        if x_array.ndim == 0 or y_array.ndim == 0:
+            logger.error(
+                "Scalar (0-d) x or y data provided",
+                x_shape=x_array.shape,
+                y_shape=y_array.shape,
+            )
+            raise ValueError(
+                "x and y must be at least 1-dimensional arrays, got 0-d input"
+            )
+
+        if x_array.ndim > 1:
+            logger.error("x data is not 1-dimensional", x_shape=x_array.shape)
+            raise ValueError(f"x must be 1-dimensional, got shape {x_array.shape}")
+
+        # Validate shapes — allow (N,) x with (N,2) y for DMTA/GMM complex
+        # data (G', G'' as separate columns). is_complex/y_real/y_imag/etc.
+        # below recognize this (N,2) convention as well as complex dtype.
+        if y_array.ndim > 2 or (y_array.ndim == 2 and y_array.shape[1] != 2):
+            logger.error("y data has unsupported shape", y_shape=y_array.shape)
+            raise ValueError(
+                f"y must be 1-dimensional (real/complex), or 2-dimensional with "
+                f"shape (N, 2) for the DMTA/GMM G'/G'' convention. Got shape {y_array.shape}"
+            )
+
         if x_array.shape[0] != y_array.shape[0]:
             logger.error(
                 "Shape mismatch between x and y data",
@@ -172,8 +209,15 @@ class RheoData:
         """Validate data for common issues."""
         logger.debug(
             "Validating data",
-            checks=["nan", "finite", "monotonic", "negative_frequency"],
+            checks=["dtype", "nan", "finite", "monotonic", "negative_frequency"],
         )
+
+        # Reject non-numeric dtypes (bool masks, object arrays) before the
+        # NaN/finite checks below — those checks trivially pass for bool/int
+        # data (never NaN, always finite), so a stray mask array would
+        # otherwise be silently treated as real physical data.
+        _check_dtype(_coerce_ndarray(self.x), "x")
+        _check_dtype(_coerce_ndarray(self.y), "y", allow_complex=True)
 
         # Check for NaN values first (NaN is also non-finite)
         if isinstance(self.x, np.ndarray):
@@ -378,11 +422,15 @@ class RheoData:
         return data_dict
 
     @classmethod
-    def from_dict(cls, data_dict: dict[str, Any]) -> RheoData:
+    def from_dict(cls, data_dict: dict[str, Any], validate: bool = True) -> RheoData:
         """Create from dictionary representation.
 
         Args:
             data_dict: Dictionary with data and metadata
+            validate: Whether to validate the deserialized data (NaN/Inf/
+                monotonicity checks). Defaults to True since this is a
+                deserialization boundary for potentially external/edited
+                payloads, matching the primary constructor's default.
 
         Returns:
             RheoData instance
@@ -404,7 +452,7 @@ class RheoData:
             domain=data_dict.get("domain", "time"),
             metadata=dict(metadata),
             initial_test_mode=test_mode,
-            validate=False,
+            validate=validate,
         )
 
     # NumPy-like interface
@@ -430,25 +478,37 @@ class RheoData:
 
     @property
     def is_complex(self) -> bool:
-        """Check if y data is complex."""
-        return np.iscomplexobj(_coerce_ndarray(self.y))
+        """Check if y data represents complex modulus data.
+
+        True for complex-dtype y (G* = G' + i*G'') and for the real-valued
+        (N,2) DMTA/GMM convention (G', G'' as separate columns) — both
+        encode the same storage/loss modulus split; see y_real/y_imag.
+        """
+        y = _coerce_ndarray(self.y)
+        return bool(np.iscomplexobj(y) or (y.ndim == 2 and y.shape[1] == 2))
 
     @property
     def modulus(self) -> np.ndarray | None:
-        """Get modulus of complex data."""
+        """Get modulus of complex modulus data (|G*| = sqrt(G'^2 + G''^2))."""
         if self.is_complex:
             if self.y is None:
                 raise ValueError("RheoData.modulus requires non-None y data")
-            return np.abs(self.y)
+            G_prime, G_double_prime = self.y_real, self.y_imag
+            if isinstance(self.y, jnp.ndarray):
+                return jnp.sqrt(G_prime**2 + G_double_prime**2)
+            return np.sqrt(G_prime**2 + G_double_prime**2)
         return None
 
     @property
     def phase(self) -> np.ndarray | None:
-        """Get phase of complex data."""
+        """Get phase angle of complex modulus data (delta = atan2(G'', G'))."""
         if self.is_complex:
             if self.y is None:
                 raise ValueError("RheoData.phase requires non-None y data")
-            return np.angle(self.y)
+            G_prime, G_double_prime = self.y_real, self.y_imag
+            if isinstance(self.y, jnp.ndarray):
+                return jnp.arctan2(G_double_prime, G_prime)
+            return np.arctan2(G_double_prime, G_prime)
         return None
 
     @property
@@ -456,7 +516,9 @@ class RheoData:
         """Get real component of y data.
 
         For complex modulus data (G* = G' + i·G''), this returns the storage
-        modulus (G'). For real data, returns y unchanged.
+        modulus (G'). For the real-valued (N,2) DMTA/GMM convention (G', G''
+        as separate columns), this returns column 0 (G'). For plain real
+        data, returns y unchanged.
 
         Returns:
             Real component of y data (G' for complex modulus)
@@ -469,10 +531,14 @@ class RheoData:
         if self.y is None:
             raise ValueError("RheoData.y_real requires non-None y data")
         y = self.y
-        if self.is_complex:
+        y_np = _coerce_ndarray(y)
+        if np.iscomplexobj(y_np):
             if isinstance(y, jnp.ndarray):
                 return jnp.real(y)
             return np.real(y)
+        if y_np.ndim == 2 and y_np.shape[1] == 2:
+            # (N,2) DMTA/GMM convention: column 0 is G' (storage modulus)
+            return y[:, 0]
         # Invariant: __post_init__ always converts x/y via _ensure_array, so y is
         # never a bare list/tuple here — narrow for mypy, raise loudly if violated.
         if not isinstance(y, (np.ndarray, jnp.ndarray)):
@@ -486,7 +552,9 @@ class RheoData:
         """Get imaginary component of y data.
 
         For complex modulus data (G* = G' + i·G''), this returns the loss
-        modulus (G''). For real data, returns zeros.
+        modulus (G''). For the real-valued (N,2) DMTA/GMM convention (G', G''
+        as separate columns), this returns column 1 (G''). For plain real
+        data, returns zeros.
 
         Returns:
             Imaginary component of y data (G'' for complex modulus)
@@ -499,10 +567,14 @@ class RheoData:
         if self.y is None:
             raise ValueError("RheoData.y_imag requires non-None y data")
         y = self.y
-        if self.is_complex:
+        y_np = _coerce_ndarray(y)
+        if np.iscomplexobj(y_np):
             if isinstance(y, jnp.ndarray):
                 return jnp.imag(y)
             return np.imag(y)
+        if y_np.ndim == 2 and y_np.shape[1] == 2:
+            # (N,2) DMTA/GMM convention: column 1 is G'' (loss modulus)
+            return y[:, 1]
         if isinstance(y, jnp.ndarray):
             return jnp.zeros_like(y)
         return np.zeros_like(y)
@@ -578,16 +650,10 @@ class RheoData:
         Returns:
             Test mode string (relaxation, creep, oscillation, rotation, unknown)
         """
-        # Prefer explicitly provided test mode
-        if self._explicit_test_mode is not None:
-            return self._explicit_test_mode
-
-        # R8-DATA-001: check private cache first, avoid shared metadata dict
-        _cached = getattr(self, "_detected_test_mode", None)
-        if _cached is not None:
-            return _cached
-
-        # Check if already set in metadata (explicit or previously detected)
+        # metadata['test_mode'] is the live source of truth: check it first so a
+        # direct `data.metadata['test_mode'] = ...` mutation takes effect, matching
+        # this docstring's contract instead of silently deferring to the frozen
+        # _explicit_test_mode snapshot taken at construction time.
         if "test_mode" in self.metadata:
             _raw = self.metadata["test_mode"]
             try:
@@ -596,6 +662,16 @@ class RheoData:
                 return TestMode(_raw.lower()).value if isinstance(_raw, str) else _raw
             except (ValueError, AttributeError):
                 return _raw
+
+        # R8-DATA-001: check private cache first, avoid shared metadata dict
+        _cached = getattr(self, "_detected_test_mode", None)
+        if _cached is not None:
+            return _cached
+
+        # Fall back to explicitly provided test mode (kept for the case where
+        # _explicit_test_mode was set without a corresponding metadata entry)
+        if self._explicit_test_mode is not None:
+            return self._explicit_test_mode
 
         # Lazy import to avoid circular dependency
         from rheojax.core.test_modes import detect_test_mode
@@ -756,14 +832,18 @@ class RheoData:
         if len(x_for_interp) > 1:
             x_np = _coerce_ndarray(x_for_interp)
             diffs = np.diff(x_np)
-            if np.all(diffs < 0):  # strictly decreasing
-                # Reverse both arrays to make x increasing
+            if not np.all(diffs > 0):  # not already strictly increasing
+                # Covers both the strictly-decreasing case and genuinely
+                # unsorted/mixed-sign x (which _validate_data only warns
+                # about) — np.interp/jnp.interp silently produce wrong
+                # values unless x is increasing.
+                order = np.argsort(x_np)
                 if isinstance(x_for_interp, jnp.ndarray):
-                    x_for_interp = jnp.flip(x_for_interp)
-                    y_for_interp = jnp.flip(y_for_interp)
+                    x_for_interp = x_for_interp[order]
+                    y_for_interp = y_for_interp[order]
                 else:
-                    x_for_interp = np.flip(x_for_interp)
-                    y_for_interp = np.flip(y_for_interp)
+                    x_for_interp = np.asarray(x_for_interp)[order]
+                    y_for_interp = np.asarray(y_for_interp)[order]
 
         if np.iscomplexobj(y_for_interp):
             # Complex data: interpolate real and imaginary parts separately.
@@ -896,6 +976,13 @@ class RheoData:
         else:
             dy_dx = np.gradient(y, x)
 
+        if not np.all(np.isfinite(np.asarray(dy_dx))):
+            logger.error("derivative() produced non-finite values")
+            raise ValueError(
+                "derivative() produced non-finite values; check for "
+                "duplicate/zero-spacing x values"
+            )
+
         return RheoData(
             x=self.x,
             y=dy_dx,
@@ -957,7 +1044,7 @@ class RheoData:
         Returns:
             Frequency domain RheoData
         """
-        if self.domain != "time":
+        if self.domain == "frequency":
             logger.debug("Data is already in frequency domain")
             warnings.warn(
                 "Data is already in frequency domain", UserWarning, stacklevel=2
@@ -976,7 +1063,7 @@ class RheoData:
         Returns:
             Time domain RheoData
         """
-        if self.domain != "frequency":
+        if self.domain == "time":
             logger.debug("Data is already in time domain")
             warnings.warn("Data is already in time domain", UserWarning, stacklevel=2)
             return self.copy()

--- a/rheojax/core/fit_orchestrator.py
+++ b/rheojax/core/fit_orchestrator.py
@@ -91,10 +91,32 @@ class FitOrchestrator:
                 "for X with a non-None y."
             )
 
+        # --- I/O boundary validation (shape/NaN/monotonicity) ---
+        # Reuses RheoData's own validation (shape-match + NaN/finite raise,
+        # non-monotonic x warns) so raw-array fit() calls get the same checks
+        # a RheoData-wrapped call already received via __post_init__.
+        self._validate_fit_data(X, y, kwargs.get("test_mode"))
+
+        # --- fail fast on an invalid uncertainty method ---
+        # Must happen before model._fit() runs: a bad method name is a caller
+        # error and should never be discovered only after an expensive fit
+        # already committed (model.fitted_ = True) further down.
+        if uncertainty is not None and uncertainty not in ("hessian", "bootstrap"):
+            raise ValueError(
+                f"Unknown uncertainty method: {uncertainty!r}. "
+                "Expected 'hessian' or 'bootstrap'."
+            )
+
+        # --- sort into ascending x order ---
+        # Non-monotonic x only warns above; many models (cumulative/ODE
+        # integration schemes) assume ascending x and would silently produce
+        # a wrong-but-converged fit otherwise. Mirrors the sort
+        # RheoData.interpolate() already performs for the same reason.
+        X, y = self._sort_by_x(X, y)
+
         # --- store data for Bayesian warm-start ---
         model.X_data = X
         model.y_data = y
-        self._normalize_stored_data(model)
 
         # --- optimization strategy auto-detection ---
         use_log_residuals, use_multi_start = model._detect_optimization_strategy(
@@ -120,11 +142,12 @@ class FitOrchestrator:
             method = "auto"
 
         # --- delegate to model._fit() ---
+        # NOTE: only model._fit() is wrapped here. Post-fit bookkeeping
+        # (fitted_ flag, kwarg stripping, completion logging) runs
+        # unconditionally below so a bug in that bookkeeping is never
+        # misreported as a fit failure after the optimizer already succeeded.
         try:
             model._fit(X, y, method=method, **kwargs)
-            model.fitted_ = True
-            self._strip_optimization_kwargs(model)
-            self._log_fit_completion(model, X, y, data_shape)
         except RuntimeError as e:
             logger.error(
                 "Fit failed with RuntimeError",
@@ -132,9 +155,9 @@ class FitOrchestrator:
                 error=str(e),
                 exc_info=True,
             )
-            if return_result:
-                return model._make_error_result(test_mode, e)
             enhanced = model._enhance_error_with_compatibility(e, X, y, test_mode)
+            if return_result:
+                return model._make_error_result(test_mode, enhanced)
             if enhanced is not e:
                 raise enhanced from e
             raise
@@ -149,6 +172,11 @@ class FitOrchestrator:
                 return model._make_error_result(test_mode, e)
             raise
 
+        # --- post-fit bookkeeping (never conflated with _fit() failures) ---
+        model.fitted_ = True
+        self._strip_optimization_kwargs(model)
+        self._log_fit_completion(model, X, y, data_shape)
+
         # --- post-fit physics check ---
         if check_physics:
             _validator.check_physics(model)
@@ -159,6 +187,27 @@ class FitOrchestrator:
             _uncertainty_result = _validator.compute_uncertainty(
                 model, X, y, uncertainty, test_mode
             )
+            # Attach regardless of return_result so the (possibly expensive)
+            # computation is never silently discarded.
+            model.uncertainty_ = _uncertainty_result
+            model.uncertainty_method_ = uncertainty
+            if not return_result:
+                if _uncertainty_result is not None:
+                    logger.info(
+                        "Uncertainty computed but return_result=False; "
+                        "result stored on model.uncertainty_ (not in a FitResult)",
+                        model=model.__class__.__name__,
+                        method=uncertainty,
+                    )
+                else:
+                    # compute_uncertainty() already logged a WARNING on
+                    # failure; don't also claim success here (model.uncertainty_
+                    # is None, not a usable result).
+                    logger.info(
+                        "Uncertainty computation failed; model.uncertainty_ is None",
+                        model=model.__class__.__name__,
+                        method=uncertainty,
+                    )
 
         # --- build FitResult if requested ---
         if return_result:
@@ -181,6 +230,11 @@ class FitOrchestrator:
         """Extract arrays and test_mode from RheoData."""
         from rheojax.core.data import RheoData
 
+        if isinstance(y, RheoData):
+            raise ValueError(
+                "y must be a plain array; RheoData should be passed as X "
+                "(with y=None), not as y."
+            )
         if isinstance(X, RheoData):
             _metadata = X.metadata
             # R10-BASE-001: propagate test_mode from RheoData
@@ -196,14 +250,47 @@ class FitOrchestrator:
         return X, y, kwargs
 
     @staticmethod
-    def _normalize_stored_data(model: Any) -> None:
-        """Ensure model.X_data / y_data are raw arrays, not RheoData."""
-        from rheojax.core.data import RheoData as _RheoData
+    def _validate_fit_data(
+        X: ArrayLike, y: ArrayLike, test_mode: str | None = None
+    ) -> None:
+        """Validate shape/NaN/monotonicity on the unpacked fit arrays.
 
-        if isinstance(model.X_data, _RheoData):
-            model.X_data = model.X_data.x
-        if isinstance(model.y_data, _RheoData):
-            model.y_data = model.y_data.y
+        Constructs a throwaway :class:`RheoData` to reuse its existing
+        validation logic (shape mismatch and NaN/non-finite values raise
+        ``ValueError``; non-monotonic x only warns). This closes the gap
+        where raw-array ``fit(X, y)`` calls previously received none of the
+        I/O-boundary checks that RheoData-wrapped calls already get via
+        ``RheoData.__post_init__``.
+
+        ``domain`` is resolved the same way ``_standard_nlsq_fit`` resolves
+        oscillation mode (explicit ``test_mode`` kwarg, else complex ``y``),
+        so the frequency-domain negative-value check in
+        ``RheoData._validate_data`` also runs for raw-array oscillation
+        fits (``domain`` otherwise defaults to "time" and skips that check).
+        """
+        from rheojax.core.data import RheoData
+
+        domain = (
+            "frequency"
+            if test_mode == "oscillation" or np.iscomplexobj(np.asarray(y))
+            else "time"
+        )
+        RheoData(x=X, y=y, domain=domain, validate=True)
+
+    @staticmethod
+    def _sort_by_x(X: ArrayLike, y: ArrayLike) -> tuple[ArrayLike, ArrayLike]:
+        """Sort X (and y in lockstep) into strictly ascending order.
+
+        No-op if X is already ascending (the common case) or not a plain
+        1-D sequence. See RheoData.interpolate() (data.py) for the same
+        sort, needed for the same reason: order-sensitive numerics silently
+        produce wrong results on unsorted input.
+        """
+        x_np = np.asarray(X)
+        if x_np.ndim != 1 or len(x_np) < 2 or np.all(np.diff(x_np) > 0):
+            return X, y
+        order = np.argsort(x_np)
+        return np.asarray(X)[order], np.asarray(y)[order]
 
     @staticmethod
     def _run_auto_init(
@@ -213,15 +300,19 @@ class FitOrchestrator:
             from rheojax.utils.initialization.auto_p0 import auto_p0 as _auto_p0
 
             p0 = _auto_p0(X, y, model, test_mode=test_mode)
+            failed_params = []
             for name, value in p0.items():
                 try:
                     model.parameters.set_value(name, value)
                 except (KeyError, ValueError):
-                    pass
-            logger.info(
+                    failed_params.append(name)
+            _log = logger.warning if failed_params else logger.info
+            _log(
                 "auto_p0 initialized parameters",
                 model=model.__class__.__name__,
-                n_params_set=len(p0),
+                n_params_set=len(p0) - len(failed_params),
+                n_params_failed=len(failed_params),
+                failed_params=failed_params,
             )
         except Exception as exc:
             logger.warning(
@@ -273,28 +364,20 @@ class FitOrchestrator:
         r2 = None
         if logger.isEnabledFor(logging.DEBUG):
             try:
-                from rheojax.core.data import RheoData as _RheoData
-
-                _X_score = X.x if isinstance(X, _RheoData) else X
+                # X is always a plain array here: execute() unpacks any
+                # RheoData into a plain array (via _unpack_rheodata) before
+                # this is ever called, and this is its only caller.
+                _X_score = X
                 _y_score = y
 
-                if (
-                    getattr(model, "_nlsq_result", None) is not None
-                    and model._nlsq_result.fun is not None
-                ):
-                    fun = np.asarray(model._nlsq_result.fun)
-                    if fun.ndim == 0:
-                        ss_res = float(np.abs(fun))
-                    else:
-                        ss_res = float(np.sum(np.abs(fun) ** 2))
-                    y_arr = np.asarray(_y_score)
-                    # Use np.abs()² for complex data — plain (y-mean)² gives
-                    # complex ss_tot which is meaningless (P0-4 fix).
-                    ss_tot = float(np.sum(np.abs(y_arr - np.mean(y_arr)) ** 2))
-                    if ss_tot > 0:
-                        r2 = 1.0 - (ss_res / ss_tot)
-                    else:
-                        r2 = 1.0 if ss_res == 0.0 else None
+                _nlsq_result = getattr(model, "_nlsq_result", None)
+                if _nlsq_result is not None:
+                    # Delegate to the canonical OptimizationResult.r_squared
+                    # property instead of re-deriving ss_res/ss_tot here: it
+                    # already handles the use_log_residuals dimensional
+                    # consistency correction, complex-data component split,
+                    # and normalization-weight un-normalization.
+                    r2 = getattr(_nlsq_result, "r_squared", None)
                 else:
                     r2 = model.score(_X_score, _y_score)
             except Exception as exc:
@@ -304,18 +387,29 @@ class FitOrchestrator:
                     error=str(exc),
                 )
 
-        logger.info(
-            "Fit completed",
-            model=model.__class__.__name__,
-            fitted=model.fitted_,
-            R2=r2,
-            data_shape=data_shape,
-        )
-        logger.debug(
-            "Exiting fit",
-            model=model.__class__.__name__,
-            parameters=model.get_params(),
-        )
+        try:
+            logger.info(
+                "Fit completed",
+                model=model.__class__.__name__,
+                fitted=model.fitted_,
+                R2=r2,
+                data_shape=data_shape,
+            )
+            logger.debug(
+                "Exiting fit",
+                model=model.__class__.__name__,
+                parameters=model.get_params(),
+            )
+        except Exception as exc:
+            # A fit that already succeeded must never be reported as failed
+            # just because completion logging/bookkeeping raised (e.g. a
+            # future get_params() override). See R2 computation above for
+            # the same catch-and-log-warning convention.
+            logger.warning(
+                "Post-fit completion logging failed",
+                model=model.__class__.__name__,
+                error=str(exc),
+            )
 
     @staticmethod
     def _build_fit_result(
@@ -337,8 +431,11 @@ class FitOrchestrator:
             return fit_result
         except Exception as exc:
             logger.warning(
-                "FitResult construction failed, returning model",
+                "FitResult construction failed, returning error FitResult",
                 model=model.__class__.__name__,
                 error=str(exc),
             )
-            return model
+            # Preserve the return_result=True -> FitResult contract even when
+            # FitResult construction itself fails, mirroring how _fit()
+            # failures are already handled via _make_error_result().
+            return model._make_error_result(test_mode, exc)

--- a/rheojax/core/fit_result.py
+++ b/rheojax/core/fit_result.py
@@ -34,6 +34,12 @@ if TYPE_CHECKING:
 
 logger = get_logger(__name__)
 
+# Statistics computed by OptimizationResult (correctly accounting for
+# _use_log_residuals / _normalization_weights) that to_dict()/save() persist
+# and load() must read back verbatim rather than recompute. See FitResult
+# ._persisted_stats.
+_STAT_KEYS = ("r_squared", "adj_r_squared", "rmse", "mae", "aic", "bic", "aicc")
+
 
 # ---------------------------------------------------------------------------
 # FitResult
@@ -80,14 +86,34 @@ class FitResult:
     )
     metadata: dict[str, Any] = field(default_factory=dict)
     _fitted_model: Any = field(default=None, repr=False, compare=False)
+    # Statistics persisted at save-time (e.g. r_squared/aic/bic computed by the
+    # original OptimizationResult, which correctly accounts for
+    # _use_log_residuals / _normalization_weights). load() cannot reconstruct
+    # those semantics from the raw y/fitted_curve arrays alone, so the
+    # statistics properties below prefer these saved values over recomputing
+    # from the reconstructed (linear-space) OptimizationResult.
+    _persisted_stats: dict[str, float] | None = field(
+        default=None, repr=False, compare=False
+    )
 
     # ------------------------------------------------------------------
     # Delegated statistical properties
     # ------------------------------------------------------------------
 
+    def _persisted(self, name: str) -> float | None:
+        """Return a saved statistic from load(), if one was persisted."""
+        if self._persisted_stats is not None:
+            val = self._persisted_stats.get(name)
+            if val is not None:
+                return val
+        return None
+
     @property
     def r_squared(self) -> float | None:
         """Coefficient of determination (R²), delegated to OptimizationResult."""
+        persisted = self._persisted("r_squared")
+        if persisted is not None:
+            return persisted
         if self.optimization_result is None:
             return None
         return self.optimization_result.r_squared
@@ -95,6 +121,9 @@ class FitResult:
     @property
     def adj_r_squared(self) -> float | None:
         """Adjusted R², delegated to OptimizationResult."""
+        persisted = self._persisted("adj_r_squared")
+        if persisted is not None:
+            return persisted
         if self.optimization_result is None:
             return None
         return self.optimization_result.adj_r_squared
@@ -102,6 +131,9 @@ class FitResult:
     @property
     def rmse(self) -> float | None:
         """Root mean squared error, delegated to OptimizationResult."""
+        persisted = self._persisted("rmse")
+        if persisted is not None:
+            return persisted
         if self.optimization_result is None:
             return None
         return self.optimization_result.rmse
@@ -109,6 +141,9 @@ class FitResult:
     @property
     def mae(self) -> float | None:
         """Mean absolute error, delegated to OptimizationResult."""
+        persisted = self._persisted("mae")
+        if persisted is not None:
+            return persisted
         if self.optimization_result is None:
             return None
         return self.optimization_result.mae
@@ -116,6 +151,9 @@ class FitResult:
     @property
     def aic(self) -> float | None:
         """Akaike Information Criterion, delegated to OptimizationResult."""
+        persisted = self._persisted("aic")
+        if persisted is not None:
+            return persisted
         if self.optimization_result is None:
             return None
         return self.optimization_result.aic
@@ -123,6 +161,9 @@ class FitResult:
     @property
     def bic(self) -> float | None:
         """Bayesian Information Criterion, delegated to OptimizationResult."""
+        persisted = self._persisted("bic")
+        if persisted is not None:
+            return persisted
         if self.optimization_result is None:
             return None
         return self.optimization_result.bic
@@ -243,13 +284,16 @@ class FitResult:
 
         AICc = AIC + 2k(k+1) / (n - k - 1)
         """
+        persisted = self._persisted("aicc")
+        if persisted is not None:
+            return persisted
         aic = self.aic
         if aic is None:
             return None
         n = self.n_data
         k = self.n_params
         if n - k - 1 <= 0:
-            return np.nan
+            return None
         return float(aic + 2 * k * (k + 1) / (n - k - 1))
 
     def summary(self) -> str:
@@ -318,6 +362,7 @@ class FitResult:
             "r_squared": self.r_squared,
             "adj_r_squared": self.adj_r_squared,
             "rmse": self.rmse,
+            "mae": self.mae,
             "aic": self.aic,
             "bic": self.bic,
             "aicc": self.aicc,
@@ -344,6 +389,22 @@ class FitResult:
                 result["fitted_curve_is_complex"] = True
             else:
                 result["fitted_curve"] = fc_arr.tolist()
+        if self.optimization_result is not None:
+            opt_residuals = getattr(self.optimization_result, "residuals", None)
+            if opt_residuals is not None:
+                # Persist the exact residuals computed by OptimizationResult
+                # (already real-valued even for complex-split fits) so
+                # load() doesn't have to re-derive log10/normalization
+                # transforms itself (see _load_json).
+                result["residuals"] = np.asarray(opt_residuals).tolist()
+                result["_use_log_residuals"] = bool(
+                    getattr(self.optimization_result, "_use_log_residuals", False)
+                )
+                norm_w = getattr(
+                    self.optimization_result, "_normalization_weights", None
+                )
+                if norm_w is not None:
+                    result["_normalization_weights"] = np.asarray(norm_w).tolist()
         return result
 
     def save(self, path: str) -> None:
@@ -390,15 +451,37 @@ class FitResult:
             "timestamp": _str_to_bytes(self.timestamp),
             "param_names": _str_to_bytes(_json.dumps(list(self.params.keys()))),
             "param_values": np.array(list(self.params.values()), dtype=np.float64),
+            "params_units": _str_to_bytes(_json.dumps(self.params_units)),
+            "metadata": _str_to_bytes(_json.dumps(self.metadata, default=str)),
             # P2-Fit-8: Persist success, n_data, and _is_complex_split for
             # correct round-trip of statistics.
             "success": np.array(self.success),
             "n_data": np.array(self.n_data),
         }
+        # Persist statistics so load() can return the exact values computed
+        # here (which correctly account for _use_log_residuals /
+        # _normalization_weights) instead of recomputing from raw arrays.
+        for stat_name in _STAT_KEYS:
+            val = getattr(self, stat_name)
+            if val is not None:
+                save_dict[stat_name] = np.array(val, dtype=np.float64)
         if self.optimization_result is not None:
             save_dict["_is_complex_split"] = np.array(
                 self.optimization_result._is_complex_split
             )
+            opt_residuals = getattr(self.optimization_result, "residuals", None)
+            if opt_residuals is not None:
+                # See to_dict(): persist the exact residuals array verbatim
+                # so load() need not re-derive log10/normalization transforms.
+                save_dict["residuals"] = np.asarray(opt_residuals)
+                save_dict["_use_log_residuals"] = np.array(
+                    getattr(self.optimization_result, "_use_log_residuals", False)
+                )
+                norm_w = getattr(
+                    self.optimization_result, "_normalization_weights", None
+                )
+                if norm_w is not None:
+                    save_dict["_normalization_weights"] = np.asarray(norm_w)
         if self.X is not None:
             save_dict["X"] = np.asarray(self.X)
         if self.y is not None:
@@ -455,7 +538,12 @@ class FitResult:
             from rheojax.utils.optimization import OptimizationResult
 
             _is_complex = np.iscomplexobj(y_arr)
-            if _is_complex:
+            if d.get("residuals") is not None:
+                # Prefer the exact residuals array persisted by to_dict(),
+                # which already accounts for _use_log_residuals /
+                # _normalization_weights transforms applied at fit time.
+                residuals = np.array(d["residuals"])
+            elif _is_complex:
                 residuals = np.concatenate(
                     [
                         y_arr.real - fitted.real,
@@ -465,6 +553,7 @@ class FitResult:
             else:
                 residuals = (y_arr - fitted).ravel()
             rss = float(np.sum(residuals**2))
+            norm_w = d.get("_normalization_weights")
             opt_result = OptimizationResult(
                 x=np.array(list(d["params"].values())),
                 fun=rss,
@@ -473,7 +562,15 @@ class FitResult:
                 residuals=residuals,
                 n_data=len(y_arr),
                 _is_complex_split=_is_complex,
+                _use_log_residuals=bool(d.get("_use_log_residuals", False)),
+                _normalization_weights=(
+                    np.array(norm_w) if norm_w is not None else None
+                ),
             )
+
+        persisted_stats = {
+            key: d[key] for key in _STAT_KEYS if d.get(key) is not None
+        }
 
         return cls(
             model_name=d["model_name"],
@@ -488,6 +585,7 @@ class FitResult:
             y=y_arr,
             timestamp=d.get("timestamp", ""),
             metadata=d.get("metadata", {}),
+            _persisted_stats=persisted_stats or None,
         )
 
     @classmethod
@@ -523,7 +621,12 @@ class FitResult:
 
             y_np = np.asarray(y_arr)
             fitted_np = np.asarray(fitted)
-            if np.iscomplexobj(y_np):
+            if "residuals" in data:
+                # Prefer the exact residuals array persisted by _save_npz(),
+                # which already accounts for _use_log_residuals /
+                # _normalization_weights transforms applied at fit time.
+                residuals = np.asarray(data["residuals"])
+            elif np.iscomplexobj(y_np):
                 residuals = np.concatenate(
                     [y_np.real - fitted_np.real, y_np.imag - fitted_np.imag]
                 )
@@ -537,20 +640,45 @@ class FitResult:
                 residuals=residuals,
                 n_data=_n_data,
                 _is_complex_split=_is_complex_split,
+                _use_log_residuals=bool(data["_use_log_residuals"])
+                if "_use_log_residuals" in data
+                else False,
+                _normalization_weights=(
+                    np.asarray(data["_normalization_weights"])
+                    if "_normalization_weights" in data
+                    else None
+                ),
             )
+
+        persisted_stats = {
+            key: float(data[key]) for key in _STAT_KEYS if key in data
+        }
+
+        # Backward-compatible: .npz files saved before params_units/metadata
+        # were persisted (see _save_npz) fall back to {} rather than KeyError.
+        params_units = (
+            _json.loads(_bytes_to_str(data["params_units"]))
+            if "params_units" in data
+            else {}
+        )
+        metadata = (
+            _json.loads(_bytes_to_str(data["metadata"])) if "metadata" in data else {}
+        )
 
         return cls(
             model_name=_bytes_to_str(data["model_name"]),
             model_class_name=_bytes_to_str(data["model_class_name"]),
             protocol=_bytes_to_str(data["protocol"]) or None,
             params=dict(zip(param_names, param_values, strict=True)),
-            params_units={},
+            params_units=params_units,
             n_params=int(data["n_params"]),
             optimization_result=opt_result,
             fitted_curve=fitted,
             X=data["X"] if "X" in data else None,
             y=y_arr,
             timestamp=_bytes_to_str(data["timestamp"]),
+            metadata=metadata,
+            _persisted_stats=persisted_stats or None,
         )
 
     def plot(self, ax=None, show_residuals: bool = True, **kwargs):
@@ -603,14 +731,43 @@ class FitResult:
         )
 
         if ax_res is not None and self.fitted_curve is not None:
-            residuals = y - np.asarray(self.fitted_curve)
+            # Prefer the log-space residuals actually used for r_squared/aic/
+            # bic (self.residuals, via OptimizationResult) when the fit used
+            # _use_log_residuals=True, so this panel doesn't contradict the
+            # R² reported in the title above. Falls back to the plain linear
+            # y - fitted_curve when unavailable or shape-incompatible with X
+            # (e.g. residuals aren't split-complex-aligned with X).
+            use_log = bool(
+                getattr(self.optimization_result, "_use_log_residuals", False)
+            )
+            residuals = None
+            res_label = "Residuals"
+            if use_log and self.residuals is not None:
+                res_arr = np.asarray(self.residuals)
+                norm_w = getattr(
+                    self.optimization_result, "_normalization_weights", None
+                )
+                if norm_w is not None:
+                    res_arr = res_arr * np.asarray(norm_w)
+                is_split = bool(
+                    getattr(self.optimization_result, "_is_complex_split", False)
+                )
+                if is_split and res_arr.size == 2 * len(X):
+                    half = res_arr.size // 2
+                    residuals = res_arr[:half] + 1j * res_arr[half:]
+                    res_label = "Log10 Residual"
+                elif not is_split and res_arr.size == len(X):
+                    residuals = res_arr
+                    res_label = "Log10 Residual"
+            if residuals is None:
+                residuals = y - np.asarray(self.fitted_curve)
             if np.iscomplexobj(residuals):
                 ax_res.plot(X, residuals.real, "o", ms=3, label="real")
                 ax_res.plot(X, residuals.imag, "s", ms=3, label="imag")
             else:
                 ax_res.plot(X, residuals, "o", ms=3)
             ax_res.axhline(0, color="k", lw=0.5)
-            ax_res.set_ylabel("Residuals")
+            ax_res.set_ylabel(res_label)
             ax_res.set_xlabel("X")
 
         fig.tight_layout()
@@ -685,7 +842,12 @@ class ModelInfo:
                 param_bounds[pname] = p.bounds if p.bounds else (None, None)
                 param_units[pname] = getattr(p, "units", "") or ""
             n_params = len(param_names)
-            supports_bayesian = hasattr(instance, "fit_bayesian")
+            # NOTE: fit_bayesian is defined unconditionally on BaseModel, so
+            # hasattr(instance, "fit_bayesian") is always True and cannot
+            # discriminate. The actual runtime contract enforced by
+            # BayesianMixin._validate_bayesian_requirements() requires
+            # model_function; check that instead.
+            supports_bayesian = hasattr(instance, "model_function")
         except Exception:
             logger.warning(
                 "ModelInfo.from_registry: instantiation failed for model '%s'",
@@ -739,6 +901,12 @@ class ModelComparison:
     delta_criterion: dict[str, float] = field(default_factory=dict)
     weights: dict[str, float] = field(default_factory=dict)
     best_model: str = ""
+    # Maps ranking key (possibly "#index"-suffixed, see _compute_rankings)
+    # back to its source FitResult, so summary() can look results up
+    # correctly even when duplicate model_names were disambiguated.
+    _entry_results: dict[str, FitResult] = field(
+        default_factory=dict, repr=False, compare=False
+    )
 
     _VALID_CRITERIA = {"aic", "bic", "aicc"}
 
@@ -753,25 +921,48 @@ class ModelComparison:
 
     def _compute_rankings(self) -> None:
         """Compute rankings and Akaike weights from results."""
-        # Collect criterion values
-        entries: list[tuple[str, float]] = []
+        # Collect criterion values, carrying the source FitResult along so
+        # it can still be recovered after any disambiguation below.
+        entries: list[tuple[str, float, FitResult]] = []
         for r in self.results:
             val = getattr(r, self.criterion, None)
             if val is not None and np.isfinite(val):
-                entries.append((r.model_name, float(val)))
+                entries.append((r.model_name, float(val), r))
 
         if not entries:
             return
 
         # Sort by criterion (lower is better)
         entries.sort(key=lambda e: e[1])
+
+        # Disambiguate duplicate model_names (e.g. two pre-instantiated
+        # instances of the same model class, as via compare_models(models=[...])).
+        # Without this, self.rankings/delta_criterion/weights below — all
+        # dict-keyed purely by model_name — would silently collide and drop
+        # every result but the last one with a given name. The suffix index
+        # is derived from position within `entries` (already filtered to
+        # finite-criterion results), not a raw self.results index, since the
+        # two lists can desync.
+        names = [name for name, _, _ in entries]
+        if len(set(names)) != len(names):
+            logger.warning(
+                "ModelComparison: duplicate model_name(s) found among "
+                "results for criterion %r; disambiguating rankings with "
+                "'#index' suffixes so no result is silently dropped.",
+                self.criterion,
+            )
+            entries = [
+                (f"{name}#{i}", val, r) for i, (name, val, r) in enumerate(entries)
+            ]
+
         best_val = entries[0][1]
 
-        self.rankings = {name: rank for rank, (name, _) in enumerate(entries, 1)}
+        self.rankings = {name: rank for rank, (name, _, _) in enumerate(entries, 1)}
         self.best_model = entries[0][0]
+        self._entry_results = {name: r for name, _, r in entries}
 
         # Delta and Akaike weights
-        deltas = {name: val - best_val for name, val in entries}
+        deltas = {name: val - best_val for name, val, _ in entries}
         self.delta_criterion = deltas
 
         raw_weights = {name: np.exp(-0.5 * d) for name, d in deltas.items()}
@@ -798,13 +989,16 @@ class ModelComparison:
         ]
         for name in self.ranked_names():
             rank = self.rankings[name]
-            r = next((x for x in self.results if x.model_name == name), None)
+            r = self._entry_results.get(name)
             crit_val = getattr(r, self.criterion, None) if r else None
             delta = self.delta_criterion.get(name, float("nan"))
             weight = self.weights.get(name, 0.0)
             crit_str = f"{crit_val:.4f}" if crit_val is not None else "--"
+            # Recover the original model_name if it was "#index"-suffixed
+            # for disambiguation (see _compute_rankings).
+            label = name.rsplit("#", 1)[0] if "#" in name else name
             lines.append(
-                f"{rank:<6}{name:<25}{crit_str:<14}{delta:<12.4f}{weight:<10.4f}"
+                f"{rank:<6}{label:<25}{crit_str:<14}{delta:<12.4f}{weight:<10.4f}"
             )
         return "\n".join(lines)
 

--- a/rheojax/core/jax_config.py
+++ b/rheojax/core/jax_config.py
@@ -96,12 +96,34 @@ def _enable_compilation_cache(jax_module: Any) -> None:
     if os.environ.get("RHEOJAX_NO_JIT_CACHE", "0") == "1":
         return
 
-    cache_dir = pathlib.Path.home() / ".cache" / "rheojax" / "jax_cache"
+    try:
+        cache_dir = pathlib.Path.home() / ".cache" / "rheojax" / "jax_cache"
+    except RuntimeError:
+        # Non-fatal: home directory can't be resolved (e.g. containers with no
+        # $HOME and no matching /etc/passwd entry) -- skip the compilation cache.
+        return
+
     try:
         cache_dir.mkdir(parents=True, exist_ok=True)
         # JAX >= 0.4.25: preferred config-based API
         jax_module.config.update("jax_compilation_cache_dir", str(cache_dir))
+        # Default min-compile-time-to-cache is 1.0s in installed JAX, which
+        # silently skips persisting the sub-second compiles typical of
+        # rheology models. Lower it so those are actually cached.
+        jax_module.config.update("jax_persistent_cache_min_compile_time_secs", 0.05)
     except (OSError, RuntimeError, AttributeError, TypeError):
+        # The experimental fallback API below has no equivalent to
+        # jax_persistent_cache_min_compile_time_secs, so the 1.0s-default
+        # problem the primary path fixes silently re-appears here. Warn so
+        # this doesn't fail silently.
+        warnings.warn(
+            "JAX compilation cache: primary config API unavailable, falling "
+            "back to the experimental compilation_cache API. This fallback "
+            "has no min-compile-time-secs knob, so sub-second JIT compiles "
+            "(typical for rheology models) will not be persisted to disk.",
+            RuntimeWarning,
+            stacklevel=2,
+        )
         try:
             # Fallback: older JAX experimental API
             from jax.experimental.compilation_cache import compilation_cache as cc
@@ -255,9 +277,14 @@ def reset_validation() -> None:
     This function is intended for use in tests that need to simulate
     different import scenarios. It should not be used in production code.
 
-    Warning:
-        This is not thread-safe and should only be used in single-threaded
-        test environments.
+    Note:
+        The state mutation itself is atomic and lock-guarded (it acquires the
+        same ``_validation_lock`` used by ``safe_import_jax()``), so no torn
+        or partial state is observable by concurrent callers. The caveat is
+        purely sequencing: a thread that captured ``jax``/``jnp`` references
+        before a concurrent reset keeps using those still-valid-but-stale
+        modules until it calls ``safe_import_jax()`` again, which will
+        legitimately re-run import/config/validation logic.
     """
     global _validation_done, _jax_module, _jnp_module
 

--- a/rheojax/core/numpyro_model_builder.py
+++ b/rheojax/core/numpyro_model_builder.py
@@ -43,8 +43,12 @@ def prior_dict_to_dist(prior_spec: dict, dist_module) -> Any | None:
         {"type": "lognormal", "loc": 0, "scale": 1}
         {"type": "exponential", "rate": 0.01}
         {"type": "halfnormal", "scale": 500}
+        {"type": "truncatednormal", "loc": 0, "scale": 1, "low": ..., "high": ...}
+        {"type": "gamma", "concentration": 2.0, "rate": 1.0}
+        {"type": "beta", "concentration0": 2.0, "concentration1": 2.0}
 
-    Returns None if the spec is unrecognized.
+    Returns None if the spec is unrecognized or malformed (a warning is
+    logged in both cases so a silently-wrong fallback prior is diagnosable).
     """
     dist_type = prior_spec.get("type", "").lower()
     try:
@@ -78,9 +82,31 @@ def prior_dict_to_dist(prior_spec: dict, dist_module) -> Any | None:
                 low=float(prior_spec.get("low", float("-inf"))),
                 high=float(prior_spec.get("high", float("inf"))),
             )
-    except (KeyError, TypeError, ValueError):
-        pass
-    return None
+        elif dist_type == "gamma":
+            return dist_module.Gamma(
+                concentration=float(prior_spec["concentration"]),
+                rate=float(prior_spec["rate"]),
+            )
+        elif dist_type == "beta":
+            return dist_module.Beta(
+                concentration1=float(prior_spec["concentration1"]),
+                concentration0=float(prior_spec["concentration0"]),
+            )
+        else:
+            logger.warning(
+                "Unrecognized prior dist_type; falling back to default prior",
+                dist_type=dist_type,
+                prior_spec=prior_spec,
+            )
+            return None
+    except (KeyError, TypeError, ValueError) as exc:
+        logger.warning(
+            "Malformed prior spec; falling back to default prior",
+            dist_type=dist_type,
+            prior_spec=prior_spec,
+            error=str(exc),
+        )
+        return None
 
 
 def build_numpyro_model(
@@ -101,7 +127,13 @@ def build_numpyro_model(
 
     Args:
         model_self: The model instance (provides model_function, parameters,
-            bayesian_prior_factory, _closure_cache).
+            bayesian_prior_factory, _closure_cache). If it sets
+            `_bayesian_nan_safe_grad_reeval = True`, non-finite
+            model_function outputs trigger a second, gradient-safe
+            re-evaluation (via stop_gradient) at ~2x the per-step cost —
+            an opt-in escape hatch for models whose non-finite outputs come
+            from a solver blow-up that can't be localized and guarded inline
+            (see the finite_check NaN-gradient note in the model closure).
         param_names: List of parameter names to sample.
         param_bounds: Dict mapping parameter names to (lower, upper) bounds.
         test_mode: TestMode enum for the current protocol.
@@ -139,7 +171,13 @@ def build_numpyro_model(
     if "model_returns_2col" not in scale_info:
         _model_returns_2col = False
         try:
-            _n_probe = max(scale_info.get("n_points", 0) or 0, 10)
+            # Use the real data length when known so the probe's synthetic
+            # call matches the actual invocation shape; only fall back to a
+            # dummy size when n_points is unknown/non-positive. A mismatched
+            # probe length can make an otherwise-fine model raise here for
+            # reasons unrelated to its true (N,2)-vs-complex output shape.
+            _n_known = scale_info.get("n_points", 0) or 0
+            _n_probe = _n_known if _n_known > 0 else 10
             _test_X = jax.ShapeDtypeStruct((_n_probe,), jnp.float64)
             _test_params = jax.ShapeDtypeStruct((len(param_names),), jnp.float64)
             _probe_fn = functools.partial(
@@ -177,6 +215,16 @@ def build_numpyro_model(
             if getattr(model_self, "_bayes_likelihood_space", "linear") == "log"
             else 0.0
         )
+
+    # Opt-in escape hatch for models whose non-finite predictions come from a
+    # solver blow-up (rather than a clean algebraic singularity a model author
+    # can localize with a safe_div/safe_log-style guard). See the NaN-gradient
+    # note near the finite_check factor below. Off by default: it costs a full
+    # second model_function evaluation per gradient step, so it must not be a
+    # blanket cost on every NUTS gradient for every model.
+    _nan_safe_grad_reeval = bool(
+        getattr(model_self, "_bayesian_nan_safe_grad_reeval", False)
+    )
 
     # Skip cache when prior_factory or param-level priors are set
     if not has_ndarray_kwargs and prior_factory is None and not _has_param_priors:
@@ -216,6 +264,7 @@ def build_numpyro_model(
                         for k, v in scale_info.items()
                     )
                 ),
+                _nan_safe_grad_reeval,
             )
         if cache_key in model_self._closure_cache:
             model_self._closure_cache.move_to_end(cache_key)
@@ -294,9 +343,12 @@ def build_numpyro_model(
                 lower is not None
                 and upper is not None
                 and abs(float(upper) - float(lower))
-                < 1e-9 * max(abs(float(lower)), abs(float(upper)), 1.0)
+                < 1e-10 * max(abs(float(lower)), 1.0)
             ):
                 # PARAMS-001: fixed parameter — use deterministic instead of Uniform.
+                # Tolerance matches BayesianMixin._validate_parameter_bounds()
+                # (bayesian.py) exactly, so both agree on what counts as "fixed"
+                # instead of disagreeing in a narrow bound-width gap.
                 param_val = numpyro.deterministic(name, lower)
                 params_dict[name] = param_val
             else:
@@ -313,12 +365,56 @@ def build_numpyro_model(
             X, params_array, test_mode, **protocol_kwargs
         )
 
-        # Guard against NaN/Inf from ODE-based models
+        # R5-JAX-002 cross-check: the model_returns_2col probe above can
+        # misclassify (e.g. its synthetic dummy call raised for a reason
+        # unrelated to the model's true output shape, silently defaulting to
+        # False). Catch that here with a cheap static-shape check on the real
+        # call so the failure is a clear diagnostic instead of an opaque
+        # NumPyro/JAX broadcasting error further down.
+        if (
+            not _model_returns_2col
+            and predictions_raw.ndim == 2
+            and predictions_raw.shape[-1] == 2
+        ):
+            raise ValueError(
+                "model_function returned a 2-column (N, 2) array but the "
+                "model_returns_2col probe misclassified it as not-2col; "
+                "check why jax.eval_shape failed for this model_function "
+                "(see the 'model_function probe failed' warning, if logged)."
+            )
+
+        # Guard against NaN/Inf from ODE-based models.
+        #
+        # NOTE: jnp.where(is_finite, predictions_raw, 0.0) below only sanitizes
+        # the primal log-density value, not its gradient. If a non-finite
+        # value here originates from a locally-singular op inside
+        # model_function (e.g. dividing by a relaxation time that hit its
+        # prior boundary), the local Jacobian at that internal node is itself
+        # NaN/Inf, and 0 * inf = NaN under IEEE754 survives lax.select's
+        # gradient rule — so NUTS can still receive a NaN gradient even though
+        # this factor's value is finite. Model authors are responsible for
+        # gradient-safe internals (guard hazards BEFORE the unsafe op, e.g.
+        # `safe_tau = jnp.where(tau > eps, tau, eps)`), unless the model opts
+        # into `_bayesian_nan_safe_grad_reeval` below.
         is_finite = jnp.isfinite(predictions_raw)
         not_finite = ~is_finite
         finite_penalty = jnp.where(is_finite, 0.0, -1e18).sum()
         numpyro.factor("finite_check", finite_penalty)
         numpyro.deterministic("num_nonfinite", not_finite.sum().astype(jnp.float64))
+        if _nan_safe_grad_reeval:
+            # Re-evaluate model_function with stop_gradient applied to the
+            # sampled params whenever any output was non-finite. stop_gradient's
+            # backward rule discards the incoming cotangent via a symbolic
+            # zero (not an arithmetic multiplication), so this severs the
+            # NaN/Inf gradient path instead of merely masking the primal
+            # value. This costs a second full model_function evaluation, so
+            # it only runs for models that explicitly opt in.
+            params_safe = jnp.where(
+                is_finite.all(), params_array, jax.lax.stop_gradient(params_array)
+            )
+            predictions_raw = model_self.model_function(
+                X, params_safe, test_mode, **protocol_kwargs
+            )
         predictions_raw = jnp.where(is_finite, predictions_raw, 0.0)
 
         # Normalize oscillation predictions: some models return (N,2) real
@@ -330,7 +426,7 @@ def build_numpyro_model(
                 predictions_raw = jnp.sqrt(
                     predictions_raw[:, 0] ** 2 + predictions_raw[:, 1] ** 2 + 1e-30
                 )
-                if y.ndim == 2 and y.shape[1] == 2:
+                if y is not None and y.ndim == 2 and y.shape[1] == 2:
                     y = jnp.sqrt(y[:, 0] ** 2 + y[:, 1] ** 2 + 1e-30)
 
         # Handle complex vs real predictions
@@ -338,7 +434,7 @@ def build_numpyro_model(
             pred_real = jnp.real(predictions_raw)
             pred_imag = jnp.imag(predictions_raw)
             n = scale_info["n_real"]
-            y_real_obs, y_imag_obs = y[:n], y[n:]
+            y_real_obs, y_imag_obs = (None, None) if y is None else (y[:n], y[n:])
 
             # Let prior_factory override noise priors if it provides them
             sigma_real_dist = None
@@ -348,10 +444,14 @@ def build_numpyro_model(
                 sigma_imag_dist = prior_factory("sigma_imag", 0.0, None)
 
             if sigma_real_dist is None:
-                sigma_real_scale = max(y_real_scale * 10.0, y_real_mean * 0.01, 1e-3)
+                # Scale noise prior to ~1x the data's peak-to-peak range,
+                # matching the real-data branch below (P0-3 fix): a 10x
+                # multiplier drowns the likelihood for small N, collapsing
+                # the posterior to the prior.
+                sigma_real_scale = max(y_real_scale * 1.0, y_real_mean * 0.01, 1e-3)
                 sigma_real_dist = dist.Exponential(rate=1.0 / sigma_real_scale)
             if sigma_imag_dist is None:
-                sigma_imag_scale = max(y_imag_scale * 10.0, y_imag_mean * 0.01, 1e-3)
+                sigma_imag_scale = max(y_imag_scale * 1.0, y_imag_mean * 0.01, 1e-3)
                 sigma_imag_dist = dist.Exponential(rate=1.0 / sigma_imag_scale)
 
             sigma_real = numpyro.sample("sigma_real", sigma_real_dist)

--- a/rheojax/core/parameters.py
+++ b/rheojax/core/parameters.py
@@ -57,6 +57,15 @@ class ParameterConstraint:
 
     def to_dict(self) -> dict[str, Any]:
         """Serialize constraint to a dictionary."""
+        if self.type == "custom":
+            # A Python callable cannot be serialized to JSON/HDF5. Fail here,
+            # at the actual point of data loss, instead of silently emitting
+            # a dict that deserializes into a no-op `validate() -> True`.
+            raise ValueError(
+                "Cannot serialize a 'custom' constraint: its validator "
+                "callable is not JSON/HDF5-serializable and would be "
+                "silently dropped on a to_dict()/from_dict() round-trip."
+            )
         d: dict[str, Any] = {"type": self.type}
         if self.type == "bounds":
             d["min_value"] = self.min_value
@@ -123,8 +132,26 @@ class ParameterConstraint:
                 return value > other_value
             elif self.relation == "equal":
                 return value == other_value
+            else:
+                # Fail closed: an unset/misspelled relation must not silently
+                # fall through to the trailing `return True` below, which
+                # would validate every value as satisfying a broken
+                # constraint (mirrors the 'custom' fail-closed pattern).
+                raise ValueError(
+                    f"Unknown or missing relation {self.relation!r} for "
+                    "relative constraint"
+                )
 
-        elif self.type == "custom" and self.validator:
+        elif self.type == "custom":
+            if self.validator is None:
+                # Fail closed: a validator-less 'custom' constraint can only
+                # arise from a broken deserialization (validators can't be
+                # serialized — see to_dict()). Accepting every value here
+                # would silently no-op the constraint.
+                raise ValueError(
+                    "custom constraint has no validator (cannot be restored "
+                    "from serialized data)"
+                )
             return self.validator(value)
 
         elif self.type not in {
@@ -209,18 +236,71 @@ class Parameter:
     @bounds.setter
     def bounds(self, new_bounds: tuple[float, float] | None) -> None:
         """Set parameter bounds and sync any bounds constraint."""
+        if new_bounds is not None and new_bounds[0] > new_bounds[1]:
+            logger.error(
+                "Invalid bounds: lower > upper",
+                parameter=self.name,
+                bounds=new_bounds,
+            )
+            raise ValueError(
+                f"Invalid bounds for parameter '{self.name}': {new_bounds}"
+            )
         self._bounds = new_bounds
         # Sync ALL bounds constraints — iterate the full list so that every
         # "bounds" constraint is updated, not only the first one.
+        found_bounds_constraint = False
         if hasattr(self, "constraints"):
             for c in self.constraints:
                 if hasattr(c, "type") and c.type == "bounds":
+                    found_bounds_constraint = True
                     if new_bounds is not None:
                         c.min_value = new_bounds[0]
                         c.max_value = new_bounds[1]
                     else:
                         c.min_value = None
                         c.max_value = None
+            # No existing "bounds" constraint to sync (e.g. the Parameter was
+            # constructed with bounds=None and bounds are being set for the
+            # first time afterward) — insert one, mirroring the same
+            # insert-if-missing logic _initialize() applies at construction.
+            if new_bounds is not None and not found_bounds_constraint:
+                self.constraints.insert(
+                    0,
+                    ParameterConstraint(
+                        type="bounds",
+                        min_value=new_bounds[0],
+                        max_value=new_bounds[1],
+                    ),
+                )
+
+        # Re-validate the currently-held value against the new bounds; clamp
+        # (with a warning) instead of leaving `self._value` silently outside
+        # `self._bounds`. `new_bounds[0] <= new_bounds[1]` always holds here
+        # since inverted bounds are rejected above.
+        if (
+            new_bounds is not None
+            and self._value is not None
+            and new_bounds[0] <= new_bounds[1]
+        ):
+            lower, upper = new_bounds
+            if self._value < lower:
+                warnings.warn(
+                    f"Parameter '{self.name}' value {self._value} is below "
+                    f"new bounds; clamped to {lower}",
+                    RuntimeWarning,
+                    stacklevel=2,
+                )
+                self._value = lower
+                self._was_clamped = True
+            elif self._value > upper:
+                warnings.warn(
+                    f"Parameter '{self.name}' value {self._value} is above "
+                    f"new bounds; clamped to {upper}",
+                    RuntimeWarning,
+                    stacklevel=2,
+                )
+                self._value = upper
+                self._was_clamped = True
 
     def _initialize(self, value: float | None) -> None:
         """Validate parameter after initialization."""
@@ -362,10 +442,10 @@ class Parameter:
         if self._clamp_on_set:
             self._was_clamped = clamped_during_init
         else:
-            # R12-B-017: _was_clamped is only meaningful at initialization time
-            # (when _clamp_on_set=True). For all subsequent set_value() calls it
-            # is reset to False because clamping is not applied — out-of-bounds
-            # values raise ValueError instead.
+            # R12-B-017: for set_value() calls (as opposed to construction or
+            # a `.bounds =` reassignment, see the bounds setter), _was_clamped
+            # is reset to False because clamping is not applied here —
+            # out-of-bounds values raise ValueError instead.
             self._was_clamped = False
 
         self._value = numeric_val
@@ -1011,7 +1091,16 @@ class ParameterSet:
                 parameter=key,
             )
         if isinstance(value, Parameter):
-            # Replace entire parameter
+            # Replace entire parameter. Reject a name mismatch rather than
+            # silently letting the ParameterSet key and Parameter.name
+            # diverge (the divergence would otherwise be masked until a
+            # to_dict()/from_dict() round-trip silently overwrites the
+            # stored Parameter's name back to the key).
+            if value.name != key:
+                raise ValueError(
+                    f"Parameter name '{value.name}' does not match "
+                    f"assignment key '{key}'"
+                )
             self._parameters[key] = value
             if key not in self._order:
                 self._order.append(key)
@@ -1206,8 +1295,13 @@ class SharedParameterSet:
 
         param = self._shared[name]
 
-        # Validate
-        if not param.validate(value):
+        # Validate. Build a context dict (mirroring ParameterSet.set_value/
+        # update) so that "relative" constraints between shared parameters
+        # are actually enforced instead of silently no-op'd.
+        context = {
+            p.name: p.value for p in self._shared.values() if p.value is not None
+        }
+        if not param.validate(value, context):
             logger.error(
                 "Value violates constraints for shared parameter",
                 parameter=name,
@@ -1379,13 +1473,17 @@ class ParameterOptimizer:
             use_jax=self.use_jax,
         )
         if not self.use_jax or not HAS_JAX:
-            # Numerical gradient
-            eps = 1e-8
-            values_array = _coerce_array(values)
+            # Numerical gradient. Force float64 so in-place perturbation below
+            # can't be silently truncated by integer casting (e.g. int64 input).
+            values_array = _coerce_array(values).astype(np.float64)
             n = len(values_array)
             grad = np.zeros(n)
 
             for i in range(n):
+                # Scale the step to the parameter's magnitude (standard
+                # relative finite-difference step) so it doesn't underflow
+                # to a no-op for large values (e.g. G0 ~ 1e5-1e9 Pa).
+                eps = max(1e-8, abs(values_array[i]) * math.sqrt(np.finfo(np.float64).eps))
                 values_plus = values_array.copy()
                 values_plus[i] += eps
 

--- a/rheojax/core/post_fit_validator.py
+++ b/rheojax/core/post_fit_validator.py
@@ -5,9 +5,11 @@ Extracted from BaseModel.fit() to reduce its cyclomatic complexity.
 
 from __future__ import annotations
 
+import warnings
 from typing import TYPE_CHECKING, Any
 
 from rheojax.core.jax_config import safe_import_jax
+from rheojax.io._exceptions import RheoJaxPhysicsWarning
 from rheojax.logging import get_logger
 
 jax, jnp = safe_import_jax()
@@ -18,6 +20,13 @@ if TYPE_CHECKING:
     type ArrayLike = np.ndarray
 
 logger = get_logger(__name__)
+
+
+class RheoJaxUncertaintyWarning(UserWarning):
+    """Emitted when uncertainty computation (hessian/bootstrap) fails to run.
+
+    Subclasses UserWarning so standard warning filters apply.
+    """
 
 
 class PostFitValidator:
@@ -31,23 +40,29 @@ class PostFitValidator:
             model: Fitted BaseModel instance.
         """
         try:
-            import warnings as _warnings
-
-            from rheojax.io._exceptions import RheoJaxPhysicsWarning
             from rheojax.utils.physics_checks import check_fit_physics
 
             violations = check_fit_physics(model)
             for v in violations:
-                _warnings.warn(
+                warnings.warn(
                     f"{v.check}: {v.message} ({v.parameter}={v.value})",
                     RheoJaxPhysicsWarning,
                     stacklevel=3,
                 )
         except Exception as exc:
-            logger.debug(
+            # check_physics is advisory: a bug in one check rule must not crash
+            # fit(), but check_physics=True still promises RheoJaxPhysicsWarning
+            # on violations, so a failure to even run has to be visible too.
+            logger.warning(
                 "Physics check failed",
                 model=model.__class__.__name__,
                 error=str(exc),
+                exc_info=True,
+            )
+            warnings.warn(
+                f"check_physics failed to run: {exc}",
+                RheoJaxPhysicsWarning,
+                stacklevel=3,
             )
 
     @staticmethod
@@ -70,21 +85,33 @@ class PostFitValidator:
         Returns:
             Uncertainty result dict, or None on failure.
         """
+        if uncertainty not in ("hessian", "bootstrap"):
+            raise ValueError(
+                f"Unknown uncertainty method: {uncertainty!r}. "
+                "Expected 'hessian' or 'bootstrap'."
+            )
+
         try:
             from rheojax.utils.uncertainty import bootstrap_ci, hessian_ci
 
             if uncertainty == "hessian":
                 return hessian_ci(model, X, y, test_mode=test_mode)
-            elif uncertainty == "bootstrap":
-                return bootstrap_ci(model, X, y, test_mode=test_mode)
             else:
-                logger.warning("Unknown uncertainty method", method=uncertainty)
-                return None
+                return bootstrap_ci(model, X, y, test_mode=test_mode)
         except Exception as exc:
+            # Mirror check_physics's policy: a failure to even run has to be
+            # visible, not just logged, otherwise the caller gets a FitResult
+            # that silently lacks uncertainty metadata.
             logger.warning(
                 "Uncertainty computation failed",
                 model=model.__class__.__name__,
                 method=uncertainty,
                 error=str(exc),
+                exc_info=True,
+            )
+            warnings.warn(
+                f"Uncertainty computation ({uncertainty}) failed to run: {exc}",
+                RheoJaxUncertaintyWarning,
+                stacklevel=3,
             )
             return None

--- a/rheojax/core/registry.py
+++ b/rheojax/core/registry.py
@@ -153,8 +153,10 @@ class Registry:
                 if isinstance(p, str):
                     try:
                         normalized_protocols.append(Protocol(p))
-                    except ValueError:
-                        logger.warning(f"Invalid protocol '{p}' for plugin '{name}'")
+                    except ValueError as exc:
+                        raise ValueError(
+                            f"Invalid protocol '{p}' for plugin '{name}'"
+                        ) from exc
                 elif isinstance(p, Protocol):  # type: ignore[unreachable]
                     normalized_protocols.append(p)
 
@@ -164,10 +166,10 @@ class Registry:
             if isinstance(transform_type, str):
                 try:
                     normalized_transform_type = TransformType(transform_type)
-                except ValueError:
-                    logger.warning(
+                except ValueError as exc:
+                    raise ValueError(
                         f"Invalid transform_type '{transform_type}' for plugin '{name}'"
-                    )
+                    ) from exc
             elif isinstance(transform_type, TransformType):  # type: ignore[unreachable]
                 normalized_transform_type = transform_type
 
@@ -202,12 +204,30 @@ class Registry:
                     raise ValueError(
                         f"Model plugin does not implement required interface: missing '{method}' method"
                     )
+            # hasattr alone can't catch an incomplete ABC subclass: the
+            # concrete fit()/predict() wrappers (and even the abstract
+            # _fit/_predict stubs) are always present via inheritance.
+            # Reject any plugin class that still has unimplemented
+            # abstract methods (e.g. BaseModel._fit/_predict never
+            # overridden).
+            if inspect.isabstract(plugin_class):
+                missing = sorted(plugin_class.__abstractmethods__)
+                raise ValueError(
+                    f"Model plugin '{plugin_class.__name__}' is abstract; "
+                    f"missing implementation for: {', '.join(missing)}"
+                )
 
         elif plugin_type == PluginType.TRANSFORM:
             # Check for required transform methods
             if not hasattr(plugin_class, "transform"):
                 raise ValueError(
                     "Transform plugin does not implement required interface: missing 'transform' method"
+                )
+            if inspect.isabstract(plugin_class):
+                missing = sorted(plugin_class.__abstractmethods__)
+                raise ValueError(
+                    f"Transform plugin '{plugin_class.__name__}' is abstract; "
+                    f"missing implementation for: {', '.join(missing)}"
                 )
 
     def get(
@@ -289,10 +309,20 @@ class Registry:
         Returns:
             Dictionary mapping plugin names to (class, type) tuples
         """
-        result = {}
+        result: dict[str, tuple[type, PluginType]] = {}
         for name, info in self._models.items():
             result[name] = (info.plugin_class, PluginType.MODEL)
         for name, info in self._transforms.items():
+            if name in result:
+                # Model and transform namespaces are independent (see
+                # __contains__/get), but get_all() flattens both into a
+                # single name-keyed dict, so a name registered as both
+                # would otherwise silently drop the model entry here.
+                logger.warning(
+                    "Plugin name registered as both a model and a transform; "
+                    "get_all() will only return the transform entry",
+                    name=name,
+                )
             result[name] = (info.plugin_class, PluginType.TRANSFORM)
         return result
 
@@ -341,11 +371,18 @@ class Registry:
         try:
             module = importlib.import_module(module_name)
         except ImportError:
+            logger.warning(
+                "Failed to import module during discovery", module_name=module_name
+            )
             return
 
         # Scan module for plugins
         for name, obj in inspect.getmembers(module):
             if inspect.isclass(obj):
+                # Only register classes actually defined in this module, not
+                # base classes merely imported into its namespace (e.g. BaseModel).
+                if getattr(obj, "__module__", None) != module_name:
+                    continue
                 # Check if it's a model
                 if hasattr(obj, "fit") and hasattr(obj, "predict"):
                     try:
@@ -422,6 +459,7 @@ class Registry:
         self,
         protocol: Protocol | str | None = None,
         transform_type: TransformType | str | None = None,
+        plugin_type: PluginType | None = None,
         **criteria,
     ) -> list[str]:
         """Find plugins matching certain criteria.
@@ -429,6 +467,9 @@ class Registry:
         Args:
             protocol: Filter models by supported protocol
             transform_type: Filter transforms by type
+            plugin_type: Restrict the scan to PluginType.MODEL or
+                PluginType.TRANSFORM. Defaults to None, which scans both
+                (preserves the historical bare-call behavior).
             **criteria: Additional criteria to match against plugin metadata
 
         Returns:
@@ -438,13 +479,17 @@ class Registry:
         compatible = []
 
         # Check models
-        if transform_type is None:
+        if transform_type is None and plugin_type in (None, PluginType.MODEL):
             for name, info in self._models.items():
                 # Protocol filtering
                 if protocol:
-                    target_proto = (
-                        Protocol(protocol) if isinstance(protocol, str) else protocol
-                    )
+                    try:
+                        target_proto = (
+                            Protocol(protocol) if isinstance(protocol, str) else protocol
+                        )
+                    except ValueError:
+                        # Unrecognized protocol string: no model can match it.
+                        continue
                     if target_proto not in info.protocols:
                         continue
 
@@ -452,15 +497,19 @@ class Registry:
                     compatible.append(name)
 
         # Check transforms
-        if protocol is None:
+        if protocol is None and plugin_type in (None, PluginType.TRANSFORM):
             for name, info in self._transforms.items():
                 # Transform type filtering
                 if transform_type:
-                    target_type = (
-                        TransformType(transform_type)
-                        if isinstance(transform_type, str)
-                        else transform_type
-                    )
+                    try:
+                        target_type = (
+                            TransformType(transform_type)
+                            if isinstance(transform_type, str)
+                            else transform_type
+                        )
+                    except ValueError:
+                        # Unrecognized transform_type string: no transform can match it.
+                        continue
                     if info.transform_type != target_type:
                         continue
 
@@ -535,7 +584,14 @@ class Registry:
                     force=True,
                     protocols=protocols,
                 )
-            except (ImportError, AttributeError):
+            except (ImportError, AttributeError, KeyError, TypeError) as exc:
+                logger.warning(
+                    "Failed to restore model from state",
+                    name=name,
+                    module=info.get("module") if isinstance(info, dict) else None,
+                    class_name=info.get("class_name") if isinstance(info, dict) else None,
+                    error=str(exc),
+                )
                 continue
 
         # Import transforms
@@ -552,7 +608,14 @@ class Registry:
                     force=True,
                     transform_type=transform_type,
                 )
-            except (ImportError, AttributeError):
+            except (ImportError, AttributeError, KeyError, TypeError) as exc:
+                logger.warning(
+                    "Failed to restore transform from state",
+                    name=name,
+                    module=info.get("module") if isinstance(info, dict) else None,
+                    class_name=info.get("class_name") if isinstance(info, dict) else None,
+                    error=str(exc),
+                )
                 continue
 
     def inventory(self) -> dict[str, Any]:
@@ -685,6 +748,7 @@ class ModelRegistry:
         cls,
         name: str,
         protocols: list[Protocol | str] | None = None,
+        validate: bool = True,
         **metadata,
     ):
         """Decorator for registering a model.
@@ -692,6 +756,9 @@ class ModelRegistry:
         Args:
             name: Name for the model
             protocols: List of supported protocols
+            validate: Whether to validate the model implements the required
+                interface (fit/predict, and no unimplemented abstract
+                methods) at registration time. Defaults to True.
             **metadata: Additional metadata for the model
 
         Returns:
@@ -711,6 +778,7 @@ class ModelRegistry:
                 model_class,
                 PluginType.MODEL,
                 metadata=metadata,
+                validate=validate,
                 protocols=protocols,
             )
             return model_class
@@ -782,7 +850,9 @@ class ModelRegistry:
 
         _ensure_all_registered()
         registry = cls._get_registry()
-        return registry.find_compatible(protocol=protocol, **criteria)
+        return registry.find_compatible(
+            protocol=protocol, plugin_type=PluginType.MODEL, **criteria
+        )
 
     @classmethod
     def get_info(cls, name: str) -> PluginInfo | None:
@@ -922,12 +992,21 @@ class TransformRegistry:
         return cls._registry
 
     @classmethod
-    def register(cls, name: str, type: TransformType | str | None = None, **metadata):
+    def register(
+        cls,
+        name: str,
+        type: TransformType | str | None = None,
+        validate: bool = True,
+        **metadata,
+    ):
         """Decorator for registering a transform.
 
         Args:
             name: Name for the transform
             type: Type of transform (TransformType)
+            validate: Whether to validate the transform implements the
+                required interface (transform, and no unimplemented
+                abstract methods) at registration time. Defaults to True.
             **metadata: Additional metadata for the transform
 
         Returns:
@@ -946,6 +1025,7 @@ class TransformRegistry:
                 transform_class,
                 PluginType.TRANSFORM,
                 metadata=metadata,
+                validate=validate,
                 transform_type=type,
             )
             return transform_class
@@ -1013,7 +1093,9 @@ class TransformRegistry:
 
         _ensure_all_registered()
         registry = cls._get_registry()
-        return registry.find_compatible(transform_type=type, **criteria)
+        return registry.find_compatible(
+            transform_type=type, plugin_type=PluginType.TRANSFORM, **criteria
+        )
 
     @classmethod
     def get_info(cls, name: str) -> PluginInfo | None:

--- a/rheojax/core/test_modes.py
+++ b/rheojax/core/test_modes.py
@@ -116,11 +116,6 @@ def is_monotonic_increasing(
     if len(data) < 2:
         return True
 
-    # Check overall trend first
-    overall_trend = data[-1] - data[0]
-    if overall_trend < 0:
-        return False
-
     # Calculate tolerance based on data magnitude
     data_mag = np.mean(np.abs(data))
     rel_tolerance = tolerance * data_mag
@@ -160,11 +155,6 @@ def is_monotonic_decreasing(
 
     if len(data) < 2:
         return True
-
-    # Check overall trend first
-    overall_trend = data[-1] - data[0]
-    if overall_trend > 0:
-        return False
 
     # Calculate tolerance based on data magnitude
     data_mag = np.mean(np.abs(data))
@@ -246,6 +236,21 @@ def detect_test_mode(rheo_data: RheoData) -> TestModeEnum:
 
         # Shear rate units → ROTATION (steady shear)
         if any(unit in x_units_lower for unit in ["1/s", "s^-1", "s-1", "/s"]):
+            # R-TESTMODE-002: '1/s'/'s^-1' is dimensionally identical to Hz
+            # (both are "per second"), so this is genuinely ambiguous between
+            # shear rate (rotation) and frequency (oscillation). domain ==
+            # 'frequency' already returned OSCILLATION above, so reaching here
+            # means domain is 'time'/None (the default) — warn instead of
+            # silently assuming ROTATION.
+            warnings.warn(
+                f"x_units='{x_units}' is ambiguous between shear rate "
+                "(rotation) and frequency (Hz = 1/s); assuming ROTATION "
+                "because domain != 'frequency'. If this is frequency-domain "
+                "oscillation/modulus data, construct RheoData with "
+                "domain='frequency' explicitly.",
+                UserWarning,
+                stacklevel=2,
+            )
             return TestModeEnum.ROTATION
 
     # 3. Time-domain analysis: check monotonicity
@@ -258,11 +263,28 @@ def detect_test_mode(rheo_data: RheoData) -> TestModeEnum:
         if np.iscomplexobj(y_data):
             y_data = np.real(y_data)
 
+        # R-TESTMODE-NAN: NaN/Inf must never fall through to the flatness
+        # heuristic below. np.max/np.min/np.mean all propagate NaN, which
+        # makes `data_magnitude > 0` False (NaN comparisons are always
+        # False), silently collapsing relative_change to 0 and misreporting
+        # NaN-poisoned data as flat RELAXATION. Fail loudly instead.
+        if not np.all(np.isfinite(y_data)):
+            warnings.warn(
+                "Time-domain y-data contains NaN or Inf; cannot reliably "
+                "detect test mode. Set test_mode explicitly in metadata.",
+                UserWarning,
+                stacklevel=2,
+            )
+            return TestModeEnum.UNKNOWN
+
         # Check if data is essentially flat (no significant change)
-        # This handles elastic solids that have fully relaxed to equilibrium
-        overall_change = abs(y_data[-1] - y_data[0])
+        # This handles elastic solids that have fully relaxed to equilibrium.
+        # Use the full-series range (not just endpoints) so an oscillatory
+        # (e.g. LAOS) trace that happens to start/end at the same value isn't
+        # mistaken for flat/relaxed data.
+        data_range = np.max(y_data) - np.min(y_data)
         data_magnitude = np.mean(np.abs(y_data))
-        relative_change = overall_change / data_magnitude if data_magnitude > 0 else 0
+        relative_change = data_range / data_magnitude if data_magnitude > 0 else 0
 
         # If change < 5% of magnitude, consider it flat
         # Flat time-domain data is more likely relaxation (reached equilibrium) than creep
@@ -370,7 +392,11 @@ def get_compatible_test_modes(model_name: str) -> list[TestMode]:
         modes = model_cls.supported_test_modes
         try:
             return [TestMode(m) if isinstance(m, str) else m for m in modes]
-        except (ValueError, KeyError):
+        except (ValueError, KeyError) as e:
+            logger.warning(
+                f"Invalid supported_test_modes on model '{model_name}': {e}. "
+                "Falling back to default test modes."
+            )
             return [TestMode.RELAXATION, TestMode.CREEP, TestMode.OSCILLATION]
 
     # Check for _fit method and infer from docstring or signature (legacy)

--- a/tests/core/test_arviz_utils.py
+++ b/tests/core/test_arviz_utils.py
@@ -174,6 +174,19 @@ def test_arviz_figure_uses_arviz_1_plot_collection_viz() -> None:
     assert arviz_utils.arviz_figure(plot_collection) is figure
 
 
+def test_import_arviz_missing_required_attr_raises_import_error(monkeypatch) -> None:
+    stub_arviz = SimpleNamespace(__version__="1.2.0")
+    monkeypatch.setitem(__import__("sys").modules, "arviz", stub_arviz)
+
+    with pytest.raises(ImportError) as excinfo:
+        arviz_utils.import_arviz(required=("plot_pair",))
+
+    message = str(excinfo.value)
+    assert "plot_pair" in message
+    assert "arviz[plots]" not in message
+    assert "arviz[matplotlib]" in message
+
+
 def test_arviz_figure_rejects_unknown_result_instead_of_guessing() -> None:
     active_figure = plt.figure()
 

--- a/tests/core/test_base.py
+++ b/tests/core/test_base.py
@@ -1286,6 +1286,75 @@ class TestStandardNlsqFitTestModeOverride:
         assert model._test_mode == "oscillation"
 
 
+class TestStandardNlsqFit0DArray:
+    """Regression test: _standard_nlsq_fit's debug-log shape computation and
+    its failure-path point-count check must not crash on a 0-d array input
+    (same root cause, and same fix pattern, as the predict()/fit_predict()/
+    fit_bayesian() 0-d fixes above -- these are sibling call sites that fix
+    missed).
+
+    nlsq_optimize itself is mocked: rheojax.utils.optimization has its own,
+    separate pre-existing 0-d-unsafe len() calls (e.g. in the r_squared
+    property and the normalization-weights length check) that are a
+    different module's bug, out of scope here. Mocking isolates exactly the
+    two lines in base.py these tests target.
+    """
+
+    def _make_model(self):
+        class LinearModel(BaseModel):
+            def __init__(self):
+                super().__init__()
+                self.parameters = ParameterSet()
+                self.parameters.add("a", value=1.0, bounds=(0.0, 10.0))
+
+            def _fit(self, X, y, **kwargs):
+                def model_fn(x, params):
+                    return params[0] * x
+
+                return self._standard_nlsq_fit(X, y, model_fn, **kwargs)
+
+            def _predict(self, X):
+                return X * self.parameters.get_value("a")
+
+        return LinearModel()
+
+    def test_standard_nlsq_fit_with_0d_array_no_indexerror(self):
+        """Success path: data_shape computation (line ~179) must not raise
+        IndexError from x_np.shape[0] on a 0-d array."""
+        from unittest.mock import MagicMock, patch
+
+        model = self._make_model()
+        X = np.array(5.0)
+        y = np.array(10.0)
+
+        stub_result = MagicMock(success=True, fun=0.0, x=np.array([2.0]), nit=3)
+        with patch(
+            "rheojax.utils.optimization.nlsq_optimize", return_value=stub_result
+        ):
+            model._fit(X, y, max_iter=5)
+
+        assert model.fitted_ is True
+
+    def test_standard_nlsq_fit_with_0d_array_failure_path_no_indexerror(self):
+        """Failure path: the len(x_np) point-count check (line ~239) must not
+        raise TypeError ('len() of unsized object') on a 0-d array; it should
+        reach the intended RuntimeError instead."""
+        from unittest.mock import MagicMock, patch
+
+        model = self._make_model()
+        X = np.array(5.0)
+        y = np.array(10.0)
+
+        stub_result = MagicMock(
+            success=False, fun=float("nan"), message="did not converge", nit=1
+        )
+        with patch(
+            "rheojax.utils.optimization.nlsq_optimize", return_value=stub_result
+        ):
+            with pytest.raises(RuntimeError, match="Optimization failed"):
+                model._fit(X, y, max_iter=5)
+
+
 class TestTransformPipelineExtrasPassthrough:
     """Regression test: TransformPipeline must not silently drop a tuple
     (data, extras) return from the pipeline's final transform step."""

--- a/tests/core/test_base.py
+++ b/tests/core/test_base.py
@@ -1225,3 +1225,108 @@ class TestJAXSupport:
 
         expected = jnp.exp(batch)
         assert jnp.allclose(result, expected)
+
+
+class TestFitPredictZeroDimensional:
+    """Regression test: fit_predict()'s debug-log shape computation must not
+    crash on a 0-d array input (same root cause as BaseModel.predict())."""
+
+    def test_fit_predict_with_0d_array_no_typeerror(self):
+        """0-d X must not raise TypeError from len() before fit() even runs."""
+
+        class DummyModel(BaseModel):
+            def _fit(self, X, y, **kwargs):
+                return self
+
+            def _predict(self, X):
+                return X
+
+            def fit(self, X, y, **kwargs):
+                # Bypass FitOrchestrator entirely; this isolates the
+                # data_shape debug-log computation in fit_predict() itself.
+                self.fitted_ = True
+                return self
+
+        model = DummyModel()
+        X = np.array(5.0)
+        y = np.array(100.0)
+        result = model.fit_predict(X, y)
+        assert float(result) == 5.0
+
+
+class TestStandardNlsqFitTestModeOverride:
+    """Regression test: _standard_nlsq_fit must honor an explicit test_mode
+    override even when X is a RheoData with its own embedded test_mode."""
+
+    def test_explicit_test_mode_overrides_rheodata_test_mode(self):
+        from rheojax.core.data import RheoData
+
+        class LinearModel(BaseModel):
+            def __init__(self):
+                super().__init__()
+                self.parameters = ParameterSet()
+                self.parameters.add("a", value=1.0, bounds=(0.0, 10.0))
+
+            def _fit(self, X, y, **kwargs):
+                def model_fn(x, params):
+                    return params[0] * x
+
+                return self._standard_nlsq_fit(X, y, model_fn, **kwargs)
+
+            def _predict(self, X):
+                return X * self.parameters.get_value("a")
+
+        model = LinearModel()
+        x = np.array([1.0, 2.0, 3.0, 4.0])
+        y = np.array([2.0, 4.0, 6.0, 8.0])
+        rheo_data = RheoData(x=x, y=y, initial_test_mode="relaxation")
+
+        model._fit(rheo_data, None, test_mode="oscillation", max_iter=5)
+
+        assert model._test_mode == "oscillation"
+
+
+class TestTransformPipelineExtrasPassthrough:
+    """Regression test: TransformPipeline must not silently drop a tuple
+    (data, extras) return from the pipeline's final transform step."""
+
+    def test_pipeline_preserves_last_step_extras(self):
+        from rheojax.core.base import TransformPipeline
+
+        class PassthroughTransform(BaseTransform):
+            def _transform(self, data):
+                return data
+
+        class ExtrasTransform(BaseTransform):
+            def _transform(self, data):
+                return data, {"shift_factor": 2.0}
+
+        pipeline = TransformPipeline([PassthroughTransform(), ExtrasTransform()])
+        result = pipeline.transform(np.array([1.0, 2.0, 3.0]))
+
+        assert isinstance(result, tuple)
+        data, extras = result
+        assert extras == {"shift_factor": 2.0}
+        assert np.array_equal(data, np.array([1.0, 2.0, 3.0]))
+
+    def test_pipeline_still_unwraps_mid_pipeline_extras(self):
+        """Mid-pipeline tuple returns must still be unwrapped so the next
+        step receives only the data, not a (data, extras) tuple."""
+        from rheojax.core.base import TransformPipeline
+
+        class ExtrasTransform(BaseTransform):
+            def _transform(self, data):
+                return data, {"shift_factor": 2.0}
+
+        class RecordingTransform(BaseTransform):
+            def _transform(self, data):
+                self.received = data
+                return data
+
+        recorder = RecordingTransform()
+        pipeline = TransformPipeline([ExtrasTransform(), recorder])
+        result = pipeline.transform(np.array([1.0, 2.0, 3.0]))
+
+        assert not isinstance(recorder.received, tuple)
+        assert np.array_equal(recorder.received, np.array([1.0, 2.0, 3.0]))
+        assert not isinstance(result, tuple)

--- a/tests/core/test_base_edge_cases.py
+++ b/tests/core/test_base_edge_cases.py
@@ -101,3 +101,15 @@ class TestBaseModelEdgeCases:
         for name in param_names:
             val = model.parameters.get_value(name)
             assert val is not None
+
+    def test_predict_with_0d_array(self):
+        """predict() must not raise TypeError on a 0-d array input.
+
+        np.array(5.0) has .shape == () which is falsy but not None; the
+        old `getattr(X, "shape", None) or (len(X),)` pattern fell through
+        to len(X), which raises TypeError on a 0-d array.
+        """
+        model = Maxwell()
+        X = np.array(5.0)
+        result = model.predict(X, test_mode="relaxation")
+        assert np.isfinite(float(result))

--- a/tests/core/test_basemodel_integration.py
+++ b/tests/core/test_basemodel_integration.py
@@ -371,3 +371,19 @@ class TestPrecompile:
         assert model.fitted_ is False
         model.precompile()
         assert model.fitted_ is False
+
+    @pytest.mark.smoke
+    def test_precompile_preserves_nlsq_result(self):
+        """precompile() must not clobber a real fit's stored NLSQ result."""
+        model = Maxwell()
+        t = np.logspace(-2, 2, 20)
+        G = 1000.0 * np.exp(-t / 1.0)
+        model.fit(t, G, test_mode="relaxation")
+        original_result = model.get_nlsq_result()
+        assert original_result is not None
+
+        model.precompile(test_mode="relaxation")
+
+        # The throwaway max_iter=1 precompile fit must not overwrite the
+        # real optimization result.
+        assert model.get_nlsq_result() is original_result

--- a/tests/core/test_bayesian.py
+++ b/tests/core/test_bayesian.py
@@ -480,26 +480,11 @@ def test_error_handling_invalid_bounds():
     """Test that invalid parameter bounds raise appropriate errors."""
     model = SimpleBayesianModel()
 
-    # Set invalid bounds (lower > upper)
-    model.parameters.get("a").bounds = (10.0, 1.0)  # Invalid
-
-    # Create synthetic data
-    X = np.linspace(0, 10, 30)
-    y = 2.0 * X + 3.0
-
-    model.X_data = X
-    model.y_data = y
-
-    # Should raise RuntimeError or ValueError for invalid bounds
+    # Setting invalid bounds (lower > upper) now raises immediately at
+    # assignment time (Parameter.bounds setter fail-closed fix), rather than
+    # silently accepting them and only failing later inside fit_bayesian().
     with pytest.raises((RuntimeError, ValueError)):
-        model.fit_bayesian(
-            X,
-            y,
-            test_mode="relaxation",
-            num_warmup=50,
-            num_samples=100,
-            num_chains=1,
-        )
+        model.parameters.get("a").bounds = (10.0, 1.0)  # Invalid
 
 
 def test_error_handling_mismatched_data_dimensions():
@@ -515,6 +500,31 @@ def test_error_handling_mismatched_data_dimensions():
 
     # Should raise RuntimeError or ValueError for mismatched dimensions
     with pytest.raises((RuntimeError, ValueError, AssertionError)):
+        model.fit_bayesian(
+            X,
+            y,
+            test_mode="relaxation",
+            num_warmup=50,
+            num_samples=100,
+            num_chains=1,
+        )
+
+
+def test_error_handling_broadcastable_but_wrong_y_shape():
+    """A (N, 1) y (e.g. from `df['col'].values.reshape(-1, 1)`) must raise,
+    not silently broadcast against the (N,)-shaped prediction inside
+    NumPyro's Normal likelihood (which would corrupt the log-likelihood
+    over N^2 mismatched pairs instead of erroring).
+    """
+    model = SimpleBayesianModel()
+
+    X = np.linspace(0, 10, 30)
+    y = np.linspace(0, 10, 30).reshape(-1, 1)  # same shape[0], wrong ndim
+
+    model.X_data = X
+    model.y_data = y
+
+    with pytest.raises(ValueError, match="1-dimensional"):
         model.fit_bayesian(
             X,
             y,

--- a/tests/core/test_bayesian_diagnostics.py
+++ b/tests/core/test_bayesian_diagnostics.py
@@ -269,6 +269,280 @@ class TestDivergenceReporting:
         # Divergences should be a non-negative integer (actual count)
         assert result.diagnostics["divergences"] >= 0
 
+    @pytest.mark.smoke
+    def test_divergence_extraction_failure_preserves_r_hat_and_ess(self):
+        """A broad (non-TypeError/KeyError/AttributeError) failure while
+        counting divergences must not discard already-computed r_hat/ess.
+
+        Regression test: previously only (KeyError, AttributeError) were
+        caught around divergence extraction, so e.g. a RuntimeError from
+        mcmc.get_extra_fields() propagated to the outer handler, which
+        unconditionally overwrote diagnostics['r_hat']/['ess'] with NaN
+        even though they had already been computed successfully.
+        """
+        from rheojax.core.bayesian_diagnostics import compute_diagnostics
+
+        class _BrokenDivergenceMCMC:
+            def get_extra_fields(self, *args, **kwargs):
+                raise RuntimeError("simulated device error")
+
+        rng = np.random.default_rng(0)
+        posterior_samples = {
+            "a": rng.normal(0.0, 1.0, 400),
+            "b": rng.normal(0.0, 1.0, 400),
+        }
+
+        diagnostics = compute_diagnostics(
+            mcmc=_BrokenDivergenceMCMC(),
+            posterior_samples=posterior_samples,
+            num_samples=200,
+            num_chains=2,
+        )
+
+        # r_hat/ess must be the real computed values, not NaN fallback
+        assert np.isfinite(diagnostics["r_hat"]["a"])
+        assert np.isfinite(diagnostics["r_hat"]["b"])
+        assert np.isfinite(diagnostics["ess"]["a"])
+        assert np.isfinite(diagnostics["ess"]["b"])
+        # Divergence count is unknown, and diagnostics as a whole are marked
+        # invalid, but the successful sub-results are not clobbered.
+        assert diagnostics["divergences"] == -1
+        assert diagnostics["diagnostics_valid"] is False
+
+    @pytest.mark.smoke
+    def test_all_nan_diagnostics_mark_invalid(self):
+        """diagnostics_valid must be False when r_hat/ess are NaN without a raise.
+
+        Regression test: numpyro's split_gelman_rubin/effective_sample_size
+        return NaN (not an exception) for degenerate/constant chains. The old
+        code only flipped all_succeeded inside the except branch, so a clean
+        NaN return left diagnostics_valid=True even though every parameter's
+        r_hat/ess was NaN.
+        """
+        from rheojax.core.bayesian_diagnostics import compute_diagnostics
+
+        class _CleanMCMC:
+            def get_extra_fields(self, *args, **kwargs):
+                return {"diverging": np.zeros((2, 100), dtype=bool)}
+
+        # Constant (zero-variance) samples for every parameter, every chain —
+        # numpyro returns NaN for these without raising.
+        posterior_samples = {
+            "a": np.ones(200),
+            "b": np.full(200, 3.0),
+        }
+
+        diagnostics = compute_diagnostics(
+            mcmc=_CleanMCMC(),
+            posterior_samples=posterior_samples,
+            num_samples=100,
+            num_chains=2,
+        )
+
+        assert np.isnan(diagnostics["r_hat"]["a"])
+        assert np.isnan(diagnostics["r_hat"]["b"])
+        assert diagnostics["divergences"] == 0
+        assert diagnostics["diagnostics_valid"] is False
+
+
+# ---------------------------------------------------------------------------
+# BFMI (E-BFMI) computation
+# ---------------------------------------------------------------------------
+
+
+class TestBFMI:
+    """Verify compute_diagnostics() computes BFMI from the energy extra field."""
+
+    @pytest.mark.smoke
+    def test_bfmi_computed_from_energy_field(self):
+        """A well-mixing synthetic energy trace should give a finite BFMI."""
+        from rheojax.core.bayesian_diagnostics import compute_diagnostics
+
+        rng = np.random.default_rng(0)
+        energy = rng.normal(10.0, 1.0, size=(2, 100))
+
+        class _EnergyMCMC:
+            def get_extra_fields(self, *args, **kwargs):
+                return {
+                    "diverging": np.zeros((2, 100), dtype=bool),
+                    "energy": energy,
+                }
+
+        posterior_samples = {
+            "a": rng.normal(0.0, 1.0, 200),
+            "b": rng.normal(0.0, 1.0, 200),
+        }
+
+        diagnostics = compute_diagnostics(
+            mcmc=_EnergyMCMC(),
+            posterior_samples=posterior_samples,
+            num_samples=100,
+            num_chains=2,
+        )
+
+        assert "bfmi" in diagnostics
+        assert np.isfinite(diagnostics["bfmi"])
+
+        # Cross-check against the direct formula (matches
+        # rheojax.gui.foundation.metrics.bfmi): mean(diff(E)**2) / var(E),
+        # reduced to the worst (minimum) chain.
+        expected = min(
+            float(np.mean(np.diff(chain) ** 2) / np.var(chain)) for chain in energy
+        )
+        assert diagnostics["bfmi"] == pytest.approx(expected)
+
+    @pytest.mark.smoke
+    def test_bfmi_nan_when_energy_field_unavailable(self):
+        """Missing 'energy' extra field should yield NaN, not a crash."""
+        from rheojax.core.bayesian_diagnostics import compute_diagnostics
+
+        class _NoEnergyMCMC:
+            def get_extra_fields(self, *args, **kwargs):
+                return {"diverging": np.zeros((2, 100), dtype=bool)}
+
+        rng = np.random.default_rng(1)
+        posterior_samples = {
+            "a": rng.normal(0.0, 1.0, 200),
+            "b": rng.normal(0.0, 1.0, 200),
+        }
+
+        diagnostics = compute_diagnostics(
+            mcmc=_NoEnergyMCMC(),
+            posterior_samples=posterior_samples,
+            num_samples=100,
+            num_chains=2,
+        )
+
+        assert np.isnan(diagnostics["bfmi"])
+        # Absence of the energy field is a normal "unavailable" state, not a
+        # diagnostics failure — r_hat/ess/divergences are unaffected.
+        assert diagnostics["diagnostics_valid"] is True
+
+    @pytest.mark.smoke
+    def test_bfmi_nan_chain_does_not_mask_worst_chain(self):
+        """A NaN-valued chain must not hide a genuinely low BFMI chain.
+
+        Regression test: the old code reduced chain_bfmis with Python's
+        min(), which is order-dependent in the presence of NaN (all
+        comparisons against NaN are False). A chain whose energy trace
+        overflowed to NaN could silently swallow the real worst (lowest)
+        BFMI from a different, genuinely poorly-mixing chain, depending on
+        list order. np.nanmin is order-independent and must be used instead.
+        """
+        from rheojax.core.bayesian_diagnostics import compute_bfmi
+
+        rng = np.random.default_rng(2)
+        # Chain 0: genuinely poor mixing (tiny variance in diffs relative to
+        # var) -> low BFMI. Chain 1: NaN energy trace (simulated leapfrog
+        # overflow).
+        good_chain = rng.normal(10.0, 1.0, size=100)
+        nan_chain = np.full(100, np.nan)
+
+        class _MockMCMC:
+            def __init__(self, energy):
+                self._energy = energy
+
+            def get_extra_fields(self, group_by_chain=False):
+                return {"energy": self._energy}
+
+        # Order 1: [poor-mixing, NaN] — old min() would return NaN here too
+        # in some numpy/py versions, but the critical case is order 2.
+        mcmc_a = _MockMCMC(np.stack([good_chain, nan_chain]))
+        bfmi_a = compute_bfmi(mcmc_a, num_chains=2)
+
+        # Order 2: [NaN, poor-mixing] — old min() definitely returns NaN
+        # here since nan compares False against everything that follows.
+        mcmc_b = _MockMCMC(np.stack([nan_chain, good_chain]))
+        bfmi_b = compute_bfmi(mcmc_b, num_chains=2)
+
+        expected = float(
+            np.mean(np.diff(good_chain) ** 2) / np.var(good_chain)
+        )
+        assert bfmi_a == pytest.approx(expected)
+        assert bfmi_b == pytest.approx(expected)
+
+    @pytest.mark.smoke
+    def test_bfmi_below_threshold_marks_diagnostics_invalid(self):
+        """A finite BFMI below BFMI_THRESHOLD must gate diagnostics_valid.
+
+        Regression test: BFMI was computed and stored in diagnostics but
+        never folded into all_valid/diagnostics_valid, so a genuinely poor
+        E-BFMI (<0.3) with healthy-looking r_hat/ess returned silently with
+        diagnostics_valid=True.
+        """
+        from rheojax.core.bayesian_diagnostics import compute_diagnostics
+
+        rng = np.random.default_rng(3)
+        # Slow random-walk energy trace: step-to-step diffs are tiny (small
+        # BFMI numerator) while the cumulative drift makes the marginal
+        # energy variance large (large BFMI denominator) -> BFMI well below
+        # the 0.3 threshold. This is the textbook "energy barely explores
+        # between draws" poor-mixing signature.
+        poor_energy = np.stack(
+            [np.cumsum(rng.normal(0.0, 0.05, size=100)) for _ in range(2)]
+        )
+
+        class _PoorBfmiMCMC:
+            def get_extra_fields(self, *args, **kwargs):
+                return {
+                    "diverging": np.zeros((2, 100), dtype=bool),
+                    "energy": poor_energy,
+                }
+
+        posterior_samples = {
+            "a": rng.normal(0.0, 1.0, 200),
+            "b": rng.normal(0.0, 1.0, 200),
+        }
+
+        diagnostics = compute_diagnostics(
+            mcmc=_PoorBfmiMCMC(),
+            posterior_samples=posterior_samples,
+            num_samples=100,
+            num_chains=2,
+        )
+
+        assert np.isfinite(diagnostics["bfmi"])
+        assert diagnostics["bfmi"] < 0.3
+        assert diagnostics["diagnostics_valid"] is False
+
+    @pytest.mark.smoke
+    def test_bfmi_group_by_chain_fallback_reshapes_per_chain(self):
+        """Legacy get_extra_fields() (no group_by_chain support) must reshape
+        the flat concatenated energy trace by num_chains, not treat it as a
+        single chain.
+
+        Regression test: compute_bfmi had no num_chains parameter, so on the
+        TypeError fallback path it did `energy[None, :]` on the flat
+        concatenated array, taking np.diff across chain boundaries and
+        collapsing multi-chain worst-case semantics into a single corrupted
+        value.
+        """
+        from rheojax.core.bayesian_diagnostics import compute_bfmi
+
+        rng = np.random.default_rng(4)
+        chain_a = rng.normal(10.0, 1.0, size=100)
+        chain_b = rng.normal(10.0, 5.0, size=100)  # different scale/mixing
+        flat_energy = np.concatenate([chain_a, chain_b])
+
+        class _LegacyMCMC:
+            """Simulates an older NumPyro without group_by_chain kwarg."""
+
+            def get_extra_fields(self):
+                return {"energy": flat_energy}
+
+        bfmi = compute_bfmi(_LegacyMCMC(), num_chains=2)
+
+        expected = min(
+            float(np.mean(np.diff(chain) ** 2) / np.var(chain))
+            for chain in (chain_a, chain_b)
+        )
+        # Flattened (wrong) single-chain value for comparison — must NOT match.
+        wrong = float(
+            np.mean(np.diff(flat_energy) ** 2) / np.var(flat_energy)
+        )
+        assert bfmi == pytest.approx(expected)
+        assert bfmi != pytest.approx(wrong)
+
 
 # ---------------------------------------------------------------------------
 # score() NaN handling fix

--- a/tests/core/test_bayesian_internals.py
+++ b/tests/core/test_bayesian_internals.py
@@ -547,12 +547,14 @@ def test_sample_prior_missing_bounds_raises():
 
 
 def test_sample_prior_unsupported_prior_dict_falls_back_to_uniform():
-    """A prior dict type not recognized by prior_dict_to_dist (e.g. 'beta',
-    which build_numpyro_model's own NUTS prior selection does not support
-    either — it is not one of prior_dict_to_dist's recognized types) falls
-    back to Uniform(lower, upper), matching NUTS exactly instead of
-    sample_prior's old hand-rolled 'beta' special case that NUTS never
-    actually implemented.
+    """A malformed prior dict falls back to Uniform(lower, upper), matching
+    NUTS exactly instead of sample_prior's old hand-rolled 'beta' special
+    case that NUTS never actually implemented. 'type': 'beta' IS recognized
+    by prior_dict_to_dist, but with keys 'concentration0'/'concentration1'
+    -- this spec's 'a'/'b' keys are wrong, so it hits the malformed-spec
+    (KeyError) fallback rather than the unrecognized-type fallback; either
+    way, prior_dict_to_dist returns None and sample_prior falls back to
+    Uniform.
     """
     model = LinearModel()
     param = model.parameters.get("a")

--- a/tests/core/test_bayesian_internals.py
+++ b/tests/core/test_bayesian_internals.py
@@ -190,6 +190,45 @@ def test_prepare_jax_data_empty_complex():
 
 
 # ---------------------------------------------------------------------------
+# _validate_xy_shapes
+# ---------------------------------------------------------------------------
+
+
+def test_validate_xy_shapes_accepts_matching_1d():
+    """Matching 1-D X/y pass without error."""
+    X, y = _linear_data(n=10)
+    BayesianMixin._validate_xy_shapes(X, y)  # no raise
+
+
+def test_validate_xy_shapes_rejects_column_vector_y():
+    """A (N, 1) y has the same shape[0] as X but must still be rejected —
+    shape[0] equality alone would silently pass through the exact
+    broadcasting bug this check exists to catch.
+    """
+    X = np.linspace(0, 1, 10)
+    y = np.linspace(0, 1, 10).reshape(-1, 1)
+    with pytest.raises(ValueError, match="1-dimensional"):
+        BayesianMixin._validate_xy_shapes(X, y)
+
+
+def test_validate_xy_shapes_accepts_n2_real_imag_columns():
+    """The (N, 2) real/imag-columns convention (supported by
+    numpyro_model_builder and RheoData) is not rejected.
+    """
+    X = np.linspace(0, 1, 10)
+    y = np.zeros((10, 2))
+    BayesianMixin._validate_xy_shapes(X, y)  # no raise
+
+
+def test_validate_xy_shapes_rejects_length_mismatch():
+    """Non-broadcastable length mismatch still raises."""
+    X = np.linspace(0, 1, 30)
+    y = np.linspace(0, 1, 50)
+    with pytest.raises(ValueError, match="same length"):
+        BayesianMixin._validate_xy_shapes(X, y)
+
+
+# ---------------------------------------------------------------------------
 # _get_parameter_bounds (lines 352-357, 361)
 # ---------------------------------------------------------------------------
 
@@ -321,6 +360,175 @@ def test_build_warm_start_complex_sigmas():
     np.testing.assert_allclose(ws["sigma_imag"], 0.4, rtol=1e-9)
 
 
+def test_build_warm_start_out_of_bounds_value_warns_and_clamps():
+    """An out-of-bounds initial_values entry is clamped (as before) but must
+    now also surface a user-visible RuntimeWarning — previously this was
+    logged at DEBUG only, silently defeating the warm-start contract.
+    """
+    model = LinearModel()
+    bounds = {"a": (0.1, 10.0), "b": (0.1, 10.0)}
+    with pytest.warns(RuntimeWarning, match="outside parameter bounds"):
+        ws = model._build_warm_start_values(
+            ["a", "b"], bounds, {"a": 100.0, "b": 1.0}, {"data_scale": 1.0}, False
+        )
+    assert ws["a"] <= 10.0
+
+
+def test_build_warm_start_within_bounds_no_warning():
+    """A value within bounds is not clamped and emits no warning."""
+    model = LinearModel()
+    bounds = {"a": (0.1, 10.0), "b": (0.1, 10.0)}
+    with warnings.catch_warnings():
+        warnings.simplefilter("error", RuntimeWarning)
+        ws = model._build_warm_start_values(
+            ["a", "b"], bounds, {"a": 2.0, "b": 1.0}, {"data_scale": 1.0}, False
+        )
+    assert ws["a"] == 2.0
+
+
+# ---------------------------------------------------------------------------
+# fit_bayesian initial_values key validation
+# ---------------------------------------------------------------------------
+
+
+def test_fit_bayesian_rejects_unrecognized_initial_values_key():
+    """A typo'd/stale key in initial_values must raise, not be silently
+    dropped (which would fall back to a midpoint init while
+    has_explicit_warm_start still reports a genuine warm start).
+    """
+    model = LinearModel()
+    X, y = _linear_data()
+    with pytest.raises(ValueError, match="unrecognized parameter"):
+        model.fit_bayesian(
+            X, y, test_mode="relaxation", initial_values={"aa": 2.0}
+        )
+
+
+# ---------------------------------------------------------------------------
+# _run_nuts_sampling has_explicit_warm_start gating (lines 563-565)
+# ---------------------------------------------------------------------------
+
+
+def _prep_run_nuts_args(model, initial_values):
+    X, y = _linear_data(n=10)
+    jax_data = model._prepare_jax_data(X, y)
+    param_names = list(model.parameters)
+    param_bounds = model._get_parameter_bounds(X, y, TestMode.RELAXATION)
+    numpyro_model = model._build_numpyro_model(
+        param_names=param_names,
+        param_bounds=param_bounds,
+        test_mode=TestMode.RELAXATION,
+        is_complex_data=False,
+        scale_info=jax_data["scale_info"],
+    )
+    warm_start_values = model._build_warm_start_values(
+        param_names, param_bounds, initial_values, jax_data["scale_info"], False
+    )
+    return jax_data, numpyro_model, warm_start_values
+
+
+@pytest.mark.slow
+def test_run_nuts_sampling_explicit_initial_values_gets_permissive_defaults():
+    """A genuine caller-supplied initial_values (no prior .fit()) must select
+    the permissive warm-start NUTS defaults, not the conservative cold-start
+    ones. Regression for the bug where has_warm_start reduced to `fitted_`
+    alone because _build_warm_start_values always returns a non-empty dict.
+    """
+    model = LinearModel()
+    assert not hasattr(model, "fitted_")
+    jax_data, numpyro_model, warm_start_values = _prep_run_nuts_args(
+        model, {"a": 2.0, "b": 1.0}
+    )
+    nuts_kwargs = {}
+    model._run_nuts_sampling(
+        numpyro_model=numpyro_model,
+        X_jax=jax_data["X_jax"],
+        y_jax=jax_data["y_jax"],
+        warm_start_values=warm_start_values,
+        num_warmup=1,
+        num_samples=1,
+        num_chains=1,
+        nuts_kwargs=nuts_kwargs,
+        seed=0,
+        has_explicit_warm_start=True,
+    )
+    assert nuts_kwargs["target_accept_prob"] == 0.90
+    assert nuts_kwargs["max_tree_depth"] == 8
+
+
+@pytest.mark.slow
+def test_run_nuts_sampling_no_explicit_warm_start_gets_conservative_defaults():
+    """Without has_explicit_warm_start, cold-start defaults apply even though
+    _build_warm_start_values still returns a fully-populated (midpoint) dict.
+    """
+    model = LinearModel()
+    assert not hasattr(model, "fitted_")
+    jax_data, numpyro_model, warm_start_values = _prep_run_nuts_args(model, None)
+    assert bool(warm_start_values)  # always non-empty, per _build_warm_start_values
+    nuts_kwargs = {}
+    model._run_nuts_sampling(
+        numpyro_model=numpyro_model,
+        X_jax=jax_data["X_jax"],
+        y_jax=jax_data["y_jax"],
+        warm_start_values=warm_start_values,
+        num_warmup=1,
+        num_samples=1,
+        num_chains=1,
+        nuts_kwargs=nuts_kwargs,
+        seed=0,
+        has_explicit_warm_start=False,
+    )
+    assert nuts_kwargs["target_accept_prob"] == 0.99
+    assert "max_tree_depth" not in nuts_kwargs
+
+
+@pytest.mark.slow
+def test_run_nuts_sampling_construction_failure_preserves_uniform_fallback_flag(
+    monkeypatch,
+):
+    """If init_to_value(values=...) raises during construction (a distinct
+    failure surface from the runtime 'Cannot find valid initial parameters'
+    RuntimeError handled separately below), _nuts_init_strategy is correctly
+    downgraded to 'uniform_fallback'. It must stay there even though the
+    subsequent run_mcmc succeeds — not get unconditionally clobbered back to
+    'warm_start' on the happy-path return.
+    """
+    import rheojax.core.bayesian as bayesian_mod
+
+    model = LinearModel()
+    jax_data, numpyro_model, warm_start_values = _prep_run_nuts_args(
+        model, {"a": 2.0, "b": 1.0}
+    )
+
+    real_import_numpyro = bayesian_mod._import_numpyro
+
+    def _broken_init_to_value(*args, **kwargs):
+        raise ValueError("simulated init_to_value construction failure")
+
+    def _patched_import_numpyro():
+        symbols = list(real_import_numpyro())
+        symbols[-1] = _broken_init_to_value  # init_to_value is the last symbol
+        return tuple(symbols)
+
+    monkeypatch.setattr(bayesian_mod, "_import_numpyro", _patched_import_numpyro)
+
+    with pytest.warns(RuntimeWarning, match="Warm-start initialization failed"):
+        model._run_nuts_sampling(
+            numpyro_model=numpyro_model,
+            X_jax=jax_data["X_jax"],
+            y_jax=jax_data["y_jax"],
+            warm_start_values=warm_start_values,
+            num_warmup=1,
+            num_samples=1,
+            num_chains=1,
+            nuts_kwargs={},
+            seed=0,
+            has_explicit_warm_start=True,
+        )
+
+    assert model._nuts_init_strategy == "uniform_fallback"
+
+
 # ---------------------------------------------------------------------------
 # sample_prior (lines 785-786, 797-800, 811-814)
 # ---------------------------------------------------------------------------
@@ -338,16 +546,80 @@ def test_sample_prior_missing_bounds_raises():
         model.sample_prior(num_samples=10)
 
 
-def test_sample_prior_beta_prior_respects_bounds():
-    """A beta prior spec draws within bounds and skews away from uniform."""
+def test_sample_prior_unsupported_prior_dict_falls_back_to_uniform():
+    """A prior dict type not recognized by prior_dict_to_dist (e.g. 'beta',
+    which build_numpyro_model's own NUTS prior selection does not support
+    either — it is not one of prior_dict_to_dist's recognized types) falls
+    back to Uniform(lower, upper), matching NUTS exactly instead of
+    sample_prior's old hand-rolled 'beta' special case that NUTS never
+    actually implemented.
+    """
     model = LinearModel()
     param = model.parameters.get("a")
-    param.prior = {"type": "beta", "a": 5.0, "b": 1.0}  # skewed toward upper
-    samples = model.sample_prior(num_samples=2000, seed=0)["a"]
+    param.prior = {"type": "beta", "a": 5.0, "b": 1.0}
+    samples = model.sample_prior(num_samples=5000, seed=0)["a"]
     lo, hi = param.bounds
     assert np.all(samples >= lo) and np.all(samples <= hi)
-    # Beta(5,1) mass concentrates near the upper bound; mean above midpoint.
-    assert samples.mean() > 0.5 * (lo + hi)
+    # Falls back to Uniform — mean near midpoint, not skewed toward upper bound.
+    assert samples.mean() == pytest.approx(0.5 * (lo + hi), abs=0.5)
+
+
+def test_sample_prior_normal_prior_dict_matches_nuts():
+    """A GUI-supported Parameter.prior dict (normal) is honored via the same
+    prior_dict_to_dist conversion NUTS uses, not the old Uniform-only fallback.
+    """
+    model = LinearModel()
+    param = model.parameters.get("a")
+    param.prior = {"type": "normal", "loc": 5.0, "scale": 0.01}
+    samples = model.sample_prior(num_samples=2000, seed=0)["a"]
+    # Tight Normal(5, 0.01) clusters near 5, well inside bounds (0.1, 10.0).
+    assert samples.mean() == pytest.approx(5.0, abs=0.05)
+    assert samples.std() < 0.1
+
+
+def test_sample_prior_alpha_suffix_uses_beta_default():
+    """Alpha-suffixed bounded parameters get the same Beta(2,2) prior NUTS
+    uses by default (numpyro_model_builder.py), not a Uniform.
+    """
+    model = LinearModel()
+    model.parameters.add("alpha", value=0.5, bounds=(0.0, 1.0), overwrite=True)
+    samples = model.sample_prior(num_samples=5000, seed=0)["alpha"]
+    assert np.all(samples >= 0.0) and np.all(samples <= 1.0)
+    # Beta(2,2) std = sqrt(1/20) ~ 0.2236, notably below Uniform(0,1)'s
+    # std = 1/sqrt(12) ~ 0.2887 — distinguishes the two distributions.
+    assert samples.std() < 0.26
+
+
+def test_sample_prior_bayesian_prior_factory_override():
+    """bayesian_prior_factory, when set, overrides both the alpha-suffix
+    Beta default and any Parameter.prior dict, matching NUTS's priority order.
+    """
+    import numpyro.distributions as dist
+
+    model = LinearModel()
+    model.bayesian_prior_factory = lambda name, lower, upper: (
+        dist.Normal(loc=3.0, scale=0.001) if name == "a" else None
+    )
+    samples = model.sample_prior(num_samples=1000, seed=0)["a"]
+    assert samples.mean() == pytest.approx(3.0, abs=0.01)
+
+
+def test_sample_prior_near_degenerate_tolerance_matches_nuts_builder():
+    """sample_prior's degenerate-bounds tolerance must exactly match the NUTS
+    model builder's (numpyro_model_builder.py) and _validate_parameter_bounds's:
+    abs(upper-lower) < 1e-10 * max(abs(lower), 1.0). Bounds (100.0,
+    100.00000005) have width 5e-8, which is real (non-degenerate) under that
+    shared 1e-10 formula (threshold 1e-8) but was wrongly flagged as
+    degenerate by sample_prior's previous 10x-looser, differently-shaped
+    tolerance (1e-9 * max(|lower|, |upper|, 1) ~= 1e-7) -- silently returning
+    a constant instead of the Uniform NUTS actually samples.
+    """
+    model = LinearModel()
+    lower, upper = 100.0, 100.00000005
+    model.parameters.add("a", value=lower, bounds=(lower, upper), overwrite=True)
+    samples = model.sample_prior(num_samples=2000, seed=0)["a"]
+    assert samples.std() > 0.0
+    assert np.all(samples >= lower) and np.all(samples <= upper)
 
 
 # ---------------------------------------------------------------------------
@@ -482,6 +754,40 @@ def test_process_mcmc_results_group_by_chain_fallback():
     assert result.diagnostics["warm_start_failed"] is True
 
 
+def test_process_mcmc_results_surfaces_nonfinite_draws_diagnostic():
+    """num_nonfinite (the numpyro.deterministic site numpyro_model_builder.py
+    records every draw to track NaN-guard activity) must reach
+    diagnostics['nonfinite_draws'] instead of being silently dropped by the
+    param_names/sigma-prefix filtering used to build posterior_samples.
+    """
+    model = LinearModel()
+    rng = np.random.default_rng(11)
+    grouped = {
+        "a": rng.normal(2.0, 0.1, (2, 50)),
+        "b": rng.normal(1.0, 0.1, (2, 50)),
+        "num_nonfinite": np.zeros((2, 50)),
+    }
+    grouped["num_nonfinite"][0, :3] = 1.0  # 3 draws hit the NaN guard
+    flat = {k: v.reshape(-1) for k, v in grouped.items()}
+    mcmc = _FakeMCMC(flat, grouped=grouped)
+
+    result = model._process_mcmc_results(mcmc, ["a", "b"], num_samples=50, num_chains=2)
+    assert result.diagnostics["nonfinite_draws"] == 3
+    assert "num_nonfinite" not in result.posterior_samples
+
+
+def test_process_mcmc_results_nonfinite_draws_defaults_zero_when_absent():
+    """Models that don't define the NaN-guard deterministic must not KeyError;
+    diagnostics['nonfinite_draws'] defaults to 0.
+    """
+    model = LinearModel()
+    rng = np.random.default_rng(12)
+    flat = {"a": rng.normal(2.0, 0.1, 100), "b": rng.normal(1.0, 0.1, 100)}
+    mcmc = _FakeMCMC(flat, grouped=None, group_raises=True)
+    result = model._process_mcmc_results(mcmc, ["a", "b"], num_samples=100, num_chains=1)
+    assert result.diagnostics["nonfinite_draws"] == 0
+
+
 def test_compute_diagnostics_delegator_handles_missing_divergences():
     """_compute_diagnostics tolerates an mcmc lacking extra fields (-1 divergences)."""
     model = LinearModel()
@@ -534,6 +840,57 @@ def test_fit_bayesian_log_space_rejects_nonpositive():
         model.fit_bayesian(X, y, test_mode="relaxation", likelihood_space="log")
 
 
+@pytest.mark.slow
+def test_fit_bayesian_warns_on_low_ess_despite_clean_r_hat_and_no_divergences(
+    monkeypatch,
+):
+    """A run with clean R-hat (<1.01), zero divergences, and
+    diagnostics_valid=True but pathologically low ESS (a well-known MCMC
+    pathology: R-hat converges on short/autocorrelated chains while ESS stays
+    low) must still trigger the questionable-convergence RuntimeWarning. ESS
+    was previously computed and logged but never included in the warning
+    gate, so this case returned silently.
+    """
+    model = LinearModel()
+    X, y = _linear_data(n=10)
+
+    fake_result = BayesianResult(
+        posterior_samples={"a": np.array([1.0]), "b": np.array([1.0])},
+        summary={},
+        diagnostics={
+            "r_hat": {"a": 1.001, "b": 1.001},
+            "ess": {"a": 3.0, "b": 3.0},
+            "divergences": 0,
+            "diagnostics_valid": True,
+        },
+        num_samples=1,
+        num_chains=1,
+        mcmc=None,
+        model_comparison={},
+    )
+    monkeypatch.setattr(model, "_process_mcmc_results", lambda *a, **k: fake_result)
+
+    with pytest.warns(RuntimeWarning, match="questionable convergence"):
+        model.fit_bayesian(
+            X, y, test_mode="relaxation", num_warmup=1, num_samples=1, num_chains=1
+        )
+
+
+def test_precompile_bayesian_rejects_nonfinite_input():
+    """precompile_bayesian must reject NaN/Inf input the same way
+    fit_bayesian does: its docstring explicitly invites passing the caller's
+    real X/y to warm the JIT cache for the actual dataset, so bad input must
+    fail loudly here too instead of only being caught by the generic
+    except-Exception-and-warn wrapper around sampling.
+    """
+    model = LinearModel()
+    X, y = _linear_data(n=10)
+    y = y.copy()
+    y[0] = np.nan
+    with pytest.raises(ValueError, match="NaN or Inf"):
+        model.precompile_bayesian(X, y, test_mode="relaxation", num_chains=1)
+
+
 # ---------------------------------------------------------------------------
 # NUTS-adjacent wiring: precompile + protocol/override/forward-mode roundtrip
 # ---------------------------------------------------------------------------
@@ -577,6 +934,29 @@ def test_precompile_bayesian_sampling_failure_returns_time_no_cache():
     assert isinstance(t, float)
     # Sampling failed -> model must NOT be marked precompiled.
     assert not getattr(model, "_precompiled_models", {})
+
+
+@pytest.mark.slow
+def test_precompile_bayesian_forwards_protocol_kwargs(monkeypatch):
+    """precompile_bayesian must forward protocol_kwargs to _build_numpyro_model,
+    mirroring fit_bayesian's Phase 5 call. Without this, the closure cache key
+    computed during precompilation (built with an empty protocol_kwargs dict)
+    never matches the key a real fit_bayesian(..., strain=...) call computes,
+    silently defeating the precompile speedup for any model using protocol
+    kwargs (LAOS, thixotropic lam_init/sigma_init, etc.).
+    """
+    model = LinearModel()
+    captured = {}
+    orig = model._build_numpyro_model
+
+    def spy(*args, **kwargs):
+        captured.update(kwargs)
+        return orig(*args, **kwargs)
+
+    monkeypatch.setattr(model, "_build_numpyro_model", spy)
+    X, y = _linear_data(n=10)
+    model.precompile_bayesian(X, y, test_mode="relaxation", num_chains=1, strain=2.5)
+    assert captured.get("strain") == 2.5
 
 
 @pytest.mark.slow

--- a/tests/core/test_bayesian_result.py
+++ b/tests/core/test_bayesian_result.py
@@ -1,0 +1,238 @@
+"""Regression tests for BayesianResult.to_inference_data() fast-path assembly.
+
+Covers the sample_stats exception-handling fix: a failure while extracting
+NUTS extra fields must not (a) leave a partially-populated, internally
+inconsistent sample_stats group silently attached, or (b) be logged only at
+DEBUG level where it is invisible at normal verbosity.
+"""
+
+from __future__ import annotations
+
+import logging
+
+import numpy as np
+
+from rheojax.core.bayesian_result import BayesianResult
+
+
+class _PartialFailExtraFields(dict):
+    """Simulates MCMC.get_extra_fields() failing partway through iteration.
+
+    Yields one field successfully (so ``stats_dict`` would be non-empty if
+    not reset) then raises, mirroring an unexpected error in the middle of
+    the per-field coercion loop rather than the documented
+    ``group_by_chain=True`` TypeError case.
+    """
+
+    def items(self):
+        yield "potential_energy", np.ones((1, 5))
+        raise RuntimeError("simulated mid-loop failure")
+
+
+class _FakeMCMC:
+    def __init__(self, extra_fields_factory):
+        self._extra_fields_factory = extra_fields_factory
+
+    def get_samples(self, group_by_chain=True):
+        return {"a": np.ones((1, 5))}
+
+    def get_extra_fields(self, group_by_chain=True):
+        return self._extra_fields_factory()
+
+
+def _make_result(mcmc) -> BayesianResult:
+    return BayesianResult(
+        posterior_samples={"a": np.ones(5)},
+        summary={},
+        diagnostics={},
+        num_samples=5,
+        num_chains=1,
+        mcmc=mcmc,
+    )
+
+
+def test_sample_stats_failure_drops_partial_stats_not_silently(caplog) -> None:
+    """A mid-loop sample_stats failure must clear stats_dict, not leak a
+    partially-built subset of fields into the returned InferenceData."""
+    result = _make_result(_FakeMCMC(_PartialFailExtraFields))
+
+    with caplog.at_level(logging.WARNING, logger="rheojax.core.bayesian_result"):
+        idata = result.to_inference_data()
+
+    # Posterior group must survive (unrelated to the sample_stats failure).
+    assert hasattr(idata, "posterior")
+    assert "a" in idata.posterior.data_vars
+
+    # sample_stats must be entirely absent, not partially populated with
+    # just the "lp"/"energy" entries collected before the exception fired.
+    assert not hasattr(idata, "sample_stats")
+
+    # The drop must be visible at WARNING level (not silently swallowed at
+    # DEBUG), so callers/log aggregators can detect the degradation.
+    warnings = [r for r in caplog.records if r.levelno == logging.WARNING]
+    assert any("sample_stats" in r.getMessage() for r in warnings)
+
+
+def test_sample_stats_success_path_still_populates_stats() -> None:
+    """Sanity check: a well-behaved get_extra_fields() still produces a
+    populated sample_stats group (fix must not regress the happy path)."""
+
+    def good_extra_fields():
+        return {"potential_energy": np.ones((1, 5)), "diverging": np.zeros((1, 5))}
+
+    result = _make_result(_FakeMCMC(good_extra_fields))
+    idata = result.to_inference_data()
+
+    assert hasattr(idata, "sample_stats")
+    assert "lp" in idata.sample_stats.data_vars
+    assert "energy" in idata.sample_stats.data_vars
+    assert "diverging" in idata.sample_stats.data_vars
+
+
+def test_lp_is_not_negated_potential_energy() -> None:
+    """Fix #2: the fast path must copy potential_energy into "lp" verbatim,
+    matching the real ArviZ NumPyroConverter (no sign flip)."""
+
+    potential = np.array([[1.0, 2.0, 3.0, 4.0, 5.0]])
+
+    def extra_fields():
+        return {"potential_energy": potential.copy()}
+
+    result = _make_result(_FakeMCMC(extra_fields))
+    idata = result.to_inference_data()
+
+    np.testing.assert_array_equal(idata.sample_stats["lp"].values, potential)
+
+
+def test_real_energy_field_is_not_overwritten_by_potential_energy_proxy() -> None:
+    """Fix #1: when NumPyro provides the genuine "energy" extra field (the
+    true Hamiltonian, potential + kinetic), it must be passed through as-is
+    rather than fabricated as a copy of potential_energy."""
+
+    potential = np.array([[1.0, 2.0, 3.0, 4.0, 5.0]])
+    true_energy = np.array([[10.0, 20.0, 30.0, 40.0, 50.0]])
+
+    def extra_fields():
+        return {
+            "potential_energy": potential.copy(),
+            "energy": true_energy.copy(),
+        }
+
+    result = _make_result(_FakeMCMC(extra_fields))
+    idata = result.to_inference_data()
+
+    np.testing.assert_array_equal(idata.sample_stats["energy"].values, true_energy)
+    # Must differ from the potential-energy-only proxy that would have been
+    # fabricated pre-fix.
+    assert not np.array_equal(idata.sample_stats["energy"].values, potential)
+
+
+def test_missing_energy_field_falls_back_with_warning(caplog) -> None:
+    """When only potential_energy is available (no real "energy" extra
+    field, e.g. an older cached MCMC object), the fast path must still
+    populate "energy" as a fallback proxy but log a WARNING noting BFMI
+    will be approximate."""
+
+    def extra_fields():
+        return {"potential_energy": np.ones((1, 5))}
+
+    result = _make_result(_FakeMCMC(extra_fields))
+    with caplog.at_level(logging.WARNING, logger="rheojax.core.bayesian_result"):
+        idata = result.to_inference_data()
+
+    assert "energy" in idata.sample_stats.data_vars
+    warnings = [r for r in caplog.records if r.levelno == logging.WARNING]
+    assert any("approximat" in r.getMessage().lower() for r in warnings)
+
+
+class _PartialFailGetSamples(dict):
+    """Simulates get_samples(group_by_chain=True) failing partway through
+    iteration, after at least one deterministic site has already been added
+    to posterior_dict."""
+
+    def items(self):
+        yield "deterministic_site", np.ones((1, 5))
+        raise RuntimeError("simulated mid-loop failure")
+
+
+class _FakeMCMCPosteriorFail(_FakeMCMC):
+    def get_samples(self, group_by_chain=True):
+        return _PartialFailGetSamples()
+
+
+def test_posterior_fallback_resets_partial_dict_and_warns(caplog) -> None:
+    """A mid-loop failure in the posterior fast path must clear
+    posterior_dict before falling back to posterior_samples, not leak
+    entries collected before the exception, and log at WARNING."""
+
+    def extra_fields():
+        return {"potential_energy": np.ones((1, 5))}
+
+    result = _make_result(_FakeMCMCPosteriorFail(extra_fields))
+
+    with caplog.at_level(logging.WARNING, logger="rheojax.core.bayesian_result"):
+        idata = result.to_inference_data()
+
+    assert hasattr(idata, "posterior")
+    # Fallback-derived entry present.
+    assert "a" in idata.posterior.data_vars
+    # Entry added before the exception must not survive into the fallback.
+    assert "deterministic_site" not in idata.posterior.data_vars
+
+    warnings = [r for r in caplog.records if r.levelno == logging.WARNING]
+    assert any("posterior_samples" in r.getMessage() for r in warnings)
+
+
+def test_eq_does_not_crash_with_multi_element_arrays() -> None:
+    """Default dataclass __eq__ raises ValueError on ndarray-valued dict
+    fields once posterior_samples has more than one element; the custom
+    __eq__ must compare by value (np.array_equal) instead."""
+    r1 = _make_result(None)
+    r2 = _make_result(None)
+    assert r1 == r2
+
+    r3 = BayesianResult(
+        posterior_samples={"a": np.array([9.0, 9.0, 9.0, 9.0, 9.0])},
+        summary={},
+        diagnostics={},
+        num_samples=5,
+        num_chains=1,
+    )
+    assert r1 != r3
+    assert r1 != "not a bayesian result"
+
+
+def test_dropped_extra_field_types_are_logged_at_debug(caplog) -> None:
+    """Fix #3: dict/tuple-valued and wrong-ndim extra fields must be logged
+    (not silently dropped), mirroring the visibility standard already
+    applied to the outer exception handler in this function."""
+
+    def extra_fields():
+        return {
+            "potential_energy": np.ones((1, 5)),
+            "adapt_state": {"step_size": 0.1},  # dict -> hits dict/tuple branch
+            "bad_ndim": np.ones((1, 5, 5)),  # ndim == 3 -> hits ndim branch
+        }
+
+    result = _make_result(_FakeMCMC(extra_fields))
+    with caplog.at_level(logging.DEBUG, logger="rheojax.core.bayesian_result"):
+        idata = result.to_inference_data()
+
+    assert "lp" in idata.sample_stats.data_vars
+    assert "adapt_state" not in idata.sample_stats.data_vars
+    assert "bad_ndim" not in idata.sample_stats.data_vars
+
+    # Structured kwargs (stat name, reason) are merged onto record.extra by
+    # RheoJAXLogger rather than interpolated into the message text.
+    def _stat_of(record):
+        return getattr(record, "extra", {}).get("stat")
+
+    messages = [r.getMessage() for r in caplog.records]
+    assert any(
+        "container type" in m and _stat_of(r) == "adapt_state"
+        for r, m in zip(caplog.records, messages)
+    )
+    assert any(
+        "ndim" in m and _stat_of(r) == "bad_ndim"
+        for r, m in zip(caplog.records, messages)
+    )

--- a/tests/core/test_data.py
+++ b/tests/core/test_data.py
@@ -259,6 +259,19 @@ class TestRheoDataMetadata:
         # Check that copy is independent
         assert "new_key" not in data2.metadata
 
+    def test_constructor_does_not_alias_caller_metadata(self):
+        """Two RheoData built from the same dict must not share state, and
+        the constructor must not mutate the caller's original dict either."""
+        shared = {"temperature": 25.0}
+        d1 = RheoData(x=np.array([1, 2, 3]), y=np.array([4, 5, 6]), metadata=shared)
+        d2 = RheoData(x=np.array([1, 2, 3]), y=np.array([4, 5, 6]), metadata=shared)
+
+        d1.update_metadata({"sample": "A"})
+
+        assert d1.metadata is not d2.metadata
+        assert "sample" not in d2.metadata
+        assert "sample" not in shared
+
 
 class TestRheoDataDomainSupport:
     """Test time/frequency domain support."""
@@ -408,6 +421,25 @@ class TestRheoDataSerialization:
         assert restored.y_units == original.y_units
         assert restored.domain == original.domain
 
+    def test_from_dict_validates_by_default(self):
+        """from_dict() is a deserialization boundary and should validate
+        by default, catching NaN in an externally-edited payload."""
+        data_dict = {
+            "x": [1, 2, 3],
+            "y": [10, float("nan"), 30],
+        }
+        with pytest.raises(ValueError, match="NaN"):
+            RheoData.from_dict(data_dict)
+
+    def test_from_dict_validate_false_opt_out(self):
+        """Callers may still opt out of validation explicitly."""
+        data_dict = {
+            "x": [1, 2, 3],
+            "y": [10, float("nan"), 30],
+        }
+        data = RheoData.from_dict(data_dict, validate=False)
+        assert np.isnan(data.y).any()
+
 
 class TestRheoDataOperations:
     """Test data operations and transformations."""
@@ -547,12 +579,30 @@ class TestRheoDataConstructorEdges:
         assert isinstance(data.y, np.ndarray)
         np.testing.assert_allclose(data.y, [4, 5, 6])
 
+    def test_scalar_xy_raises_value_error(self):
+        """0-d scalar x/y must raise a clear ValueError, not IndexError."""
+        with pytest.raises(ValueError, match="0-d"):
+            RheoData(x=5, y=10)
+
     def test_update_metadata_test_mode_invalidates_detection(self):
         """Setting test_mode via update_metadata syncs explicit mode and clears cache."""
         data = RheoData(x=np.array([1, 2, 3]), y=np.array([4, 5, 6]))
         data.update_metadata({"test_mode": "creep"})
         assert data._explicit_test_mode == "creep"
         assert "detected_test_mode" not in data.metadata
+        assert data.test_mode == "creep"
+
+    def test_direct_metadata_mutation_overrides_test_mode(self):
+        """Directly mutating metadata['test_mode'] (bypassing update_metadata)
+        must be reflected by the test_mode property, per its own docstring
+        ('If explicitly set in metadata["test_mode"], returns that value')."""
+        data = RheoData(
+            x=np.array([1, 2, 3]),
+            y=np.array([4, 5, 6]),
+            initial_test_mode="relaxation",
+        )
+        assert data.test_mode == "relaxation"
+        data.metadata["test_mode"] = "creep"
         assert data.test_mode == "creep"
 
 
@@ -834,6 +884,16 @@ class TestRheoDataOperationBranches:
         out = data.interpolate(jnp.array([1.5, 2.5, 3.5]))
         np.testing.assert_allclose(np.asarray(out.y), [15.0, 25.0, 35.0])
 
+    def test_interpolate_unsorted_mixed_sign_numpy(self):
+        """x that is neither strictly increasing nor strictly decreasing
+        (validate=True only warns) must still interpolate correctly."""
+        x = np.array([1.0, 5.0, 2.0, 4.0, 3.0])
+        y = np.array([10.0, 50.0, 20.0, 40.0, 30.0])
+        with pytest.warns(UserWarning, match="not monotonic"):
+            data = RheoData(x=x, y=y, validate=True)
+        out = data.interpolate(np.array([3.5, 4.5]))
+        np.testing.assert_allclose(out.y, [35.0, 45.0])
+
     def test_interpolate_complex_numpy(self):
         x = np.array([1.0, 2.0, 3.0])
         y = np.array([1 + 1j, 2 + 2j, 3 + 3j])
@@ -932,6 +992,16 @@ class TestRheoDataOperationBranches:
         out = data.derivative()
         assert out.y_units == "d(Pa)/d(s)"
 
+    def test_derivative_duplicate_x_raises(self):
+        """Duplicate adjacent x (warn-only in validation) causes zero
+        spacing in np.gradient; derivative() must raise, not return NaN."""
+        x = np.array([0.0, 1.0, 1.0, 2.0, 3.0])
+        y = np.array([0.0, 1.0, 2.0, 3.0, 4.0])
+        with pytest.warns(UserWarning, match="not monotonic"):
+            data = RheoData(x=x, y=y, validate=True)
+        with pytest.raises(ValueError, match="non-finite"):
+            data.derivative()
+
     def test_integral_jax(self):
         x = jnp.linspace(0, 10, 100)
         y = jnp.ones_like(x)
@@ -975,6 +1045,20 @@ class TestRheoDataDomainConversion:
             x=np.array([0.1, 1.0, 10.0]), y=np.array([1.0, 2.0, 3.0]),
             domain="frequency",
         )
+        with pytest.raises(NotImplementedError):
+            data.to_time_domain()
+
+    def test_non_canonical_domain_not_implemented_not_warn(self):
+        """A non-canonical domain (e.g. 'scalar', as produced by
+        mutation_number transforms) is neither 'time' nor 'frequency', so
+        both conversion methods must fall through to NotImplementedError
+        instead of the '!=' bug that made them both claim success."""
+        data = RheoData(
+            x=np.array([0.0]), y=np.array([1.0]),
+            domain="scalar", validate=False,
+        )
+        with pytest.raises(NotImplementedError):
+            data.to_frequency_domain()
         with pytest.raises(NotImplementedError):
             data.to_time_domain()
 
@@ -1092,3 +1176,131 @@ class TestRheoDataNoneGuards:
         data.y = None
         with pytest.raises(ValueError, match="requires non-None"):
             _ = data.y_imag
+
+
+class TestRheoData2DYContract:
+    """RheoData's own accessors (is_complex/y_real/y_imag/modulus/phase/
+    storage_modulus/loss_modulus) must correctly split the real-valued
+    (N,2) DMTA/GMM convention (G', G'' as separate columns), not just
+    complex-dtype y — this is the root-cause fix for the contract mismatch
+    where __post_init__ documented/allowed (N,2) y but the accessors only
+    ever checked np.iscomplexobj and silently returned the full array."""
+
+    def _2d_data(self):
+        x = np.array([1.0, 2.0, 3.0])
+        y = np.column_stack([[3.0, 6.0, 1.0], [4.0, 8.0, 0.0]])
+        return RheoData(x=x, y=y, domain="frequency")
+
+    def test_2d_y_still_constructs_without_opt_in(self):
+        """A real-valued (N,2) y must remain constructible (e.g. GMM/multimode
+        model.fit(omega, G_star) with G_star built via np.column_stack passes
+        raw 2-D y straight through FitOrchestrator's RheoData validation)."""
+        data = self._2d_data()
+        assert data.y.shape == (3, 2)
+
+    def test_2d_y_is_complex_true(self):
+        """is_complex must recognize the (N,2) convention, not just complex dtype."""
+        assert self._2d_data().is_complex is True
+
+    def test_2d_y_real_imag_split_columns(self):
+        """y_real/y_imag must split the two columns (G', G''), not return
+        the full (N,2) array unchanged (the original silent-bug behavior)."""
+        data = self._2d_data()
+        np.testing.assert_allclose(data.y_real, [3.0, 6.0, 1.0])
+        np.testing.assert_allclose(data.y_imag, [4.0, 8.0, 0.0])
+
+    def test_2d_y_modulus_phase(self):
+        data = self._2d_data()
+        np.testing.assert_allclose(data.modulus, [5.0, 10.0, 1.0])
+        np.testing.assert_allclose(
+            data.phase, np.arctan2([4.0, 8.0, 0.0], [3.0, 6.0, 1.0])
+        )
+
+    def test_2d_y_storage_loss_modulus(self):
+        data = self._2d_data()
+        np.testing.assert_allclose(data.storage_modulus, [3.0, 6.0, 1.0])
+        np.testing.assert_allclose(data.loss_modulus, [4.0, 8.0, 0.0])
+
+    def test_2d_y_matches_equivalent_complex_construction(self):
+        """The (N,2) convention and the complex-dtype convention must agree
+        on every accessor for the same underlying G'/G'' values."""
+        x = np.array([1.0, 2.0, 3.0])
+        two_d = RheoData(
+            x=x, y=np.column_stack([[3.0, 6.0, 1.0], [4.0, 8.0, 0.0]]),
+            domain="frequency",
+        )
+        complex_ = RheoData(
+            x=x, y=np.array([3 + 4j, 6 + 8j, 1 + 0j]), domain="frequency"
+        )
+        np.testing.assert_allclose(two_d.y_real, complex_.y_real)
+        np.testing.assert_allclose(two_d.y_imag, complex_.y_imag)
+        np.testing.assert_allclose(two_d.modulus, complex_.modulus)
+        np.testing.assert_allclose(two_d.phase, complex_.phase)
+
+
+class TestRheoDataDtypeAndShapeValidation:
+    """Dtype and x.ndim boundary checks at the RheoData construction contract."""
+
+    def test_bool_x_rejected(self):
+        x = np.array([True, False, True, True, False])
+        y = np.array([1.0, 2.0, 3.0, 4.0, 5.0])
+        with pytest.raises(ValueError, match="x data must be"):
+            RheoData(x=x, y=y)
+
+    def test_bool_y_rejected(self):
+        x = np.array([1.0, 2.0, 3.0])
+        y = np.array([True, False, True])
+        with pytest.raises(ValueError, match="y data must be"):
+            RheoData(x=x, y=y)
+
+    def test_object_dtype_x_rejected(self):
+        x = np.array([1.0, 2.0, "3.0"], dtype=object)
+        y = np.array([1.0, 2.0, 3.0])
+        with pytest.raises(ValueError, match="x data must be"):
+            RheoData(x=x, y=y)
+
+    def test_int_x_and_y_still_allowed(self):
+        """Integer dtype is legitimate numeric data, not a mask — must not
+        be rejected by the new dtype check."""
+        data = RheoData(x=np.array([0, 1, 2, 3, 4]), y=np.array([0, 1, 0, 1, 0]))
+        assert data.x.dtype.kind in "iu"
+
+    def test_complex_y_still_allowed(self):
+        """Complex y (DMTA/GMM complex modulus) must remain valid."""
+        data = RheoData(
+            x=np.array([1.0, 2.0, 3.0]),
+            y=np.array([1 + 2j, 3 + 4j, 5 + 6j]),
+            domain="frequency",
+        )
+        assert data.is_complex
+
+    def test_2d_x_rejected(self):
+        """A (N,1) x (common pandas df[['col']].values footgun) must raise,
+        not silently pass through to model.X_data unreshaped."""
+        x = np.array([[1.0], [2.0], [3.0], [4.0], [5.0]])
+        y = np.array([1.0, 2.0, 3.0, 4.0, 5.0])
+        with pytest.raises(ValueError, match="1-dimensional"):
+            RheoData(x=x, y=y)
+
+    def test_y_3_columns_rejected(self):
+        """y with shape (N, 3) is neither the plain (N,) nor the (N, 2)
+        DMTA/GMM G'/G'' convention the class supports — must raise, not
+        silently pass through as if it were valid scalar data."""
+        x = np.array([1.0, 2.0, 3.0])
+        y = np.array([[1.0, 2.0, 3.0], [4.0, 5.0, 6.0], [7.0, 8.0, 9.0]])
+        with pytest.raises(ValueError, match="unsupported|2-dimensional"):
+            RheoData(x=x, y=y)
+
+    def test_y_3d_rejected(self):
+        """y with ndim > 2 must raise."""
+        x = np.array([1.0, 2.0, 3.0])
+        y = np.zeros((3, 2, 2))
+        with pytest.raises(ValueError, match="unsupported|2-dimensional"):
+            RheoData(x=x, y=y)
+
+    def test_y_2_columns_still_allowed(self):
+        """The documented (N, 2) DMTA/GMM convention must still construct."""
+        x = np.array([1.0, 2.0, 3.0])
+        y = np.array([[1.0, 0.5], [2.0, 1.0], [3.0, 1.5]])
+        data = RheoData(x=x, y=y)
+        assert data.y.shape == (3, 2)

--- a/tests/core/test_fit_orchestrator.py
+++ b/tests/core/test_fit_orchestrator.py
@@ -1,0 +1,339 @@
+"""Tests for FitOrchestrator: the shared execute() pipeline behind fit().
+
+Covers regressions found in a targeted audit of fit_orchestrator.py:
+- uncertainty silently discarded when return_result=False
+- _build_fit_result silently downgrading its return type on internal failure
+- post-fit bookkeeping misreported as fit failure
+- RheoData passed as y (argument-order misuse)
+- missing shape/NaN validation on raw-array fit() calls
+- DEBUG R2 log reimplementing ss_res/ss_tot instead of delegating to
+  OptimizationResult.r_squared
+- "Uncertainty computed" info log firing even when compute_uncertainty()
+  silently failed and returned None
+- missing frequency-domain negative-value check for raw-array oscillation fits
+- auto_p0 partial-failure misreported as full success
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import patch
+
+import numpy as np
+import pytest
+
+from rheojax.core.data import RheoData
+from rheojax.core.fit_orchestrator import FitOrchestrator
+from rheojax.core.fit_result import FitResult
+from rheojax.core.post_fit_validator import PostFitValidator
+from rheojax.models.classical.maxwell import Maxwell
+
+
+def _relaxation_data(n=30):
+    t = np.logspace(-2, 1, n)
+    G0, tau = 1e5, 1.0
+    G = G0 * np.exp(-t / tau)
+    return t, G
+
+
+@pytest.mark.smoke
+class TestUncertaintyAttachment:
+    """Bug 1: uncertainty result must not be discarded when return_result=False."""
+
+    def test_uncertainty_attached_without_return_result(self):
+        model = Maxwell()
+        t, G = _relaxation_data()
+        model.fit(t, G, uncertainty="hessian")  # return_result defaults to False
+
+        assert getattr(model, "uncertainty_", None) is not None
+        assert model.uncertainty_method_ == "hessian"
+
+    def test_uncertainty_still_in_fit_result_metadata(self):
+        model = Maxwell()
+        t, G = _relaxation_data()
+        result = model.fit(t, G, uncertainty="hessian", return_result=True)
+
+        assert isinstance(result, FitResult)
+        assert "uncertainty" in result.metadata
+        # Both paths should agree
+        assert model.uncertainty_ is result.metadata["uncertainty"]
+
+
+@pytest.mark.smoke
+class TestBuildFitResultContract:
+    """Bug 2: return_result=True must always yield a FitResult, even on
+    internal build_fit_result() failure."""
+
+    def test_build_fit_result_failure_yields_error_fit_result(self):
+        model = Maxwell()
+        t, G = _relaxation_data()
+
+        with patch(
+            "rheojax.utils.model_selection.build_fit_result",
+            side_effect=RuntimeError("boom"),
+        ):
+            result = FitOrchestrator()._build_fit_result(
+                model, t, G, "relaxation", None, None
+            )
+
+        assert isinstance(result, FitResult)
+        assert result.metadata["error"] == "boom"
+        assert result.metadata["error_type"] == "RuntimeError"
+
+
+@pytest.mark.smoke
+class TestPostFitBookkeepingIsolation:
+    """Bug 3: a post-fit logging/bookkeeping failure must not be reported as
+    a fit failure, and fitted_ must remain True."""
+
+    def test_log_fit_completion_failure_does_not_undo_fit(self):
+        model = Maxwell()
+        t, G = _relaxation_data()
+
+        with patch.object(
+            Maxwell, "get_params", side_effect=RuntimeError("logging exploded")
+        ):
+            # get_params() is called inside _log_fit_completion's debug-log
+            # tail. It must NOT be reported as a fit failure.
+            result = model.fit(t, G)
+
+        assert result is model
+        assert model.fitted_ is True
+
+    def test_get_params_failure_inside_log_completion_is_swallowed(self):
+        model = Maxwell()
+        t, G = _relaxation_data()
+        model.fit(t, G)  # real fit succeeds first
+
+        with patch.object(
+            Maxwell, "get_params", side_effect=RuntimeError("get_params broke")
+        ):
+            # Directly exercise the now-guarded tail of _log_fit_completion.
+            FitOrchestrator._log_fit_completion(model, t, G, t.shape)
+        # No exception propagated, model still reports fitted.
+        assert model.fitted_ is True
+
+
+@pytest.mark.smoke
+class TestRheoDataAsYMisuse:
+    """Bug 4: passing a RheoData as y (argument-order confusion) must raise
+    a clear error, not flow unconverted into _fit()."""
+
+    def test_rheodata_as_y_raises_value_error(self):
+        model = Maxwell()
+        t, G = _relaxation_data()
+        rheo_y = RheoData(x=t, y=G, initial_test_mode="relaxation")
+
+        with pytest.raises(ValueError, match="y must be a plain array"):
+            model.fit(t, rheo_y)
+
+
+@pytest.mark.smoke
+class TestRawArrayValidation:
+    """Bug 6: raw-array fit() calls must get the same shape/NaN checks that
+    RheoData-wrapped calls already receive."""
+
+    def test_nan_in_y_raises(self):
+        model = Maxwell()
+        t, _ = _relaxation_data()
+        y = np.full_like(t, np.nan)
+        with pytest.raises(ValueError, match="NaN"):
+            model.fit(t, y)
+
+    def test_shape_mismatch_raises(self):
+        model = Maxwell()
+        t = np.linspace(0.1, 10, 10)
+        y = np.linspace(1, 2, 5)
+        with pytest.raises(ValueError, match="same first dimension"):
+            model.fit(t, y)
+
+
+@pytest.mark.smoke
+class TestLogFitCompletionR2:
+    """DEBUG R2 log must delegate to OptimizationResult.r_squared instead of
+    reimplementing ss_res/ss_tot (which breaks use_log_residuals dimensional
+    consistency)."""
+
+    def test_delegates_to_nlsq_result_r_squared(self):
+        model = Maxwell()
+        t, G = _relaxation_data()
+        model.fit(t, G)
+        # Stand in for the real OptimizationResult with a duck-typed object
+        # exposing only `.r_squared` (no `.fun`) -- if _log_fit_completion
+        # still hand-rolled ss_res from `.fun`, this would raise internally
+        # and fall back to R2=None instead of using this sentinel.
+        model._nlsq_result = SimpleNamespace(r_squared=0.4242)
+
+        with patch("rheojax.core.fit_orchestrator.logger") as mock_logger:
+            mock_logger.isEnabledFor.return_value = True
+            FitOrchestrator._log_fit_completion(model, t, G, t.shape)
+
+        info_kwargs = mock_logger.info.call_args_list[0].kwargs
+        assert info_kwargs["R2"] == 0.4242
+
+
+@pytest.mark.smoke
+class TestUncertaintyFailureLogging:
+    """The 'Uncertainty computed' info log must not fire when
+    compute_uncertainty() silently failed and returned None."""
+
+    def test_no_success_log_when_uncertainty_computation_fails(self):
+        model = Maxwell()
+        t, G = _relaxation_data()
+
+        with patch.object(PostFitValidator, "compute_uncertainty", return_value=None):
+            with patch("rheojax.core.fit_orchestrator.logger") as mock_logger:
+                mock_logger.isEnabledFor.return_value = True
+                model.fit(t, G, uncertainty="hessian")
+
+        assert model.uncertainty_ is None
+        info_messages = [c.args[0] for c in mock_logger.info.call_args_list]
+        assert not any("Uncertainty computed" in m for m in info_messages)
+        assert any("Uncertainty computation failed" in m for m in info_messages)
+
+
+@pytest.mark.smoke
+class TestFrequencyDomainValidation:
+    """Raw-array fit() validation must detect frequency domain (oscillation
+    test_mode, or complex y) so RheoData's negative-frequency-value warning
+    actually fires, matching RheoData-wrapped calls."""
+
+    def _oscillation_data_with_negative_value(self):
+        omega = np.logspace(-2, 2, 10)
+        g_star = np.linspace(1, 10, 10) * (1 + 1j)
+        g_star[0] = -1 + 1j  # negative real part
+        return omega, g_star
+
+    def test_oscillation_test_mode_warns_on_negative_value(self):
+        omega, g_star = self._oscillation_data_with_negative_value()
+        with pytest.warns(UserWarning, match="negative values in frequency domain"):
+            FitOrchestrator._validate_fit_data(omega, g_star, test_mode="oscillation")
+
+    def test_complex_y_without_test_mode_warns_on_negative_value(self):
+        omega, g_star = self._oscillation_data_with_negative_value()
+        with pytest.warns(UserWarning, match="negative values in frequency domain"):
+            FitOrchestrator._validate_fit_data(omega, g_star)
+
+
+@pytest.mark.smoke
+class TestAutoInitFailureReporting:
+    """auto_p0 partial failures must be tracked and reported, not
+    misrepresented as full success via n_params_set=len(p0)."""
+
+    def test_partial_failure_tracked_not_reported_as_full_success(self):
+        model = Maxwell()
+        t, G = _relaxation_data()
+
+        with patch(
+            "rheojax.utils.initialization.auto_p0.auto_p0",
+            return_value={"G0": 1e5, "not_a_real_param": 999.0},
+        ):
+            with patch("rheojax.core.fit_orchestrator.logger") as mock_logger:
+                FitOrchestrator._run_auto_init(model, t, G, None)
+
+        # Bug 5: a partial failure must be visible at WARNING (not just
+        # INFO, which is routinely filtered out in production), so it is
+        # never logged at INFO-only-success level.
+        assert mock_logger.info.call_count == 0
+        warning_kwargs = mock_logger.warning.call_args_list[0].kwargs
+        assert warning_kwargs["n_params_set"] == 1
+        assert warning_kwargs["n_params_failed"] == 1
+        assert warning_kwargs["failed_params"] == ["not_a_real_param"]
+
+    def test_full_success_still_logs_at_info(self):
+        model = Maxwell()
+        t, G = _relaxation_data()
+
+        with patch(
+            "rheojax.utils.initialization.auto_p0.auto_p0",
+            return_value={"G0": 1e5},
+        ):
+            with patch("rheojax.core.fit_orchestrator.logger") as mock_logger:
+                FitOrchestrator._run_auto_init(model, t, G, None)
+
+        assert mock_logger.warning.call_count == 0
+        info_kwargs = mock_logger.info.call_args_list[0].kwargs
+        assert info_kwargs["n_params_failed"] == 0
+
+
+@pytest.mark.smoke
+class TestInvalidUncertaintyMethod:
+    """Bug: an invalid uncertainty method must raise before the fit commits,
+    not after model.fitted_ is already True."""
+
+    def test_invalid_uncertainty_raises_before_fit_commits(self):
+        model = Maxwell()
+        t, G = _relaxation_data()
+
+        with pytest.raises(ValueError, match="Unknown uncertainty method"):
+            model.fit(t, G, uncertainty="monte_carlo", return_result=True)
+
+        # The fit must never have run/committed.
+        assert model.fitted_ is False
+
+    def test_invalid_uncertainty_raises_regardless_of_return_result(self):
+        model = Maxwell()
+        t, G = _relaxation_data()
+
+        with pytest.raises(ValueError, match="Unknown uncertainty method"):
+            model.fit(t, G, uncertainty="monte_carlo", return_result=False)
+
+
+@pytest.mark.smoke
+class TestRuntimeErrorEnhancementWithReturnResult:
+    """Bug: return_result=True must get the same compatibility-enhanced
+    error message as the return_result=False (raising) path."""
+
+    def test_enhancement_applied_when_return_result_true(self):
+        model = Maxwell()
+        t, G = _relaxation_data()
+
+        from rheojax.utils.compatibility import DecayType, MaterialType
+
+        compat = {
+            "compatible": False,
+            "confidence": 0.9,
+            "decay_type": DecayType.UNKNOWN,
+            "material_type": MaterialType.UNKNOWN,
+            "warnings": ["mismatch"],
+            "recommendations": ["try another model"],
+        }
+
+        with patch.object(
+            Maxwell,
+            "_fit",
+            side_effect=RuntimeError("Optimization failed: did not converge"),
+        ):
+            with patch.object(Maxwell, "_check_compatibility", return_value=compat):
+                result = model.fit(t, G, return_result=True)
+
+        assert isinstance(result, FitResult)
+        assert "Model-data compatibility issue detected" in result.metadata["error"]
+
+
+@pytest.mark.smoke
+class TestNonMonotonicXSorted:
+    """Bug: non-monotonic x must be sorted (not just warned about) before
+    reaching model._fit(), since many models assume ascending x."""
+
+    def test_unsorted_x_is_sorted_before_fit(self):
+        t, G = _relaxation_data()
+        rng = np.random.default_rng(0)
+        perm = rng.permutation(len(t))
+        t_shuffled, G_shuffled = t[perm], G[perm]
+
+        model = Maxwell()
+        with pytest.warns(UserWarning, match="not monotonic"):
+            model.fit(t_shuffled, G_shuffled)
+
+        assert np.all(np.diff(model.X_data) > 0)
+        # y must have been permuted in lockstep with x, not left shuffled.
+        order = np.argsort(t_shuffled)
+        np.testing.assert_allclose(model.X_data, t_shuffled[order])
+        np.testing.assert_allclose(model.y_data, G_shuffled[order])
+
+    def test_already_sorted_x_is_a_no_op(self):
+        t, G = _relaxation_data()
+        X_out, y_out = FitOrchestrator._sort_by_x(t, G)
+        assert X_out is t
+        assert y_out is G

--- a/tests/core/test_fit_result.py
+++ b/tests/core/test_fit_result.py
@@ -146,8 +146,151 @@ class TestFitResultSerialization:
             loaded = FitResult.load(path)
             assert loaded.model_name == "maxwell"
             assert loaded.params["G"] == 1000.0
+            # Regression: params_units and metadata used to be silently
+            # dropped by the npz round-trip (unlike the JSON path).
+            assert loaded.params_units == {"G": "Pa", "eta": "Pa·s"}
+            assert loaded.metadata == {"test_key": "test_value"}
         finally:
             Path(path).unlink(missing_ok=True)
+
+    def test_load_npz_missing_params_units_metadata_backward_compat(self):
+        """Loading a .npz saved before params_units/metadata were persisted
+        must fall back to {} rather than raising KeyError."""
+        import json as _json
+
+        def _str_to_bytes(s: str) -> np.ndarray:
+            return np.frombuffer(s.encode("utf-8"), dtype=np.uint8)
+
+        with tempfile.NamedTemporaryFile(suffix=".npz", delete=False) as f:
+            path = f.name
+        try:
+            np.savez(
+                path,
+                model_name=_str_to_bytes("maxwell"),
+                model_class_name=_str_to_bytes("Maxwell"),
+                protocol=_str_to_bytes("relaxation"),
+                n_params=np.array(2),
+                timestamp=_str_to_bytes("2024-01-01T00:00:00"),
+                param_names=_str_to_bytes(_json.dumps(["G", "eta"])),
+                param_values=np.array([1000.0, 100.0], dtype=np.float64),
+                success=np.array(True),
+                n_data=np.array(20),
+            )
+            loaded = FitResult.load(path)
+            assert loaded.params_units == {}
+            assert loaded.metadata == {}
+            assert loaded.params["G"] == 1000.0
+        finally:
+            Path(path).unlink(missing_ok=True)
+
+    def _make_log_residual_result(self):
+        """FitResult wrapping an OptimizationResult with _use_log_residuals=True.
+
+        Mirrors the common production case (SGR/STZ/fIKH/fluidity/EPM/Giesekus
+        default to use_log_residuals=True) where G'/G'' data spans multiple
+        decades, so r_squared/aic/bic must be computed in log10 space to avoid
+        a spurious R^2 (see OptimizationResult.r_squared).
+        """
+        from rheojax.utils.optimization import OptimizationResult
+
+        rng = np.random.default_rng(0)
+        t = np.linspace(0, 4, 40)  # log10 decades 0..4
+        y = 10.0**t
+        log_noise = rng.normal(scale=0.3, size=t.shape)
+        fitted = 10.0 ** (t + log_noise)
+        log_residuals = np.log10(fitted) - np.log10(y)
+
+        opt_result = OptimizationResult(
+            x=np.array([1.0, 2.0]),
+            fun=float(np.sum(log_residuals**2)),
+            success=True,
+            y_data=y,
+            residuals=log_residuals,
+            n_data=len(y),
+            _use_log_residuals=True,
+        )
+        return FitResult(
+            model_name="test",
+            model_class_name="Test",
+            protocol=None,
+            params={"a": 1.0, "b": 2.0},
+            params_units={},
+            n_params=2,
+            optimization_result=opt_result,
+            fitted_curve=fitted,
+            y=y,
+        )
+
+    def test_save_load_json_preserves_log_residual_stats(self):
+        """load() must return the persisted stats, not recompute them from
+        raw (linear-space) y/fitted_curve arrays, which silently discards
+        _use_log_residuals semantics and gives wrong numbers with no error."""
+        result = self._make_log_residual_result()
+        original_r2 = result.r_squared
+        original_aic = result.aic
+        original_bic = result.bic
+        original_residuals = result.residuals
+        assert original_r2 is not None
+
+        with tempfile.NamedTemporaryFile(suffix=".json", delete=False) as f:
+            path = f.name
+        try:
+            result.save(path)
+            loaded = FitResult.load(path)
+            assert loaded.r_squared == pytest.approx(original_r2)
+            assert loaded.aic == pytest.approx(original_aic)
+            assert loaded.bic == pytest.approx(original_bic)
+            # Regression: .residuals used to be silently reconstructed as
+            # linear-space (y - fitted_curve) on load, even though the
+            # original fit used log10 residuals -- no exception, just a
+            # completely different array with matching r_squared/aic/bic.
+            np.testing.assert_allclose(loaded.residuals, original_residuals)
+        finally:
+            Path(path).unlink(missing_ok=True)
+
+    def test_save_load_npz_preserves_log_residual_stats(self):
+        result = self._make_log_residual_result()
+        original_r2 = result.r_squared
+        original_aic = result.aic
+        original_bic = result.bic
+        original_residuals = result.residuals
+        assert original_r2 is not None
+
+        with tempfile.NamedTemporaryFile(suffix=".npz", delete=False) as f:
+            path = f.name
+        try:
+            result.save(path)
+            loaded = FitResult.load(path)
+            assert loaded.r_squared == pytest.approx(original_r2)
+            assert loaded.aic == pytest.approx(original_aic)
+            assert loaded.bic == pytest.approx(original_bic)
+            np.testing.assert_allclose(loaded.residuals, original_residuals)
+        finally:
+            Path(path).unlink(missing_ok=True)
+
+    def test_plot_residual_panel_uses_log_space_for_log_residual_fits(self):
+        """plot()'s residual panel must not silently ignore
+        _use_log_residuals=True and show raw linear residuals (y - fitted),
+        which would contradict the log-space R^2 shown in the title above
+        it and look badly heteroscedastic for a genuinely good fit."""
+        import matplotlib
+
+        matplotlib.use("Agg", force=True)
+        import matplotlib.pyplot as plt
+
+        result = self._make_log_residual_result()
+        result.X = np.linspace(0, 4, len(result.y))
+
+        fig = result.plot()
+        try:
+            ax_res = fig.axes[1]
+            plotted_y = ax_res.lines[0].get_ydata()
+            np.testing.assert_allclose(plotted_y, result.residuals)
+            linear_residuals = result.y - np.asarray(result.fitted_curve)
+            assert not np.allclose(plotted_y, linear_residuals)
+            assert ax_res.get_ylabel() == "Log10 Residual"
+        finally:
+            plt.close(fig)
 
 
 @pytest.mark.smoke
@@ -182,6 +325,39 @@ class TestFitResultSummary:
         assert "Maxwell" in latex
         assert "\\\\" in latex
 
+    def test_aicc_none_when_insufficient_dof(self):
+        """aicc must return None (matching every sibling stat property's
+        undefined-value convention), not np.nan, when n - k - 1 <= 0.
+        A bare np.nan breaks JSON serialization (not RFC-8259-valid) and
+        defeats the `if val is not None` guards in summary()/exporters."""
+        from rheojax.utils.optimization import OptimizationResult
+
+        y = np.array([1.0, 2.0, 3.0])
+        fitted = np.array([1.1, 1.9, 3.2])
+        residuals = y - fitted
+        opt_result = OptimizationResult(
+            x=np.zeros(3),
+            fun=float(np.sum(residuals**2)),
+            success=True,
+            y_data=y,
+            residuals=residuals,
+            n_data=len(y),
+        )
+        result = FitResult(
+            model_name="test",
+            model_class_name="Test",
+            protocol=None,
+            params={"a": 1.0, "b": 2.0, "c": 3.0},
+            params_units={},
+            n_params=3,  # n_data(3) - n_params(3) - 1 = -1 <= 0
+            optimization_result=opt_result,
+            fitted_curve=fitted,
+            y=y,
+        )
+        assert result.aic is not None
+        assert result.aicc is None
+        assert "AICc" not in result.summary()
+
 
 @pytest.mark.smoke
 class TestModelInfo:
@@ -199,6 +375,30 @@ class TestModelInfo:
         with pytest.raises(KeyError):
             ModelInfo.from_registry("nonexistent_model_xyz")
 
+    def test_supports_bayesian_requires_model_function(self):
+        """supports_bayesian must reflect BayesianMixin's actual runtime
+        contract (model_function), not hasattr(instance, "fit_bayesian")
+        which is always True since BaseModel defines fit_bayesian
+        unconditionally for every subclass."""
+        from rheojax.core.base import BaseModel
+        from rheojax.core.registry import ModelRegistry
+
+        class _NoModelFunction(BaseModel):
+            def _fit(self, X, y, **kwargs):
+                self.fitted_ = True
+                return self
+
+            def _predict(self, X, **kwargs):
+                return X
+
+        name = "_test_no_model_function_xyz"
+        ModelRegistry.register(name)(_NoModelFunction)
+        try:
+            info = ModelInfo.from_registry(name)
+            assert info.supports_bayesian is False
+        finally:
+            ModelRegistry.unregister(name)
+
 
 @pytest.mark.smoke
 class TestModelComparison:
@@ -211,3 +411,40 @@ class TestModelComparison:
     def test_invalid_criterion(self):
         with pytest.raises(ValueError, match="criterion must be"):
             ModelComparison(results=[], criterion="invalid")
+
+    def test_duplicate_model_names_not_silently_dropped(self):
+        """Two FitResults sharing model_name (e.g. two pre-instantiated
+        instances of the same model class) must both survive ranking.
+
+        Regression test: rankings/delta_criterion/weights used to be dict
+        comprehensions keyed purely by model_name, so a duplicate silently
+        collided and discarded one result with no warning.
+        """
+
+        def _make(aic):
+            return FitResult(
+                model_name="maxwell",
+                model_class_name="Maxwell",
+                protocol="relaxation",
+                params={"G": 1.0},
+                params_units={},
+                n_params=1,
+                optimization_result=None,
+                _persisted_stats={"aic": aic},
+            )
+
+        r1 = _make(10.0)
+        r2 = _make(20.0)
+        comp = ModelComparison(results=[r1, r2], criterion="aic")
+
+        assert len(comp.rankings) == 2
+        assert len(comp.delta_criterion) == 2
+        assert len(comp.weights) == 2
+        assert sorted(comp.rankings.values()) == [1, 2]
+        assert sorted(comp.delta_criterion.values()) == [0.0, 10.0]
+
+        # Display should still show the original, un-suffixed model_name
+        # for both rows rather than the internal disambiguation key.
+        summary = comp.summary()
+        assert summary.count("maxwell") == 2
+        assert "#" not in summary

--- a/tests/core/test_jax_config.py
+++ b/tests/core/test_jax_config.py
@@ -45,3 +45,172 @@ class TestSafeImportJax:
         jax2, jnp2 = safe_import_jax()
         assert jax1 is jax2
         assert jnp1 is jnp2
+
+    def test_verify_float64_failure_is_wrapped_in_runtime_error(self, monkeypatch):
+        """The RuntimeError from verify_float64() must be caught and re-raised
+        with additional context, not left to propagate unwrapped."""
+        from rheojax.core import jax_config
+
+        jax_config.reset_validation()
+
+        def boom():
+            raise RuntimeError("dtype mismatch")
+
+        monkeypatch.setattr(jax_config, "verify_float64", boom)
+
+        with pytest.raises(RuntimeError, match="Float64 verification failed"):
+            jax_config.safe_import_jax()
+
+        # Leave cached state clean so later tests re-run the (unpatched,
+        # real) validation path once monkeypatch tears down.
+        jax_config.reset_validation()
+
+
+class TestEnableCompilationCache:
+    """Tests for _enable_compilation_cache()."""
+
+    def test_sets_min_compile_time_secs_below_default_threshold(self, monkeypatch, tmp_path):
+        """jax_persistent_cache_min_compile_time_secs defaults to 1.0s in the
+        installed JAX, which silently skips persisting sub-second rheology
+        model compiles. It must be explicitly lowered."""
+        import pathlib
+        from unittest.mock import MagicMock
+
+        from rheojax.core.jax_config import _enable_compilation_cache
+
+        monkeypatch.delenv("RHEOJAX_NO_JIT_CACHE", raising=False)
+        monkeypatch.setattr(pathlib.Path, "home", lambda: tmp_path)
+
+        fake_jax = MagicMock()
+        _enable_compilation_cache(fake_jax)
+
+        calls = dict(
+            call.args for call in fake_jax.config.update.call_args_list
+        )
+        assert calls["jax_compilation_cache_dir"] == str(
+            tmp_path / ".cache" / "rheojax" / "jax_cache"
+        )
+        assert "jax_persistent_cache_min_compile_time_secs" in calls
+        assert calls["jax_persistent_cache_min_compile_time_secs"] < 1.0
+
+    def test_disabled_by_env_var(self, monkeypatch):
+        from unittest.mock import MagicMock
+
+        from rheojax.core.jax_config import _enable_compilation_cache
+
+        monkeypatch.setenv("RHEOJAX_NO_JIT_CACHE", "1")
+        fake_jax = MagicMock()
+        _enable_compilation_cache(fake_jax)
+        fake_jax.config.update.assert_not_called()
+
+    def test_falls_back_to_experimental_api_on_attribute_error(self, monkeypatch, tmp_path):
+        """If the config-based API raises (e.g. older JAX), fall back to the
+        experimental compilation_cache module instead of crashing."""
+        import pathlib
+        from unittest.mock import MagicMock
+
+        from jax.experimental.compilation_cache import compilation_cache as cc
+
+        from rheojax.core.jax_config import _enable_compilation_cache
+
+        monkeypatch.delenv("RHEOJAX_NO_JIT_CACHE", raising=False)
+        monkeypatch.setattr(pathlib.Path, "home", lambda: tmp_path)
+
+        fake_jax = MagicMock()
+        fake_jax.config.update.side_effect = AttributeError("no such config option")
+
+        set_cache_dir_mock = MagicMock()
+        monkeypatch.setattr(cc, "set_cache_dir", set_cache_dir_mock)
+
+        with pytest.warns(RuntimeWarning, match="min-compile-time"):
+            _enable_compilation_cache(fake_jax)
+
+        set_cache_dir_mock.assert_called_once_with(
+            str(tmp_path / ".cache" / "rheojax" / "jax_cache")
+        )
+
+    def test_home_resolution_failure_is_non_fatal(self, monkeypatch):
+        """pathlib.Path.home() raises RuntimeError when $HOME is unset and the
+        UID has no /etc/passwd entry (e.g. arbitrary-UID containers). This
+        must be swallowed, not propagate out of safe_import_jax()."""
+        import pathlib
+        from unittest.mock import MagicMock
+
+        from rheojax.core.jax_config import _enable_compilation_cache
+
+        monkeypatch.delenv("RHEOJAX_NO_JIT_CACHE", raising=False)
+
+        def raise_runtime_error():
+            raise RuntimeError("Could not determine home directory.")
+
+        monkeypatch.setattr(pathlib.Path, "home", raise_runtime_error)
+
+        fake_jax = MagicMock()
+        _enable_compilation_cache(fake_jax)  # must not raise
+
+        fake_jax.config.update.assert_not_called()
+
+
+class TestLazyImport:
+    """Tests for lazy_import() / _LazyModule."""
+
+    def test_defers_import_until_first_attribute_access(self, monkeypatch):
+        import importlib
+        from unittest.mock import MagicMock
+
+        from rheojax.core.jax_config import lazy_import
+
+        fake_module = MagicMock()
+        fake_module.some_attr = "value"
+        import_mock = MagicMock(return_value=fake_module)
+        monkeypatch.setattr(importlib, "import_module", import_mock)
+
+        proxy = lazy_import("some.fake.module")
+        import_mock.assert_not_called()
+
+        assert proxy.some_attr == "value"
+        import_mock.assert_called_once_with("some.fake.module")
+
+    def test_forwards_calls_to_loaded_module(self, monkeypatch):
+        import importlib
+        from unittest.mock import MagicMock
+
+        from rheojax.core.jax_config import lazy_import
+
+        fake_module = MagicMock()
+        fake_module.some_method.return_value = 42
+        monkeypatch.setattr(importlib, "import_module", MagicMock(return_value=fake_module))
+
+        proxy = lazy_import("some.fake.module")
+        assert proxy.some_method() == 42
+
+    def test_loads_module_only_once_across_accesses(self, monkeypatch):
+        import importlib
+        from unittest.mock import MagicMock
+
+        from rheojax.core.jax_config import lazy_import
+
+        fake_module = MagicMock()
+        import_mock = MagicMock(return_value=fake_module)
+        monkeypatch.setattr(importlib, "import_module", import_mock)
+
+        proxy = lazy_import("some.fake.module")
+        _ = proxy.attr_a
+        _ = proxy.attr_b
+        assert import_mock.call_count == 1
+
+    def test_repr_reflects_loaded_state(self, monkeypatch):
+        import importlib
+        from unittest.mock import MagicMock
+
+        from rheojax.core.jax_config import lazy_import
+
+        fake_module = MagicMock()
+        monkeypatch.setattr(importlib, "import_module", MagicMock(return_value=fake_module))
+
+        proxy = lazy_import("some.fake.module")
+        assert "loaded=False" in repr(proxy)
+
+        _ = proxy.anything
+
+        assert "loaded=True" in repr(proxy)

--- a/tests/core/test_model_transform_registry.py
+++ b/tests/core/test_model_transform_registry.py
@@ -86,6 +86,29 @@ class TestModelRegistryDecorator:
         assert isinstance(model, TestModel)
         assert isinstance(model, BaseModel)
 
+    def test_register_validates_by_default(self):
+        """@ModelRegistry.register() must validate the plugin interface by
+        default: a BaseModel subclass that never overrides the abstract
+        _fit/_predict hooks must be rejected at registration time, not
+        silently accepted and only fail later at instantiation."""
+        with pytest.raises(ValueError, match="abstract"):
+
+            @ModelRegistry.register("incomplete_model")
+            class IncompleteModel(BaseModel):
+                """Never implements _fit/_predict."""
+
+        assert "incomplete_model" not in ModelRegistry.list_models()
+
+    def test_register_validate_false_opts_out(self):
+        """validate=False must still allow registering an incomplete
+        BaseModel subclass, preserving the escape hatch."""
+
+        @ModelRegistry.register("incomplete_model_opt_out", validate=False)
+        class IncompleteModel(BaseModel):
+            """Never implements _fit/_predict."""
+
+        assert "incomplete_model_opt_out" in ModelRegistry.list_models()
+
 
 class TestModelRegistryFactory:
     """Test ModelRegistry factory method (Task 6.2)."""
@@ -234,6 +257,25 @@ class TestModelRegistryDiscovery:
         assert info.metadata["domain"] == "frequency"
         assert "Test model documentation" in info.doc
 
+    def test_compatible_models_with_unrecognized_test_mode_does_not_raise(self):
+        """compatible_models() must degrade gracefully (empty list), not
+        crash, for real RheoData.test_mode values like 'rotation'/'unknown'
+        that are valid TestModeEnum members but not Protocol enum members."""
+
+        @ModelRegistry.register("test_model_for_mode_check")
+        class TestModelForModeCheck(BaseModel):
+            def _fit(self, X, y, **kwargs):
+                return self
+
+            def _predict(self, X):
+                return X
+
+        class FakeData:
+            test_mode = "unknown"
+
+        result = ModelRegistry.compatible_models(FakeData())
+        assert result == []
+
 
 class TestTransformRegistryDecorator:
     """Test TransformRegistry decorator registration (Task 6.3)."""
@@ -288,6 +330,28 @@ class TestTransformRegistryDecorator:
         info = TransformRegistry.get_info("mastercurve")
         assert info.metadata["method"] == "wlf"
         assert info.metadata["algorithm"] == "ml"
+
+    def test_register_validates_by_default(self):
+        """@TransformRegistry.register() must validate the plugin interface
+        by default: a BaseTransform subclass that never overrides the
+        abstract _transform hook must be rejected at registration time."""
+        with pytest.raises(ValueError, match="abstract"):
+
+            @TransformRegistry.register("incomplete_transform")
+            class IncompleteTransform(BaseTransform):
+                """Never implements _transform."""
+
+        assert "incomplete_transform" not in TransformRegistry.list_transforms()
+
+    def test_register_validate_false_opts_out(self):
+        """validate=False must still allow registering an incomplete
+        BaseTransform subclass, preserving the escape hatch."""
+
+        @TransformRegistry.register("incomplete_transform_opt_out", validate=False)
+        class IncompleteTransform(BaseTransform):
+            """Never implements _transform."""
+
+        assert "incomplete_transform_opt_out" in TransformRegistry.list_transforms()
 
 
 class TestTransformRegistryFactory:
@@ -472,3 +536,27 @@ class TestRegistryIsolation:
         # Verify unregistration
         assert "temp_model" not in ModelRegistry.list_models()
         assert "temp_transform" not in TransformRegistry.list_transforms()
+
+    def test_find_does_not_leak_across_namespaces(self):
+        """ModelRegistry.find()/TransformRegistry.find() must each only ever
+        return names from their own namespace, even when a model and a
+        transform share matching metadata and no protocol/type is given."""
+
+        @ModelRegistry.register("shared_domain_model", domain="leak_test")
+        class SharedDomainModel(BaseModel):
+            def _fit(self, X, y, **kwargs):
+                return self
+
+            def _predict(self, X):
+                return X
+
+        @TransformRegistry.register("shared_domain_transform", domain="leak_test")
+        class SharedDomainTransform(BaseTransform):
+            def _transform(self, data):
+                return data
+
+        model_matches = ModelRegistry.find(domain="leak_test")
+        transform_matches = TransformRegistry.find(domain="leak_test")
+
+        assert model_matches == ["shared_domain_model"]
+        assert transform_matches == ["shared_domain_transform"]

--- a/tests/core/test_numpyro_model_builder.py
+++ b/tests/core/test_numpyro_model_builder.py
@@ -1,0 +1,444 @@
+"""Unit tests for rheojax.core.numpyro_model_builder.
+
+Targets prior_dict_to_dist() directly and build_numpyro_model()'s internal
+branches (closure cache, model_returns_2col probe, fixed/alpha/default
+parameter sampling) using synthetic model_self stand-ins — no full NUTS run
+is needed to exercise any of this logic.
+"""
+
+from __future__ import annotations
+
+import logging
+
+import jax
+import numpyro
+import numpyro.distributions as dist
+import pytest
+from jax import numpy as jnp
+from jax import random as jax_random
+
+from rheojax.core.numpyro_model_builder import build_numpyro_model, prior_dict_to_dist
+from rheojax.core.parameters import ParameterSet
+from rheojax.core.test_modes import TestMode
+
+
+class _FakeModel:
+    """Minimal model_self stand-in: parameters + model_function only."""
+
+    def __init__(self, names_and_bounds: dict[str, tuple[float, float]]):
+        self.parameters = ParameterSet()
+        for name, bounds in names_and_bounds.items():
+            self.parameters.add(name, value=bounds[0], bounds=bounds)
+        self.model_function = None  # set per-test
+
+
+def _linear_model_function(X, params, test_mode, **kwargs):
+    return params[0] * X
+
+
+def _trace_model(numpyro_model, X, y):
+    return numpyro.handlers.trace(
+        numpyro.handlers.seed(numpyro_model, jax_random.PRNGKey(0))
+    ).get_trace(X, y)
+
+
+# ---------------------------------------------------------------------------
+# prior_dict_to_dist
+# ---------------------------------------------------------------------------
+
+
+def test_prior_dict_to_dist_gamma():
+    """GUI-configured Gamma priors must not be silently dropped (P0)."""
+    d = prior_dict_to_dist(
+        {"type": "gamma", "concentration": 2.0, "rate": 1.0}, dist
+    )
+    assert d is not None
+    assert isinstance(d, dist.Gamma)
+    assert float(d.concentration) == pytest.approx(2.0)
+    assert float(d.rate) == pytest.approx(1.0)
+
+
+def test_prior_dict_to_dist_beta():
+    """GUI-configured Beta priors must not be silently dropped (P0)."""
+    d = prior_dict_to_dist(
+        {"type": "beta", "concentration0": 3.0, "concentration1": 5.0}, dist
+    )
+    assert d is not None
+    assert isinstance(d, dist.Beta)
+    assert float(d.concentration0) == pytest.approx(3.0)
+    assert float(d.concentration1) == pytest.approx(5.0)
+
+
+def test_prior_dict_to_dist_unrecognized_type_logs_warning(caplog):
+    """Unrecognized dist_type returns None (existing contract) AND warns —
+    the fall-through path raises no exception, so logging-via-except alone
+    would not catch it."""
+    with caplog.at_level(logging.WARNING, logger="rheojax.core.numpyro_model_builder"):
+        result = prior_dict_to_dist({"type": "nope"}, dist)
+    assert result is None
+    assert any("Unrecognized prior dist_type" in r.message for r in caplog.records)
+
+
+def test_prior_dict_to_dist_malformed_known_type_logs_warning(caplog):
+    """A recognized dist_type with a missing required key still returns
+    None but must now log a warning instead of silently swallowing it."""
+    with caplog.at_level(logging.WARNING, logger="rheojax.core.numpyro_model_builder"):
+        result = prior_dict_to_dist({"type": "normal", "loc": 1.0}, dist)  # no scale
+    assert result is None
+    assert any("Malformed prior spec" in r.message for r in caplog.records)
+
+
+# ---------------------------------------------------------------------------
+# build_numpyro_model: parameter-branch selection
+# ---------------------------------------------------------------------------
+
+
+def test_build_numpyro_model_applies_gamma_prior_from_parameter():
+    """End-to-end regression for the P0 bug: a Parameter.prior of type
+    'gamma' (as set by the GUI PriorsEditor) must actually produce a Gamma
+    sample site, not silently fall back to Uniform."""
+    model = _FakeModel({"a": (0.1, 10.0)})
+    model.parameters.get("a").prior = {
+        "type": "gamma",
+        "concentration": 2.0,
+        "rate": 1.0,
+    }
+    model.model_function = _linear_model_function
+
+    numpyro_model = build_numpyro_model(
+        model, ["a"], {"a": (0.1, 10.0)}, TestMode.RELAXATION, False, {"n_points": 5}
+    )
+    X = jnp.linspace(0.1, 10.0, 5)
+    y = X * 2.0
+    trace = _trace_model(numpyro_model, X, y)
+    assert isinstance(trace["a"]["fn"], dist.Gamma)
+
+
+def test_build_numpyro_model_default_uniform_prior():
+    """No custom prior, no alpha suffix, distinct bounds -> Uniform."""
+    model = _FakeModel({"a": (0.1, 10.0)})
+    model.model_function = _linear_model_function
+
+    numpyro_model = build_numpyro_model(
+        model, ["a"], {"a": (0.1, 10.0)}, TestMode.RELAXATION, False, {"n_points": 5}
+    )
+    X = jnp.linspace(0.1, 10.0, 5)
+    y = X * 2.0
+    trace = _trace_model(numpyro_model, X, y)
+    assert trace["a"]["type"] == "sample"
+    assert isinstance(trace["a"]["fn"], dist.Uniform)
+
+
+def test_build_numpyro_model_alpha_param_uses_beta_prior():
+    """Parameters whose name ends in 'alpha' with bounds in [0, 1] get the
+    weakly-informative Beta(2, 2) heuristic."""
+    model = _FakeModel({"alpha": (0.0, 1.0)})
+    model.model_function = _linear_model_function
+
+    numpyro_model = build_numpyro_model(
+        model,
+        ["alpha"],
+        {"alpha": (0.0, 1.0)},
+        TestMode.RELAXATION,
+        False,
+        {"n_points": 5},
+    )
+    X = jnp.linspace(0.1, 10.0, 5)
+    y = X * 0.5
+    trace = _trace_model(numpyro_model, X, y)
+    assert trace["alpha"]["type"] == "sample"
+    assert isinstance(trace["alpha"]["fn"], dist.Beta)
+
+
+def test_build_numpyro_model_fixed_parameter_uses_deterministic():
+    """Genuinely equal bounds -> parameter pinned via numpyro.deterministic,
+    not sampled."""
+    model = _FakeModel({"a": (5.0, 5.0)})
+    model.model_function = _linear_model_function
+
+    numpyro_model = build_numpyro_model(
+        model, ["a"], {"a": (5.0, 5.0)}, TestMode.RELAXATION, False, {"n_points": 5}
+    )
+    X = jnp.linspace(0.1, 10.0, 5)
+    y = X * 5.0
+    trace = _trace_model(numpyro_model, X, y)
+    assert trace["a"]["type"] == "deterministic"
+    assert float(trace["a"]["value"]) == pytest.approx(5.0)
+
+
+def test_build_numpyro_model_fixed_tolerance_matches_bounds_validation():
+    """Regression: the builder's fixed-parameter tolerance must match
+    BayesianMixin._validate_parameter_bounds's ``1e-10 * max(|lo|, 1)``
+    formula. Before the fix the builder used a 10x looser
+    ``1e-9 * max(|lo|, |hi|, 1)``, so a bound width of 5e-8 at lower=100.0
+    was wrongly classified as fixed here while validate() treated it as a
+    genuine, sampled parameter."""
+    bounds = (100.0, 100.00000005)  # diff = 5e-8; new threshold = 1e-8 -> not fixed
+    model = _FakeModel({"a": bounds})
+    model.model_function = _linear_model_function
+
+    numpyro_model = build_numpyro_model(
+        model, ["a"], {"a": bounds}, TestMode.RELAXATION, False, {"n_points": 5}
+    )
+    X = jnp.linspace(0.1, 10.0, 5)
+    y = X * 100.0
+    trace = _trace_model(numpyro_model, X, y)
+    assert trace["a"]["type"] == "sample"
+
+
+# ---------------------------------------------------------------------------
+# build_numpyro_model: model_returns_2col probe
+# ---------------------------------------------------------------------------
+
+
+def test_build_numpyro_model_2col_probe_uses_real_n_points_not_dummy():
+    """The probe must synthesize its dummy call using the real data length
+    (when known) rather than max(n_points, 10) — otherwise a model whose
+    internals are sensitive to array length can raise on the mismatched
+    dummy size and get misclassified as not-2col (P2 fix)."""
+    model = _FakeModel({"a": (0.1, 10.0)})
+
+    def shape_sensitive_2col_fn(X, params, test_mode, **kwargs):
+        n = X.shape[0]
+        if n % 6 != 0:
+            raise ValueError("probe called with wrong length")
+        g1 = jnp.sum(X) * params[0] * jnp.ones((n,))
+        g2 = g1 * 0.5
+        return jnp.column_stack([g1, g2])
+
+    model.model_function = shape_sensitive_2col_fn
+    scale_info = {"n_points": 6}
+    build_numpyro_model(
+        model, ["a"], {"a": (0.1, 10.0)}, TestMode.OSCILLATION, True, scale_info
+    )
+    assert scale_info["model_returns_2col"] == 1
+
+
+def test_build_numpyro_model_runtime_check_catches_2col_misclassification():
+    """If the probe result was (somehow) wrongly cached as not-2col, the
+    runtime cross-check after the real model_function call must raise a
+    clear, diagnosable error instead of an opaque broadcasting failure
+    downstream (P2 fix)."""
+    model = _FakeModel({"a": (0.1, 10.0)})
+
+    def real_2col_fn(X, params, test_mode, **kwargs):
+        n = X.shape[0]
+        g1 = jnp.sum(X) * params[0] * jnp.ones((n,))
+        g2 = g1 * 0.5
+        return jnp.column_stack([g1, g2])
+
+    model.model_function = real_2col_fn
+    # Pre-seed scale_info so the probe block is skipped entirely, simulating
+    # a probe that already ran and (wrongly) cached False.
+    scale_info = {"n_points": 5, "model_returns_2col": 0}
+    numpyro_model = build_numpyro_model(
+        model, ["a"], {"a": (0.1, 10.0)}, TestMode.OSCILLATION, True, scale_info
+    )
+    X = jnp.linspace(0.1, 10.0, 5)
+    y = jnp.zeros(10)
+    with pytest.raises(ValueError, match="model_returns_2col probe misclassified"):
+        _trace_model(numpyro_model, X, y)
+
+
+# ---------------------------------------------------------------------------
+# build_numpyro_model: closure cache
+# ---------------------------------------------------------------------------
+
+
+def test_build_numpyro_model_cache_hit_returns_same_closure():
+    model = _FakeModel({"a": (0.1, 10.0)})
+    model.model_function = _linear_model_function
+
+    m1 = build_numpyro_model(
+        model, ["a"], {"a": (0.1, 10.0)}, TestMode.RELAXATION, False, {"n_points": 5}
+    )
+    m2 = build_numpyro_model(
+        model, ["a"], {"a": (0.1, 10.0)}, TestMode.RELAXATION, False, {"n_points": 5}
+    )
+    assert m1 is m2
+    assert len(model._closure_cache) == 1
+
+
+def test_build_numpyro_model_lru_cache_evicts_at_32():
+    model = _FakeModel({"a": (0.1, 10.0)})
+    model.model_function = _linear_model_function
+
+    for i in range(40):
+        bounds = {"a": (0.1, 10.0 + i)}
+        build_numpyro_model(
+            model, ["a"], bounds, TestMode.RELAXATION, False, {"n_points": 5}
+        )
+    assert len(model._closure_cache) == 32
+
+
+# ---------------------------------------------------------------------------
+# build_numpyro_model: NaN-safe primal guard poisons the gradient
+# ---------------------------------------------------------------------------
+
+
+def _singular_model_function(X, params, test_mode, **kwargs):
+    """A model with a clean algebraic singularity: blows up at theta=0."""
+    theta = params[0]
+    return (1.0 / theta) * jnp.ones_like(X)
+
+
+def _potential_at_theta(numpyro_model, X, y, theta_val):
+    """-log_joint as a function of the "theta" sample site's value, with the
+    site substituted directly (bypassing its prior sample) so jax.grad sees
+    exactly the path NUTS differentiates through."""
+    seeded = numpyro.handlers.seed(numpyro_model, jax_random.PRNGKey(0))
+    substituted = numpyro.handlers.substitute(seeded, data={"theta": theta_val})
+    from numpyro.infer.util import log_density
+
+    log_joint, _ = log_density(substituted, (X, y), {}, {})
+    return -log_joint
+
+
+def test_finite_check_guard_poisons_gradient_at_singularity():
+    """P0 regression for the shared NaN/Inf guard: jnp.where(is_finite,
+    predictions_raw, 0.0) sanitizes the primal likelihood but not the
+    gradient. When predictions_raw is non-finite because of a genuine
+    algebraic singularity inside model_function (here 1/theta at theta=0),
+    0 * inf = NaN survives back through lax.select, so jax.grad of the
+    potential energy comes back NaN even though the guard's own factor is
+    finite. This must reproduce with the default (opt-out) builder config."""
+    model = _FakeModel({"theta": (-1.0, 1.0)})
+    model.model_function = _singular_model_function
+    numpyro_model = build_numpyro_model(
+        model, ["theta"], {"theta": (-1.0, 1.0)}, TestMode.RELAXATION, False,
+        {"n_points": 5},
+    )
+    X = jnp.linspace(0.1, 1.0, 5)
+    y = jnp.ones(5)
+
+    grad = jax.grad(lambda t: _potential_at_theta(numpyro_model, X, y, t))(0.0)
+    assert jnp.isnan(grad)
+
+
+def test_nan_safe_grad_reeval_opt_in_fixes_gradient_at_singularity():
+    """With model_self._bayesian_nan_safe_grad_reeval = True, the builder
+    re-evaluates model_function with stop_gradient applied to the sampled
+    params whenever any output was non-finite, severing the NaN gradient
+    path (stop_gradient's backward rule is a symbolic zero, not the
+    arithmetic 0 * inf that leaks through jnp.where alone)."""
+    model = _FakeModel({"theta": (-1.0, 1.0)})
+    model.model_function = _singular_model_function
+    model._bayesian_nan_safe_grad_reeval = True
+    numpyro_model = build_numpyro_model(
+        model, ["theta"], {"theta": (-1.0, 1.0)}, TestMode.RELAXATION, False,
+        {"n_points": 5},
+    )
+    X = jnp.linspace(0.1, 1.0, 5)
+    y = jnp.ones(5)
+
+    grad = jax.grad(lambda t: _potential_at_theta(numpyro_model, X, y, t))(0.0)
+    assert jnp.isfinite(grad)
+
+
+# ---------------------------------------------------------------------------
+# build_numpyro_model: sigma prior scale (P0-3 fix parity, complex vs real)
+# ---------------------------------------------------------------------------
+
+
+def _complex_model_function(X, params, test_mode, **kwargs):
+    """Returns true complex G* directly (not the (N,2) real form), so the
+    is_complex_data branch is exercised without the model_returns_2col
+    reconstruction path."""
+    n = X.shape[0]
+    real = params[0] * jnp.ones((n,))
+    imag = 0.5 * params[0] * jnp.ones((n,))
+    return real + 1j * imag
+
+
+@pytest.mark.parametrize("is_complex_data", [True, False])
+def test_sigma_prior_uses_1x_not_10x_data_scale(is_complex_data):
+    """P0 regression: the complex-data (oscillation) sigma_real/sigma_imag
+    priors must use the same 1x data-scale multiplier as the real-data
+    sigma prior (P0-3 fix) — a stale 10x multiplier drowns the likelihood
+    for small N and collapses the posterior to the prior."""
+    model = _FakeModel({"a": (0.1, 10.0)})
+    X = jnp.linspace(0.1, 10.0, 5)
+
+    if is_complex_data:
+        model.model_function = _complex_model_function
+        scale_info = {
+            "n_points": 5,
+            "n_real": 5,
+            "y_real_scale": 2.0,
+            "y_imag_scale": 3.0,
+            "y_real_mean": 1.0,
+            "y_imag_mean": 1.0,
+        }
+        y = jnp.concatenate([jnp.ones(5), jnp.ones(5)])
+        numpyro_model = build_numpyro_model(
+            model, ["a"], {"a": (0.1, 10.0)}, TestMode.OSCILLATION, True, scale_info
+        )
+        trace = _trace_model(numpyro_model, X, y)
+
+        expected_real_scale = max(2.0 * 1.0, 1.0 * 0.01, 1e-3)
+        expected_imag_scale = max(3.0 * 1.0, 1.0 * 0.01, 1e-3)
+        assert isinstance(trace["sigma_real"]["fn"], dist.Exponential)
+        assert isinstance(trace["sigma_imag"]["fn"], dist.Exponential)
+        assert float(trace["sigma_real"]["fn"].rate) == pytest.approx(
+            1.0 / expected_real_scale
+        )
+        assert float(trace["sigma_imag"]["fn"].rate) == pytest.approx(
+            1.0 / expected_imag_scale
+        )
+    else:
+        model.model_function = _linear_model_function
+        scale_info = {"n_points": 5, "data_scale": 2.0, "data_mean": 1.0}
+        y = X * 2.0
+        numpyro_model = build_numpyro_model(
+            model, ["a"], {"a": (0.1, 10.0)}, TestMode.RELAXATION, False, scale_info
+        )
+        trace = _trace_model(numpyro_model, X, y)
+
+        expected_scale = max(2.0 * 1.0, 1.0 * 0.01, 1e-3)
+        assert isinstance(trace["sigma"]["fn"], dist.Exponential)
+        assert float(trace["sigma"]["fn"].rate) == pytest.approx(1.0 / expected_scale)
+
+
+# ---------------------------------------------------------------------------
+# build_numpyro_model: y=None tolerated (unconditioned/Predictive-style call)
+# ---------------------------------------------------------------------------
+
+
+def test_numpyro_model_tolerates_y_none_for_2col_real_data():
+    """P2 regression: with model_returns_2col=True and is_complex_data=False,
+    the builder dereferenced y.ndim unconditionally, crashing with
+    AttributeError on y=None — the exact call shape the `y=None` default in
+    the signature implies should be supported (e.g. via Predictive)."""
+    model = _FakeModel({"a": (0.1, 10.0)})
+
+    def _real_2col_fn(X, params, test_mode, **kwargs):
+        n = X.shape[0]
+        g1 = params[0] * jnp.ones((n,))
+        g2 = 0.5 * g1
+        return jnp.column_stack([g1, g2])
+
+    model.model_function = _real_2col_fn
+    numpyro_model = build_numpyro_model(
+        model, ["a"], {"a": (0.1, 10.0)}, TestMode.OSCILLATION, False, {"n_points": 5}
+    )
+    X = jnp.linspace(0.1, 10.0, 5)
+    # Must not raise AttributeError: 'NoneType' object has no attribute 'ndim'
+    _trace_model(numpyro_model, X, None)
+
+
+def test_numpyro_model_tolerates_y_none_for_complex_data():
+    """P2 regression: the is_complex_data branch dereferenced y[:n]/y[n:]
+    unconditionally, crashing with TypeError on y=None."""
+    model = _FakeModel({"a": (0.1, 10.0)})
+    model.model_function = _complex_model_function
+    numpyro_model = build_numpyro_model(
+        model,
+        ["a"],
+        {"a": (0.1, 10.0)},
+        TestMode.OSCILLATION,
+        True,
+        {"n_points": 5, "n_real": 5},
+    )
+    X = jnp.linspace(0.1, 10.0, 5)
+    # Must not raise TypeError: 'NoneType' object is not subscriptable
+    _trace_model(numpyro_model, X, None)

--- a/tests/core/test_parameters.py
+++ b/tests/core/test_parameters.py
@@ -117,6 +117,86 @@ class TestParameterConstraints:
         assert param.validate(11.0) == False  # Out of bounds
         assert param.validate(5.5) == False  # Not integer
 
+    @pytest.mark.smoke
+    def test_bounds_setter_none_to_tuple_creates_constraint(self):
+        """bounds setter must insert a bounds constraint when none exists yet.
+
+        Regression test: a Parameter created with bounds=None has no bounds
+        constraint. Assigning `.bounds =` afterward must create one so that
+        `.validate()` actually enforces the newly-set range (previously it
+        silently accepted any value because the constraint list stayed empty).
+        """
+        param = Parameter("x", value=5.0)
+        assert param.constraints == []
+
+        param.bounds = (0.0, 10.0)
+
+        assert any(c.type == "bounds" for c in param.constraints)
+        assert param.validate(50.0) is False
+        assert param.validate(5.0) is True
+
+    @pytest.mark.smoke
+    def test_bounds_setter_does_not_duplicate_constraint(self):
+        """Repeated `.bounds =` assignment must sync, not append, constraints."""
+        param = Parameter("x", value=5.0, bounds=(0.0, 10.0))
+        assert sum(1 for c in param.constraints if c.type == "bounds") == 1
+
+        param.bounds = (0.0, 20.0)
+
+        assert sum(1 for c in param.constraints if c.type == "bounds") == 1
+        assert param.validate(15.0) is True
+
+    @pytest.mark.smoke
+    def test_bounds_setter_clamps_out_of_range_value(self):
+        """Narrowing bounds past the current value must clamp it, with a warning,
+        instead of leaving `.value` silently outside the new `.bounds`.
+        """
+        param = Parameter("x", value=5.0, bounds=(0.0, 10.0))
+
+        with pytest.warns(RuntimeWarning):
+            param.bounds = (6.0, 20.0)
+
+        assert param.value == 6.0
+        assert param.bounds == (6.0, 20.0)
+        assert param.was_clamped is True
+
+    @pytest.mark.smoke
+    def test_bounds_setter_rejects_inverted_bounds(self):
+        """The bounds setter must reject lower > upper, matching the
+        validation already performed at construction time (_initialize)
+        and by ParameterSet.set_bounds(). Without this check, a direct
+        `.bounds =` assignment can install unsatisfiable bounds that make
+        every subsequent value rejected with an opaque error.
+        """
+        param = Parameter("x", value=5.0, bounds=(0.0, 10.0))
+
+        with pytest.raises(ValueError, match="Invalid bounds"):
+            param.bounds = (10.0, 0.0)
+
+        # Original bounds must be left untouched after the rejected assignment.
+        assert param.bounds == (0.0, 10.0)
+
+    @pytest.mark.smoke
+    def test_custom_constraint_to_dict_raises(self):
+        """Serializing a 'custom' constraint must fail loudly, not silently
+        drop the validator callable (which cannot round-trip through JSON/HDF5).
+        """
+        constraint = ParameterConstraint(
+            type="custom", validator=lambda value: value % 2 == 0
+        )
+        with pytest.raises(ValueError):
+            constraint.to_dict()
+
+    @pytest.mark.smoke
+    def test_custom_constraint_without_validator_fails_closed(self):
+        """A 'custom' constraint with no validator (e.g. a hand-built dict that
+        bypassed to_dict()'s guard) must raise on validate(), not silently
+        return True for every value.
+        """
+        constraint = ParameterConstraint(type="custom", validator=None)
+        with pytest.raises(ValueError):
+            constraint.validate(4.0)
+
 
 class TestSharedParameters:
     """Test shared parameter management across models."""
@@ -191,6 +271,33 @@ class TestSharedParameters:
         # Invalid update should raise
         with pytest.raises(ValueError, match="violates constraints"):
             shared.set_value("ratio", 1.5)
+
+    def test_shared_parameter_relative_constraint_enforced(self):
+        """SharedParameterSet.set_value must build a validation context so
+        'relative' constraints between shared parameters are actually
+        enforced, instead of silently no-op'ing (ParameterConstraint.validate
+        only evaluates the 'relative' branch when a context dict is passed).
+        """
+        shared = SharedParameterSet()
+        shared.add_shared("param_a", value=5.0)
+        shared.add_shared(
+            "param_b",
+            value=10.0,
+            constraints=[
+                ParameterConstraint(
+                    type="relative", relation="less_than", other_param="param_a"
+                )
+            ],
+        )
+
+        # Valid: 8.0 < param_a (5.0)? No -- pick values that satisfy first.
+        shared.set_value("param_a", 20.0)
+        shared.set_value("param_b", 8.0)
+        assert shared.get_value("param_b") == 8.0
+
+        # Invalid update should raise: param_b must stay less_than param_a.
+        with pytest.raises(ValueError, match="violates constraints"):
+            shared.set_value("param_b", 100.0)
 
     def test_shared_parameter_groups(self):
         """Test grouping related shared parameters."""
@@ -481,6 +588,38 @@ class TestParameterSensitivity:
         # Check condition number (high = poor identifiability)
         condition_number = np.linalg.cond(fim)
         assert condition_number > 100  # Indicates poor identifiability
+
+
+class TestParameterSetItem:
+    """Test ParameterSet.__setitem__ Parameter-replacement identity guard."""
+
+    @pytest.mark.smoke
+    def test_setitem_rejects_name_mismatch(self):
+        """Replacing a stored Parameter via subscript assignment must reject
+        a Parameter whose .name differs from the assignment key. Otherwise
+        the ParameterSet key and Parameter.name silently diverge, which is
+        masked (rather than fixed) by from_dict() forcibly overwriting the
+        name on every serialization round-trip.
+        """
+        params = ParameterSet()
+        params.add("alpha", value=0.5, bounds=(0, 1))
+
+        with pytest.raises(ValueError, match="does not match"):
+            params["alpha"] = Parameter("beta", value=0.8, bounds=(0, 1))
+
+        # Original parameter must be untouched after the rejected assignment.
+        assert params["alpha"].name == "alpha"
+        assert params["alpha"].value == 0.5
+
+    @pytest.mark.smoke
+    def test_setitem_accepts_matching_name(self):
+        """Sanity check: replacement with a matching name still works."""
+        params = ParameterSet()
+        params.add("alpha", value=0.5, bounds=(0, 1))
+
+        params["alpha"] = Parameter("alpha", value=0.8, bounds=(0, 1))
+
+        assert params["alpha"].value == 0.8
 
 
 class TestParameterSetUnpack:

--- a/tests/core/test_registry.py
+++ b/tests/core/test_registry.py
@@ -180,6 +180,43 @@ class TestRegistryRegistration:
         with pytest.raises(ValueError, match="Invalid plugin type"):
             registry.register("test", Mock(), plugin_type="invalid")
 
+    def test_register_invalid_protocol_string_raises_error(self):
+        """A typo'd protocol string must fail loudly at registration time,
+        not silently register the model with an empty protocols list."""
+        registry = Registry()
+
+        class MockModel:
+            pass
+
+        with pytest.raises(ValueError, match="Invalid protocol"):
+            registry.register(
+                "maxwell",
+                MockModel,
+                plugin_type=PluginType.MODEL,
+                protocols=["relaxaton"],
+            )
+
+        # The model must not have been silently registered either.
+        assert "maxwell" not in registry.get_all_models()
+
+    def test_register_invalid_transform_type_raises_error(self):
+        """A typo'd transform_type string must fail loudly at registration
+        time, not silently register the transform with transform_type=None."""
+        registry = Registry()
+
+        class MockTransform:
+            pass
+
+        with pytest.raises(ValueError, match="Invalid transform_type"):
+            registry.register(
+                "fft",
+                MockTransform,
+                plugin_type=PluginType.TRANSFORM,
+                transform_type="not_a_real_type",
+            )
+
+        assert "fft" not in registry.get_all_transforms()
+
 
 class TestRegistryRetrieval:
     """Test plugin retrieval."""
@@ -354,6 +391,41 @@ class TestRegistryValidation:
                 validate=True,
             )
 
+    def test_validate_model_interface_rejects_incomplete_abc_subclass(self):
+        """hasattr(fit)/hasattr(predict) alone can't catch an incomplete ABC
+        subclass, since abstract stubs and inherited concrete wrappers are
+        still present via attribute lookup. validate=True must additionally
+        reject a class that still has unimplemented abstract methods."""
+        import abc
+
+        registry = Registry()
+
+        class AbstractModel(abc.ABC):
+            @abc.abstractmethod
+            def fit(self, data): ...
+
+            @abc.abstractmethod
+            def predict(self, data): ...
+
+        class IncompleteModel(AbstractModel):
+            """Overrides fit but never implements predict."""
+
+            def fit(self, data):
+                pass
+
+        # hasattr checks alone would pass (predict is still present as the
+        # inherited abstract stub), so this only fails via the abstractness
+        # check.
+        assert hasattr(IncompleteModel, "predict")
+
+        with pytest.raises(ValueError, match="abstract"):
+            registry.register(
+                "incomplete",
+                IncompleteModel,
+                plugin_type=PluginType.MODEL,
+                validate=True,
+            )
+
     def test_skip_validation(self):
         """Test that validation can be skipped."""
         registry = Registry()
@@ -448,12 +520,72 @@ class TestRegistryDiscovery:
             mock_module.CustomModel = type(
                 "CustomModel", (), {"fit": None, "predict": None}
             )
+            # discover() now only registers classes actually defined in the
+            # scanned module (obj.__module__ == module_name), so the mock
+            # class must claim membership in "custom_model" to be picked up.
+            mock_module.CustomModel.__module__ = "custom_model"
             mock_import.return_value = mock_module
 
             registry.discover_directory("/custom/plugins")
 
             # Should discover custom plugins
             assert len(registry.get_all_models()) > 0
+
+    def test_discover_skips_classes_imported_from_elsewhere(self):
+        """discover() must not register classes merely imported into the
+        scanned module's namespace (e.g. a base class), only ones actually
+        defined there - otherwise e.g. BaseModel pollutes get_all_models()."""
+        registry = Registry()
+
+        class BaseModelLike:
+            """Stand-in for a base class defined in another module."""
+
+            def fit(self, data):
+                pass
+
+            def predict(self, data):
+                pass
+
+        # Simulate importing BaseModelLike into the scanned module: its
+        # __module__ still points at its real (different) origin module.
+        BaseModelLike.__module__ = "some.other.module"
+
+        class LocalModel:
+            def fit(self, data):
+                pass
+
+            def predict(self, data):
+                pass
+
+        LocalModel.__module__ = "fake_scanned_module"
+
+        fake_module = Mock()
+        fake_module.BaseModelLike = BaseModelLike
+        fake_module.LocalModel = LocalModel
+
+        with patch("importlib.import_module", return_value=fake_module):
+            registry.discover("fake_scanned_module")
+
+        assert "LocalModel" in registry.get_all_models()
+        assert "BaseModelLike" not in registry.get_all_models()
+
+    def test_discover_logs_warning_on_import_error(self, caplog):
+        """A broken module path must be logged, not silently swallowed."""
+        registry = Registry()
+
+        with (
+            patch(
+                "importlib.import_module", side_effect=ImportError("no such module")
+            ),
+            caplog.at_level("WARNING"),
+        ):
+            registry.discover("nonexistent.module.path")
+
+        assert len(caplog.records) >= 1
+        assert any(
+            "nonexistent.module.path" in str(record.__dict__)
+            for record in caplog.records
+        )
 
 
 class TestRegistryManagement:
@@ -506,6 +638,51 @@ class TestRegistryManagement:
         assert len(registry.get_all_models()) == 0
         assert len(registry.get_all_transforms()) == 0
 
+    def test_get_all_returns_models_and_transforms(self):
+        """get_all() must return every registered plugin with its type."""
+        registry = Registry()
+
+        class MockModel:
+            pass
+
+        class MockTransform:
+            pass
+
+        registry.register("some_model", MockModel, plugin_type=PluginType.MODEL)
+        registry.register(
+            "some_transform", MockTransform, plugin_type=PluginType.TRANSFORM
+        )
+
+        all_plugins = registry.get_all()
+        assert all_plugins["some_model"] == (MockModel, PluginType.MODEL)
+        assert all_plugins["some_transform"] == (MockTransform, PluginType.TRANSFORM)
+
+    def test_get_all_warns_on_cross_type_name_collision(self, caplog):
+        """A name registered as both a model and a transform is valid (see
+        test_registry_namespaces - separate namespaces by design), but
+        get_all() can only return one entry per name. It must log a
+        warning instead of silently dropping the model entry."""
+        registry = Registry()
+
+        class MockModel:
+            pass
+
+        class MockTransform:
+            pass
+
+        registry.register("dual", MockModel, plugin_type=PluginType.MODEL)
+        registry.register("dual", MockTransform, plugin_type=PluginType.TRANSFORM)
+
+        with caplog.at_level("WARNING"):
+            all_plugins = registry.get_all()
+
+        # Both registrations remain independently retrievable via get().
+        assert registry.get("dual", PluginType.MODEL) is MockModel
+        assert registry.get("dual", PluginType.TRANSFORM) is MockTransform
+        # get_all() can only surface one; make sure the collision is logged.
+        assert all_plugins["dual"] == (MockTransform, PluginType.TRANSFORM)
+        assert any("dual" in str(record.__dict__) for record in caplog.records)
+
     def test_registry_stats(self):
         """Test getting registry statistics."""
         registry = Registry()
@@ -552,6 +729,66 @@ class TestRegistryManagement:
         # Verify restoration
         assert "model1" in registry.get_all_models()
         assert "transform1" in registry.get_all_transforms()
+
+    def test_import_state_logs_warning_on_missing_class(self, caplog):
+        """A renamed/moved class must be logged, not silently dropped."""
+        registry = Registry()
+
+        state = {
+            "models": {
+                "ghost_model": {
+                    "class_name": "NoLongerExists",
+                    "module": "unittest.mock",
+                    "metadata": {},
+                    "protocols": [],
+                }
+            },
+            "transforms": {},
+        }
+
+        with caplog.at_level("WARNING"):
+            registry.import_state(state)
+
+        assert "ghost_model" not in registry.get_all_models()
+        assert len(caplog.records) >= 1
+        assert any(
+            "ghost_model" in str(record.__dict__) for record in caplog.records
+        )
+
+    def test_import_state_skips_malformed_entries_without_crashing(self, caplog):
+        """Entries missing required keys (or not dict-shaped) must be skipped
+        per-entry, not crash import_state and abort remaining restoration."""
+        registry = Registry()
+
+        state = {
+            "models": {
+                # Missing "module" key entirely -> KeyError on info["module"]
+                "no_module": {"class_name": "Mock"},
+                # Not a dict at all -> TypeError on info["module"]
+                "not_a_dict": None,
+                # Well-formed entry that should still restore successfully
+                "good_model": {
+                    "class_name": "Mock",
+                    "module": "unittest.mock",
+                    "metadata": {},
+                    "protocols": [],
+                },
+            },
+            "transforms": {
+                "no_class_name": {"module": "unittest.mock"},
+                "also_not_a_dict": ["oops"],
+            },
+        }
+
+        with caplog.at_level("WARNING"):
+            registry.import_state(state)
+
+        assert "no_module" not in registry.get_all_models()
+        assert "not_a_dict" not in registry.get_all_models()
+        assert "no_class_name" not in registry.get_all_transforms()
+        assert "also_not_a_dict" not in registry.get_all_transforms()
+        # The well-formed entry must still be restored despite the bad ones.
+        assert "good_model" in registry.get_all_models()
 
 
 class TestRegistryCompatibility:
@@ -621,6 +858,86 @@ class TestRegistryCompatibility:
 
         assert "freq_model" in compatible
         assert "time_model" not in compatible
+
+    def test_find_compatible_plugin_type_scopes_search(self):
+        """find_compatible(plugin_type=...) must not mix models and transforms.
+
+        Without a protocol/transform_type filter, a bare find_compatible()
+        call still scans both namespaces (back-compat default), but callers
+        that scope with plugin_type must get only that namespace back.
+        """
+        registry = Registry()
+
+        class MyModel:
+            pass
+
+        class MyTransform:
+            pass
+
+        registry.register(
+            "mymodel",
+            MyModel,
+            plugin_type=PluginType.MODEL,
+            metadata={"domain": "x"},
+        )
+        registry.register(
+            "mytransform",
+            MyTransform,
+            plugin_type=PluginType.TRANSFORM,
+            metadata={"domain": "x"},
+        )
+
+        # Bare call (no scoping) still searches both, preserving existing behavior.
+        both = registry.find_compatible(domain="x")
+        assert set(both) == {"mymodel", "mytransform"}
+
+        # Scoped calls must not leak across namespaces.
+        models_only = registry.find_compatible(
+            domain="x", plugin_type=PluginType.MODEL
+        )
+        assert models_only == ["mymodel"]
+
+        transforms_only = registry.find_compatible(
+            domain="x", plugin_type=PluginType.TRANSFORM
+        )
+        assert transforms_only == ["mytransform"]
+
+    def test_find_compatible_invalid_protocol_returns_no_matches(self):
+        """An unrecognized protocol string must not raise, just match nothing."""
+        registry = Registry()
+
+        class SomeModel:
+            pass
+
+        registry.register(
+            "some_model",
+            SomeModel,
+            plugin_type=PluginType.MODEL,
+            protocols=["relaxation"],
+        )
+
+        # "rotation"/"unknown" are real RheoData.test_mode values that are not
+        # members of the Protocol enum (see TestModeEnum) - must not crash.
+        compatible = registry.find_compatible(protocol="unknown")
+        assert compatible == []
+
+    def test_find_compatible_invalid_transform_type_returns_no_matches(self):
+        """An unrecognized transform_type string must not raise, just match
+        nothing (mirrors the protocol-side graceful-degradation contract)."""
+        registry = Registry()
+
+        class SomeTransform:
+            pass
+
+        registry.register(
+            "some_transform",
+            SomeTransform,
+            plugin_type=PluginType.TRANSFORM,
+            transform_type="spectral",
+        )
+
+        compatible = registry.find_compatible(transform_type="not_a_real_type")
+        assert compatible == []
 
     def test_plugin_versioning(self):
         """Test plugin versioning support."""

--- a/tests/core/test_test_modes.py
+++ b/tests/core/test_test_modes.py
@@ -1,5 +1,7 @@
 """Tests for test mode detection functionality."""
 
+import warnings
+
 import numpy as np
 import pytest
 
@@ -93,6 +95,49 @@ class TestModeDetection:
         mode = detect_test_mode(data)
         assert mode == TestMode.ROTATION
 
+    def test_rotation_detection_shear_rate_warns_ambiguous_units(self):
+        """'1/s'/'s^-1' is dimensionally identical to Hz, so classifying it as
+        ROTATION (not OSCILLATION) must not be silent.
+
+        Regression test for R-TESTMODE-002: frequency-domain data labeled with
+        SI shear-rate-style units was silently misclassified as ROTATION with
+        zero warnings, even though '1/s' == Hz and could equally be a
+        frequency sweep left at the default domain='time'.
+        """
+        shear_rate = np.logspace(-2, 3, 50)
+        viscosity = 100 * shear_rate ** (-0.3)
+
+        data = RheoData(
+            x=shear_rate,
+            y=viscosity,
+            x_units="1/s",
+            y_units="Pa.s",
+            domain="time",
+        )
+
+        with pytest.warns(UserWarning, match="ambiguous between shear rate"):
+            mode = detect_test_mode(data)
+
+        # Classification itself must be unchanged (locked in by
+        # test_rotation_detection_shear_rate above).
+        assert mode == TestMode.ROTATION
+
+    def test_oscillation_detection_frequency_domain_no_ambiguous_warning(self):
+        """Explicit domain='frequency' with '1/s' units must resolve cleanly
+        to OSCILLATION without the ambiguous-units warning firing."""
+        freq = np.logspace(-2, 2, 50)
+        G_prime = 1000 * freq**0.5
+
+        data = RheoData(
+            x=freq, y=G_prime, x_units="1/s", y_units="Pa", domain="frequency"
+        )
+
+        with warnings.catch_warnings():
+            warnings.simplefilter("error", UserWarning)
+            mode = detect_test_mode(data)
+
+        assert mode == TestMode.OSCILLATION
+
     def test_explicit_metadata_override(self):
         """Test explicit test mode specification in metadata."""
         # Data that might look like relaxation but explicitly marked as oscillation
@@ -123,6 +168,23 @@ class TestModeDetection:
 
         mode = detect_test_mode(data)
         assert mode == TestMode.UNKNOWN
+
+    def test_time_domain_oscillation_integer_cycles_not_flat(self):
+        """Time-domain oscillatory data spanning whole cycles must not be
+        misclassified as RELAXATION just because endpoints coincide.
+
+        Regression test for R10-TESTMODE-001-B: the old flatness heuristic
+        compared only y[0] and y[-1], so a LAOS-style waveform recorded over
+        an integer number of periods (endpoints ~equal, large interior
+        amplitude) was silently defaulted to 'relaxation'.
+        """
+        time = np.linspace(0, 4 * np.pi * 10, 200)  # exactly 2 periods of sin(t/10)
+        stress = 1000 * np.sin(time / 10)
+
+        data = RheoData(x=time, y=stress, x_units="s", y_units="Pa", domain="time")
+
+        mode = detect_test_mode(data)
+        assert mode != TestMode.RELAXATION
 
     def test_complex_oscillation_data(self):
         """Test detection with complex modulus data."""
@@ -164,6 +226,43 @@ class TestModeDetection:
         mode = detect_test_mode(data)
         assert mode == TestMode.RELAXATION
 
+    def test_nan_in_y_data_does_not_misclassify_as_flat_relaxation(self):
+        """NaN-poisoned y-data must not be silently reported as flat RELAXATION.
+
+        Regression test: np.max/np.min/np.mean all propagate NaN, making
+        `data_magnitude > 0` False (NaN comparisons are always False), which
+        used to make relative_change fall back to the literal 0 and trigger
+        the flat-data heuristic. detect_test_mode() must instead return
+        UNKNOWN with a warning that names NaN/Inf explicitly, not "flat".
+        """
+        time = np.linspace(0, 100, 100)
+        stress = 1000 * np.exp(-time / 10)
+        stress[10] = np.nan
+
+        data = RheoData(
+            x=time, y=stress, x_units="s", y_units="Pa", domain="time", validate=False
+        )
+
+        with pytest.warns(UserWarning, match="NaN or Inf"):
+            mode = detect_test_mode(data)
+
+        assert mode == TestMode.UNKNOWN
+
+    def test_inf_in_y_data_does_not_misclassify_as_flat_relaxation(self):
+        """Same as above, for +/-Inf rather than NaN."""
+        time = np.linspace(0, 100, 100)
+        stress = 1000 * np.exp(-time / 10)
+        stress[-1] = np.inf
+
+        data = RheoData(
+            x=time, y=stress, x_units="s", y_units="Pa", domain="time", validate=False
+        )
+
+        with pytest.warns(UserWarning, match="NaN or Inf"):
+            mode = detect_test_mode(data)
+
+        assert mode == TestMode.UNKNOWN
+
 
 class TestMonotonicityChecks:
     """Test monotonicity checking utilities."""
@@ -201,6 +300,27 @@ class TestMonotonicityChecks:
         # Too much noise
         data = np.array([100, 50, 90, 40, 80])
         assert not is_monotonic_decreasing(data)
+
+    def test_monotonic_increasing_with_noisy_endpoint(self):
+        """A single noisy last sample must not defeat allow_fraction.
+
+        Regression test: is_monotonic_increasing used to hard-fail on
+        `data[-1] - data[0] < 0` before the tolerant diff-based violation
+        count ever ran, so one bad endpoint could flip the whole result even
+        though only 1/49 diffs (well under the 30% allow_fraction) actually
+        violate monotonicity.
+        """
+        from rheojax.core.test_modes import is_monotonic_increasing
+
+        data = np.concatenate([np.linspace(100, 200, 49), [50.0]])
+        assert is_monotonic_increasing(data, allow_fraction=0.3)
+
+    def test_monotonic_decreasing_with_noisy_endpoint(self):
+        """Mirror of the increasing case for is_monotonic_decreasing."""
+        from rheojax.core.test_modes import is_monotonic_decreasing
+
+        data = np.concatenate([np.linspace(200, 100, 49), [250.0]])
+        assert is_monotonic_decreasing(data, allow_fraction=0.3)
 
 
 class TestModeEnum:
@@ -385,6 +505,93 @@ class TestValidationDataset:
         assert accuracy > 95.0, (
             f"Detection accuracy {accuracy:.2f}% is below target of 95%"
         )
+
+
+class TestModelSuggestionFunctions:
+    """Test get_compatible_test_modes and suggest_models_for_test_mode.
+
+    Regression coverage: these are documented public API
+    (docs/source/api/core.rst) with zero prior test coverage anywhere in
+    the repo.
+    """
+
+    def test_get_compatible_test_modes_registered_model_with_protocols(self):
+        """A registered model with protocols should return protocol-derived modes."""
+        from rheojax.core.test_modes import get_compatible_test_modes
+
+        modes = get_compatible_test_modes("maxwell")
+        assert TestMode.RELAXATION in modes
+        assert TestMode.CREEP in modes
+        assert TestMode.OSCILLATION in modes
+
+    def test_get_compatible_test_modes_unregistered_model_default(self):
+        """An unknown model name should fall back to the 3-mode default."""
+        from rheojax.core.test_modes import get_compatible_test_modes
+
+        modes = get_compatible_test_modes("nonexistent_model_xyz")
+        assert modes == [TestMode.RELAXATION, TestMode.CREEP, TestMode.OSCILLATION]
+
+    def test_suggest_models_for_test_mode_relaxation_priority_ordering(self):
+        """suggest_models_for_test_mode should priority-sort, maxwell first."""
+        from rheojax.core.test_modes import suggest_models_for_test_mode
+
+        models = suggest_models_for_test_mode(TestMode.RELAXATION)
+        assert len(models) > 0
+        assert models[0].lower() == "maxwell"
+
+    def test_suggest_models_for_test_mode_unknown_returns_empty_list(self):
+        """TestMode.UNKNOWN has no Protocol mapping, so it must return []."""
+        from rheojax.core.test_modes import suggest_models_for_test_mode
+
+        assert suggest_models_for_test_mode(TestMode.UNKNOWN) == []
+
+    def test_get_compatible_test_modes_falls_back_for_model_without_protocols(self):
+        """Models registered without protocols (a still-supported, optional
+        kwarg on ModelRegistry.register) must still get a sane default list
+        via the legacy fallback branch, not an empty list or an exception.
+        """
+        from rheojax.core.registry import ModelRegistry
+        from rheojax.core.test_modes import get_compatible_test_modes
+
+        @ModelRegistry.register(
+            "ponytail_throwaway_no_protocols_model", protocols=None, validate=False
+        )
+        class _ThrowawayModel:
+            pass
+
+        try:
+            modes = get_compatible_test_modes("ponytail_throwaway_no_protocols_model")
+            assert modes == [
+                TestMode.RELAXATION,
+                TestMode.CREEP,
+                TestMode.OSCILLATION,
+            ]
+        finally:
+            ModelRegistry.unregister("ponytail_throwaway_no_protocols_model")
+
+    def test_get_compatible_test_modes_warns_on_invalid_supported_test_modes(self):
+        """A malformed supported_test_modes value must not be silently
+        swallowed -- it should log a warning before falling back to the
+        default (instead of a bare `except: return [...]`).
+        """
+        from rheojax.core.registry import ModelRegistry
+        from rheojax.core.test_modes import get_compatible_test_modes
+
+        @ModelRegistry.register(
+            "ponytail_throwaway_bad_modes_model", protocols=None, validate=False
+        )
+        class _ThrowawayBadModesModel:
+            supported_test_modes = ["not_a_real_test_mode"]
+
+        try:
+            modes = get_compatible_test_modes("ponytail_throwaway_bad_modes_model")
+            assert modes == [
+                TestMode.RELAXATION,
+                TestMode.CREEP,
+                TestMode.OSCILLATION,
+            ]
+        finally:
+            ModelRegistry.unregister("ponytail_throwaway_bad_modes_model")
 
 
 if __name__ == "__main__":

--- a/tests/core/test_validation.py
+++ b/tests/core/test_validation.py
@@ -5,6 +5,8 @@ from types import MappingProxyType
 import pytest
 
 from rheojax.core._validation import reject_removed_options
+from rheojax.core.post_fit_validator import PostFitValidator, RheoJaxUncertaintyWarning
+from rheojax.io._exceptions import RheoJaxPhysicsWarning
 
 
 @pytest.mark.parametrize(
@@ -41,3 +43,55 @@ def test_reject_removed_options_accepts_mapping_without_mutating_it():
     reject_removed_options(readonly_options)
 
     assert options == {"method": "scipy", "max_iter": 23}
+
+
+def test_check_physics_surfaces_failure_via_warning_and_log(monkeypatch, caplog):
+    """A bug in check_fit_physics must not silently defeat check_physics=True."""
+
+    def _boom(model):
+        raise AttributeError("model missing expected field")
+
+    monkeypatch.setattr(
+        "rheojax.utils.physics_checks.check_fit_physics", _boom
+    )
+
+    with caplog.at_level("WARNING", logger="rheojax.core.post_fit_validator"):
+        with pytest.warns(RheoJaxPhysicsWarning, match="check_physics failed to run"):
+            PostFitValidator.check_physics(object())
+
+    assert any(record.levelname == "WARNING" for record in caplog.records)
+
+
+def test_compute_uncertainty_rejects_unknown_method():
+    with pytest.raises(ValueError, match="Unknown uncertainty method"):
+        PostFitValidator.compute_uncertainty(
+            model=object(),
+            X=None,
+            y=None,
+            uncertainty="bootstrp",
+            test_mode=None,
+        )
+
+
+def test_compute_uncertainty_surfaces_failure_via_warning_and_log(monkeypatch, caplog):
+    """A bug in hessian_ci must not silently return None with no visible signal."""
+
+    def _boom(model, X, y, test_mode=None):
+        raise AttributeError("model missing expected field")
+
+    monkeypatch.setattr("rheojax.utils.uncertainty.hessian_ci", _boom)
+
+    with caplog.at_level("WARNING", logger="rheojax.core.post_fit_validator"):
+        with pytest.warns(
+            RheoJaxUncertaintyWarning, match="Uncertainty computation .* failed to run"
+        ):
+            result = PostFitValidator.compute_uncertainty(
+                model=object(),
+                X=None,
+                y=None,
+                uncertainty="hessian",
+                test_mode=None,
+            )
+
+    assert result is None
+    assert any(record.levelname == "WARNING" for record in caplog.records)


### PR DESCRIPTION
## Summary

Multi-agent audit of `rheojax/core` (14 files, ~9,600 lines) using the `superpowers:systematic-debugging` root-cause methodology and `dev-suite:smart-debug`'s scientific-computing bug taxonomy (NaN/Inf propagation, JAX JIT-safety, shape/dtype mismatches, MCMC diagnostics), plus 3 cross-cutting data-flow passes (model↔registry contract, the full Bayesian pipeline, data→parameters→fit flow). Every finding was independently adversarially verified before a fix was applied; 42 of 43 raw findings survived verification and were fixed, one per file to avoid conflicting concurrent edits.

## Highlights

- **base.py**: `precompile()` leaked `_nlsq_result`; `predict()`/`fit_predict()` crashed on 0-d array input; an explicit `test_mode` override was silently ignored when passing `RheoData`; `TransformPipeline` dropped the last step's extras tuple
- **bayesian.py**: no shape/length validation between `X`/`y` for plain-array inputs (silent likelihood corruption via broadcasting); unrecognized `initial_values` keys silently dropped; out-of-bounds warm-start values silently clamped at DEBUG only
- **numpyro_model_builder.py** (shared across *all* Bayesian models): stale 10x sigma-prior multiplier on complex/oscillation data; `y=None` crashed instead of supporting unconditioned/Predictive calls; the NaN/Inf guard masked the primal likelihood but still poisoned NUTS gradients (added an opt-in `_bayesian_nan_safe_grad_reeval` escape hatch); malformed/unrecognized prior specs silently fell back to defaults with no warning
- **data.py**: `test_mode` property ignored direct `metadata` mutation, contradicting its own docstring; domain conversion used inverted guards; unsupported `y`-array shapes silently accepted
- **parameters.py**: inverted `(min>max)` bounds accepted with no validation; numerical gradient step size underflowed for large-magnitude parameters; relative constraints with an unset/unrecognized relation silently no-op'd; `ParameterSet.__setitem__` allowed key/name identity to desync
- **registry.py**: `import_state()` crashed on malformed entries instead of degrading per-entry; invalid protocol/transform_type strings silently vanished instead of raising
- **fit_result.py**: `plot()` and post-serialization `.residuals` ignored log-residual mode, showing wrong-space values; `aicc` returned `NaN` instead of `None` like its sibling stats
- **fit_orchestrator.py**: invalid uncertainty method raised *after* the fit already committed; `return_result=True` skipped compatibility-error enhancement; unsorted `x` reached `model._fit()` unsorted; `auto_p0` partial failures were under-logged
- **bayesian_result.py**: default dataclass `__eq__` crashed on multi-sample posteriors; posterior fast-path exception handler leaked partial state
- **bayesian_diagnostics.py**: `compute_bfmi()`'s `min()` over NaN masked genuinely bad chains; BFMI was computed but never gated into `diagnostics_valid`
- **test_modes.py / jax_config.py / arviz_utils.py**: NaN/Inf silently misclassified as flat relaxation; a noise-tolerant monotonicity check was defeated by an endpoint-only pre-check; compilation-cache fallback failures were silent; `import_arviz` raised `RuntimeError` instead of `ImportError`, escaping every one of its 8 call sites' `except ImportError`

One cross-file regression surfaced by the `parameters.py` bounds-validation fix was corrected directly: `tests/core/test_bayesian.py::test_error_handling_invalid_bounds` assumed bounds validation was deferred until fit time; it's now eager (that deferral was itself one of the fixed bugs), so the test's `pytest.raises` now wraps the assignment.

Known pre-existing, out-of-scope issue (not touched here): `tests/core/test_base.py` defines `class TestBaseModel:` twice — the second definition silently shadows the first at module scope, so roughly 600 lines of tests are never collected by pytest. This predates this branch (confirmed present at `main`'s `HEAD`) and the two class bodies have diverged enough that blindly re-enabling the dead half risks surfacing unrelated failures; flagging for a separate pass.

## Test plan

- [x] ~160 new regression tests added, one per fix, each independently verified to fail before and pass after
- [x] `uv run pytest tests/core -q`: 625 passed, 0 failed (baseline before this branch: 463 passed)
- [x] `uv run ruff check rheojax/core tests/core`: all checks passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)