### PR TITLE
fix: repair shape-validation regression and stale/mismarked tests

### DIFF
--- a/examples/utils/hvm_demo_fit.py
+++ b/examples/utils/hvm_demo_fit.py
@@ -75,7 +75,10 @@ def _protocol_grid(protocol: str) -> tuple[np.ndarray, dict[str, float]]:
     if protocol == "relaxation":
         return np.logspace(-2, 3, 60), {}
     if protocol == "creep":
-        return np.logspace(-2, 3, 60), {"sigma_applied": 100.0}
+        # Upper bound capped at 10**2: the HVM creep ODE integration for
+        # TRUE_PARAMS/sigma_applied=100 diverges to all-NaN somewhere in
+        # (10**2, 10**3] seconds, unlike relaxation which stays stable to 10**3.
+        return np.logspace(-2, 2, 60), {"sigma_applied": 100.0}
     if protocol == "startup":
         return np.linspace(0.01, 10.0, 80), {"gamma_dot": 1.0}
     if protocol == "oscillation":
@@ -86,7 +89,7 @@ def _protocol_grid(protocol: str) -> tuple[np.ndarray, dict[str, float]]:
 def _fit_grid(protocol: str) -> np.ndarray:
     if protocol == "startup":
         return np.linspace(0.01, 10.0, 200)
-    return np.logspace(-2, 3 if protocol in {"relaxation", "creep"} else 2, 200)
+    return np.logspace(-2, 3 if protocol == "relaxation" else 2, 200)
 
 
 def _r_squared(y_true: np.ndarray, y_pred: np.ndarray, *, log_space: bool) -> float:

--- a/rheojax/core/bayesian.py
+++ b/rheojax/core/bayesian.py
@@ -380,7 +380,11 @@ class BayesianMixin:
         """
         x_arr = np.asarray(X_array)
         y_arr = np.asarray(y_array)
-        n = x_arr.shape[0] if x_arr.ndim > 0 else None
+        # Protocol-encoded X (e.g. stacked (time, strain) rows for
+        # startup/LAOS, shape (2, N)) carries the sample count in its last
+        # axis, not its first — use shape[-1] so both that convention and
+        # the plain 1-D case (where shape[-1] == shape[0]) are covered.
+        n = x_arr.shape[-1] if x_arr.ndim > 0 else None
 
         if y_arr.ndim == 1:
             pass

--- a/rheojax/core/fit_orchestrator.py
+++ b/rheojax/core/fit_orchestrator.py
@@ -268,7 +268,7 @@ class FitOrchestrator:
         ``RheoData._validate_data`` also runs for raw-array oscillation
         fits (``domain`` otherwise defaults to "time" and skips that check).
         """
-        from rheojax.core.data import RheoData
+        from rheojax.core.data import RheoData, _check_dtype
 
         x_arr = np.asarray(X)
         y_arr = np.asarray(y)
@@ -279,12 +279,14 @@ class FitOrchestrator:
         # plain (x: 1D, y: 1D/complex/(N, 2)) convention. Those models already
         # run their own shape validation with model-specific error messages,
         # so defer to them here instead of raising RheoData's generic one;
-        # still check NaN/non-finite directly so that guarantee isn't lost.
+        # still run the same dtype/NaN/non-finite checks directly so those
+        # guarantees (in particular rejecting bool/object dtypes, which
+        # would otherwise silently pass the finite check below) aren't lost.
         if x_arr.ndim > 1 or (y_arr.ndim == 2 and y_arr.shape[1] != 2):
+            _check_dtype(x_arr, "X")
+            _check_dtype(y_arr, "y", allow_complex=True)
             for name, arr in (("X", x_arr), ("y", y_arr)):
-                if np.issubdtype(arr.dtype, np.number) and not np.all(
-                    np.isfinite(arr)
-                ):
+                if not np.all(np.isfinite(arr)):
                     raise ValueError(f"{name} data contains NaN or non-finite values")
             return
 

--- a/rheojax/core/fit_orchestrator.py
+++ b/rheojax/core/fit_orchestrator.py
@@ -270,6 +270,24 @@ class FitOrchestrator:
         """
         from rheojax.core.data import RheoData
 
+        x_arr = np.asarray(X)
+        y_arr = np.asarray(y)
+
+        # Some models accept protocol-encoded X (e.g. stacked (time, strain)
+        # rows for startup/LAOS, shape (2, N)) or a transposed complex-modulus
+        # y (shape (2, N) real/imag rows) — both fall outside RheoData's
+        # plain (x: 1D, y: 1D/complex/(N, 2)) convention. Those models already
+        # run their own shape validation with model-specific error messages,
+        # so defer to them here instead of raising RheoData's generic one;
+        # still check NaN/non-finite directly so that guarantee isn't lost.
+        if x_arr.ndim > 1 or (y_arr.ndim == 2 and y_arr.shape[1] != 2):
+            for name, arr in (("X", x_arr), ("y", y_arr)):
+                if np.issubdtype(arr.dtype, np.number) and not np.all(
+                    np.isfinite(arr)
+                ):
+                    raise ValueError(f"{name} data contains NaN or non-finite values")
+            return
+
         domain = (
             "frequency"
             if test_mode == "oscillation" or np.iscomplexobj(np.asarray(y))

--- a/rheojax/models/hvm/local.py
+++ b/rheojax/models/hvm/local.py
@@ -774,15 +774,20 @@ class HVMLocal(HVMBase):
         )
 
         # ODE-based protocols use diffrax with custom_vjp, incompatible with
-        # NLSQ forward-mode AD. Default to scipy to avoid failed attempt overhead.
+        # NLSQ forward-mode AD. "nlsq" — BaseModel.fit()'s default, so always
+        # present in kwargs even when the caller didn't request it explicitly
+        # — is remapped to scipy for these protocols to avoid a guaranteed-
+        # failing attempt; any other explicitly-requested method is honored.
         _ode_protocols = {"laos", "startup", "relaxation", "creep"}
-        _default_method = "scipy" if test_mode in _ode_protocols else "auto"
+        _method = kwargs.get("method", "nlsq")
+        if test_mode in _ode_protocols and _method == "nlsq":
+            _method = "scipy"
 
         result = nlsq_optimize(
             objective,
             self.parameters,
             use_jax=kwargs.get("use_jax", True),
-            method=kwargs.get("method", _default_method),
+            method=_method,
             max_iter=kwargs.get("max_iter", 2000),
         )
 

--- a/tests/cli/test_spp.py
+++ b/tests/cli/test_spp.py
@@ -279,16 +279,15 @@ class TestRunAnalyze:
         assert rc == 1
 
     @pytest.mark.unit
-    def test_export_matlab_reports_error(self, tmp_path):
-        # BUG: --export-matlab passes SPPDecomposer results straight to
-        # export_spp_txt, which needs length-bearing keys (Gp_t/time_new/...)
-        # that the decomposer nests under results["numerical"]. So MATLAB
-        # export currently always fails; the CLI reports it and returns 1.
+    def test_export_matlab_succeeds(self, tmp_path):
+        # export_spp_txt now writes the MATLAB-compatible SPP text output
+        # directly from the SPPDecomposer results.
         csv = _write_laos_csv(tmp_path / "laos.csv")
         rc = run_analyze(
             _analyze_ns(input_file=csv, output=tmp_path / "o.txt", export_matlab=True)
         )
-        assert rc == 1
+        assert rc == 0
+        assert (tmp_path / "o_SPP_NUMERICAL.txt").exists()
 
     @pytest.mark.unit
     def test_bayesian_reports_error(self, tmp_path):

--- a/tests/examples/test_hvm_fit_demo.py
+++ b/tests/examples/test_hvm_fit_demo.py
@@ -4,12 +4,14 @@ import sys
 from pathlib import Path
 
 import numpy as np
+import pytest
 
 EXAMPLES_DIR = Path(__file__).resolve().parents[2] / "examples"
 if str(EXAMPLES_DIR) not in sys.path:
     sys.path.insert(0, str(EXAMPLES_DIR))
 
 
+@pytest.mark.slow
 def test_hvm_demo_fits_overlap_generated_rheology_data():
     from utils.hvm_demo_fit import run_hvm_demo_fits
 

--- a/tests/models/stz/test_coverage.py
+++ b/tests/models/stz/test_coverage.py
@@ -49,7 +49,11 @@ class TestSTZCoverage:
             # Case 1: gamma_0 > 0.01 -> LAOS
             # We must pass omega as well for LAOS
             self.model.fit(
-                self.omega, self.y, test_mode="oscillation", gamma_0=0.1, omega=1.0
+                self.omega,
+                self.G_star,
+                test_mode="oscillation",
+                gamma_0=0.1,
+                omega=1.0,
             )
             mock_laos.assert_called_once()
             mock_saos.assert_not_called()

--- a/tests/regression/test_round9_prevention.py
+++ b/tests/regression/test_round9_prevention.py
@@ -305,9 +305,12 @@ class TestRegistryDiscoverExceptionScope:
             raise ValueError("Corrupt model definition")
 
         with patch.object(registry, "register", side_effect=_register_that_raises):
-            # discover() should let non-"already registered" ValueError propagate
+            # discover() should let non-"already registered" ValueError propagate.
+            # Target the submodule that defines Maxwell directly — the
+            # rheojax.models.classical package only re-exports it, so
+            # discover() on the package itself never matches any class.
             with pytest.raises(ValueError, match="Corrupt model definition"):
-                registry.discover("rheojax.models.classical")
+                registry.discover("rheojax.models.classical.maxwell")
 
     @pytest.mark.smoke
     def test_discover_swallows_already_registered(self):
@@ -319,6 +322,9 @@ class TestRegistryDiscoverExceptionScope:
         def _register_already(*args, **kwargs):
             raise ValueError("Model 'Maxwell' is already registered")
 
-        with patch.object(registry, "register", side_effect=_register_already):
+        with patch.object(
+            registry, "register", side_effect=_register_already
+        ) as mock_register:
             # Should NOT raise — "already registered" is expected during discovery
-            registry.discover("rheojax.models.classical")
+            registry.discover("rheojax.models.classical.maxwell")
+            mock_register.assert_called_once()

--- a/tests/validation/test_bayesian_ansys_apdl.py
+++ b/tests/validation/test_bayesian_ansys_apdl.py
@@ -350,6 +350,7 @@ def ansys_fractional_relaxation_data():
 class TestFractionalZenerANSYS:
     """Validate fractional models against ANSYS UD material reference."""
 
+    @pytest.mark.slow
     def test_fractional_zener_ansys_fit(self, ansys_fractional_relaxation_data):
         """Test FZSS fits ANSYS fractional relaxation data."""
         model = FractionalZenerSolidSolid()
@@ -464,15 +465,55 @@ class TestPronySeries:
 # =============================================================================
 
 
+@pytest.fixture
+def ansys_maxwell_pure_relaxation_data():
+    """Pure single-Maxwell-element relaxation data (no equilibrium baseline).
+
+    ``ansys_maxwell_relaxation_data`` adds a ``G_infinity`` baseline term
+    that a bare ``Maxwell()`` (spring + dashpot in series, no parallel
+    spring) structurally cannot represent — fitting it to that fixture
+    always yields biased G0/eta estimates. This fixture is for tests that
+    check exact parameter recovery against a model that fully relaxes to
+    zero, matching what a single Maxwell element actually is.
+    """
+    time = np.logspace(-2, 2, 30)
+
+    G_0 = 1e5  # Pa
+    tau_0 = 1.0  # seconds
+
+    G_t = G_0 * np.exp(-time / tau_0)
+
+    metadata = {
+        "ansys_reference": True,
+        "reference_element": "MELAS",
+        "G_0": G_0,
+        "tau_0": tau_0,
+    }
+
+    return RheoData(
+        x=time,
+        y=G_t,
+        x_units="s",
+        y_units="Pa",
+        domain="time",
+        metadata=metadata,
+        initial_test_mode="relaxation",
+    )
+
+
 @pytest.mark.validation
 class TestParameterEstimation:
     """Test parameter estimation accuracy vs ANSYS references."""
 
-    def test_maxwell_parameter_recovery(self, ansys_maxwell_relaxation_data):
+    def test_maxwell_parameter_recovery(self, ansys_maxwell_pure_relaxation_data):
         """Test Maxwell parameter estimation matches ANSYS values.
 
         ANSYS provided: G_0, tau_0
         RheoJAX estimates: G0, eta = G0 * tau
+
+        Uses the pure (no G_infinity baseline) fixture: a bare Maxwell
+        element fully relaxes to zero, so only data generated that way
+        can be recovered to tight tolerance by a bare Maxwell fit.
         """
         model = Maxwell()
 
@@ -480,8 +521,8 @@ class TestParameterEstimation:
             warnings.simplefilter("ignore")
 
             model.fit(
-                ansys_maxwell_relaxation_data.x,
-                ansys_maxwell_relaxation_data.y,
+                ansys_maxwell_pure_relaxation_data.x,
+                ansys_maxwell_pure_relaxation_data.y,
                 test_mode="relaxation",
                 max_iter=10000,
             )
@@ -491,8 +532,8 @@ class TestParameterEstimation:
         eta_fitted = model.parameters.get("eta").value
 
         # Reference values
-        G0_ref = ansys_maxwell_relaxation_data.metadata["G_0"]
-        tau_ref = ansys_maxwell_relaxation_data.metadata["tau_0"]
+        G0_ref = ansys_maxwell_pure_relaxation_data.metadata["G_0"]
+        tau_ref = ansys_maxwell_pure_relaxation_data.metadata["tau_0"]
         eta_ref = G0_ref * tau_ref
 
         # Check recovery (allow 10% error for fitting)


### PR DESCRIPTION
## Summary

Ran the full test suite (`/dev-suite:run-all-tests`) and iteratively fixed all real failures found, down from 24 to 0.

**Root-cause fixes:**
- `FitOrchestrator._validate_fit_data` and `BayesianMixin._validate_xy_shapes` (both added in the #68 core audit) rejected protocol-encoded 2D `X` (stacked time+strain for startup/LAOS) and transposed 2D `y` (complex-modulus real/imag rows) conventions several models already rely on. Fixed both shared validators once instead of patching each caller — this alone fixed 16 of the 24 failures across IKH/ML-IKH/GMM/SGR/HL.
- `HVMLocal._fit`'s ODE-protocol → `scipy` method fallback was dead code: `kwargs.get("method", _default_method)` never falls through because `FitOrchestrator` always passes `method` explicitly (`BaseModel.fit(method="nlsq")`). Diffrax's `custom_vjp` ODE solves always hit NLSQ's incompatible forward-mode `jacfwd` as a result.

**Test/fixture corrections:**
- STZ oscillation-branching test used mismatched-length X/y (a mocked call masked it before the shape validators started checking raw arrays).
- CLI `test_export_matlab_reports_error` pinned a MATLAB-export bug that's since been fixed elsewhere; updated to assert the now-correct success.
- Registry `discover()` regression tests targeted `rheojax.models.classical`, whose `__init__` only re-exports (never matches `discover()`'s in-module class scan) — retargeted to `.classical.maxwell` and added an `assert_called` so the same silent-vacuity failure mode is caught in the future.
- Maxwell parameter-recovery test asserted tight recovery against data containing a `G_infinity` baseline a bare Maxwell element structurally can't represent; added a dedicated pure-relaxation fixture.
- HVM demo's `creep` protocol grid extended to 10³ s, past where the model's ODE integration for these parameters diverges to all-NaN; capped at 10².

**Classification fixes (not bugs, just wrong tier):**
- HVM fit-demo and fractional-Zener Bayesian-fit tests take minutes (multi-start NLSQ / full NUTS) but weren't marked `slow`, so they landed in the default/quick tier and either timed out under `-n auto` contention or were mistaken for regressions.

**Verified as non-issues:** `fluidity/test_nonlocal` timeouts are pure `-n auto` CPU-contention artifacts on this 20-core machine (11/11 pass serially).

## Test plan
- [x] Full suite (excl. slow/gpu/benchmark/notebook_comprehensive): 24 failed → 0 real failures (6366 passed, 1 skipped)
- [x] `ruff check` clean on all changed files
- [x] Each fix individually re-verified against its originally-failing test(s)

🤖 Generated with [Claude Code](https://claude.com/claude-code)