### PR TITLE
fix(gmm): warn on poor R² steady-shear fit

### DIFF
--- a/rheojax/models/multimode/generalized_maxwell.py
+++ b/rheojax/models/multimode/generalized_maxwell.py
@@ -2004,19 +2004,31 @@ class GeneralizedMaxwell(BaseModel):
             self.parameters.set_value(f"{symbol}_{i + 1}", float(G_i_guess[i]))
             self.parameters.set_value(f"tau_{i + 1}", float(tau_i_guess[i]))
 
-        r_squared = compute_r_squared(eta, np.full_like(np.asarray(eta), eta_avg))
+        # NOTE: compute_r_squared(eta, full_like(eta, eta_avg)) is mathematically
+        # identical to 0.0 for any non-constant data (R² of a mean-predictor is 0
+        # by construction: SS_res == SS_tot), so it cannot distinguish a poor
+        # (shear-thinning) fit from a good (near-Newtonian) one. Use the
+        # coefficient of variation of the raw data instead — it directly
+        # measures how far the data deviates from the constant viscosity this
+        # linear model predicts.
+        eta_arr = np.asarray(eta)
+        eta_std = float(np.std(eta_arr))
+        cv = eta_std / abs(eta_avg) if eta_avg != 0 else 0.0
 
         logger.info(
             "GMM fitted to steady-shear mode",
             eta_0=eta_avg,
-            r_squared=r_squared,
+            coefficient_of_variation=cv,
             note="Linear model gives constant viscosity η₀=ΣGᵢτᵢ",
         )
 
-        if r_squared < 0.5:
+        # ponytail: 10% relative variability is a heuristic threshold, not a
+        # statistically derived one; tighten/loosen if it proves noisy in practice.
+        if cv > 0.1:
             warnings.warn(
-                "GeneralizedMaxwell: steady-shear/flow-curve fit gives "
-                f"R²={r_squared:.3g}. This model is linear viscoelastic and "
+                "GeneralizedMaxwell: steady-shear/flow-curve data shows "
+                f"{cv:.1%} relative variability (std/mean of η), suggesting "
+                "non-constant viscosity. This model is linear viscoelastic and "
                 "can only predict a constant viscosity — it cannot capture "
                 "shear-thinning or shear-thickening behavior. If your data "
                 "shows non-constant viscosity, use a flow model instead "

--- a/rheojax/models/multimode/generalized_maxwell.py
+++ b/rheojax/models/multimode/generalized_maxwell.py
@@ -2004,11 +2004,26 @@ class GeneralizedMaxwell(BaseModel):
             self.parameters.set_value(f"{symbol}_{i + 1}", float(G_i_guess[i]))
             self.parameters.set_value(f"tau_{i + 1}", float(tau_i_guess[i]))
 
+        r_squared = compute_r_squared(eta, np.full_like(np.asarray(eta), eta_avg))
+
         logger.info(
             "GMM fitted to steady-shear mode",
             eta_0=eta_avg,
+            r_squared=r_squared,
             note="Linear model gives constant viscosity η₀=ΣGᵢτᵢ",
         )
+
+        if r_squared < 0.5:
+            warnings.warn(
+                "GeneralizedMaxwell: steady-shear/flow-curve fit gives "
+                f"R²={r_squared:.3g}. This model is linear viscoelastic and "
+                "can only predict a constant viscosity — it cannot capture "
+                "shear-thinning or shear-thickening behavior. If your data "
+                "shows non-constant viscosity, use a flow model instead "
+                "(e.g. Cross or Carreau in rheojax.models.flow).",
+                UserWarning,
+                stacklevel=2,
+            )
 
     @staticmethod
     @jax.jit

--- a/tests/models/multimode/test_generalized_maxwell.py
+++ b/tests/models/multimode/test_generalized_maxwell.py
@@ -6,6 +6,8 @@ Test coverage:
 - Task Group 2.2: Creep Mode (Phase 2)
 """
 
+import warnings
+
 import numpy as np
 import pytest
 
@@ -573,6 +575,31 @@ class TestGMMSteadyShearMode:
 
         assert np.all(np.isfinite(eta_pred))
         np.testing.assert_allclose(eta_pred, eta_avg, rtol=1e-6)
+
+    def test_steady_shear_fit_warns_on_shear_thinning_data(self):
+        """Shear-thinning η(γ̇) (order-of-magnitude drop) should trigger the
+        poor-fit warning since the linear GMM can only predict constant η."""
+        gamma_dot = np.logspace(-2, 2, 30)
+        eta_data = 5e3 / (1.0 + gamma_dot)  # strongly shear-thinning
+
+        model = GeneralizedMaxwell(n_modes=3)
+        with pytest.warns(UserWarning, match="non-constant viscosity"):
+            model.fit(gamma_dot, eta_data, test_mode="steady_shear")
+
+    def test_steady_shear_fit_no_warning_on_noisy_but_flat_data(self):
+        """Near-constant η with small measurement noise should NOT warn --
+        regression guard for a prior bug where R² was computed against the
+        fit's own mean prediction, making it identically 0.0 (and thus always
+        below threshold) for any data with nonzero variance."""
+        rng = np.random.default_rng(0)
+        gamma_dot = np.logspace(-2, 2, 30)
+        eta_avg = 5e3
+        eta_data = eta_avg + rng.normal(0, eta_avg * 0.01, size=gamma_dot.shape)
+
+        model = GeneralizedMaxwell(n_modes=3)
+        with warnings.catch_warnings():
+            warnings.simplefilter("error", UserWarning)
+            model.fit(gamma_dot, eta_data, test_mode="steady_shear")
 
 
 class TestGMMStartupMode:


### PR DESCRIPTION
## Summary
- GeneralizedMaxwell's steady-shear/flow-curve fit path (`_fit_steady_shear_mode`) never runs NLSQ — it's a linear model, so it can only match a constant viscosity η₀=ΣGᵢτᵢ. On shear-thinning data (e.g. `examples/data/flow/hydrogels/cellulose_hydrogel_flow.csv`) this silently reports `success=True` with R²≈0.
- Added an R² computation + `UserWarning` when R² < 0.5, pointing the user at Cross/Carreau flow models instead.

## Test plan
- [x] `uv run pytest tests/models/multimode/test_generalized_maxwell.py -k "steady or shear or flow"` — 7 passed
- [x] Manually fit real cellulose hydrogel flow-curve data, confirmed warning fires with correct R²=0 message