### PR TITLE
fix(gui): map rotation test_mode to flow_curve protocol on import

### DIFF
--- a/rheojax/gui/workspace/window.py
+++ b/rheojax/gui/workspace/window.py
@@ -1065,11 +1065,14 @@ class WorkspaceWindow(QMainWindow):
         self._notifier.changed.emit()
 
     # detect_test_mode() reports "flow" for flow-curve data (F-IO-R... naming
-    # predates Protocol.FLOW_CURVE), which never equality-matches
-    # DatasetLibrary.datasets_of_type("flow_curve") -- normalize it here so
-    # imported flow-curve datasets actually show up in the Fit/Transform Data
-    # step instead of silently landing in no protocol bucket at all.
-    _IMPORT_TEST_MODE_ALIASES = {"flow": "flow_curve"}
+    # predates Protocol.FLOW_CURVE), and the CSV/Excel reader's column-based
+    # detector (_utils.detect_test_mode_from_columns) tags the same data
+    # "rotation" (shear rate / viscosity columns -> steady-shear rotation
+    # test). Neither equality-matches DatasetLibrary.datasets_of_type(
+    # "flow_curve") -- normalize both here so imported flow-curve datasets
+    # actually show up in the Fit/Transform Data step instead of silently
+    # landing in no protocol bucket at all.
+    _IMPORT_TEST_MODE_ALIASES = {"flow": "flow_curve", "rotation": "flow_curve"}
 
     def _on_import_requested(self) -> None:
         """Handle LibraryRail's "+ Import data..." button."""

--- a/rheojax/gui/workspace/window.py
+++ b/rheojax/gui/workspace/window.py
@@ -1065,14 +1065,29 @@ class WorkspaceWindow(QMainWindow):
         self._notifier.changed.emit()
 
     # detect_test_mode() reports "flow" for flow-curve data (F-IO-R... naming
-    # predates Protocol.FLOW_CURVE), and the CSV/Excel reader's column-based
-    # detector (_utils.detect_test_mode_from_columns) tags the same data
-    # "rotation" (shear rate / viscosity columns -> steady-shear rotation
-    # test). Neither equality-matches DatasetLibrary.datasets_of_type(
-    # "flow_curve") -- normalize both here so imported flow-curve datasets
-    # actually show up in the Fit/Transform Data step instead of silently
-    # landing in no protocol bucket at all.
-    _IMPORT_TEST_MODE_ALIASES = {"flow": "flow_curve", "rotation": "flow_curve"}
+    # predates Protocol.FLOW_CURVE) -- not a TestModeEnum member, so it needs
+    # its own alias below. Every other test_mode string the reader can emit
+    # (e.g. "rotation" from the CSV/Excel column-based detector in
+    # _utils.detect_test_mode_from_columns) already has an authoritative
+    # equivalence encoded in TestModeEnum.to_protocol() -- delegate to that
+    # in _normalize_import_test_mode() instead of re-encoding the same
+    # rotation->flow_curve mapping a second time here. Without normalizing,
+    # a dataset's protocol_type never equality-matches
+    # DatasetLibrary.datasets_of_type("flow_curve") and it silently lands in
+    # no protocol bucket at all, invisible to the Fit/Transform Data step.
+    _IMPORT_TEST_MODE_ALIASES = {"flow": "flow_curve"}
+
+    @classmethod
+    def _normalize_import_test_mode(cls, test_mode: str | None) -> str | None:
+        if test_mode in cls._IMPORT_TEST_MODE_ALIASES:
+            return cls._IMPORT_TEST_MODE_ALIASES[test_mode]
+        try:
+            from rheojax.core.test_modes import TestModeEnum
+
+            protocol = TestModeEnum(str(test_mode).lower()).to_protocol()
+        except ValueError:
+            return test_mode
+        return protocol.value if protocol is not None else test_mode
 
     def _on_import_requested(self) -> None:
         """Handle LibraryRail's "+ Import data..." button."""
@@ -1190,7 +1205,7 @@ class WorkspaceWindow(QMainWindow):
             meta = rheo_data.metadata
             source_file = meta.pop("_source_file", None)
             test_mode = meta.get("test_mode") or service.detect_test_mode(rheo_data)
-            test_mode = self._IMPORT_TEST_MODE_ALIASES.get(test_mode, test_mode)
+            test_mode = self._normalize_import_test_mode(test_mode)
             meta["test_mode"] = test_mode
 
             if source_file and source_file not in hash_cache:

--- a/tests/gui/workspace/test_window_import.py
+++ b/tests/gui/workspace/test_window_import.py
@@ -110,6 +110,24 @@ def test_import_completed_maps_rotation_test_mode_to_flow_curve_protocol(
     assert ref.protocol_type == "flow_curve"
 
 
+@pytest.mark.parametrize(
+    ("raw", "expected"),
+    [
+        ("flow", "flow_curve"),  # legacy alias, not a TestModeEnum member
+        ("rotation", "flow_curve"),  # TestModeEnum.to_protocol() delegation
+        ("flow_curve", "flow_curve"),  # already canonical -- identity
+        ("startup", "startup"),  # other protocols pass through unchanged
+        ("unknown", "unknown"),  # to_protocol() returns None -- keep as-is
+        ("not_a_real_mode", "not_a_real_mode"),  # invalid enum value -- keep as-is
+    ],
+)
+def test_normalize_import_test_mode(raw, expected):
+    # Unit-level coverage for the alias-dict vs TestModeEnum.to_protocol()
+    # branches in WorkspaceWindow._normalize_import_test_mode, independent
+    # of the full import pipeline exercised by the tests above.
+    assert WorkspaceWindow._normalize_import_test_mode(raw) == expected
+
+
 def test_import_failed_shows_message_box(qtbot, monkeypatch):
     messages = []
     monkeypatch.setattr(QMessageBox, "critical", lambda *a, **k: messages.append(a[-1]))

--- a/tests/gui/workspace/test_window_import.py
+++ b/tests/gui/workspace/test_window_import.py
@@ -82,6 +82,34 @@ def test_import_completed_maps_flow_test_mode_to_flow_curve_protocol(qtbot, tmp_
     assert ref.protocol_type == "flow_curve"
 
 
+def test_import_completed_maps_rotation_test_mode_to_flow_curve_protocol(
+    qtbot, tmp_path
+):
+    # Regression: the CSV/Excel reader's column-based detector tags
+    # shear-rate/viscosity data "rotation" (see
+    # rheojax/io/readers/_utils.py::detect_test_mode_from_columns), which
+    # the old alias map didn't cover -- imported flow-curve CSVs like
+    # "Shear Rate, Viscosity" silently never appeared in any protocol's
+    # Data step even though the import itself reported success.
+    state = AppState()
+    win = WorkspaceWindow(state)
+    qtbot.addWidget(win)
+
+    source = tmp_path / "flow.csv"
+    source.write_text("Shear Rate,Viscosity\n0.1,7348.0\n1.0,831.83\n")
+    data = RheoData(
+        x=np.array([0.1, 1.0, 10.0]),
+        y=np.array([7348.0, 831.83, 94.353]),
+        domain="time",
+        metadata={"_source_file": str(source), "test_mode": "rotation"},
+    )
+
+    win._on_import_completed([data])
+
+    ref = next(iter(state.library.all()))
+    assert ref.protocol_type == "flow_curve"
+
+
 def test_import_failed_shows_message_box(qtbot, monkeypatch):
     messages = []
     monkeypatch.setattr(QMessageBox, "critical", lambda *a, **k: messages.append(a[-1]))


### PR DESCRIPTION
## Summary
- Reader-level CSV/Excel auto-detect tags shear-rate/viscosity flow-curve data `test_mode="rotation"` (`rheojax/io/readers/_utils.py::detect_test_mode_from_columns`), but `WorkspaceWindow._IMPORT_TEST_MODE_ALIASES` only translated `"flow" -> "flow_curve"`.
- Result: imported flow-curve CSVs (e.g. `Shear Rate, Viscosity` columns) got `protocol_type="rotation"` on their `DatasetRef`, which never equality-matches `DatasetLibrary.datasets_of_type("flow_curve")` — the import succeeded with no error, but the dataset silently never showed up in the Fit/Transform Data step.
- Fix: extend the alias map to also translate `"rotation" -> "flow_curve"`. Verified `plot_service.py` already treats `"rotation"` and `"flow_curve"` identically for axis-scale purposes, and no test asserts `protocol_type == "rotation"` for imported data, so this is a safe, root-cause fix at the single shared normalization point.

## Test plan
- [x] `uv run pytest tests/gui/workspace/test_window_import.py -q` — 13 passed, including new regression test `test_import_completed_maps_rotation_test_mode_to_flow_curve_protocol`
- [x] `uv run pytest tests/gui/workspace/ -q -k "import or rotation or flow"` — 14 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)