### PR TITLE
fix(models): recognize rotation/flow_curve aliases in GMM fit dispatch

### DIFF
--- a/rheojax/models/multimode/generalized_maxwell.py
+++ b/rheojax/models/multimode/generalized_maxwell.py
@@ -196,7 +196,7 @@ class GeneralizedMaxwell(BaseModel):
                     self._fit_creep_mode(
                         X, y, optimization_factor=optimization_factor, **kwargs
                     )
-                elif test_mode == "steady_shear":
+                elif test_mode in ("steady_shear", "rotation", "flow_curve"):
                     self._fit_steady_shear_mode(
                         X, y, optimization_factor=optimization_factor, **kwargs
                     )
@@ -1381,7 +1381,7 @@ class GeneralizedMaxwell(BaseModel):
             return self._predict_oscillation(X)
         elif test_mode == "creep":
             return self._predict_creep(X)
-        elif test_mode in ("steady_shear", "flow_curve"):
+        elif test_mode in ("steady_shear", "rotation", "flow_curve"):
             return self._predict_steady_shear(X)
         elif test_mode == "startup":
             return self._predict_startup(X)
@@ -1940,7 +1940,7 @@ class GeneralizedMaxwell(BaseModel):
             return self._predict_creep_jit(
                 jnp.asarray(X), E_inf, E_i, tau_i, sigma_0=1.0
             )
-        elif test_mode == "steady_shear":
+        elif test_mode in ("steady_shear", "rotation", "flow_curve"):
             return self._predict_steady_shear_jit(E_inf, E_i, tau_i)
         elif test_mode == "startup":
             gamma_dot = kwargs.get(

--- a/tests/models/multimode/test_generalized_maxwell.py
+++ b/tests/models/multimode/test_generalized_maxwell.py
@@ -557,6 +557,23 @@ class TestGMMSteadyShearMode:
         eta_0_expected = 1e4 * 0.1 + 1e3 * 1.0
         np.testing.assert_allclose(eta_pred, eta_0_expected, rtol=1e-6)
 
+    @pytest.mark.parametrize("alias", ["flow_curve", "rotation"])
+    def test_fit_accepts_steady_shear_aliases(self, alias):
+        """Regression: fit() previously only recognized test_mode='steady_shear',
+        raising ValueError('Unknown test_mode') for the 'flow_curve'/'rotation'
+        aliases every other model and GMM's own predict()/model_function()
+        already accept (GUI datasets are tagged 'flow_curve' after import)."""
+        gamma_dot = np.logspace(-2, 2, 30)
+        eta_avg = 5e3
+        eta_data = np.full_like(gamma_dot, eta_avg)
+
+        model = GeneralizedMaxwell(n_modes=3)
+        model.fit(gamma_dot, eta_data, test_mode=alias)
+        eta_pred = np.asarray(model.predict(gamma_dot, test_mode=alias))
+
+        assert np.all(np.isfinite(eta_pred))
+        np.testing.assert_allclose(eta_pred, eta_avg, rtol=1e-6)
+
 
 class TestGMMStartupMode:
     """Test GMM startup flow (stress growth) protocol."""
@@ -753,6 +770,19 @@ class TestGMMModelFunction:
         gamma_dot = np.logspace(-1, 1, 20)
         eta_0 = np.asarray(
             model.model_function(gamma_dot, self._params(), test_mode="steady_shear")
+        )
+        expected = 1e5 * 0.01 + 1e4 * 1.0
+        np.testing.assert_allclose(float(eta_0), expected, rtol=1e-6)
+
+    @pytest.mark.parametrize("alias", ["flow_curve", "rotation"])
+    def test_model_function_accepts_steady_shear_aliases(self, alias):
+        """Regression: model_function() previously only recognized
+        test_mode='steady_shear', raising ValueError for the 'flow_curve'/
+        'rotation' aliases (needed for NumPyro NUTS on GUI-imported flow data)."""
+        model = GeneralizedMaxwell(n_modes=2)
+        gamma_dot = np.logspace(-1, 1, 20)
+        eta_0 = np.asarray(
+            model.model_function(gamma_dot, self._params(), test_mode=alias)
         )
         expected = 1e5 * 0.01 + 1e4 * 1.0
         np.testing.assert_allclose(float(eta_0), expected, rtol=1e-6)

--- a/tests/models/multimode/test_gmm_bayesian.py
+++ b/tests/models/multimode/test_gmm_bayesian.py
@@ -53,7 +53,7 @@ class TestGMMBayesianInference:
         omega = np.logspace(-2, 2, 30)
         G_prime = 1e6 * (omega * 0.1) ** 2 / (1 + (omega * 0.1) ** 2)
         G_double_prime = 1e6 * (omega * 0.1) / (1 + (omega * 0.1) ** 2)
-        G_star = np.vstack([G_prime, G_double_prime])
+        G_star = np.column_stack([G_prime, G_double_prime])  # (M, 2): G', G'' convention
         model.fit(omega, G_star, test_mode="oscillation")
 
         # Test model_function


### PR DESCRIPTION
## Summary
- `GeneralizedMaxwell` is registered with `Protocol.FLOW_CURVE` support, and its own `predict()`/`model_function()` already treat `"steady_shear"` and `"flow_curve"` as synonyms for the same fitting path — matching the codebase-wide convention where every other model checks `test_mode in ("steady_shear", "rotation", "flow_curve")`.
- But `_fit()`'s dispatch only matched the literal string `"steady_shear"`, so fitting a GUI-imported flow-curve dataset (tagged `test_mode="flow_curve"` since #74) raised `ValueError: Unknown test_mode: flow_curve`.
- `predict()` and `model_function()` were also missing the `"rotation"` alias (only had `"steady_shear"`/`"flow_curve"`), which would have failed identically for CLI-imported or programmatically-constructed datasets still tagged `"rotation"`.
- Widened all three dispatch sites in `rheojax/models/multimode/generalized_maxwell.py` to `test_mode in ("steady_shear", "rotation", "flow_curve")`.
- This bug was previously unreachable via the GUI: before #74 fixed dataset classification, a flow-curve import was invisible in the Fit workflow's Data step under any protocol, so a user could never reach this fit call at all. #74 exposed it, this PR fixes it.

## Also fixed
- `tests/models/multimode/test_gmm_bayesian.py::test_model_function_oscillation_mode` — a pre-existing failure unrelated to the above (confirmed by reproducing it against unmodified `main`): it built `G_star` with `np.vstack([G_prime, G_double_prime])` giving shape `(2, M)`, violating `RheoData`'s documented `(M, 2)` G'/G'' convention. Fixed to use `np.column_stack`.

## Test plan
- [x] Reproduced the exact traceback end-to-end (`GeneralizedMaxwell(n_modes=3).fit(x, y, test_mode='flow_curve')` on `examples/data/flow/hydrogels/cellulose_hydrogel_flow.csv`) — now succeeds
- [x] Added regression tests: `test_fit_accepts_steady_shear_aliases` and `test_model_function_accepts_steady_shear_aliases`, parametrized over `["flow_curve", "rotation"]`
- [x] `uv run pytest tests/models/multimode/ -q` — 84 passed (was 79 passed + 1 pre-existing failure)
- [x] `uv run ruff check` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)