### PR TITLE
test(gui): restore workspace-shell coverage lost in legacy-shell removal

### DIFF
--- a/tests/gui/workspace/fit/test_end_to_end_fit_to_export.py
+++ b/tests/gui/workspace/fit/test_end_to_end_fit_to_export.py
@@ -121,3 +121,68 @@ def test_full_fit_workflow_seeds_tables_and_exports(monkeypatch, qapp, tmp_path)
     #    because nlsq_result["x"] was always None.
     written = bodies[5].export_bundle(tmp_path)
     assert written["fitted_curve"].exists()
+
+
+def test_nuts_advanced_options_reach_run_bayesian_isolated(monkeypatch, qapp):
+    # Regression guard for issue #69 (a coverage gap left by the legacy
+    # RheoJAXMainWindow/BayesianPage removal, which deleted
+    # test_advanced_options_reach_make_bayesian_worker with no
+    # workspace-shell replacement): the surviving workspace shell's Bayesian
+    # fit step (NutsStep) must actually forward user-edited
+    # target_accept/max_tree_depth through to the sampler entry point, not
+    # silently drop them in favor of hardcoded defaults. Drives the real
+    # QDoubleSpinBox/QSpinBox widgets (not state.nuts_config directly) so the
+    # test fails if a future edit breaks the widget -> _on_settings_changed
+    # -> NutsStep.run()'s cfg dict -> _make_sample_fn -> run_bayesian_isolated
+    # chain at any link.
+    captured: dict = {}
+
+    def _fake_run_bayesian_isolated(*args, **kwargs):
+        captured.update(kwargs)
+        return {
+            "posterior_samples": {"eta": [1.0]},
+            "sample_stats": {},
+            "r_hat": {},
+            "ess": {},
+            "bfmi": None,
+        }
+
+    monkeypatch.setattr(
+        fit_controller, "run_bayesian_isolated", _fake_run_bayesian_isolated
+    )
+
+    library = DatasetLibrary()
+    library.add(
+        DatasetRef(
+            id="ds1",
+            name="ds1",
+            protocol_type="oscillation",
+            origin="imported",
+            units={"x": "rad/s"},
+            row_count=5,
+            hash="h",
+            provenance={},
+            lineage=[],
+        )
+    )
+    x = np.linspace(0.1, 10.0, 5)
+    y = np.linspace(0.2, 5.0, 5)
+    library.store_payload("ds1", _RheoData(x, y))
+    app_state = AppState(library=library)
+
+    ctl, bodies = build_fit_controller(app_state)
+    bodies[0].set_protocol("oscillation")
+    bodies[0].set_model("maxwell")
+    bodies[1].select_dataset("ds1")
+
+    nuts_body = bodies[3]
+    # Drive the real widgets away from their library defaults (0.8 /
+    # unset-> None), matching a user actually opening Advanced Options and
+    # changing them.
+    nuts_body._target.setValue(0.95)
+    nuts_body._max_tree_depth.setValue(7)
+
+    nuts_body.run()
+
+    assert captured["target_accept"] == pytest.approx(0.95)
+    assert captured["max_tree_depth"] == 7

--- a/tests/gui/workspace/transform/test_end_to_end_slot_to_library.py
+++ b/tests/gui/workspace/transform/test_end_to_end_slot_to_library.py
@@ -98,3 +98,56 @@ def test_pick_fill_run_save_round_trips_through_library(qapp, monkeypatch):
     payload = app_state.library.load_payload(new_id)
     assert payload.x == [1.0, 2.0]
     assert payload.y == [3.0, 4.0]
+
+
+def test_run_uses_only_slot_selected_dataset_not_full_library(qapp, monkeypatch):
+    """Regression guard for issue #70 (a coverage gap left by the legacy
+    RheoJAXMainWindow/TransformPage removal, which deleted
+    test_apply_transform_uses_checked_subset_not_all_datasets with no
+    workspace-shell replacement): a transform run must operate only on the
+    dataset(s) explicitly bound into slots, never silently pull in every
+    dataset loaded in the library. The legacy shell's bug applied a
+    transform to all loaded datasets instead of the checked subset; this
+    shell's slot-based design structurally can't do that (RunStep passes
+    state.slots, not library.all(), to run_fn) -- proved here end-to-end
+    through the real TransformWorker -> TransformService.apply_transform
+    boundary (not just by reading the source), with two other same-typed
+    datasets loaded and offered as candidates but never selected.
+    """
+    captured: dict = {}
+
+    def fake_apply_transform(self, name, data, params):
+        captured["data"] = data
+        return _RheoData([1.0, 2.0], [3.0, 4.0])
+
+    monkeypatch.setattr(
+        "rheojax.gui.services.transform_service.TransformService.apply_transform",
+        fake_apply_transform,
+    )
+
+    library = DatasetLibrary()
+    selected_payload = _RheoData([0.0, 1.0], [0.0, 1.0])
+    library.add(_ref("ds-selected", "oscillation"))
+    library.store_payload("ds-selected", selected_payload)
+    for extra_id in ("ds-other-1", "ds-other-2"):
+        library.add(_ref(extra_id, "oscillation"))
+        library.store_payload(extra_id, _RheoData([99.0], [99.0]))
+
+    app_state = AppState(library=library)
+    ctl, bodies = build_transform_controller(app_state)
+
+    bodies[0].set_transform("smooth_derivative")
+    combo = bodies[1]._combo_widgets["input"]
+    # All three same-typed datasets are offered as candidates -- the run
+    # below must still only touch the one actually selected.
+    assert set(bodies[1].candidates("input")) == {
+        "ds-selected",
+        "ds-other-1",
+        "ds-other-2",
+    }
+    combo.setCurrentText("ds-selected")
+
+    bodies[2].run()
+
+    assert app_state.transform.result is not None
+    assert captured["data"] is selected_payload


### PR DESCRIPTION
## Summary
Closes #69, closes #70.

Both issues were flagged as out-of-scope gaps during PR #71's legacy `RheoJAXMainWindow` shell removal, which deleted the tests driving through the deleted `TransformPage`/`BayesianPage` widgets with no workspace-shell replacement.

Investigation found both underlying behaviors are already correct in the current `WorkspaceWindow` architecture — only the regression coverage was missing:

- **#70** (checked-dataset-subset transform behavior): Transform mode is slot-based (`SlotsStep` explicitly binds specific dataset ids into named slots), so `RunStep`'s `run_fn` only ever sees `state.slots`, never `library.all()` — the legacy "applies to all loaded datasets instead of the checked subset" bug class is structurally impossible here. Added `test_run_uses_only_slot_selected_dataset_not_full_library`, which loads two extra same-typed datasets into the library, selects only one via the real `SlotsStep` combo widget, and proves (via a captured `TransformService.apply_transform` call) only the selected dataset's payload was ever touched.

- **#69** (`max_tree_depth`/`target_accept_prob` reaching the Bayesian worker): `NutsStep.run()` already builds its config dict from the real `target_accept`/`max_tree_depth` widgets, and `fit_controller.py`'s `_make_sample_fn` already forwards both into `run_bayesian_isolated()`. Added `test_nuts_advanced_options_reach_run_bayesian_isolated`, which drives the real `QDoubleSpinBox`/`QSpinBox` widgets away from their defaults and asserts the monkeypatched `run_bayesian_isolated` receives the edited values end-to-end through the real `build_fit_controller()` wiring.

## Test plan
- [x] `tests/gui/workspace/` — 323 passed, 0 failed