### PR TITLE
refactor(gui): consolidate dropdowns into RheoComboBox, migrate layout margins to tokens

### DIFF
--- a/rheojax/gui/dialogs/bayesian_options.py
+++ b/rheojax/gui/dialogs/bayesian_options.py
@@ -11,7 +11,6 @@ from typing import Any
 
 from rheojax.gui.compat import (
     QCheckBox,
-    QComboBox,
     QDialog,
     QDialogButtonBox,
     QFormLayout,
@@ -29,6 +28,7 @@ from rheojax.gui.compat import (
     QWidget,
 )
 from rheojax.gui.resources.styles.tokens import Typography, themed
+from rheojax.gui.widgets import RheoComboBox
 from rheojax.logging import get_logger
 
 logger = get_logger(__name__)
@@ -89,8 +89,8 @@ class BayesianOptionsDialog(QDialog):
         sampler_group = QGroupBox("Sampler")
         sampler_layout = QFormLayout()
 
-        self.sampler_combo = QComboBox()
-        self.sampler_combo.addItems(["NUTS (No U-Turn Sampler)"])
+        self.sampler_combo = RheoComboBox()
+        self.sampler_combo.set_items_safely(["NUTS (No U-Turn Sampler)"])
         self.sampler_combo.currentTextChanged.connect(self._on_sampler_changed)
         sampler_layout.addRow("Sampling Method:", self.sampler_combo)
 

--- a/rheojax/gui/dialogs/column_mapper.py
+++ b/rheojax/gui/dialogs/column_mapper.py
@@ -24,6 +24,7 @@ from rheojax.gui.compat import (
     QVBoxLayout,
     QWidget,
 )
+from rheojax.gui.widgets import RheoComboBox
 from rheojax.logging import get_logger
 
 logger = get_logger(__name__)
@@ -108,7 +109,7 @@ class ColumnMapperDialog(QDialog):
         x_label = QLabel("X (Frequency/Time):")
         x_label.setMinimumWidth(150)
         x_layout.addWidget(x_label)
-        self.x_combo = QComboBox()
+        self.x_combo = RheoComboBox(placeholder="Select a column...")
         self.x_combo.currentTextChanged.connect(
             lambda value: logger.debug(
                 "Value changed",
@@ -125,7 +126,7 @@ class ColumnMapperDialog(QDialog):
         y_label = QLabel("Y (Modulus/Viscosity):")
         y_label.setMinimumWidth(150)
         y_layout.addWidget(y_label)
-        self.y_combo = QComboBox()
+        self.y_combo = RheoComboBox(placeholder="Select a column...")
         self.y_combo.currentTextChanged.connect(
             lambda value: logger.debug(
                 "Value changed",
@@ -142,7 +143,7 @@ class ColumnMapperDialog(QDialog):
         y2_label = QLabel("Y2 (Optional, e.g., G''):")
         y2_label.setMinimumWidth(150)
         y2_layout.addWidget(y2_label)
-        self.y2_combo = QComboBox()
+        self.y2_combo = RheoComboBox(placeholder="None (optional)")
         self.y2_combo.currentTextChanged.connect(
             lambda value: logger.debug(
                 "Value changed",
@@ -159,7 +160,7 @@ class ColumnMapperDialog(QDialog):
         temp_label = QLabel("Temperature (Optional):")
         temp_label.setMinimumWidth(150)
         temp_layout.addWidget(temp_label)
-        self.temp_combo = QComboBox()
+        self.temp_combo = RheoComboBox(placeholder="None (optional)")
         self.temp_combo.currentTextChanged.connect(
             lambda value: logger.debug(
                 "Value changed",
@@ -269,22 +270,11 @@ class ColumnMapperDialog(QDialog):
 
     def _populate_combos(self) -> None:
         """Populate combo boxes with column names."""
-        # X and Y are required
-        self.x_combo.clear()
-        self.y_combo.clear()
-
-        self.x_combo.addItems(self.columns)
-        self.y_combo.addItems(self.columns)
-
-        # Y2 and Temperature are optional
-        self.y2_combo.clear()
-        self.temp_combo.clear()
-
-        self.y2_combo.addItem("(None)")
-        self.y2_combo.addItems(self.columns)
-
-        self.temp_combo.addItem("(None)")
-        self.temp_combo.addItems(self.columns)
+        # X and Y are required; Y2 and Temperature are optional (placeholder = unset)
+        self.x_combo.set_items_safely(self.columns)
+        self.y_combo.set_items_safely(self.columns)
+        self.y2_combo.set_items_safely(self.columns)
+        self.temp_combo.set_items_safely(self.columns)
 
     def _apply_current_mapping(self) -> None:
         """Apply current mapping to combo boxes."""
@@ -344,8 +334,6 @@ class ColumnMapperDialog(QDialog):
             """Find best match for column."""
             for i in range(combo.count()):
                 text = combo.itemText(i).lower()
-                if text == "(none)":
-                    continue
                 for pattern in patterns:
                     # Alphanumeric boundaries (not \b): \b fails after symbolic
                     # modulus patterns like g', g'', g* whose last char is non-word,
@@ -406,13 +394,13 @@ class ColumnMapperDialog(QDialog):
             "y": self.y_combo.currentText(),
         }
 
-        # Add optional columns if selected
+        # Add optional columns if selected (empty text = placeholder/unset)
         y2_col = self.y2_combo.currentText()
-        if y2_col and y2_col != "(None)":
+        if y2_col:
             mapping["y2"] = y2_col
 
         temp_col = self.temp_combo.currentText()
-        if temp_col and temp_col != "(None)":
+        if temp_col:
             mapping["temperature"] = temp_col
 
         logger.debug(

--- a/rheojax/gui/dialogs/column_mapper.py
+++ b/rheojax/gui/dialogs/column_mapper.py
@@ -195,6 +195,13 @@ class ColumnMapperDialog(QDialog):
 
     def _on_accept(self) -> None:
         """Handle dialog accept."""
+        if self.x_combo.currentIndex() == -1 or self.y_combo.currentIndex() == -1:
+            QMessageBox.warning(
+                self,
+                "Missing Column Mapping",
+                "Please select both an X and a Y column before continuing.",
+            )
+            return
         logger.debug("Dialog closed", dialog=self.__class__.__name__, result="accepted")
         self.accept()
 

--- a/rheojax/gui/dialogs/export_options.py
+++ b/rheojax/gui/dialogs/export_options.py
@@ -10,7 +10,6 @@ from typing import Any
 from rheojax.gui.compat import (
     QButtonGroup,
     QCheckBox,
-    QComboBox,
     QDialog,
     QDialogButtonBox,
     QFormLayout,
@@ -20,6 +19,7 @@ from rheojax.gui.compat import (
     QVBoxLayout,
     QWidget,
 )
+from rheojax.gui.widgets import RheoComboBox
 from rheojax.logging import get_logger
 
 logger = get_logger(__name__)
@@ -135,8 +135,8 @@ class ExportOptionsDialog(QDialog):
         settings_layout.addRow("Resolution (DPI):", self.dpi_spin)
 
         # Style preset
-        self.style_combo = QComboBox()
-        self.style_combo.addItems(
+        self.style_combo = RheoComboBox()
+        self.style_combo.set_items_safely(
             [
                 "default",
                 "publication",

--- a/rheojax/gui/dialogs/fitting_options.py
+++ b/rheojax/gui/dialogs/fitting_options.py
@@ -9,7 +9,6 @@ from typing import Any
 
 from rheojax.gui.compat import (
     QCheckBox,
-    QComboBox,
     QDialog,
     QDialogButtonBox,
     QDoubleSpinBox,
@@ -23,6 +22,7 @@ from rheojax.gui.compat import (
     QVBoxLayout,
     QWidget,
 )
+from rheojax.gui.widgets import RheoComboBox
 from rheojax.logging import get_logger
 
 logger = get_logger(__name__)
@@ -80,16 +80,16 @@ class FittingOptionsDialog(QDialog):
         algo_group = QGroupBox("Algorithm")
         algo_layout = QFormLayout()
 
-        self.algo_combo = QComboBox()
-        self.algo_combo.addItems(
+        self.algo_combo = RheoComboBox()
+        self.algo_combo.set_items_safely(
             ["NLSQ (default)", "NLSQ Global", "L-BFGS-B", "Trust Region"]
         )
         self.algo_combo.currentTextChanged.connect(self._on_algorithm_changed)
         algo_layout.addRow("Optimization Method:", self.algo_combo)
 
         # Workflow dropdown (auto / auto_global)
-        self.workflow_combo = QComboBox()
-        self.workflow_combo.addItems(["auto", "auto_global"])
+        self.workflow_combo = RheoComboBox()
+        self.workflow_combo.set_items_safely(["auto", "auto_global"])
         self.workflow_combo.setToolTip(
             "auto: single multi-start NLSQ run; "
             "auto_global: basin-hopping global search before refinement"
@@ -112,8 +112,8 @@ class FittingOptionsDialog(QDialog):
         algo_layout.addRow("", self.auto_bounds_check)
 
         # Stability dropdown (auto / on / off)
-        self.stability_combo = QComboBox()
-        self.stability_combo.addItems(["auto", "on", "off"])
+        self.stability_combo = RheoComboBox()
+        self.stability_combo.set_items_safely(["auto", "on", "off"])
         self.stability_combo.setToolTip(
             "Stability analysis after fitting: "
             "auto = run when convergence is borderline, "
@@ -127,8 +127,8 @@ class FittingOptionsDialog(QDialog):
         algo_layout.addRow("Stability:", self.stability_combo)
 
         # Jacobian mode
-        self.jacobian_combo = QComboBox()
-        self.jacobian_combo.addItems(["Auto", "Forward (fwd)", "Reverse (rev)"])
+        self.jacobian_combo = RheoComboBox()
+        self.jacobian_combo.set_items_safely(["Auto", "Forward (fwd)", "Reverse (rev)"])
         self.jacobian_combo.setToolTip(
             "Jacobian computation mode: Auto selects based on problem size. "
             "Forward is better for few parameters, Reverse for many."

--- a/rheojax/gui/dialogs/import_wizard.py
+++ b/rheojax/gui/dialogs/import_wizard.py
@@ -12,7 +12,6 @@ import pandas as pd
 
 from rheojax.gui.compat import (
     QCheckBox,
-    QComboBox,
     QFileDialog,
     QGroupBox,
     QHBoxLayout,
@@ -32,6 +31,7 @@ from rheojax.gui.compat import (
     QWizardPage,
     Signal,
 )
+from rheojax.gui.widgets import RheoComboBox
 from rheojax.logging import get_logger
 
 logger = get_logger(__name__)
@@ -207,7 +207,7 @@ class ColumnMappingPage(QWizardPage):
         # X axis (frequency/time)
         x_layout = QHBoxLayout()
         x_layout.addWidget(QLabel("X (Frequency/Time):"))
-        self.x_combo = QComboBox()
+        self.x_combo = RheoComboBox()
         # Ignore the emitted text; we only care that completion state may have changed
         self.x_combo.currentTextChanged.connect(self._on_x_column_changed)
         x_layout.addWidget(self.x_combo, 1)
@@ -216,7 +216,7 @@ class ColumnMappingPage(QWizardPage):
         # Y axis (modulus/compliance/viscosity)
         y_layout = QHBoxLayout()
         y_layout.addWidget(QLabel("Y (Modulus/Viscosity):"))
-        self.y_combo = QComboBox()
+        self.y_combo = RheoComboBox()
         self.y_combo.currentTextChanged.connect(self._on_y_column_changed)
         y_layout.addWidget(self.y_combo, 1)
         mapping_layout.addLayout(y_layout)
@@ -224,7 +224,7 @@ class ColumnMappingPage(QWizardPage):
         # Y2 axis (optional, e.g., G'')
         y2_layout = QHBoxLayout()
         y2_layout.addWidget(QLabel("Y2 (Optional, e.g., G''):"))
-        self.y2_combo = QComboBox()
+        self.y2_combo = RheoComboBox()
         self.y2_combo.currentTextChanged.connect(self._on_y2_column_changed)
         y2_layout.addWidget(self.y2_combo, 1)
         mapping_layout.addLayout(y2_layout)
@@ -232,7 +232,7 @@ class ColumnMappingPage(QWizardPage):
         # Temperature (optional)
         temp_layout = QHBoxLayout()
         temp_layout.addWidget(QLabel("Temperature (Optional):"))
-        self.temp_combo = QComboBox()
+        self.temp_combo = RheoComboBox()
         self.temp_combo.currentTextChanged.connect(self._on_temp_column_changed)
         temp_layout.addWidget(self.temp_combo, 1)
         mapping_layout.addLayout(temp_layout)
@@ -346,19 +346,10 @@ class ColumnMappingPage(QWizardPage):
         )
 
         # Populate combo boxes
-        self.x_combo.clear()
-        self.y_combo.clear()
-        self.y2_combo.clear()
-        self.temp_combo.clear()
-
-        self.x_combo.addItems(columns)
-        self.y_combo.addItems(columns)
-
-        self.y2_combo.addItem("(None)")
-        self.y2_combo.addItems(columns)
-
-        self.temp_combo.addItem("(None)")
-        self.temp_combo.addItems(columns)
+        self.x_combo.set_items_safely(columns)
+        self.y_combo.set_items_safely(columns)
+        self.y2_combo.set_items_safely(["(None)", *columns])
+        self.temp_combo.set_items_safely(["(None)", *columns])
 
         # Update preview
         self._update_preview(df)
@@ -398,7 +389,7 @@ class ColumnMappingPage(QWizardPage):
 
         claimed: set[str] = set()
 
-        def find_match(combo: QComboBox, patterns: list[str]) -> None:
+        def find_match(combo: RheoComboBox, patterns: list[str]) -> None:
             """Find best match for column, skipping columns already claimed
             by another field (e.g. "g'" is a substring of "g''", so G''
             must be claimed by y2 before y is matched against it)."""
@@ -444,8 +435,8 @@ class TestModeSelectionPage(QWizardPage):
         mode_group = QGroupBox("Test Mode")
         mode_layout = QVBoxLayout()
 
-        self.test_mode_combo = QComboBox()
-        self.test_mode_combo.addItems(
+        self.test_mode_combo = RheoComboBox()
+        self.test_mode_combo.set_items_safely(
             [
                 "oscillation",
                 "relaxation",

--- a/rheojax/gui/dialogs/import_wizard.py
+++ b/rheojax/gui/dialogs/import_wizard.py
@@ -356,6 +356,13 @@ class ColumnMappingPage(QWizardPage):
 
         self._auto_detect()
 
+        # set_items_safely() blocks signals during populate, and _auto_detect()'s
+        # setCurrentIndex() only emits when the index actually changes — so
+        # currentTextChanged (and therefore completeChanged) can go un-fired even
+        # though x_combo/y_combo now hold valid selections. Force one explicit
+        # re-check so the wizard's Next button reflects the real completion state.
+        self.completeChanged.emit()
+
     def _on_columns_load_failed(self, error: str) -> None:
         """Handle a failed background column read."""
         logger.error(

--- a/rheojax/gui/dialogs/pipeline_templates.py
+++ b/rheojax/gui/dialogs/pipeline_templates.py
@@ -22,6 +22,7 @@ from rheojax.gui.compat import (
     QWidget,
 )
 from rheojax.gui.resources.styles.tokens import Spacing, Typography, themed
+from rheojax.gui.utils.layout_helpers import set_panel_margins, set_zero_margins
 from rheojax.logging import get_logger
 
 logger = get_logger(__name__)
@@ -69,8 +70,7 @@ class PipelineTemplateDialog(QDialog):
     def _setup_ui(self) -> None:
         """Build the dialog layout."""
         root = QVBoxLayout(self)
-        root.setContentsMargins(Spacing.MD, Spacing.MD, Spacing.MD, Spacing.MD)
-        root.setSpacing(Spacing.SM)
+        set_panel_margins(root)
 
         # Instruction label
         instruction = QLabel(
@@ -91,7 +91,7 @@ class PipelineTemplateDialog(QDialog):
         # Left: template list
         left_widget = QWidget()
         left_layout = QVBoxLayout(left_widget)
-        left_layout.setContentsMargins(0, 0, 0, 0)
+        set_zero_margins(left_layout)
         left_layout.setSpacing(Spacing.XS)
 
         list_label = QLabel("Templates")
@@ -110,7 +110,7 @@ class PipelineTemplateDialog(QDialog):
         # Right: YAML preview
         right_widget = QWidget()
         right_layout = QVBoxLayout(right_widget)
-        right_layout.setContentsMargins(0, 0, 0, 0)
+        set_zero_margins(right_layout)
         right_layout.setSpacing(Spacing.XS)
 
         preview_label = QLabel("Preview")

--- a/rheojax/gui/dialogs/preferences.py
+++ b/rheojax/gui/dialogs/preferences.py
@@ -144,7 +144,7 @@ class PreferencesDialog(QDialog):
         theme_layout = QFormLayout()
 
         self.theme_combo = RheoComboBox()
-        self.theme_combo.addItems(["Light", "Dark", "System"])
+        self.theme_combo.set_items_safely(["Light", "Dark", "System"])
         self.theme_combo.currentTextChanged.connect(
             lambda value: logger.debug(
                 "Value changed",
@@ -163,7 +163,7 @@ class PreferencesDialog(QDialog):
         worker_layout = QFormLayout()
 
         self.worker_isolation_combo = RheoComboBox()
-        self.worker_isolation_combo.addItems(["subprocess", "thread"])
+        self.worker_isolation_combo.set_items_safely(["subprocess", "thread"])
         self.worker_isolation_combo.setToolTip(
             "subprocess: each fit/Bayesian job runs in an isolated process "
             "(safer on macOS, killable); "
@@ -264,7 +264,7 @@ class PreferencesDialog(QDialog):
         device_layout = QFormLayout()
 
         self.device_combo = RheoComboBox()
-        self.device_combo.addItems(["cpu", "gpu", "tpu"])
+        self.device_combo.set_items_safely(["cpu", "gpu", "tpu"])
         self.device_combo.currentTextChanged.connect(
             lambda value: logger.debug(
                 "Value changed",
@@ -365,7 +365,7 @@ class PreferencesDialog(QDialog):
         style_layout = QFormLayout()
 
         self.plot_style_combo = RheoComboBox()
-        self.plot_style_combo.addItems(
+        self.plot_style_combo.set_items_safely(
             [
                 "default",
                 "publication",
@@ -388,7 +388,7 @@ class PreferencesDialog(QDialog):
         style_layout.addRow("Default Plot Style:", self.plot_style_combo)
 
         self.color_palette_combo = RheoComboBox()
-        self.color_palette_combo.addItems(
+        self.color_palette_combo.set_items_safely(
             [
                 "tab10",
                 "Set1",

--- a/rheojax/gui/dialogs/preferences.py
+++ b/rheojax/gui/dialogs/preferences.py
@@ -9,7 +9,6 @@ from typing import Any
 
 from rheojax.gui.compat import (
     QCheckBox,
-    QComboBox,
     QDialog,
     QDialogButtonBox,
     QFormLayout,
@@ -24,6 +23,7 @@ from rheojax.gui.compat import (
     QVBoxLayout,
     QWidget,
 )
+from rheojax.gui.widgets import RheoComboBox
 from rheojax.logging import get_logger
 
 logger = get_logger(__name__)
@@ -143,7 +143,7 @@ class PreferencesDialog(QDialog):
         theme_group = QGroupBox("Appearance")
         theme_layout = QFormLayout()
 
-        self.theme_combo = QComboBox()
+        self.theme_combo = RheoComboBox()
         self.theme_combo.addItems(["Light", "Dark", "System"])
         self.theme_combo.currentTextChanged.connect(
             lambda value: logger.debug(
@@ -162,7 +162,7 @@ class PreferencesDialog(QDialog):
         worker_group = QGroupBox("Worker Settings")
         worker_layout = QFormLayout()
 
-        self.worker_isolation_combo = QComboBox()
+        self.worker_isolation_combo = RheoComboBox()
         self.worker_isolation_combo.addItems(["subprocess", "thread"])
         self.worker_isolation_combo.setToolTip(
             "subprocess: each fit/Bayesian job runs in an isolated process "
@@ -263,7 +263,7 @@ class PreferencesDialog(QDialog):
         device_group = QGroupBox("Device Configuration")
         device_layout = QFormLayout()
 
-        self.device_combo = QComboBox()
+        self.device_combo = RheoComboBox()
         self.device_combo.addItems(["cpu", "gpu", "tpu"])
         self.device_combo.currentTextChanged.connect(
             lambda value: logger.debug(
@@ -364,7 +364,7 @@ class PreferencesDialog(QDialog):
         style_group = QGroupBox("Plot Style")
         style_layout = QFormLayout()
 
-        self.plot_style_combo = QComboBox()
+        self.plot_style_combo = RheoComboBox()
         self.plot_style_combo.addItems(
             [
                 "default",
@@ -387,7 +387,7 @@ class PreferencesDialog(QDialog):
         )
         style_layout.addRow("Default Plot Style:", self.plot_style_combo)
 
-        self.color_palette_combo = QComboBox()
+        self.color_palette_combo = RheoComboBox()
         self.color_palette_combo.addItems(
             [
                 "tab10",

--- a/rheojax/gui/resources/styles/base.qss
+++ b/rheojax/gui/resources/styles/base.qss
@@ -36,6 +36,11 @@ QPushButton {
     min-width: 80px;
 }
 
+QPushButton:focus {
+    border: 2px solid @border_focus;
+    padding: 7px 15px;
+}
+
 QPushButton:hover {
     background-color: qlineargradient(x1:0, y1:0, x2:0, y2:1, stop:0 @primary_hover_grad_start, stop:1 @primary_hover_grad_end);
     border-color: @primary_dark;

--- a/rheojax/gui/widgets/__init__.py
+++ b/rheojax/gui/widgets/__init__.py
@@ -9,6 +9,7 @@ Reusable UI components for the RheoJAX GUI.
 from rheojax.gui.state.store import PipelineStep, StepStatus
 from rheojax.gui.widgets.arviz_canvas import ArviZCanvas, ArvizCanvas
 from rheojax.gui.widgets.base_arviz_widget import BaseArviZWidget, PlotMetrics
+from rheojax.gui.widgets.dropdown import RheoComboBox
 from rheojax.gui.widgets.parameter_form import ParameterFormBuilder
 from rheojax.gui.widgets.parameter_table import ParameterTable
 from rheojax.gui.widgets.plot_canvas import PlotCanvas
@@ -35,4 +36,5 @@ __all__ = [
     "is_pyqtgraph_available",
     "ParameterFormBuilder",
     "PYQTGRAPH_AVAILABLE",
+    "RheoComboBox",
 ]

--- a/rheojax/gui/widgets/arviz_canvas.py
+++ b/rheojax/gui/widgets/arviz_canvas.py
@@ -12,7 +12,6 @@ from matplotlib.figure import Figure
 
 from rheojax.core.arviz_utils import arviz_figure, arviz_plot_kwargs
 from rheojax.gui.compat import (
-    QComboBox,
     QHBoxLayout,
     QLabel,
     QPushButton,
@@ -23,8 +22,9 @@ from rheojax.gui.compat import (
     Signal,
 )
 from rheojax.gui.resources.styles.tokens import Spacing
-from rheojax.gui.utils.layout_helpers import set_toolbar_margins
+from rheojax.gui.utils.layout_helpers import set_toolbar_margins, set_zero_margins
 from rheojax.gui.widgets.base_arviz_widget import BaseArviZWidget
+from rheojax.gui.widgets.dropdown import RheoComboBox
 from rheojax.logging import get_logger
 
 logger = get_logger(__name__)
@@ -125,7 +125,7 @@ class ArvizCanvas(BaseArviZWidget):
         user can scroll vertically instead of having everything squashed.
         """
         layout = QVBoxLayout(self)
-        layout.setContentsMargins(0, 0, 0, 0)
+        set_zero_margins(layout)
         layout.setSpacing(Spacing.XS)
 
         # --- Fixed header: Plot Type selector + Refresh/Export buttons ---
@@ -135,7 +135,7 @@ class ArvizCanvas(BaseArviZWidget):
         type_label = QLabel("Plot Type:")
         toolbar_layout.addWidget(type_label)
 
-        self._type_combo = QComboBox()
+        self._type_combo = RheoComboBox()
         self._type_combo.setMinimumWidth(120)
         for plot_id, display_name, tooltip in PLOT_TYPES:
             self._type_combo.addItem(display_name, plot_id)
@@ -234,7 +234,7 @@ class ArvizCanvas(BaseArviZWidget):
         index : int
             New combo box index
         """
-        plot_type = self._type_combo.currentData()
+        plot_type = self._type_combo.current_data()
         old_plot_type = self._current_plot_type
         self._current_plot_type = plot_type
 
@@ -410,9 +410,7 @@ class ArvizCanvas(BaseArviZWidget):
         plot_type : str
             Plot type identifier
         """
-        idx = self._type_combo.findData(plot_type)
-        if idx >= 0:
-            self._type_combo.setCurrentIndex(idx)
+        self._type_combo.set_current_data(plot_type)
 
     def get_plot_type(self) -> str:
         """Get current plot type.

--- a/rheojax/gui/widgets/dropdown.py
+++ b/rheojax/gui/widgets/dropdown.py
@@ -36,22 +36,17 @@ class RheoComboBox(QComboBox):
 
     def set_items_safely(
         self,
-        items: list[str] | list[tuple[str, Any]] | dict[str, Any],
+        items: list[str] | list[tuple[str, Any]],
         selected_data: Any = None,
     ) -> None:
         """Clear and repopulate without emitting signals mid-update."""
         was_blocked = self.blockSignals(True)
         try:
             self.clear()
-            if isinstance(items, dict):
-                pairs = items.items()
-            elif isinstance(items, list):
-                pairs = (
-                    item if isinstance(item, tuple) and len(item) == 2 else (item, item)
-                    for item in items
-                )
-            else:
-                raise TypeError("items must be a dict, list of strings, or list of tuples")
+            pairs = (
+                item if isinstance(item, tuple) and len(item) == 2 else (item, item)
+                for item in items
+            )
             for text, data in pairs:
                 self.addItem(str(text), data)
 
@@ -63,7 +58,12 @@ class RheoComboBox(QComboBox):
             self.blockSignals(was_blocked)
 
     def set_current_data(self, data: Any) -> bool:
-        """Select the item whose UserRole data matches. Returns False if not found."""
+        """Select the item whose UserRole data matches.
+
+        Returns True if selected, including clearing the selection when
+        `data` is None. Returns False only when `data` is not None and no
+        item matches it.
+        """
         if data is None:
             self.setCurrentIndex(-1)
             return True

--- a/rheojax/gui/widgets/dropdown.py
+++ b/rheojax/gui/widgets/dropdown.py
@@ -1,0 +1,104 @@
+"""Reusable theme-aware combo box for RheoJAX."""
+
+from __future__ import annotations
+
+from typing import Any, Literal
+
+from rheojax.gui.compat import QComboBox, QtCore, QtGui, QtWidgets
+from rheojax.gui.resources.styles.tokens import themed
+
+
+class RheoComboBox(QComboBox):
+    """QComboBox subclass with safe repopulation, data-keyed selection,
+    disabled group headers, and a muted placeholder state.
+    """
+
+    def __init__(
+        self,
+        parent: QtWidgets.QWidget | None = None,
+        placeholder: str = "",
+        density: Literal["standard", "compact"] = "standard",
+    ) -> None:
+        super().__init__(parent)
+        self._placeholder = placeholder
+        self._setup_placeholder_color()
+        if placeholder:
+            self.setPlaceholderText(placeholder)
+            self.setCurrentIndex(-1)
+        self.set_density(density)
+
+    def _setup_placeholder_color(self) -> None:
+        palette = self.palette()
+        color_role = getattr(QtGui.QPalette.ColorRole, "PlaceholderText", None)
+        if color_role is not None:
+            palette.setColor(color_role, QtGui.QColor(themed("TEXT_MUTED")))
+            self.setPalette(palette)
+
+    def set_items_safely(
+        self,
+        items: list[str] | list[tuple[str, Any]] | dict[str, Any],
+        selected_data: Any = None,
+    ) -> None:
+        """Clear and repopulate without emitting signals mid-update."""
+        was_blocked = self.blockSignals(True)
+        try:
+            self.clear()
+            if isinstance(items, dict):
+                pairs = items.items()
+            elif isinstance(items, list):
+                pairs = (
+                    item if isinstance(item, tuple) and len(item) == 2 else (item, item)
+                    for item in items
+                )
+            else:
+                raise TypeError("items must be a dict, list of strings, or list of tuples")
+            for text, data in pairs:
+                self.addItem(str(text), data)
+
+            if selected_data is not None:
+                self.set_current_data(selected_data)
+            elif self._placeholder:
+                self.setCurrentIndex(-1)
+        finally:
+            self.blockSignals(was_blocked)
+
+    def set_current_data(self, data: Any) -> bool:
+        """Select the item whose UserRole data matches. Returns False if not found."""
+        if data is None:
+            self.setCurrentIndex(-1)
+            return True
+        for idx in range(self.count()):
+            if self.itemData(idx, QtCore.Qt.ItemDataRole.UserRole) == data:
+                self.setCurrentIndex(idx)
+                return True
+        return False
+
+    def current_data(self) -> Any:
+        idx = self.currentIndex()
+        if idx == -1:
+            return None
+        return self.itemData(idx, QtCore.Qt.ItemDataRole.UserRole)
+
+    def add_group_header(self, text: str) -> None:
+        """Add a bold, muted, disabled category separator that can't be selected."""
+        self.addItem(text)
+        idx = self.count() - 1
+        model = self.model()
+        item = model.item(idx) if hasattr(model, "item") else None
+        if item is not None:
+            item.setEnabled(False)
+            item.setSelectable(False)
+            item.setForeground(QtGui.QColor(themed("TEXT_MUTED")))
+            font = item.font()
+            font.setBold(True)
+            item.setFont(font)
+
+    def set_density(self, density: Literal["standard", "compact"]) -> None:
+        if density not in ("standard", "compact"):
+            raise ValueError("density must be 'standard' or 'compact'")
+        self.setProperty("density", density)
+        style = self.style()
+        if style is not None:
+            style.unpolish(self)
+            style.polish(self)
+        self.update()

--- a/rheojax/gui/widgets/log_dock.py
+++ b/rheojax/gui/widgets/log_dock.py
@@ -14,7 +14,6 @@ import logging
 from collections import deque
 
 from rheojax.gui.compat import (
-    QComboBox,
     QDockWidget,
     QFileDialog,
     QHBoxLayout,
@@ -24,6 +23,8 @@ from rheojax.gui.compat import (
     QVBoxLayout,
     QWidget,
 )
+from rheojax.gui.utils.layout_helpers import set_compact_margins
+from rheojax.gui.widgets.dropdown import RheoComboBox
 
 _MAX_RECORDS = 2000
 
@@ -49,13 +50,12 @@ class LogDockWidget(QDockWidget):
 
         container = QWidget(self)
         layout = QVBoxLayout(container)
-        layout.setContentsMargins(4, 4, 4, 4)
+        set_compact_margins(layout)
 
         toolbar = QHBoxLayout()
         toolbar.addWidget(QLabel("Level:", container))
-        self.level_combo = QComboBox(container)
-        self.level_combo.addItems(_LEVEL_NAMES)
-        self.level_combo.setCurrentText("INFO")
+        self.level_combo = RheoComboBox(container)
+        self.level_combo.set_items_safely(list(_LEVEL_NAMES), selected_data="INFO")
         self.level_combo.currentTextChanged.connect(self._rerender)
         toolbar.addWidget(self.level_combo)
         toolbar.addStretch(1)

--- a/rheojax/gui/widgets/parameter_form.py
+++ b/rheojax/gui/widgets/parameter_form.py
@@ -20,6 +20,8 @@ from rheojax.gui.compat import (
     Signal,
 )
 from rheojax.gui.resources.styles.tokens import Spacing, Typography
+from rheojax.gui.utils.layout_helpers import set_zero_margins
+from rheojax.gui.widgets.dropdown import RheoComboBox
 from rheojax.logging import get_logger
 
 logger = get_logger(__name__)
@@ -59,8 +61,8 @@ class ParameterFormBuilder(QWidget):
 
     def _build_form(self) -> None:
         layout = QFormLayout(self)
+        set_zero_margins(layout)
         layout.setSpacing(Spacing.SM)
-        layout.setContentsMargins(0, 0, 0, 0)
         layout.setFieldGrowthPolicy(QFormLayout.ExpandingFieldsGrow)
 
         for name, spec in self._specs.items():
@@ -103,11 +105,10 @@ class ParameterFormBuilder(QWidget):
                 widget.blockSignals(False)
                 widget.stateChanged.connect(self._on_change)
             elif ptype == "choice":
-                widget = QComboBox()
-                widget.blockSignals(True)
-                widget.addItems(spec.get("choices", []))
-                widget.setCurrentText(str(spec["default"]))
-                widget.blockSignals(False)
+                widget = RheoComboBox()
+                widget.set_items_safely(
+                    spec.get("choices", []), selected_data=str(spec["default"])
+                )
                 widget.currentTextChanged.connect(self._on_change)
             else:
                 logger.warning("Unknown param type", param=name, type=ptype)

--- a/rheojax/gui/widgets/parameter_table.py
+++ b/rheojax/gui/widgets/parameter_table.py
@@ -23,6 +23,7 @@ from rheojax.gui.compat import (
 )
 from rheojax.gui.resources.styles.tokens import Typography, themed
 from rheojax.gui.state.store import ParameterState
+from rheojax.gui.utils.layout_helpers import set_zero_margins
 from rheojax.logging import get_logger
 
 logger = get_logger(__name__)
@@ -291,7 +292,7 @@ class ParameterTable(QTableWidget):
         """
         widget = QWidget()
         layout = QHBoxLayout(widget)
-        layout.setContentsMargins(0, 0, 0, 0)
+        set_zero_margins(layout)
         layout.setAlignment(Qt.AlignCenter)
 
         checkbox = QCheckBox()

--- a/rheojax/gui/widgets/plot_canvas.py
+++ b/rheojax/gui/widgets/plot_canvas.py
@@ -11,6 +11,7 @@ from matplotlib.figure import Figure
 
 from rheojax.gui.compat import QVBoxLayout, QWidget
 from rheojax.gui.resources.styles.tokens import themed
+from rheojax.gui.utils.layout_helpers import set_zero_margins
 from rheojax.logging import get_logger
 
 logger = get_logger(__name__)
@@ -74,7 +75,7 @@ class PlotCanvas(QWidget):
         layout = QVBoxLayout(self)
         layout.addWidget(self.toolbar)
         layout.addWidget(self.canvas)
-        layout.setContentsMargins(0, 0, 0, 0)
+        set_zero_margins(layout)
 
         # Track plot data for tooltips
         self._plot_data: list[tuple[np.ndarray, np.ndarray, str]] = []

--- a/rheojax/gui/widgets/priors_editor.py
+++ b/rheojax/gui/widgets/priors_editor.py
@@ -12,7 +12,6 @@ from matplotlib.backends.backend_qtagg import FigureCanvasQTAgg
 from matplotlib.figure import Figure
 
 from rheojax.gui.compat import (
-    QComboBox,
     QDoubleSpinBox,
     QFormLayout,
     QFrame,
@@ -31,6 +30,8 @@ from rheojax.gui.compat import (
     Signal,
 )
 from rheojax.gui.resources.styles.tokens import Spacing
+from rheojax.gui.utils.layout_helpers import set_zero_margins
+from rheojax.gui.widgets.dropdown import RheoComboBox
 from rheojax.logging import get_logger
 
 logger = get_logger(__name__)
@@ -107,7 +108,7 @@ class PriorsEditor(QWidget):
     def _setup_ui(self) -> None:
         """Set up the user interface."""
         layout = QVBoxLayout(self)
-        layout.setContentsMargins(0, 0, 0, 0)
+        set_zero_margins(layout)
         layout.setSpacing(Spacing.SM)
 
         # Splitter for table and editor
@@ -116,7 +117,7 @@ class PriorsEditor(QWidget):
         # Left: Parameter table
         table_frame = QFrame()
         table_layout = QVBoxLayout(table_frame)
-        table_layout.setContentsMargins(0, 0, 0, 0)
+        set_zero_margins(table_layout)
 
         table_label = QLabel("Parameters")
         table_label.setStyleSheet("font-weight: bold;")
@@ -149,9 +150,10 @@ class PriorsEditor(QWidget):
         dist_group = QGroupBox("Distribution")
         dist_layout = QFormLayout(dist_group)
 
-        self._dist_combo = QComboBox()
-        for dist_id, display_name, _ in DISTRIBUTIONS:
-            self._dist_combo.addItem(display_name, dist_id)
+        self._dist_combo = RheoComboBox()
+        self._dist_combo.set_items_safely(
+            [(display_name, dist_id) for dist_id, display_name, _ in DISTRIBUTIONS]
+        )
         dist_layout.addRow("Type:", self._dist_combo)
 
         editor_layout.addWidget(dist_group)
@@ -310,9 +312,7 @@ class PriorsEditor(QWidget):
         params = prior.get("params", DIST_DEFAULTS.get(dist, {}))
 
         # Set distribution
-        idx = self._dist_combo.findData(dist)
-        if idx >= 0:
-            self._dist_combo.setCurrentIndex(idx)
+        self._dist_combo.set_current_data(dist)
 
         # Set parameter values
         for key, spinbox in self._param_spinboxes.items():

--- a/rheojax/gui/widgets/priors_editor.py
+++ b/rheojax/gui/widgets/priors_editor.py
@@ -309,10 +309,20 @@ class PriorsEditor(QWidget):
         """
         prior = self._priors.get(param, {})
         dist = prior.get("distribution", "normal")
-        params = prior.get("params", DIST_DEFAULTS.get(dist, {}))
 
-        # Set distribution
-        self._dist_combo.set_current_data(dist)
+        # Fall back to "normal" if the persisted distribution isn't one of
+        # the combo's known ids (e.g. stale/foreign data), so the dropdown,
+        # params, and visibility stay in sync instead of silently diverging.
+        if not self._dist_combo.set_current_data(dist):
+            logger.warning(
+                "Unknown prior distribution, falling back to normal",
+                param=param,
+                distribution=dist,
+            )
+            dist = "normal"
+            self._dist_combo.set_current_data(dist)
+
+        params = prior.get("params", DIST_DEFAULTS.get(dist, {}))
 
         # Set parameter values
         for key, spinbox in self._param_spinboxes.items():

--- a/rheojax/gui/widgets/pyqtgraph_canvas.py
+++ b/rheojax/gui/widgets/pyqtgraph_canvas.py
@@ -37,13 +37,14 @@ except ImportError:
     PYQTGRAPH_AVAILABLE = False
 
 from rheojax.gui.compat import (
-    QComboBox,
     QHBoxLayout,
     QPushButton,
     Qt,
     QVBoxLayout,
     QWidget,
 )
+from rheojax.gui.utils.layout_helpers import set_toolbar_margins, set_zero_margins
+from rheojax.gui.widgets.dropdown import RheoComboBox
 from rheojax.logging import get_logger
 
 logger = get_logger(__name__)
@@ -168,7 +169,7 @@ class PyQtGraphCanvas(QWidget):
         layout = QVBoxLayout(self)
         layout.addWidget(toolbar)
         layout.addWidget(self._plot_widget)
-        layout.setContentsMargins(0, 0, 0, 0)
+        set_zero_margins(layout)
 
         logger.debug("PyQtGraph canvas initialized")
 
@@ -176,11 +177,11 @@ class PyQtGraphCanvas(QWidget):
         """Create toolbar with scale and export controls."""
         toolbar = QWidget()
         layout = QHBoxLayout(toolbar)
-        layout.setContentsMargins(0, 0, 0, 0)
+        set_toolbar_margins(layout)
 
         # Scale selector
-        self._scale_combo = QComboBox()
-        self._scale_combo.addItems(["Log-Log", "Lin-Lin", "Log-Lin", "Lin-Log"])
+        self._scale_combo = RheoComboBox()
+        self._scale_combo.set_items_safely(["Log-Log", "Lin-Lin", "Log-Lin", "Lin-Log"])
         self._scale_combo.currentTextChanged.connect(self._on_scale_changed)
         layout.addWidget(self._scale_combo)
 

--- a/rheojax/gui/widgets/residuals_panel.py
+++ b/rheojax/gui/widgets/residuals_panel.py
@@ -10,7 +10,6 @@ from matplotlib.backends.backend_qtagg import FigureCanvasQTAgg, NavigationToolb
 from matplotlib.figure import Figure
 
 from rheojax.gui.compat import (
-    QComboBox,
     QFileDialog,
     QHBoxLayout,
     QLabel,
@@ -22,7 +21,8 @@ from rheojax.gui.compat import (
     Signal,
 )
 from rheojax.gui.resources.styles.tokens import Spacing, themed
-from rheojax.gui.utils.layout_helpers import set_toolbar_margins
+from rheojax.gui.utils.layout_helpers import set_toolbar_margins, set_zero_margins
+from rheojax.gui.widgets.dropdown import RheoComboBox
 from rheojax.logging import get_logger
 
 logger = get_logger(__name__)
@@ -121,7 +121,7 @@ class ResidualsPanel(QWidget):
     def _setup_ui(self) -> None:
         """Set up the user interface."""
         layout = QVBoxLayout(self)
-        layout.setContentsMargins(0, 0, 0, 0)
+        set_zero_margins(layout)
         layout.setSpacing(Spacing.XS)
 
         # Toolbar
@@ -132,11 +132,12 @@ class ResidualsPanel(QWidget):
         type_label = QLabel("Plot Type:")
         toolbar_layout.addWidget(type_label)
 
-        self._type_combo = QComboBox()
+        self._type_combo = RheoComboBox()
         self._type_combo.setMinimumWidth(140)
-        for plot_id, display_name, tooltip in PLOT_TYPES:
-            self._type_combo.addItem(display_name, plot_id)
-            idx = self._type_combo.count() - 1
+        self._type_combo.set_items_safely(
+            [(display_name, plot_id) for plot_id, display_name, _tooltip in PLOT_TYPES]
+        )
+        for idx, (_plot_id, _display_name, tooltip) in enumerate(PLOT_TYPES):
             self._type_combo.setItemData(idx, tooltip, Qt.ItemDataRole.ToolTipRole)
         toolbar_layout.addWidget(self._type_combo)
 
@@ -200,7 +201,7 @@ class ResidualsPanel(QWidget):
         index : int
             New combo box index
         """
-        plot_type = self._type_combo.currentData()
+        plot_type = self._type_combo.current_data()
         self._current_plot_type = plot_type
         logger.debug(
             "User interaction",
@@ -653,9 +654,7 @@ class ResidualsPanel(QWidget):
             action="set_plot_type",
             plot_type=plot_type,
         )
-        idx = self._type_combo.findData(plot_type)
-        if idx >= 0:
-            self._type_combo.setCurrentIndex(idx)
+        self._type_combo.set_current_data(plot_type)
 
     def get_plot_type(self) -> str:
         """Get current plot type.

--- a/rheojax/gui/workspace/fit/step1_protocol_model.py
+++ b/rheojax/gui/workspace/fit/step1_protocol_model.py
@@ -21,6 +21,7 @@ from rheojax.gui.foundation.state import FitState
 from rheojax.gui.resources.styles.tokens import field_label_style
 from rheojax.gui.services.model_service import FAMILY_LABELS, ModelService
 from rheojax.gui.utils.layout_helpers import set_panel_margins
+from rheojax.gui.widgets import RheoComboBox
 
 _PROTOCOLS = ["flow_curve", "creep", "relaxation", "startup", "oscillation", "laos"]
 
@@ -79,9 +80,10 @@ def _make_config_widget(annotation: Any, default: Any):
         w.setChecked(bool(default))
         return w, w.isChecked
     if get_origin(annotation) is Literal:
-        w = QComboBox()
-        w.addItems([str(a) for a in get_args(annotation)])
-        w.setCurrentText(str(default))
+        w = RheoComboBox()
+        w.set_items_safely(
+            [str(a) for a in get_args(annotation)], selected_data=str(default)
+        )
         return w, w.currentText
     if annotation is int:
         w = QSpinBox()
@@ -114,9 +116,9 @@ class ProtocolModelStep(QWidget):
         _ensure_all_registered()
         self._state = state
         self._config_widgets: dict[str, tuple[QWidget, Any]] = {}
-        self._protocol = QComboBox(self)
+        self._protocol = RheoComboBox(self)
         self._protocol.addItems([""] + _PROTOCOLS)
-        self._model = QComboBox(self)
+        self._model = RheoComboBox(self)
         self._config_form = QFormLayout()
         self._params = QLabel("", self)
         lay = QVBoxLayout(self)
@@ -163,13 +165,7 @@ class ProtocolModelStep(QWidget):
                 if not names:
                     continue
                 label = FAMILY_LABELS.get(family, family.replace("_", " ").title())
-                self._model.addItem(f"── {label} ──", None)
-                header_idx = self._model.count() - 1
-                item_model = self._model.model()
-                if item_model is not None:
-                    item = item_model.item(header_idx)
-                    if item is not None:
-                        item.setEnabled(False)
+                self._model.add_group_header(f"── {label} ──")
                 for name in names:
                     self._model.addItem(f"  {name}", name)
         self._model.blockSignals(False)

--- a/rheojax/gui/workspace/fit/step2_data.py
+++ b/rheojax/gui/workspace/fit/step2_data.py
@@ -4,13 +4,14 @@ from dataclasses import replace
 
 import numpy as np
 from PySide6.QtCore import Signal
-from PySide6.QtWidgets import QComboBox, QLabel, QPushButton, QVBoxLayout, QWidget
+from PySide6.QtWidgets import QLabel, QPushButton, QVBoxLayout, QWidget
 
 from rheojax.gui.foundation.contract import input_contract
 from rheojax.gui.foundation.library import DatasetLibrary
 from rheojax.gui.foundation.state import FitState
 from rheojax.gui.resources.styles.tokens import field_label_style
 from rheojax.gui.utils.layout_helpers import set_panel_margins
+from rheojax.gui.widgets import RheoComboBox
 
 
 def _validate_shape_and_values(rheo_data) -> list[str]:
@@ -58,8 +59,8 @@ class DataStep(QWidget):
         # Guard: protocol may be None on a fresh AppState; defer contract build until set
         self._contract, cols_text = self._build_contract()
         self._expected = QLabel(cols_text, self)
-        self._source = QComboBox(self)
-        self._source.addItems([""] + self.available_datasets())
+        self._source = RheoComboBox(self)
+        self._source.set_items_safely([""] + self.available_datasets())
         self._guard = QLabel("", self)
         self._convert_btn = QPushButton("⇄ Convert Hz → rad/s", self)
         self._error_label = QLabel("", self)
@@ -113,11 +114,9 @@ class DataStep(QWidget):
             bool(current) and current in new_datasets and not y_quantity_changed
         )
 
-        self._source.blockSignals(True)
-        self._source.clear()
-        self._source.addItems([""] + new_datasets)
-        self._source.setCurrentText(current if still_valid else "")
-        self._source.blockSignals(False)
+        self._source.set_items_safely(
+            [""] + new_datasets, selected_data=current if still_valid else None
+        )
 
         if still_valid:
             # The upstream Step-1 edit cascade clears state.data_ref/column_map

--- a/rheojax/gui/workspace/pipeline/step1_configure_run.py
+++ b/rheojax/gui/workspace/pipeline/step1_configure_run.py
@@ -18,7 +18,6 @@ from PySide6.QtCore import Qt, Signal
 from PySide6.QtWidgets import (
     QAbstractItemView,
     QCheckBox,
-    QComboBox,
     QLineEdit,
     QListWidget,
     QListWidgetItem,
@@ -29,6 +28,7 @@ from PySide6.QtWidgets import (
 
 from rheojax.core.registry import ModelRegistry, TransformRegistry
 from rheojax.gui.foundation.state import PipelineStepConfig
+from rheojax.gui.widgets import RheoComboBox
 from rheojax.gui.workspace.transform.slots_spec import _MULTI, _TYPED_PAIRS
 
 _EXCLUDED_TRANSFORM_KEYS = set(_MULTI) | set(_TYPED_PAIRS)
@@ -56,13 +56,13 @@ class PipelineConfigureRunStep(QWidget):
         self._state = state
         self._library = library
 
-        self._step_type_combo = QComboBox(self)
+        self._step_type_combo = RheoComboBox(self)
         self._step_type_combo.addItems(["transform", "fit", "export"])
 
-        self._transform_key_combo = QComboBox(self)
+        self._transform_key_combo = RheoComboBox(self)
         self._transform_key_combo.addItems(self.available_transform_keys())
 
-        self._fit_model_combo = QComboBox(self)
+        self._fit_model_combo = RheoComboBox(self)
         self._fit_model_combo.addItems(ModelRegistry.list_models())
         self._fit_run_nuts_checkbox = QCheckBox("Run NUTS after NLSQ", self)
 
@@ -70,7 +70,7 @@ class PipelineConfigureRunStep(QWidget):
         self._export_path_edit.setPlaceholderText(
             "/path/to/output_{id}.csv  ({id} = dataset id)"
         )
-        self._export_format_combo = QComboBox(self)
+        self._export_format_combo = RheoComboBox(self)
         self._export_format_combo.addItems(["csv", "json", "xlsx", "hdf5"])
 
         self._add_step_btn = QPushButton("+ Add Step", self)

--- a/rheojax/gui/workspace/transform/step2_slots.py
+++ b/rheojax/gui/workspace/transform/step2_slots.py
@@ -131,9 +131,7 @@ class SlotsStep(QWidget):
             self._state.slots.pop(spec.name, None)
             current = None
         combo = RheoComboBox(self)
-        combo.set_items_safely([""] + candidates)
-        if current:
-            combo.setCurrentText(current)
+        combo.set_items_safely([""] + candidates, selected_data=current or None)
         combo.currentTextChanged.connect(
             lambda text, name=spec.name: self._on_single_slot_changed(name, text)
         )

--- a/rheojax/gui/workspace/transform/step2_slots.py
+++ b/rheojax/gui/workspace/transform/step2_slots.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 from PySide6.QtCore import Signal
 from PySide6.QtWidgets import (
-    QComboBox,
     QLabel,
     QListWidget,
     QPushButton,
@@ -15,6 +14,7 @@ from rheojax.gui.foundation.state import TransformState
 from rheojax.gui.resources.styles.tokens import field_label_style
 from rheojax.gui.services.transform_service import TransformService
 from rheojax.gui.utils.layout_helpers import set_panel_margins
+from rheojax.gui.widgets import RheoComboBox
 from rheojax.gui.widgets.parameter_form import ParameterFormBuilder
 from rheojax.gui.workspace.transform.slots_spec import SlotSpec, transform_slots
 
@@ -34,9 +34,9 @@ class SlotsStep(QWidget):
         self._library = library
         self._transform_service = transform_service or TransformService()
         self._specs: list[SlotSpec] = []
-        self._combo_widgets: dict[str, QComboBox] = {}
+        self._combo_widgets: dict[str, RheoComboBox] = {}
         self._list_widgets: dict[str, QListWidget] = {}
-        self._list_add_combos: dict[str, QComboBox] = {}
+        self._list_add_combos: dict[str, RheoComboBox] = {}
         self._list_add_buttons: dict[str, QPushButton] = {}
         self._list_remove_buttons: dict[str, QPushButton] = {}
         self._param_form: ParameterFormBuilder | None = None
@@ -130,8 +130,8 @@ class SlotsStep(QWidget):
         if isinstance(current, str) and current not in candidates:
             self._state.slots.pop(spec.name, None)
             current = None
-        combo = QComboBox(self)
-        combo.addItems([""] + candidates)
+        combo = RheoComboBox(self)
+        combo.set_items_safely([""] + candidates)
         if current:
             combo.setCurrentText(current)
         combo.currentTextChanged.connect(
@@ -151,8 +151,8 @@ class SlotsStep(QWidget):
 
         list_widget = QListWidget(self)
         list_widget.addItems(current_list)
-        add_combo = QComboBox(self)
-        add_combo.addItems(
+        add_combo = RheoComboBox(self)
+        add_combo.set_items_safely(
             [""] + [c for c in self.candidates(spec.name) if c not in current_list]
         )
         add_btn = QPushButton("Add", self)

--- a/tests/gui/widgets/test_dropdown.py
+++ b/tests/gui/widgets/test_dropdown.py
@@ -1,0 +1,75 @@
+"""Behavior tests for RheoComboBox."""
+
+from __future__ import annotations
+
+from rheojax.gui.widgets.dropdown import RheoComboBox
+
+
+def test_set_items_safely_does_not_emit_signals_mid_repopulate(qtbot):
+    """Regression guard: repopulating must not fire currentIndexChanged for
+    intermediate/auto-selected states while items are being cleared+added.
+    """
+    combo = RheoComboBox()
+    qtbot.addWidget(combo)
+    combo.set_items_safely(["a", "b"])
+
+    fired = []
+    combo.currentIndexChanged.connect(lambda idx: fired.append(idx))
+
+    combo.set_items_safely(["c", "d", "e"], selected_data="d")
+
+    assert fired == []
+    assert combo.currentText() == "d"
+
+
+def test_add_group_header_is_disabled_and_unselectable(qtbot):
+    combo = RheoComboBox()
+    qtbot.addWidget(combo)
+    combo.addItem("real item")
+    combo.add_group_header("── Group ──")
+    combo.addItem("another item")
+
+    header_idx = 1
+    model = combo.model()
+    item = model.item(header_idx)
+
+    assert item is not None
+    assert item.isEnabled() is False
+    assert item.isSelectable() is False
+
+
+def test_placeholder_starts_unselected(qtbot):
+    combo = RheoComboBox(placeholder="Select a column...")
+    qtbot.addWidget(combo)
+    combo.set_items_safely(["x", "y", "z"])
+
+    assert combo.currentIndex() == -1
+    assert combo.current_data() is None
+
+
+def test_set_current_data_found_and_not_found(qtbot):
+    combo = RheoComboBox()
+    qtbot.addWidget(combo)
+    combo.set_items_safely([("A", 1), ("B", 2), ("C", 3)])
+
+    assert combo.set_current_data(2) is True
+    assert combo.current_data() == 2
+
+    assert combo.set_current_data(999) is False
+    # A not-found lookup leaves the previous valid selection in place.
+    assert combo.current_data() == 2
+
+    assert combo.set_current_data(None) is True
+    assert combo.currentIndex() == -1
+
+
+def test_set_density_round_trip(qtbot):
+    combo = RheoComboBox(density="standard")
+    qtbot.addWidget(combo)
+    assert combo.property("density") == "standard"
+
+    combo.set_density("compact")
+    assert combo.property("density") == "compact"
+
+    combo.set_density("standard")
+    assert combo.property("density") == "standard"


### PR DESCRIPTION
## Summary
- New `RheoComboBox` (`rheojax/gui/widgets/dropdown.py`) consolidates 37 raw `QComboBox()` instantiations across 18 files: signal-safe repopulation (`set_items_safely`), data-keyed selection (`set_current_data`/`current_data`), disabled+non-selectable group headers (`add_group_header`), muted placeholder state, density variants.
- Fixes a real bug in `step1_protocol_model.py`: model-family group headers in the dropdown were only `setEnabled(False)`, never `setSelectable(False)` — still keyboard-selectable, could leave `model_key` in a bogus state.
- Migrates 8 files off hardcoded `setContentsMargins`/`setSpacing` onto the existing `layout_helpers.py` token helpers (`set_page_margins`, `set_panel_margins`, `set_compact_margins`, `set_toolbar_margins`, `set_zero_margins`). Scope corrected from an initial ~31-file estimate down to the 8 files that actually had hardcoded margins, verified by grep before dispatch.
- `column_mapper.py`: x/y (required) and y2/temp (optional) column dropdowns now show a blank placeholder instead of defaulting to column 0 / a `"(None)"` sentinel item — forces explicit user selection. Confirmed with user this is the desired behavior (not a regression).

Built via `/ecc:multi-frontend`: research → ideation/planning through Antigravity CLI (`agy`, substituted for Gemini after Gemini Code Assist free-tier auth broke — `IneligibleTierError`) → 19 files migrated in parallel by isolated single-file agents → verified.

Deferred to follow-up (context budget): the command's Phase 5 (external code review call) and Phase 6 (final accessibility/responsiveness pass) were skipped this round — worth a dedicated review pass before merge.

## Test plan
- [x] `uv run ruff check rheojax/gui/` — clean
- [x] `uv run pytest tests/gui/test_gui_smoke.py tests/gui/workspace/test_widgets.py tests/gui/widgets -q` — 72 passed
- [x] Live offscreen Qt smoke test on `step1_protocol_model.py` (group-header fix) and `step2_slots.py` — both instantiate and behave correctly under `QT_QPA_PLATFORM=offscreen`
- [ ] Full `tests/gui/` suite (has slow-marked tests, not run to completion this round — should run before merge)
- [ ] Manual smoke: light + dark theme, one dialog, one wizard flow

🤖 Generated with [Claude Code](https://claude.com/claude-code)