### PR TITLE
fix(gui): resolve 15 bugs found in fit-workflow end-to-end audit

### DIFF
--- a/rheojax/gui/foundation/import_service.py
+++ b/rheojax/gui/foundation/import_service.py
@@ -81,6 +81,17 @@ def import_dataset(path: Path, protocol: str) -> tuple[DatasetRef, RheoData]:
             data.x = np.asarray(data.x) * (2 * np.pi)
             data.x_units = "rad/s"
         units["x"] = data.x_units
+    # Same reasoning as the x block above, for the flow_curve stress<->
+    # viscosity guard (contract.py's "y": "stress<->viscosity" entry,
+    # step2_data.py's needs_quantity_conversion()): the reader auto-detects
+    # y_units (including inferring it from a bare "Viscosity"/"Stress"
+    # header via infer_y_unit_from_name()), but this CLI import path
+    # previously never copied it into DatasetRef.units, so the guard could
+    # never see it -- unlike the interactive GUI import (window.py), which
+    # does copy both x and y units. Without this, a CLI-imported viscosity
+    # column silently gets fit as stress with no warning.
+    if data.y_units:
+        units["y"] = data.y_units
 
     ref = DatasetRef(
         id=uuid.uuid4().hex,

--- a/rheojax/gui/jobs/subprocess_fit.py
+++ b/rheojax/gui/jobs/subprocess_fit.py
@@ -137,7 +137,12 @@ def run_fit_isolated(
         "chi_squared": float(getattr(service_result, "chi_squared", 0.0)),
         "fit_time": fit_time,
         "timestamp": datetime.now().isoformat(),
-        "num_iterations": svc_metadata.get("n_iterations", last_iteration),
+        # dict.get()'s default only applies when the key is ABSENT --
+        # ModelService.fit() always inserts "n_iterations" (possibly None,
+        # since no model actually sets _n_iterations today), so `.get(...,
+        # last_iteration)` never fell back to the real iteration count
+        # tracked from progress_callback. `or` falls back on None too.
+        "num_iterations": svc_metadata.get("n_iterations") or last_iteration,
         "message": getattr(service_result, "message", ""),
         "dataset_id": dataset_id,
         "x_fit": _to_numpy(getattr(service_result, "x_fit", None)),

--- a/rheojax/gui/services/model_service.py
+++ b/rheojax/gui/services/model_service.py
@@ -7,6 +7,8 @@ Service for model fitting, prediction, and parameter management.
 
 from __future__ import annotations
 
+import math
+import warnings
 from collections.abc import Callable
 from datetime import datetime
 from typing import TYPE_CHECKING, Any
@@ -1059,6 +1061,35 @@ class ModelService:
             elif hasattr(model, "_nlsq_result") and model._nlsq_result:
                 fit_success = getattr(model._nlsq_result, "success", True)
                 fit_message = getattr(model._nlsq_result, "message", fit_message)
+
+            # A converged optimizer (nlsq_result.success=True) and a
+            # genuinely poor fit (low R²) are independent things -- NLSQ
+            # reports "success" for hitting a convergence tolerance, not
+            # for explaining the data. Without this, a fit like MIKH's
+            # flow-curve mode at R²=0.09 (several parameters pinned at
+            # their initial value, per the identifiability-check warning
+            # logged during optimization) reports an unqualified "Fit
+            # successful" with nothing pointing the user at the mismatch.
+            # GeneralizedMaxwell already has a narrower, model-specific
+            # version of this warning for its steady-shear case; this is
+            # the model-agnostic version so every model gets the same
+            # basic goodness-of-fit signal.
+            if (
+                fit_success
+                and r_squared is not None
+                and not (isinstance(r_squared, float) and math.isnan(r_squared))
+                and r_squared < 0.5
+            ):
+                warnings.warn(
+                    f"{model_name}: fit reports success but R²={r_squared:.3g} "
+                    "indicates a poor fit -- some parameters may not be "
+                    "well-constrained by this data/protocol. Check the fit "
+                    "log for an identifiability warning, or try a different "
+                    "model/protocol.",
+                    UserWarning,
+                    stacklevel=2,
+                )
+                fit_message = f"{fit_message} (poor fit: R²={r_squared:.3g})"
 
             logger.info(
                 "Model fit complete",

--- a/rheojax/gui/widgets/base_arviz_widget.py
+++ b/rheojax/gui/widgets/base_arviz_widget.py
@@ -143,7 +143,7 @@ class BaseArviZWidget(QWidget):
         # tab) it's destroyed via Qt's parent-cascade deleteLater() instead,
         # which closeEvent never sees. destroyed fires on every teardown
         # path, so wiring cleanup() to it covers both -- same fix already
-        # applied to residuals_panel.py (PR #48/#52) for the identical
+        # applied to residuals_panel.py (PR #48) for the identical
         # deferred-draw_idle()-on-a-freed-canvas crash class.
         self.destroyed.connect(lambda: self.cleanup())
         logger.debug(

--- a/rheojax/gui/widgets/base_arviz_widget.py
+++ b/rheojax/gui/widgets/base_arviz_widget.py
@@ -138,6 +138,14 @@ class BaseArviZWidget(QWidget):
         self._figure: Figure | None = None
         self._canvas: FigureCanvasQTAgg | None = None
         self._pending_cleanup: list[Figure] = []
+        # closeEvent() only fires for top-level widgets; when embedded as a
+        # child (e.g. ArvizCanvas inside step5_visualize.py's Diagnostics
+        # tab) it's destroyed via Qt's parent-cascade deleteLater() instead,
+        # which closeEvent never sees. destroyed fires on every teardown
+        # path, so wiring cleanup() to it covers both -- same fix already
+        # applied to residuals_panel.py (PR #48/#52) for the identical
+        # deferred-draw_idle()-on-a-freed-canvas crash class.
+        self.destroyed.connect(lambda: self.cleanup())
         logger.debug(
             "Widget initialization complete",
             widget=self.__class__.__name__,

--- a/rheojax/gui/workspace/fit/fit_controller.py
+++ b/rheojax/gui/workspace/fit/fit_controller.py
@@ -153,12 +153,15 @@ def _make_fit_fn(library, fit_state, active_jobs=None):
         model_key,
         model_config,
         data_ref,
-        column_map,  # ponytail: accepted but not read, same as FitState.control_vars
-        # (state.py) -- oscillation/flow_curve data always uses the fixed
-        # RheoData.x/.y(complex) convention regardless of column_map's
-        # contents, so _fit_fn_body below loads the payload and uses x/y
-        # directly. Not currently exploitable; wire it in if/when a protocol
-        # needs per-column selection instead of the fixed convention.
+        column_map,  # ponytail: accepted but not read HERE -- unlike
+        # FitState.control_vars (state.py), which no GUI step writes and no
+        # fit call reads at all, column_map IS actively populated by
+        # DataStep and gates its is_ready()/validation; it just never
+        # reaches this fixed-convention fit call. _fit_fn_body below loads
+        # the payload and always uses RheoData.x/.y directly regardless of
+        # column_map's contents. Not currently exploitable; wire it in if/
+        # when a protocol needs per-column selection instead of the fixed
+        # convention.
         initial_params=None,
         multi_start=None,
         options=None,

--- a/rheojax/gui/workspace/fit/fit_controller.py
+++ b/rheojax/gui/workspace/fit/fit_controller.py
@@ -153,7 +153,12 @@ def _make_fit_fn(library, fit_state, active_jobs=None):
         model_key,
         model_config,
         data_ref,
-        column_map,
+        column_map,  # ponytail: accepted but not read, same as FitState.control_vars
+        # (state.py) -- oscillation/flow_curve data always uses the fixed
+        # RheoData.x/.y(complex) convention regardless of column_map's
+        # contents, so _fit_fn_body below loads the payload and uses x/y
+        # directly. Not currently exploitable; wire it in if/when a protocol
+        # needs per-column selection instead of the fixed convention.
         initial_params=None,
         multi_start=None,
         options=None,
@@ -164,14 +169,20 @@ def _make_fit_fn(library, fit_state, active_jobs=None):
         # worker.cancel() -> the same cancel_event run_fit_isolated already
         # polls between restarts. Previously no "worker" key was registered at
         # all, so Close/New/Open could only wait out the timeout, never cancel.
-        token = ProcessCancellationToken(job_id=data_ref)
+        # job_id carries a ":nlsq" suffix (not the bare data_ref) so a
+        # concurrent NUTS run on the same dataset (_make_sample_fn below)
+        # can't clobber this entry in active_jobs.by_id -- window.py's
+        # dataset-delete guard does a prefix match on data_ref, see its
+        # own NOTE at window.py's _on_delete_dataset_clicked.
+        job_id = f"{data_ref}:nlsq"
+        token = ProcessCancellationToken(job_id=job_id)
         # Register for the whole call (all multi-start restarts), not per
         # _run_on_thread call -- _run_on_thread pumps a nested QEventLoop, so
         # New/Open/Close (which only check active_jobs.by_id) would otherwise
         # see it empty and rebuild the workspace out from under this step
         # while the loop is still suspended waiting on the worker thread.
         if active_jobs is not None:
-            active_jobs.by_id[data_ref] = {"status": "running", "worker": token}
+            active_jobs.by_id[job_id] = {"status": "running", "worker": token}
         try:
             return _fit_fn_body(
                 library,
@@ -184,10 +195,11 @@ def _make_fit_fn(library, fit_state, active_jobs=None):
                 options,
                 token.event,
                 active_jobs,
+                job_id,
             )
         finally:
             if active_jobs is not None:
-                active_jobs.by_id.pop(data_ref, None)
+                active_jobs.by_id.pop(job_id, None)
 
     return _fit_fn
 
@@ -203,6 +215,7 @@ def _fit_fn_body(
     options,
     cancel_event,
     active_jobs=None,
+    job_id=None,
 ):
     rheo_data = library.load_payload(data_ref)
     # ponytail: Step 1's protocol combo uses the same vocabulary as
@@ -220,6 +233,15 @@ def _fit_fn_body(
     rng = np.random.default_rng(0)
     best = None
     for i in range(max(count, 1)):
+        # Multi-start's only other cancellation check is inside
+        # run_fit_isolated's progress_callback, which doesn't fire until a
+        # restart's fit is already underway -- Cancel clicked in the gap
+        # between one restart finishing and the next starting would
+        # otherwise go unnoticed until that next restart's first iteration.
+        if cancel_event is not None and cancel_event.is_set():
+            from rheojax.gui.jobs.cancellation import CancellationError
+
+            raise CancellationError("Operation cancelled by user")
         # First run uses the caller's initial_params as-is; restarts 2..N
         # jitter each value by +/-20% (seeded, so runs are reproducible).
         start_params = initial_params
@@ -252,7 +274,7 @@ def _fit_fn_body(
                     metadata=metadata,
                 ),
                 progress_queue=progress_queue,
-                on_progress=_make_progress_reporter(active_jobs, data_ref),
+                on_progress=_make_progress_reporter(active_jobs, job_id or data_ref),
             )
         finally:
             # Release the queue's feeder thread/fds/semaphore -- mirrors
@@ -291,12 +313,16 @@ def _make_sample_fn(library, fit_state, active_jobs=None):
         rheo_data = library.load_payload(fit_state.data_ref)
         # Same real, cancellable token as _fit_fn (see its comment) so
         # "Cancel them and continue?" can actually stop a running NUTS sample.
-        token = ProcessCancellationToken(job_id=fit_state.data_ref)
+        # job_id carries a ":nuts" suffix (not the bare data_ref) -- see
+        # _make_fit_fn's matching comment: NLSQ and NUTS running against the
+        # same dataset must not collide on the same active_jobs.by_id key.
+        job_id = f"{fit_state.data_ref}:nuts"
+        token = ProcessCancellationToken(job_id=job_id)
         # See _fit_fn's comment above: _run_on_thread pumps a nested
         # QEventLoop, so New/Open/Close must see this NUTS run as active for
         # its whole duration, not just while a signal happens to be in flight.
         if active_jobs is not None:
-            active_jobs.by_id[fit_state.data_ref] = {
+            active_jobs.by_id[job_id] = {
                 "status": "running",
                 "worker": token,
             }
@@ -323,7 +349,7 @@ def _make_sample_fn(library, fit_state, active_jobs=None):
                     max_tree_depth=config.get("max_tree_depth"),
                 ),
                 progress_queue=progress_queue,
-                on_progress=_make_progress_reporter(active_jobs, fit_state.data_ref),
+                on_progress=_make_progress_reporter(active_jobs, job_id),
             )
         finally:
             # Release the queue's feeder thread/fds/semaphore -- mirrors
@@ -334,7 +360,7 @@ def _make_sample_fn(library, fit_state, active_jobs=None):
             except (OSError, ValueError, BrokenPipeError):
                 pass
             if active_jobs is not None:
-                active_jobs.by_id.pop(fit_state.data_ref, None)
+                active_jobs.by_id.pop(job_id, None)
 
     return _sample_fn
 

--- a/rheojax/gui/workspace/fit/step1_protocol_model.py
+++ b/rheojax/gui/workspace/fit/step1_protocol_model.py
@@ -234,9 +234,25 @@ class ProtocolModelStep(QWidget):
         if not self._state.model_key:
             self._params.setText("")
             return
-        instance = ModelRegistry.create(
-            self._state.model_key, **self._state.model_config
-        )
+        # A model constructor can raise on an out-of-range constructor-config
+        # value (e.g. N_y=1 on a model that divides by N_y-1) -- letting
+        # that propagate out of this Qt slot means _on_config_changed()'s
+        # config_edited.emit() (and _on_model()'s edited.emit()) never run,
+        # since both call this AFTER already committing the bad config to
+        # the shared FitState. That leaves state.model_config permanently
+        # holding an un-constructible value with no cascade/re-lock ever
+        # having run, and no feedback beyond a log line PySide6's
+        # excepthook swallows -- the wizard just looks unchanged. Catch and
+        # surface it instead, so the caller's edited/config_edited signal
+        # still fires normally (the cascade needs to run either way -- the
+        # config genuinely changed, even if it doesn't build).
+        try:
+            instance = ModelRegistry.create(
+                self._state.model_key, **self._state.model_config
+            )
+        except Exception as exc:
+            self._params.setText(f"⚠ invalid config: {exc}")
+            return
         self._params.setText(", ".join(instance.parameters.keys()))
 
     def is_ready(self) -> bool:

--- a/rheojax/gui/workspace/fit/step2_data.py
+++ b/rheojax/gui/workspace/fit/step2_data.py
@@ -155,13 +155,27 @@ class DataStep(QWidget):
             # same logic _on_select uses for a fresh pick, since signals were
             # blocked above and _on_select was never triggered for `current`.
             self._on_select(current)
-        elif self._state.data_ref is not None or self._state.column_map:
-            self._state.data_ref = None
-            self._state.column_map = {}
+        else:
+            # Regression: in the real wired app, the upstream cascade
+            # (fit_controller.py's _cascade_and_relock, connected BEFORE
+            # data_body.refresh) already nulls state.data_ref/column_map
+            # before this runs -- so gating label-clearing on "was there
+            # something to clear" left a stale guard/quantity-mismatch
+            # message on screen after a model switch that changes the
+            # combo box back to empty. Clear the labels unconditionally;
+            # only mutate state and emit `edited` when there was an actual
+            # selection to invalidate, to avoid a no-op signal on every
+            # refresh() call.
             self._guard.setText("")
             self._quantity_guard.setText("")
             self._set_errors([])
-            self.edited.emit()
+            had_selection = (
+                self._state.data_ref is not None or self._state.column_map
+            )
+            if had_selection:
+                self._state.data_ref = None
+                self._state.column_map = {}
+                self.edited.emit()
 
     def expected_columns(self) -> list[str]:
         return [c.role for c in self._contract.columns] if self._contract else []

--- a/rheojax/gui/workspace/fit/step3_nlsq.py
+++ b/rheojax/gui/workspace/fit/step3_nlsq.py
@@ -82,9 +82,20 @@ class NlsqStep(QWidget):
     def load_parameters_from_model(self) -> None:
         if not self._state.model_key:
             return
-        instance = ModelRegistry.create(
-            self._state.model_key, **self._state.model_config
-        )
+        # Same fallible call as step1_protocol_model.py's _refresh_preview()
+        # (an out-of-range constructor-config value, e.g. N_y=1, can raise) --
+        # this method is wired directly to Step 1's edited/config_edited
+        # signals (fit_controller.py), so it runs in the same tick as a bad
+        # config edit. Without this guard, step1's own try/except only
+        # prevented ITS crash; this identical unguarded call one signal
+        # handler later would still raise uncaught, leaving the parameter
+        # table showing the PREVIOUS model's params with no indication why.
+        try:
+            instance = ModelRegistry.create(
+                self._state.model_key, **self._state.model_config
+            )
+        except Exception:
+            return
         # instance.parameters is a ParameterSet of core.parameters.Parameter
         # (`.bounds` tuple, no `.fixed`) -- ParameterTable needs gui.state.store
         # .ParameterState (`.min_bound`/`.max_bound`/`.fixed`). Convert here,
@@ -255,6 +266,15 @@ class NlsqStep(QWidget):
         fit_time = result.get("fit_time")
         if fit_time is not None:
             lines.append(f"time={float(fit_time):.2f}s")
+
+        # ModelService.fit() appends a poor-fit note to `message` when
+        # r_squared < 0.5 despite nlsq reporting success (model_service.py) --
+        # without surfacing it here, that's the only place the warning was
+        # ever written, and nothing else in the GUI reads it. A plain
+        # "Fit successful" is the boring default and not worth a line.
+        message = result.get("message")
+        if message and message != "Fit successful":
+            lines.append(f"⚠ {message}")
 
         # Recompute locally from pcov (sorted param names + shape-checked
         # sqrt(diag)) rather than trusting a precomputed uncertainties list's

--- a/rheojax/gui/workspace/fit/step3_nlsq.py
+++ b/rheojax/gui/workspace/fit/step3_nlsq.py
@@ -133,6 +133,13 @@ class NlsqStep(QWidget):
         # button must be disabled for the duration or a second click launches
         # an overlapping fit that corrupts shared active_jobs tracking.
         self._run_btn.setEnabled(False)
+        # Snapshot: _fit_fn pumps a nested QEventLoop, so the user can
+        # navigate elsewhere/edit Step 1 while this run is in flight --
+        # that invalidation bumps FitState.revision (invalidation.py). If it
+        # changed by the time the fit returns, the result no longer
+        # corresponds to the current model/protocol/data selection and must
+        # be discarded rather than silently written over the newer state.
+        revision_at_start = self._state.revision
         try:
             # This step's own _ms_enabled/_ms_count widgets are the single
             # source of truth for multi-start (outer restart loop in
@@ -167,9 +174,44 @@ class NlsqStep(QWidget):
                 # ponytail: real solver wiring is out of scope here (tracked separately);
                 # this guard only keeps an unwired Run button from crashing the Qt slot.
                 self._result.setText("NLSQ solver is not wired up yet.")
+                # A first-ever failure with nlsq_result already None needs no
+                # change -- is_ready() already reads that as not-ready. Only
+                # a STALE successful result (from an earlier run) needs to
+                # be cleared here; leaving it as a fresh {"success": False}
+                # dict rather than None would be an unrelated contract
+                # change with no is_ready() difference.
+                if (
+                    self._state.revision == revision_at_start
+                    and self._state.nlsq_result is not None
+                ):
+                    self._state.nlsq_result = {
+                        "success": False,
+                        "message": "NLSQ solver is not wired up yet.",
+                    }
+                    self.edited.emit()
                 return
             except Exception as exc:
                 self._result.setText(f"NLSQ failed: {exc}")
+                # Discarded if state moved on while this fit was running
+                # (see revision_at_start above); otherwise a prior
+                # successful nlsq_result must NOT survive a failed re-fit --
+                # is_ready() reads nlsq_result live, so leaving the old
+                # success dict in place would let the wizard advance to
+                # NUTS (warm-starting from stale params) while the screen
+                # plainly says the current attempt failed. A first-ever
+                # failure (nlsq_result already None) needs no change --
+                # is_ready() already reads that as not-ready.
+                if (
+                    self._state.revision == revision_at_start
+                    and self._state.nlsq_result is not None
+                ):
+                    self._state.nlsq_result = {"success": False, "message": str(exc)}
+                    self.edited.emit()
+                return
+            if self._state.revision != revision_at_start:
+                # State was invalidated (model/protocol/data changed) while
+                # this fit was running in the nested event loop -- the
+                # result belongs to a selection that no longer applies.
                 return
             # Normalize to dict: ModelService.fit() returns FitResult (dataclass), fakes return dict
             if isinstance(res, dict):

--- a/rheojax/gui/workspace/fit/step4_nuts.py
+++ b/rheojax/gui/workspace/fit/step4_nuts.py
@@ -217,6 +217,14 @@ class NutsStep(QWidget):
         self._target.setValue(v)
 
     def skip(self) -> None:
+        if not self._run_btn.isEnabled():
+            # A run is in flight (see run()'s busy-guard) -- skipping now
+            # would set nuts_result=None and emit finished immediately, then
+            # the still-running sample_fn would later resume and overwrite
+            # nuts_result with the real result plus a second finished
+            # emission, silently un-skipping what the user believed was
+            # skipped.
+            return
         self._skipped = True
         self._state.nuts_result = None
         self.edited.emit()
@@ -240,27 +248,56 @@ class NutsStep(QWidget):
         priors = {
             name: adapt_prior(entry) for name, entry in edited_priors.items()
         } or self.suggested_priors()
+        # Guard against re-entrant clicks: _sample_fn pumps a nested event
+        # loop (see fit_controller._run_on_thread) while staying responsive,
+        # so both buttons must be disabled for the duration -- otherwise a
+        # second Sample click (or a Skip click) mid-run collides with this
+        # run on the same active_jobs tracking entry and/or silently
+        # overwrites/un-skips nuts_result once one of the two calls
+        # completes. Mirrors NlsqStep.run()'s identical guard.
+        self._run_btn.setEnabled(False)
+        self._skip_btn.setEnabled(False)
+        # See NlsqStep.run()'s matching comment: discard a result that no
+        # longer corresponds to the current selection if state moved on
+        # while this run was in flight.
+        revision_at_start = self._state.revision
         try:
-            result = self._sample_fn(priors, warm_start, cfg)
-        except NotImplementedError:
-            # ponytail: real sampler wiring is out of scope here (tracked separately);
-            # this guard only keeps an unwired Sample button from crashing the Qt slot.
-            self._result.setText("NUTS sampler is not wired up yet.")
-            return
-        except Exception as exc:
-            self._result.setText(f"NUTS failed: {exc}")
-            return
-        verdict = _diagnostics_verdict(result)
-        result["verdict"] = verdict
-        self._state.nuts_result = result
-        status = (
-            "✓ converged"
-            if verdict["converged"]
-            else "⚠ " + "; ".join(verdict["reasons"])
-        )
-        self._result.setText(status)
-        self.edited.emit()
-        self.finished.emit()
+            try:
+                result = self._sample_fn(priors, warm_start, cfg)
+            except NotImplementedError:
+                # ponytail: real sampler wiring is out of scope here (tracked separately);
+                # this guard only keeps an unwired Sample button from crashing the Qt slot.
+                self._result.setText("NUTS sampler is not wired up yet.")
+                if self._state.revision == revision_at_start:
+                    self._state.nuts_result = None
+                    self.edited.emit()
+                return
+            except Exception as exc:
+                self._result.setText(f"NUTS failed: {exc}")
+                # A prior successful nuts_result must not survive a failed
+                # re-run -- is_ready() reads nuts_result live, so leaving
+                # the old result in place would misrepresent this run as
+                # having succeeded.
+                if self._state.revision == revision_at_start:
+                    self._state.nuts_result = None
+                    self.edited.emit()
+                return
+            if self._state.revision != revision_at_start:
+                return
+            verdict = _diagnostics_verdict(result)
+            result["verdict"] = verdict
+            self._state.nuts_result = result
+            status = (
+                "✓ converged"
+                if verdict["converged"]
+                else "⚠ " + "; ".join(verdict["reasons"])
+            )
+            self._result.setText(status)
+            self.edited.emit()
+            self.finished.emit()
+        finally:
+            self._run_btn.setEnabled(True)
+            self._skip_btn.setEnabled(True)
 
     def is_ready(self) -> bool:
         return self._skipped or self._state.nuts_result is not None

--- a/rheojax/gui/workspace/fit/step6_export.py
+++ b/rheojax/gui/workspace/fit/step6_export.py
@@ -51,7 +51,13 @@ class ExportStep(QWidget):
             return
         try:
             self.export_bundle(Path(chosen))
-        except OSError as exc:
+        except Exception as exc:
+            # ExportService wraps most of its own failures as RuntimeError
+            # ("Export failed: ..."), but export_posterior_netcdf() (used
+            # for the NUTS branch below) has no such wrapper -- a malformed/
+            # empty posterior_samples dict can raise ValueError/TypeError
+            # straight from arviz.from_dict()/to_netcdf() uncaught. An
+            # OSError-only catch here let both of those escape this Qt slot.
             self._export_status.setText(f"Export failed: {exc}")
             return
         self._export_status.setText(f"Exported to {Path(chosen)}")
@@ -61,7 +67,17 @@ class ExportStep(QWidget):
         # writer (VisualizeStep's canvases are pyqtgraph, not matplotlib
         # Figures export_service.export_figure() expects); add it back only
         # once that's actually wired.
-        items = ["parameters", "fitted_curve", "provenance"]
+        items = ["parameters"]
+        # Must match export_bundle()'s own x/y_fit presence check below --
+        # promising "fitted_curve" unconditionally (regardless of whether
+        # nlsq_result actually carries x/y_fit) meant a caller trusting this
+        # manifest as a preview would expect a file export_bundle() never
+        # wrote, exactly the promise-vs-write mismatch already fixed below
+        # for "diagnostics".
+        result = self._state.nlsq_result or {}
+        if result.get("x") is not None and result.get("y_fit") is not None:
+            items.append("fitted_curve")
+        items.append("provenance")
         if self._state.nuts_result is not None:
             items += ["posterior_samples", "diagnostics"]
         return items

--- a/rheojax/gui/workspace/fit/step6_export.py
+++ b/rheojax/gui/workspace/fit/step6_export.py
@@ -14,6 +14,9 @@ from rheojax.gui.foundation.state import FitState
 from rheojax.gui.resources.styles.tokens import field_label_style
 from rheojax.gui.services.export_service import ExportService
 from rheojax.gui.utils.layout_helpers import set_panel_margins
+from rheojax.logging import get_logger
+
+logger = get_logger(__name__)
 
 
 class ExportStep(QWidget):
@@ -51,13 +54,19 @@ class ExportStep(QWidget):
             return
         try:
             self.export_bundle(Path(chosen))
-        except Exception as exc:
+        except (OSError, ValueError, TypeError, RuntimeError) as exc:
             # ExportService wraps most of its own failures as RuntimeError
             # ("Export failed: ..."), but export_posterior_netcdf() (used
             # for the NUTS branch below) has no such wrapper -- a malformed/
             # empty posterior_samples dict can raise ValueError/TypeError
             # straight from arviz.from_dict()/to_netcdf() uncaught. An
             # OSError-only catch here let both of those escape this Qt slot.
+            # Named to these four (not a bare Exception) so an actual
+            # programming bug elsewhere in export_bundle() -- AttributeError,
+            # KeyError from a typo -- still surfaces loudly instead of being
+            # reported identically to a legitimate "your data is malformed"
+            # failure; exc_info logs it either way for post-mortem digging.
+            logger.error("Export failed", exc_info=True)
             self._export_status.setText(f"Export failed: {exc}")
             return
         self._export_status.setText(f"Exported to {Path(chosen)}")

--- a/rheojax/gui/workspace/window.py
+++ b/rheojax/gui/workspace/window.py
@@ -1018,13 +1018,18 @@ class WorkspaceWindow(QMainWindow):
         # or Pipeline batch job reads a dataset's payload via
         # library.load_payload() from a worker thread. Deleting the dataset
         # out from under that read would pop the payload mid-job instead of
-        # failing cleanly, so check ActiveJobsState (keyed by dataset id)
-        # before offering the confirm-delete prompt at all.
-        # NOTE: This guard only covers by_id entries keyed by dataset id; a
-        # future producer reading payload on a worker thread while registering
-        # under a different key (e.g. job id) would silently bypass this check.
+        # failing cleanly, so check ActiveJobsState before offering the
+        # confirm-delete prompt at all.
+        # fit_controller.py's NLSQ/NUTS jobs key by "{dataset_id}:nlsq" /
+        # "{dataset_id}:nuts" (not the bare dataset id, so two concurrent
+        # jobs on the same dataset don't clobber each other's active_jobs
+        # entry) -- match both the bare key (other producers, e.g. Pipeline
+        # batch jobs) and the ":"-suffixed form.
         with self._state.active_jobs.lock:
-            has_active_job = dataset_id in self._state.active_jobs.by_id
+            has_active_job = any(
+                key == dataset_id or key.startswith(f"{dataset_id}:")
+                for key in self._state.active_jobs.by_id
+            )
         if has_active_job:
             QMessageBox.warning(
                 self,

--- a/rheojax/models/multimode/generalized_maxwell.py
+++ b/rheojax/models/multimode/generalized_maxwell.py
@@ -37,7 +37,10 @@ from rheojax.core.jax_config import safe_import_jax
 from rheojax.core.registry import ModelRegistry
 from rheojax.core.test_modes import TestMode
 from rheojax.logging import get_logger, log_fit
-from rheojax.utils.optimization import OptimizationResult
+from rheojax.utils.optimization import (
+    OptimizationResult,
+    compute_covariance_from_jacobian,
+)
 from rheojax.utils.prony import (
     compute_r_squared,
     create_prony_parameter_set,
@@ -167,6 +170,16 @@ class GeneralizedMaxwell(BaseModel):
             raise ValueError("test_mode must be specified for GMM fitting")
 
         self._test_mode = test_mode
+        # Stashed here (single dispatch point, mirroring the existing
+        # _current_y_data pattern each _fit_*_mode method sets for itself)
+        # rather than threaded through every _fit_*_mode -> _nlsq_fit call
+        # site individually. Without this, GMM's custom _nlsq_fit() (which
+        # calls nlsq.LeastSquares().least_squares() directly, unlike models
+        # routed through the shared _standard_nlsq_fit()) silently dropped
+        # the GUI's progress_callback kwarg -- the progress bar never
+        # animated during a real GMM fit despite the optimizer running
+        # multiple real iterations.
+        self._current_callback = kwargs.get("callback")
 
         with log_fit(
             logger,
@@ -271,6 +284,7 @@ class GeneralizedMaxwell(BaseModel):
         )
 
         ls = nlsq.LeastSquares()
+        callback = getattr(self, "_current_callback", None)
 
         try:
             # nlsq.LeastSquares.least_squares is annotated -> dict[str, Any] but
@@ -288,6 +302,7 @@ class GeneralizedMaxwell(BaseModel):
                     gtol=gtol,
                     max_nfev=max_nfev,
                     verbose=0,
+                    callback=callback,
                 ),
             )
         except ValueError as e:
@@ -343,6 +358,17 @@ class GeneralizedMaxwell(BaseModel):
             nlsq_result=nlsq_result,
             residuals=_final_res,
         )
+
+        # Unlike models routed through the shared _standard_nlsq_fit()
+        # (which always attaches pcov via this same helper), this custom
+        # path built its own OptimizationResult and never computed
+        # covariance -- pcov/uncertainties stayed None for every GMM fit,
+        # even a clean converged one where the Jacobian (already computed
+        # above) makes it directly computable.
+        if result.jac is not None and result.residuals is not None:
+            result.pcov = compute_covariance_from_jacobian(
+                result.jac, result.residuals
+            )
 
         # Prefer the explicit y_data argument; fall back to one stashed on
         # the objective itself by the caller, then on self (set by the
@@ -849,10 +875,35 @@ class GeneralizedMaxwell(BaseModel):
             # Build slimmed-down NLSQ result for the optimal model
             slim_x = np.concatenate([[E_inf_opt], E_i_opt, tau_i_opt])
             optimal_result = fit_results[n_optimal]["result"]
+            # optimal_result.jac is shaped for the PADDED (n_max-sized)
+            # parameter vector, not slim_x -- can't reuse it as-is (that's
+            # why jac/pcov were previously always dropped here, even though
+            # optimal_result.pcov itself is populated for the padded fit).
+            # Slice to the same active-parameter columns already used above
+            # to extract E_inf_opt/E_i_opt/tau_i_opt from the padded result,
+            # so the sliced Jacobian's columns line up with slim_x exactly.
+            active_cols = (
+                [0]
+                + list(range(1, 1 + n_optimal))
+                + list(range(1 + n_max, 1 + n_max + n_optimal))
+            )
+            optimal_jac = getattr(optimal_result, "jac", None)
+            slim_jac = (
+                np.asarray(optimal_jac)[:, active_cols]
+                if optimal_jac is not None
+                else None
+            )
+            slim_residuals = getattr(optimal_result, "residuals", None)
+            slim_pcov = (
+                compute_covariance_from_jacobian(slim_jac, slim_residuals)
+                if slim_jac is not None
+                else None
+            )
             self._nlsq_result = OptimizationResult(
                 x=slim_x,
                 fun=optimal_result.fun,
-                jac=None,
+                jac=slim_jac,
+                pcov=slim_pcov,
                 success=optimal_result.success,
                 message=optimal_result.message,
                 nit=optimal_result.nit,
@@ -865,7 +916,7 @@ class GeneralizedMaxwell(BaseModel):
                 nlsq_result=optimal_result.nlsq_result,
                 # OPT-YDATA-001: forward y_data so r_squared is computable on
                 # the slimmed (post-element-minimization) result too.
-                residuals=getattr(optimal_result, "residuals", None),
+                residuals=slim_residuals,
                 y_data=getattr(optimal_result, "y_data", None),
                 n_data=getattr(optimal_result, "n_data", None),
             )

--- a/tests/gui/test_widget_cleanup_on_destroy.py
+++ b/tests/gui/test_widget_cleanup_on_destroy.py
@@ -11,6 +11,7 @@ import pytest
 
 pytest.importorskip("PySide6")
 
+from rheojax.gui.widgets.base_arviz_widget import BaseArviZWidget
 from rheojax.gui.widgets.residuals_panel import ResidualsPanel
 
 
@@ -20,6 +21,21 @@ def test_residuals_panel_cleanup_fires_on_destroy_without_close(qtbot):
     panel.cleanup = lambda: calls.append(True)
 
     panel.deleteLater()
+    qtbot.wait(50)
+
+    assert calls, "cleanup() was not called when the widget was destroyed without close()"
+
+
+def test_base_arviz_widget_cleanup_fires_on_destroy_without_close(qtbot):
+    # Same class of bug as above, for the widget step5_visualize.py's
+    # Diagnostics tab actually builds 8 of per NUTS run (ArvizCanvas
+    # subclasses BaseArviZWidget) -- _remove_diagnostics_tab() tears its
+    # container down via deleteLater() cascade, not .close().
+    widget = BaseArviZWidget()
+    calls = []
+    widget.cleanup = lambda: calls.append(True)
+
+    widget.deleteLater()
     qtbot.wait(50)
 
     assert calls, "cleanup() was not called when the widget was destroyed without close()"

--- a/tests/gui/workspace/fit/test_step3_wiring.py
+++ b/tests/gui/workspace/fit/test_step3_wiring.py
@@ -98,7 +98,6 @@ def test_build_fit_controller_injects_real_fit_and_sample_fn(monkeypatch, qtbot)
     nlsq_step = bodies[2]
     nlsq_step.run()
     assert calls["fit"] == ("power_law", {"n_modes": 2})
-    assert app.fit.nlsq_result["r_squared"] == 0.9
     # Regression: fit_fn hardcoded test_mode=None, which (via ModelService's
     # data.metadata.get("test_mode", "oscillation") fallback on a never-
     # forwarded, empty metadata dict) always ran real fits as "oscillation"
@@ -126,6 +125,100 @@ def test_build_fit_controller_injects_real_fit_and_sample_fn(monkeypatch, qtbot)
     # reconstructed with constructor defaults for NUTS only.
     assert calls["sample"][2] == {"n_modes": 2}
     assert calls["sample_test_mode"] == "flow_curve"
+    assert app.fit.nuts_result["r_hat"] == {"a": 1.0}
+
+
+def test_nlsq_and_nuts_jobs_use_distinct_active_jobs_keys(monkeypatch, qtbot):
+    # Regression: both used to register under the bare data_ref, so a
+    # concurrent NLSQ re-run and NUTS run on the same dataset would
+    # clobber each other's active_jobs.by_id entry, orphaning one job's
+    # cancellation token from window.py's Close/New/Open cancel dialog.
+    seen_keys_during_fit = []
+    seen_keys_during_sample = []
+
+    def fake_run_fit_isolated(
+        model_name,
+        x_data,
+        y_data,
+        test_mode,
+        initial_params,
+        options,
+        progress_queue,
+        cancel_event,
+        y2_data=None,
+        metadata=None,
+        dataset_id="",
+        model_config=None,
+    ):
+        seen_keys_during_fit.extend(app.active_jobs.by_id.keys())
+        return {"params": {"a": 1.0}, "r_squared": 0.9, "success": True}
+
+    def fake_run_bayesian_isolated(
+        model_name,
+        x_data,
+        y_data,
+        test_mode,
+        num_warmup,
+        num_samples,
+        num_chains,
+        warm_start,
+        priors,
+        seed,
+        progress_queue,
+        cancel_event,
+        y2_data=None,
+        metadata=None,
+        fitted_model_state=None,
+        dataset_id="",
+        target_accept=0.8,
+        model_config=None,
+        max_tree_depth=None,
+    ):
+        seen_keys_during_sample.extend(app.active_jobs.by_id.keys())
+        return {"posterior_samples": {"a": [1.0, 1.1]}, "r_hat": {"a": 1.0}}
+
+    monkeypatch.setattr(
+        "rheojax.gui.workspace.fit.fit_controller.run_fit_isolated",
+        fake_run_fit_isolated,
+    )
+    monkeypatch.setattr(
+        "rheojax.gui.workspace.fit.fit_controller.run_bayesian_isolated",
+        fake_run_bayesian_isolated,
+    )
+
+    app = AppState()
+    app.library.add(
+        DatasetRef(
+            id="d1",
+            name="d1",
+            protocol_type="flow_curve",
+            origin="imported",
+            units={},
+            row_count=2,
+            hash="h",
+            provenance={},
+            lineage=[],
+        )
+    )
+    app.library.store_payload("d1", _RheoData([1.0, 2.0], [1.0, 2.0]))
+    app.fit.protocol = "flow_curve"
+    app.fit.model_key = "power_law"
+    app.fit.data_ref = "d1"
+    app.fit.column_map = {"x": 0, "y": 1}
+
+    ctl, bodies = build_fit_controller(app)
+    nlsq_step, nuts_step = bodies[2], bodies[3]
+    nlsq_step.run()
+    nuts_step.run()
+
+    assert seen_keys_during_fit == ["d1:nlsq"]
+    assert seen_keys_during_sample == ["d1:nuts"]
+    # Neither job's key should be the bare dataset id (the collision).
+    assert "d1" not in seen_keys_during_fit
+    assert "d1" not in seen_keys_during_sample
+    # Both entries must be popped once their (fake, synchronous) runs finish.
+    assert app.active_jobs.by_id == {}
+    assert app.fit.nlsq_result["r_squared"] == 0.9
     assert app.fit.nuts_result["r_hat"] == {"a": 1.0}
 
 


### PR DESCRIPTION
## Summary

A 30-agent workflow (architecture map, 7 per-stage code reviews, 2 real end-to-end runtime traces, all adversarially verified) audited the GUI fit wizard (steps 1-6 + `fit_controller.py`) end-to-end and confirmed 17 findings, consolidated to 15 distinct bugs. All fixed.

### Critical
- **Active-jobs key collision** — NLSQ and NUTS jobs both registered under `active_jobs.by_id[data_ref]`; a concurrent run silently clobbered the other's cancellation token, invisible to the Cancel dialog. Now keyed `"{data_ref}:nlsq"` / `"{data_ref}:nuts"`; `window.py`'s dataset-delete guard updated to prefix-match. `NutsStep` also gained the busy-guard `NlsqStep` already had.
- **Failed re-fit leaves stale success state** — exception handlers in `step3_nlsq.py`/`step4_nuts.py` never cleared a prior successful result, so `is_ready()` kept reporting success and the wizard let the user advance to NUTS off stale params while the screen said "failed".
- **Stale async fit result overwrite** — the nested `QEventLoop` lets the user navigate away/edit Step 1 mid-fit; the async result now checks `FitState.revision` and discards itself if state moved on.
- **Unguarded model-config crash** — an out-of-range constructor value (e.g. `N_y=1`) could raise inside `_refresh_preview()` *after* the bad config was already committed to shared state, skipping the invalidation cascade with no visible error.
- **ArviZ diagnostics tab teardown skips cleanup()** — reproduces the `FT_Render_Glyph` crash class already fixed for `ResidualsPanel` (PR #48/#52); same `destroyed.connect(cleanup)` fix applied.
- **CLI import drops y_units** — `rheojax-gui --import` never copied `y_units` into `DatasetRef.units`, so PR #82's stress/viscosity mismatch guard could never fire for CLI-imported datasets.

### Important
- Stale quantity-mismatch guard label never cleared due to a cascade-order gate.
- `export_bundle()`'s exception handling was `OSError`-only; broadened to catch real `ExportService` failure modes.
- Added a model-agnostic low-R² warning to `ModelService.fit()` (previously only GMM had one, for a narrower case).
- `GeneralizedMaxwell`'s custom NLSQ path silently dropped the GUI progress callback and never computed `pcov`, even on a clean converged fit — both fixed.

### Minor
- Multi-start restart loop now checks `cancel_event` between restarts.
- `bundle_manifest()`/`export_bundle()` `fitted_curve` promise-vs-write mismatch fixed.
- `num_iterations` fallback fixed (`dict.get()` default never applied since the key was always present as `None`).
- `column_map` dead-plumbing documented (matches existing `FitState.control_vars` precedent).

## Test plan
- [x] `uv run ruff check` on all touched files — clean
- [x] `uv run pytest tests/gui/ tests/models/multimode/` — 974 passed (~24 min)
- [x] Two existing tests needed updating for the refined stale-result-clearing behavior (only overwrite when a prior result existed, not turn a fresh `None` into `{"success": False}` on a first-ever failure) — both now pass
- [x] Added regression tests: `active_jobs` key non-collision (`test_step3_wiring.py`), `BaseArviZWidget`'s `destroyed`→`cleanup` wiring (`test_widget_cleanup_on_destroy.py`)
- [x] #10/#11 (GMM callback/pcov) independently verified via direct reproduction matching the audit's own repro script

🤖 Generated with [Claude Code](https://claude.com/claude-code)