### PR TITLE
fix(gui): progress-callback signature + flow-curve stress/viscosity quantity mismatch

### DIFF
--- a/rheojax/gui/foundation/contract.py
+++ b/rheojax/gui/foundation/contract.py
@@ -78,7 +78,8 @@ def input_contract(protocol: str, model_key: str | None = None) -> InputContract
         # Stress (Pa) and viscosity (Pa·s) are the two quantities flow-curve
         # models fit; a dataset labeled with the other one is silently
         # wrong-scale, not just wrong-unit, so DataStep needs a converter
-        # (sigma = eta * gamma_dot), same as the x Hz->rad/s guard below.
+        # (sigma = eta * gamma_dot), same as the oscillation template's x
+        # Hz->rad/s guard above.
         unit_conversions["y"] = "stress<->viscosity"
     else:
         cols = [ColumnSpec(role, unit) for role, unit in t["columns"]]

--- a/rheojax/gui/foundation/contract.py
+++ b/rheojax/gui/foundation/contract.py
@@ -61,6 +61,7 @@ def input_contract(protocol: str, model_key: str | None = None) -> InputContract
     if protocol not in _TEMPLATES:
         raise ValueError(f"unknown protocol: {protocol}")
     t = _TEMPLATES[protocol]
+    unit_conversions = dict(t.get("unit_conversions", {}))
     y_quantity = None
     if protocol == "flow_curve":
         if model_key is not None:
@@ -74,6 +75,11 @@ def input_contract(protocol: str, model_key: str | None = None) -> InputContract
                 "Pa·s" if y_quantity == "viscosity" else "Pa",
             ),
         ]
+        # Stress (Pa) and viscosity (Pa·s) are the two quantities flow-curve
+        # models fit; a dataset labeled with the other one is silently
+        # wrong-scale, not just wrong-unit, so DataStep needs a converter
+        # (sigma = eta * gamma_dot), same as the x Hz->rad/s guard below.
+        unit_conversions["y"] = "stress<->viscosity"
     else:
         cols = [ColumnSpec(role, unit) for role, unit in t["columns"]]
     return InputContract(
@@ -81,6 +87,6 @@ def input_contract(protocol: str, model_key: str | None = None) -> InputContract
         columns=cols,
         domain=t["domain"],
         y_quantity=y_quantity,
-        unit_conversions=dict(t.get("unit_conversions", {})),
+        unit_conversions=unit_conversions,
         control_vars=list(t["control_vars"]),
     )

--- a/rheojax/gui/jobs/fit_worker.py
+++ b/rheojax/gui/jobs/fit_worker.py
@@ -193,16 +193,16 @@ class FitWorker(QRunnable):
             _progress_lock = threading.Lock()
 
             # Add progress callback that checks cancellation and emits percentage
-            def progress_callback(iteration: int, loss: float, **kwargs):
+            def progress_callback(iteration: int, cost: float, **kwargs):
                 """Progress callback for NLSQ optimization."""
                 nonlocal _last_nlsq_progress
                 with _progress_lock:
                     _last_nlsq_progress = time.perf_counter()
                 self.cancel_token.check()
                 self._last_iteration = iteration
-                self._last_loss = loss
+                self._last_loss = cost
                 percent = min(int(iteration / max_iter * 100), 100)
-                message = f"Iteration {iteration}: loss = {loss:.6e}"
+                message = f"Iteration {iteration}: loss = {cost:.6e}"
 
                 # Log iteration timing at DEBUG level
                 elapsed = time.perf_counter() - start_time
@@ -210,7 +210,7 @@ class FitWorker(QRunnable):
                     "Iteration complete",
                     iteration=iteration,
                     elapsed=elapsed,
-                    loss=loss,
+                    loss=cost,
                     percent=percent,
                 )
 

--- a/rheojax/gui/jobs/subprocess_fit.py
+++ b/rheojax/gui/jobs/subprocess_fit.py
@@ -78,16 +78,16 @@ def run_fit_isolated(
     last_iteration = 0
     last_loss = float("inf")
 
-    def progress_callback(iteration: int, loss: float, **kwargs):
+    def progress_callback(iteration: int, cost: float, **kwargs):
         nonlocal last_iteration, last_loss
         if cancel_event.is_set():
             from rheojax.gui.jobs.cancellation import CancellationError
 
             raise CancellationError("Operation cancelled by user")
         last_iteration = iteration
-        last_loss = loss
+        last_loss = cost
         percent = min(int(iteration / max_iter * 100), 100)
-        message = f"Iteration {iteration}: loss = {loss:.6e}"
+        message = f"Iteration {iteration}: loss = {cost:.6e}"
         progress_queue.put(
             {
                 "type": "progress",

--- a/rheojax/gui/workspace/fit/step2_data.py
+++ b/rheojax/gui/workspace/fit/step2_data.py
@@ -14,6 +14,30 @@ from rheojax.gui.utils.layout_helpers import set_panel_margins
 from rheojax.gui.widgets import RheoComboBox
 
 
+def _classify_y_unit(unit: str) -> str | None:
+    """Classify a y-axis unit string as "stress" or "viscosity".
+
+    Returns None when the unit is empty or doesn't match either pattern
+    (e.g. an unrelated protocol's units) -- callers should treat that as
+    "unknown, don't flag a mismatch" rather than a hard error.
+    """
+    normalized = (
+        unit.strip()
+        .lower()
+        .replace("·", "")
+        .replace("*", "")
+        .replace(" ", "")
+        .replace(".", "")
+    )
+    if not normalized:
+        return None
+    if "poise" in normalized or normalized.endswith("pas") or normalized == "cp":
+        return "viscosity"
+    if normalized in ("pa", "kpa", "mpa", "gpa"):
+        return "stress"
+    return None
+
+
 def _validate_shape_and_values(rheo_data) -> list[str]:
     """Shape/NaN/monotonicity checks against a loaded RheoData. Empty = valid."""
     errors: list[str] = []
@@ -56,6 +80,7 @@ class DataStep(QWidget):
         self._library = library
         self._errors: list[str] = []
         self._unit_converted = False
+        self._quantity_converted = False
         # Guard: protocol may be None on a fresh AppState; defer contract build until set
         self._contract, cols_text = self._build_contract()
         self._expected = QLabel(cols_text, self)
@@ -63,6 +88,8 @@ class DataStep(QWidget):
         self._source.set_items_safely([""] + self.available_datasets())
         self._guard = QLabel("", self)
         self._convert_btn = QPushButton("⇄ Convert Hz → rad/s", self)
+        self._quantity_guard = QLabel("", self)
+        self._quantity_convert_btn = QPushButton("⇄ Convert σ ↔ η", self)
         self._error_label = QLabel("", self)
         lay = QVBoxLayout(self)
         set_panel_margins(lay)
@@ -74,11 +101,14 @@ class DataStep(QWidget):
             self._source,
             self._guard,
             self._convert_btn,
+            self._quantity_guard,
+            self._quantity_convert_btn,
             self._error_label,
         ):
             lay.addWidget(w)
         self._source.currentTextChanged.connect(self._on_select)
         self._convert_btn.clicked.connect(self.apply_unit_conversion)
+        self._quantity_convert_btn.clicked.connect(self.apply_quantity_conversion)
 
     def _build_contract(self):
         """Derive (contract, label text) from the current state's protocol/model_key."""
@@ -129,6 +159,7 @@ class DataStep(QWidget):
             self._state.data_ref = None
             self._state.column_map = {}
             self._guard.setText("")
+            self._quantity_guard.setText("")
             self._set_errors([])
             self.edited.emit()
 
@@ -143,6 +174,7 @@ class DataStep(QWidget):
 
     def _on_select(self, ds_id: str) -> None:
         self._unit_converted = False
+        self._quantity_converted = False
         self._state.data_ref = ds_id or None
         errors: list[str] = []
         if ds_id and self._contract:
@@ -155,6 +187,7 @@ class DataStep(QWidget):
                 if self.needs_hz_conversion()
                 else ""
             )
+            self._quantity_guard.setText(self._quantity_mismatch_message())
             try:
                 payload = self._library.load_payload(ds_id)
             except KeyError:
@@ -222,6 +255,73 @@ class DataStep(QWidget):
 
     def unit_conversion_applied(self) -> bool:
         return self._unit_converted
+
+    def _actual_y_quantity(self) -> str | None:
+        """Classify the loaded dataset's y-column as "stress" or "viscosity".
+
+        None means unclassifiable (missing/unrecognized unit) -- treated as
+        "no mismatch" everywhere this is consulted, since we can't tell
+        whether it disagrees with the contract's expected quantity.
+        """
+        if not self._contract or "y" not in self._contract.unit_conversions:
+            return None
+        if not self._state.data_ref:
+            return None
+        ref = self._library.get(self._state.data_ref)
+        return _classify_y_unit(ref.units.get("y", ""))
+
+    def needs_quantity_conversion(self) -> bool:
+        if self.quantity_conversion_applied():
+            return False
+        actual = self._actual_y_quantity()
+        expected = self._contract.y_quantity if self._contract else None
+        return actual is not None and expected is not None and actual != expected
+
+    def _quantity_mismatch_message(self) -> str:
+        if not self.needs_quantity_conversion():
+            return ""
+        actual = self._actual_y_quantity()
+        expected = self._contract.y_quantity
+        formula = "σ = η·γ̇" if expected == "stress" else "η = σ/γ̇"
+        return (
+            f"⚠ y data is {actual}, model expects {expected} → convert ({formula})"
+        )
+
+    def apply_quantity_conversion(self) -> None:
+        """Convert loaded y data between stress (Pa) and viscosity (Pa·s).
+
+        Uses the already-loaded shear_rate (x) column: sigma = eta * gamma_dot
+        in the viscosity->stress direction, eta = sigma / gamma_dot in the
+        stress->viscosity direction.
+        """
+        if not self.needs_quantity_conversion():
+            return
+        actual = self._actual_y_quantity()
+        expected = self._contract.y_quantity
+        rheo_data = self._library.load_payload(self._state.data_ref)
+        gamma_dot = np.asarray(rheo_data.x)
+        y = np.asarray(rheo_data.y)
+        if actual == "viscosity" and expected == "stress":
+            rheo_data.y = y * gamma_dot
+            new_unit = "Pa"
+        else:  # actual == "stress" and expected == "viscosity"
+            rheo_data.y = y / gamma_dot
+            new_unit = "Pa.s"
+        # Same persistence ordering as apply_unit_conversion(): update the
+        # library's authoritative units metadata before re-storing the
+        # converted payload, so needs_quantity_conversion() doesn't flag a
+        # second conversion on the very next _on_select()/refresh() call.
+        ref = self._library.get(self._state.data_ref)
+        self._library.add(
+            replace(ref, units={**ref.units, "y": new_unit}), overwrite=True
+        )
+        self._library.store_payload(self._state.data_ref, rheo_data)
+        self._quantity_converted = True
+        self._quantity_guard.setText("")
+        self.edited.emit()
+
+    def quantity_conversion_applied(self) -> bool:
+        return self._quantity_converted
 
     def is_ready(self) -> bool:
         return bool(

--- a/rheojax/gui/workspace/fit/step2_data.py
+++ b/rheojax/gui/workspace/fit/step2_data.py
@@ -305,6 +305,10 @@ class DataStep(QWidget):
             rheo_data.y = y * gamma_dot
             new_unit = "Pa"
         else:  # actual == "stress" and expected == "viscosity"
+            # gamma_dot == 0 (a legitimate flow-curve point) divides to inf,
+            # not an exception -- _validate_shape_and_values() below is what
+            # actually catches it, same as it catches a raw NaN/Inf y-column
+            # loaded straight from a file.
             rheo_data.y = y / gamma_dot
             new_unit = "Pa.s"
         # Same persistence ordering as apply_unit_conversion(): update the
@@ -318,6 +322,10 @@ class DataStep(QWidget):
         self._library.store_payload(self._state.data_ref, rheo_data)
         self._quantity_converted = True
         self._quantity_guard.setText("")
+        # The conversion mutates y in place -- re-run the same NaN/Inf check
+        # _on_select() runs on load, or a divide-by-zero at gamma_dot==0
+        # silently reaches NLSQ/NUTS as a "valid", already-passed dataset.
+        self._set_errors(_validate_shape_and_values(rheo_data))
         self.edited.emit()
 
     def quantity_conversion_applied(self) -> bool:

--- a/rheojax/io/readers/_utils.py
+++ b/rheojax/io/readers/_utils.py
@@ -30,6 +30,7 @@ __all__ = [
     "VALID_TRANSFORMS",
     "TRANSFORM_REQUIREMENTS",
     "extract_unit_from_header",
+    "infer_y_unit_from_name",
     "detect_domain",
     "detect_test_mode_from_columns",
     "check_tensile_guard",
@@ -268,6 +269,30 @@ def extract_unit_from_header(header: str) -> tuple[str, str | None]:
         return name, unit
     logger.debug("No unit found in header", name=header)
     return header, None
+
+
+def infer_y_unit_from_name(name: str) -> str | None:
+    """Infer a default SI y-unit from a bare flow-curve column name.
+
+    Flow-curve exports frequently label the y-column "Viscosity" or "Stress"
+    with no bracketed unit (``extract_unit_from_header`` returns ``None`` for
+    these). Stress and viscosity have the same order of magnitude at low
+    shear rates, so leaving the unit unset lets a viscosity column silently
+    be fit as stress (or vice versa) with no error -- only a bad fit.
+
+    Args:
+        name: Column header string (already unit-stripped, or bare).
+
+    Returns:
+        "Pa.s" for a viscosity-labeled column, "Pa" for a stress-labeled
+        column, or None if the name doesn't match either.
+    """
+    normalized = name.strip().lower()
+    if "viscosity" in normalized:
+        return "Pa.s"
+    if "stress" in normalized:
+        return "Pa"
+    return None
 
 
 # =============================================================================

--- a/rheojax/io/readers/csv_reader.py
+++ b/rheojax/io/readers/csv_reader.py
@@ -20,6 +20,7 @@ from rheojax.io.readers._utils import (
     detect_domain,
     detect_test_mode_from_columns,
     extract_unit_from_header,
+    infer_y_unit_from_name,
     normalize_units,
     validate_transform,
 )
@@ -418,6 +419,11 @@ def load_csv(
     if y_units is None:
         # Use first y column header for units
         _, extracted_y_units = extract_unit_from_header(y_headers[0])
+        if extracted_y_units is None:
+            # No bracketed unit (e.g. header is just "Viscosity" or "Stress")
+            # -- infer from the name itself so a flow-curve viscosity column
+            # never gets silently treated as stress (or vice versa) downstream.
+            extracted_y_units = infer_y_unit_from_name(y_headers[0])
         if extracted_y_units is not None:
             if is_complex:
                 real_part, y_units = normalize_units(y_data.real, extracted_y_units)

--- a/rheojax/io/readers/excel_reader.py
+++ b/rheojax/io/readers/excel_reader.py
@@ -18,6 +18,7 @@ from rheojax.io.readers._utils import (
     detect_domain,
     detect_test_mode_from_columns,
     extract_unit_from_header,
+    infer_y_unit_from_name,
     normalize_units,
     validate_transform,
 )
@@ -304,6 +305,11 @@ def load_excel(
     if y_units is None:
         # Use first y column header for units
         _, extracted_y_units = extract_unit_from_header(y_headers[0])
+        if extracted_y_units is None:
+            # No bracketed unit (e.g. header is just "Viscosity" or "Stress")
+            # -- infer from the name itself so a flow-curve viscosity column
+            # never gets silently treated as stress (or vice versa) downstream.
+            extracted_y_units = infer_y_unit_from_name(y_headers[0])
         if extracted_y_units is not None:
             if is_complex:
                 real_part, y_units = normalize_units(y_data.real, extracted_y_units)

--- a/tests/gui/test_process_worker.py
+++ b/tests/gui/test_process_worker.py
@@ -432,6 +432,78 @@ class TestRunFitIsolated:
         if result.get("residuals") is not None:
             assert isinstance(result["residuals"], np.ndarray)
 
+    def test_progress_callback_matches_nlsq_kwarg_contract(self):
+        # Regression: nlsq's trf callback invokes callback(iteration=,
+        # cost=, params=, info=) by keyword only. A stale signature (e.g.
+        # requiring a `loss` argument nlsq never passes) doesn't crash the
+        # fit -- nlsq's broad except swallows the TypeError into an
+        # invisible RuntimeWarning and silently drops progress reporting
+        # (and cancellation, which is checked from inside the same
+        # callback). Assert progress messages actually made it through.
+        #
+        # Uses MIKH's flow-curve fit (the original repro shape: 11 params)
+        # rather than a small 2-param model -- nlsq's "auto" workflow takes
+        # a different internal fast path for very small problems that
+        # never invokes the user callback at all (confirmed by patching
+        # TrustRegionReflective._invoke_callback and counting calls: 0 for
+        # a 2-param Maxwell fit, 11 for this 11-param MIKH fit), which
+        # would make a small-model version of this test pass regardless of
+        # the callback's signature.
+        import multiprocessing as mp
+        import warnings
+
+        import numpy as np
+
+        from rheojax.gui.jobs.subprocess_fit import run_fit_isolated
+
+        gamma_dot = np.array(
+            [0.1, 0.178, 0.316, 0.562, 1.0, 1.78, 3.16, 5.62, 10.0, 17.8, 31.6, 56.2]
+        )
+        viscosity = np.array(
+            [
+                7348.0,
+                4264.943820224719,
+                2478.4493670886077,
+                1436.0498220640568,
+                831.83,
+                481.7865168539326,
+                279.98417721518985,
+                162.52313167259786,
+                94.353,
+                54.75,
+                31.816455696202528,
+                18.243772241992882,
+            ]
+        )
+        stress = viscosity * gamma_dot  # sigma = eta * gamma_dot
+        progress_queue = mp.Queue()
+
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter("always")
+            result = run_fit_isolated(
+                model_name="mikh",
+                x_data=gamma_dot,
+                y_data=stress,
+                test_mode="flow_curve",
+                initial_params={},
+                options={"max_iter": 500},
+                progress_queue=progress_queue,
+                cancel_event=mp.Event(),
+            )
+
+        assert result["success"]
+        assert not any(
+            "Callback raised exception" in str(w.message) for w in caught
+        ), "progress_callback raised inside nlsq -- kwarg signature mismatch"
+
+        messages = []
+        while not progress_queue.empty():
+            messages.append(progress_queue.get_nowait())
+        assert any(m.get("type") == "progress" for m in messages), (
+            "progress_callback never reported progress -- likely a kwarg "
+            "mismatch with nlsq's actual callback signature"
+        )
+
 
 # ===========================================================================
 # Tests for run_bayesian_isolated

--- a/tests/gui/workspace/fit/test_step2.py
+++ b/tests/gui/workspace/fit/test_step2.py
@@ -1,18 +1,20 @@
+import numpy as np
 import pytest
 
 pytest.importorskip("PySide6")
+from rheojax.core.data import RheoData
 from rheojax.gui.foundation.library import DatasetLibrary, DatasetRef
 from rheojax.gui.foundation.state import FitState
 from rheojax.gui.workspace.fit.step2_data import DataStep
 
 
-def _ref(i, t):
+def _ref(i, t, units=None):
     return DatasetRef(
         id=i,
         name=i,
         protocol_type=t,
         origin="imported",
-        units={"x": "Hz"},
+        units=units if units is not None else {"x": "Hz"},
         row_count=64,
         hash="h",
         provenance={},
@@ -88,3 +90,52 @@ def test_data_step_refresh_clears_stale_selection(qtbot):
     assert st.data_ref is None
     assert st.column_map == {}
     assert step.available_datasets() == ["c1"]
+
+
+def test_data_step_flags_viscosity_data_for_stress_model(qtbot):
+    # Regression: MIKH (flow_quantity="stress") silently fit raw viscosity
+    # values as stress when a flow_curve CSV had no explicit unit conversion.
+    st = FitState(protocol="flow_curve", model_key="mikh")
+    lib = DatasetLibrary()
+    lib.add(_ref("flow1", "flow_curve", units={"y": "Pa.s"}))
+    step = DataStep(st, lib)
+    qtbot.addWidget(step)
+    step.select_dataset("flow1")
+    assert step.needs_quantity_conversion() is True
+    assert "viscosity" in step._quantity_mismatch_message()
+    assert "stress" in step._quantity_mismatch_message()
+
+
+def test_data_step_no_quantity_mismatch_when_units_match(qtbot):
+    st = FitState(protocol="flow_curve", model_key="mikh")
+    lib = DatasetLibrary()
+    lib.add(_ref("flow1", "flow_curve", units={"y": "Pa"}))
+    step = DataStep(st, lib)
+    qtbot.addWidget(step)
+    step.select_dataset("flow1")
+    assert step.needs_quantity_conversion() is False
+
+
+def test_data_step_apply_quantity_conversion_viscosity_to_stress(qtbot):
+    st = FitState(protocol="flow_curve", model_key="mikh")
+    lib = DatasetLibrary()
+    lib.add(_ref("flow1", "flow_curve", units={"y": "Pa.s"}))
+    gamma_dot = np.array([0.1, 1.0, 10.0])
+    viscosity = np.array([7348.0, 831.83, 94.353])
+    lib.store_payload(
+        "flow1", RheoData(x=gamma_dot, y=viscosity, x_units="1/s", y_units="Pa.s")
+    )
+    step = DataStep(st, lib)
+    qtbot.addWidget(step)
+    step.select_dataset("flow1")
+    assert step.needs_quantity_conversion() is True
+
+    step.apply_quantity_conversion()
+
+    assert step.needs_quantity_conversion() is False
+    assert step.quantity_conversion_applied() is True
+    converted = lib.load_payload("flow1")
+    np.testing.assert_allclose(
+        np.asarray(converted.y), viscosity * gamma_dot, rtol=1e-10
+    )
+    assert lib.get("flow1").units["y"] == "Pa"

--- a/tests/gui/workspace/fit/test_step2.py
+++ b/tests/gui/workspace/fit/test_step2.py
@@ -5,7 +5,7 @@ pytest.importorskip("PySide6")
 from rheojax.core.data import RheoData
 from rheojax.gui.foundation.library import DatasetLibrary, DatasetRef
 from rheojax.gui.foundation.state import FitState
-from rheojax.gui.workspace.fit.step2_data import DataStep
+from rheojax.gui.workspace.fit.step2_data import DataStep, _classify_y_unit
 
 
 def _ref(i, t, units=None):
@@ -139,3 +139,75 @@ def test_data_step_apply_quantity_conversion_viscosity_to_stress(qtbot):
         np.asarray(converted.y), viscosity * gamma_dot, rtol=1e-10
     )
     assert lib.get("flow1").units["y"] == "Pa"
+
+
+def test_data_step_apply_quantity_conversion_stress_to_viscosity(qtbot):
+    # power_law has flow_quantity="viscosity" -- the mirror direction of the
+    # MIKH (flow_quantity="stress") case above.
+    st = FitState(protocol="flow_curve", model_key="power_law")
+    lib = DatasetLibrary()
+    lib.add(_ref("flow1", "flow_curve", units={"y": "Pa"}))
+    gamma_dot = np.array([0.1, 1.0, 10.0])
+    stress = np.array([734.8, 831.83, 943.53])
+    lib.store_payload(
+        "flow1", RheoData(x=gamma_dot, y=stress, x_units="1/s", y_units="Pa")
+    )
+    step = DataStep(st, lib)
+    qtbot.addWidget(step)
+    step.select_dataset("flow1")
+    assert step.needs_quantity_conversion() is True
+
+    step.apply_quantity_conversion()
+
+    assert step.needs_quantity_conversion() is False
+    assert step.quantity_conversion_applied() is True
+    converted = lib.load_payload("flow1")
+    np.testing.assert_allclose(np.asarray(converted.y), stress / gamma_dot, rtol=1e-10)
+    assert lib.get("flow1").units["y"] == "Pa.s"
+
+
+def test_data_step_apply_quantity_conversion_zero_gamma_dot_surfaces_error(qtbot):
+    # Regression: dividing by a gamma_dot=0 point (a legitimate flow-curve
+    # value) produces inf silently -- apply_quantity_conversion() must
+    # re-validate the mutated payload so this reaches validation_errors(),
+    # not a fit that silently trains on inf.
+    st = FitState(protocol="flow_curve", model_key="power_law")
+    lib = DatasetLibrary()
+    lib.add(_ref("flow1", "flow_curve", units={"y": "Pa"}))
+    gamma_dot = np.array([0.0, 1.0, 10.0])
+    stress = np.array([10.0, 20.0, 30.0])
+    lib.store_payload(
+        "flow1", RheoData(x=gamma_dot, y=stress, x_units="1/s", y_units="Pa")
+    )
+    step = DataStep(st, lib)
+    qtbot.addWidget(step)
+    step.select_dataset("flow1")
+    assert step.validation_errors() == []  # pre-conversion data is valid
+
+    step.apply_quantity_conversion()
+
+    converted = lib.load_payload("flow1")
+    assert not np.isfinite(np.asarray(converted.y)).all()
+    assert step.validation_errors() != []
+    assert step.is_ready() is False
+
+
+@pytest.mark.parametrize(
+    "unit,expected",
+    [
+        ("Pa", "stress"),
+        ("kPa", "stress"),
+        ("MPa", "stress"),
+        ("GPa", "stress"),
+        ("Pa.s", "viscosity"),
+        ("Pa·s", "viscosity"),
+        ("mPa*s", "viscosity"),
+        ("cP", "viscosity"),
+        ("poise", "viscosity"),
+        ("", None),
+        ("rad/s", None),
+        ("G'", None),
+    ],
+)
+def test_classify_y_unit(unit, expected):
+    assert _classify_y_unit(unit) == expected

--- a/tests/io/test_unit_conversion.py
+++ b/tests/io/test_unit_conversion.py
@@ -5,9 +5,28 @@ import pytest
 
 from rheojax.io.readers._utils import (
     UNIFIED_UNIT_CONVERSIONS,
+    infer_y_unit_from_name,
     normalize_temperature,
     normalize_units,
 )
+
+
+@pytest.mark.smoke
+def test_infer_y_unit_from_name_viscosity():
+    assert infer_y_unit_from_name("Viscosity") == "Pa.s"
+    assert infer_y_unit_from_name("  viscosity  ") == "Pa.s"
+
+
+@pytest.mark.smoke
+def test_infer_y_unit_from_name_stress():
+    assert infer_y_unit_from_name("Stress") == "Pa"
+    assert infer_y_unit_from_name("Shear Stress") == "Pa"
+
+
+@pytest.mark.smoke
+def test_infer_y_unit_from_name_unrecognized():
+    assert infer_y_unit_from_name("G_prime") is None
+    assert infer_y_unit_from_name("") is None
 
 
 @pytest.mark.smoke

--- a/tests/io/test_unit_conversion.py
+++ b/tests/io/test_unit_conversion.py
@@ -1,8 +1,11 @@
 """Tests for unified unit normalization (Phase 1)."""
 
+from pathlib import Path
+
 import numpy as np
 import pytest
 
+from rheojax.io.readers import load_csv
 from rheojax.io.readers._utils import (
     UNIFIED_UNIT_CONVERSIONS,
     infer_y_unit_from_name,
@@ -27,6 +30,27 @@ def test_infer_y_unit_from_name_stress():
 def test_infer_y_unit_from_name_unrecognized():
     assert infer_y_unit_from_name("G_prime") is None
     assert infer_y_unit_from_name("") is None
+
+
+def test_load_csv_infers_pa_s_from_bare_viscosity_header(tmp_path: Path):
+    # Regression: the reported repro (cellulose_hydrogel_flow.csv) has a
+    # "Viscosity" header with no bracketed unit -- confirms load_csv actually
+    # wires infer_y_unit_from_name() in, not just the helper in isolation.
+    csv_path = tmp_path / "flow.csv"
+    csv_path.write_text("Shear Rate\tViscosity\n0.1\t7348.0\n1.0\t831.83\n")
+
+    data = load_csv(csv_path, x_col=0, y_col=1, delimiter="\t")
+
+    assert data.y_units == "Pa.s"
+
+
+def test_load_csv_infers_pa_from_bare_stress_header(tmp_path: Path):
+    csv_path = tmp_path / "flow.csv"
+    csv_path.write_text("Shear Rate\tStress\n0.1\t734.8\n1.0\t831.83\n")
+
+    data = load_csv(csv_path, x_col=0, y_col=1, delimiter="\t")
+
+    assert data.y_units == "Pa"
 
 
 @pytest.mark.smoke


### PR DESCRIPTION
## Summary

Two bugs found while debugging a poor MIKH flow-curve fit (R²=0.12, 7/11 params pinned):

**1. `progress_callback` kwarg mismatch**
- nlsq's `trf` callback invokes with keyword `cost`, never `loss`. The GUI's `progress_callback` closures in `fit_worker.py` and `subprocess_fit.py` required a mandatory `loss` parameter, so every callback call raised `TypeError` — silently swallowed by nlsq's broad `except Exception`, surfacing only as `RuntimeWarning: Callback raised exception ... Continuing optimization.` in logs.
- Fix: rename the parameter from `loss` to `cost` to match nlsq's actual call signature.

**2. Flow-curve stress/viscosity quantity mismatch (root cause of the bad MIKH fit)**
- The reported "MIKH overparameterization" traced back to a data-quantity bug, not a model identifiability problem: the CSV's y-column was viscosity (Pa·s), but MIKH's `flow_quantity` is stress (Pa). `DataStep`'s `InputContract` labeled the column "stress" without ever validating or converting the actual physical quantity (unlike the x-axis Hz→rad/s path, which has an explicit guard/button). Raw viscosity values got fit as if they were stress, at the wrong scale (rmse≈2020, matching the viscosity range, not the true stress range of ~700–1000 Pa).
- `rheojax/io/readers/_utils.py`: `infer_y_unit_from_name()` infers Pa vs Pa.s from a bare "Viscosity"/"Stress" column header when no bracketed unit is present.
- `csv_reader.py` / `excel_reader.py`: wire that inference in as a fallback.
- `contract.py`: flow_curve's `InputContract` now declares a `"y"` entry in `unit_conversions`, mirroring the existing oscillation `"x"` Hz→rad/s entry.
- `step2_data.py`: `DataStep` gains `needs_quantity_conversion()` / `apply_quantity_conversion()`, detecting a stress↔viscosity mismatch and converting via `sigma = eta * gamma_dot` (or the inverse), same UX pattern as the existing Hz guard/button.
- Verified against the reported repro (`cellulose_hydrogel_flow.csv` + MIKH): fitting the corrected stress data raises R² from 0.12 to 0.65. The remaining pinned parameters (G, eta, mu_p absent from the steady-state closed form by design; gamma_dyn/m/C and Gamma/tau_thix each collapsing to one identifiable combination for a single flow curve) are expected identifiability limits, already surfaced correctly by the existing NLSQ stuck-parameter warning — not a bug.

## Test plan
- [x] `uv run pytest tests/gui/test_process_worker.py tests/gui/workspace/fit/test_step3_wiring.py -q` — 49 passed
- [x] `uv run pytest tests/gui/workspace/fit/ tests/gui/foundation/ tests/io/ -q` — 719 passed
- [x] `uv run ruff check` on all touched files — clean
- [x] Manual repro: `auto_load` on the reported CSV now infers `y_units="Pa.s"`; `DataStep.needs_quantity_conversion()` correctly flags the MIKH mismatch and `apply_quantity_conversion()` produces the expected stress values (734.8, 759.16, 783.19, ... Pa)

🤖 Generated with [Claude Code](https://claude.com/claude-code)