### PR TITLE
fix(gui): resolve e2e-audit findings across data loading, fitting, visualization

### DIFF
--- a/rheojax/gui/dialogs/column_mapper.py
+++ b/rheojax/gui/dialogs/column_mapper.py
@@ -337,10 +337,17 @@ class ColumnMapperDialog(QDialog):
         y2_patterns = ["g''", "gpp", "loss"]
         temp_patterns = ["temp", "temperature"]
 
+        claimed: set[str] = set()
+
         def find_match(combo: QComboBox, patterns: list[str]) -> bool:
-            """Find best match for column."""
+            """Find best match for column, skipping columns already claimed
+            by another field (e.g. "stress" matches both x and y patterns
+            for a "shear stress" column, so a field claimed by an earlier
+            call must not be re-matched by a later one)."""
             for i in range(combo.count()):
                 text = combo.itemText(i).lower()
+                if text in claimed:
+                    continue
                 for pattern in patterns:
                     # Alphanumeric boundaries (not \b): \b fails after symbolic
                     # modulus patterns like g', g'', g* whose last char is non-word,
@@ -349,12 +356,15 @@ class ColumnMapperDialog(QDialog):
                         r"(?<![a-z0-9])" + re.escape(pattern) + r"(?![a-z0-9])", text
                     ):
                         combo.setCurrentIndex(i)
+                        claimed.add(text)
                         return True
             return False
 
+        # y2 claims before y: "g''" is a substring pattern-space neighbor of
+        # "g'", so G'' must be claimed by y2 before y is matched against it.
         x_found = find_match(self.x_combo, x_patterns)
-        y_found = find_match(self.y_combo, y_patterns)
         y2_found = find_match(self.y2_combo, y2_patterns)
+        y_found = find_match(self.y_combo, y_patterns)
         temp_found = find_match(self.temp_combo, temp_patterns)
 
         logger.debug(

--- a/rheojax/gui/services/bayesian_service.py
+++ b/rheojax/gui/services/bayesian_service.py
@@ -16,6 +16,7 @@ import numpy as np
 from rheojax.core.arviz_utils import inference_data_from_dict
 from rheojax.core.data import RheoData
 from rheojax.core.registry import Registry
+from rheojax.gui.jobs.cancellation import CancellationError
 from rheojax.gui.services.model_service import normalize_model_name
 from rheojax.gui.state.store import BayesianResult, DatasetState
 from rheojax.gui.utils.rheodata import rheodata_from_dataset_state
@@ -371,6 +372,11 @@ class BayesianService:
                 diagnostics_valid=bool(diagnostics.get("diagnostics_valid", True)),
             )
 
+        except CancellationError:
+            # Re-raise instead of wrapping into RuntimeError below: the
+            # caller (run_bayesian_isolated/step4_nuts) needs to distinguish
+            # "the user cancelled" from "sampling errored out".
+            raise
         except Exception as e:
             logger.error(
                 f"MCMC failed for {model_name}: {e}",

--- a/rheojax/gui/services/data_service.py
+++ b/rheojax/gui/services/data_service.py
@@ -1234,7 +1234,10 @@ class DataService:
         suffix = file_path.suffix.lower()
         try:
             if suffix in {".csv", ".txt", ".dat", ".tsv"}:
-                df = pd.read_csv(str(file_path), nrows=200, comment="#")
+                delimiter = detect_csv_delimiter(file_path)
+                df = pd.read_csv(
+                    str(file_path), sep=delimiter, nrows=200, comment="#"
+                )
             elif suffix in {".xlsx", ".xls"}:
                 df = pd.read_excel(str(file_path), nrows=200)
             else:

--- a/rheojax/gui/services/model_service.py
+++ b/rheojax/gui/services/model_service.py
@@ -17,6 +17,7 @@ import numpy as np
 
 from rheojax.core.data import RheoData
 from rheojax.core.registry import Registry
+from rheojax.gui.jobs.cancellation import CancellationError
 from rheojax.gui.state.store import FitResult
 from rheojax.logging import get_logger
 from rheojax.utils.compatibility import check_model_compatibility
@@ -1121,6 +1122,12 @@ class ModelService:
                 metadata=metadata,
             )
 
+        except CancellationError:
+            # Re-raise instead of falling into the broad except below: the
+            # caller (run_fit_isolated/step3_nlsq) needs to distinguish "the
+            # user cancelled" from "the fit errored out" -- collapsing both
+            # into FitResult(success=False) shows a misleading error chip.
+            raise
         except Exception as e:
             logger.error(
                 "Fit failed",

--- a/rheojax/gui/widgets/plot_canvas.py
+++ b/rheojax/gui/widgets/plot_canvas.py
@@ -93,6 +93,13 @@ class PlotCanvas(QWidget):
         # Annotation for tooltips
         self._annotation = None
 
+        # closeEvent() never fires when this widget is torn down via Qt's
+        # parent-cascade delete (e.g. as a child in a tab widget) instead of
+        # being closed directly -- the same deferred-draw_idle()-on-freed-
+        # canvas crash class fixed for ResidualsPanel/BaseArviZWidget
+        # (PR #48, PR #83). Wire destroyed the same way for symmetry.
+        self.destroyed.connect(lambda: self.cleanup())
+
         logger.debug(
             "Initialization complete",
             class_name=self.__class__.__name__,

--- a/rheojax/gui/widgets/pyqtgraph_canvas.py
+++ b/rheojax/gui/widgets/pyqtgraph_canvas.py
@@ -184,6 +184,11 @@ class PyQtGraphCanvas(QWidget):
         self._scale_combo.set_items_safely(["Log-Log", "Lin-Lin", "Log-Lin", "Lin-Log"])
         self._scale_combo.currentTextChanged.connect(self._on_scale_changed)
         layout.addWidget(self._scale_combo)
+        # set_items_safely() populates the combo (defaulting to "Log-Log")
+        # before currentTextChanged is connected above, so that initial
+        # selection never actually applied setLogMode -- the plot stayed
+        # lin-lin while the combo claimed log-log. Sync once, explicitly.
+        self._on_scale_changed(self._scale_combo.currentText())
 
         # Auto-range button
         auto_btn = QPushButton("Auto Range")

--- a/rheojax/gui/workspace/fit/step3_nlsq.py
+++ b/rheojax/gui/workspace/fit/step3_nlsq.py
@@ -16,6 +16,7 @@ from PySide6.QtWidgets import (
 
 from rheojax.core.registry import ModelRegistry
 from rheojax.gui.foundation.state import FitState
+from rheojax.gui.jobs.cancellation import CancellationError
 from rheojax.gui.state.store import ParameterState
 from rheojax.gui.utils.layout_helpers import set_panel_margins
 from rheojax.gui.widgets.parameter_table import ParameterTable
@@ -200,6 +201,14 @@ class NlsqStep(QWidget):
                         "message": "NLSQ solver is not wired up yet.",
                     }
                     self.edited.emit()
+                return
+            except CancellationError:
+                # A user-initiated cancel is not a fit failure -- show a
+                # clean cancelled state and leave a stale successful result
+                # in place untouched (unlike a real failure, cancelling
+                # doesn't invalidate a prior success the user hasn't acted
+                # on yet).
+                self._result.setText("Cancelled.")
                 return
             except Exception as exc:
                 self._result.setText(f"NLSQ failed: {exc}")

--- a/rheojax/gui/workspace/fit/step4_nuts.py
+++ b/rheojax/gui/workspace/fit/step4_nuts.py
@@ -18,6 +18,7 @@ from PySide6.QtWidgets import (
 from rheojax.gui.foundation.metrics import bfmi
 from rheojax.gui.foundation.priors import adapt_prior, map_centered_priors
 from rheojax.gui.foundation.state import FitState
+from rheojax.gui.jobs.cancellation import CancellationError
 from rheojax.gui.utils.layout_helpers import set_panel_margins
 from rheojax.gui.widgets.priors_editor import PriorsEditor
 
@@ -271,6 +272,13 @@ class NutsStep(QWidget):
                 if self._state.revision == revision_at_start:
                     self._state.nuts_result = None
                     self.edited.emit()
+                return
+            except CancellationError:
+                # A user-initiated cancel is not a sampling failure -- show
+                # a clean cancelled state and leave a stale successful
+                # nuts_result untouched (mirrors NlsqStep.run()'s identical
+                # branch).
+                self._result.setText("Cancelled.")
                 return
             except Exception as exc:
                 self._result.setText(f"NUTS failed: {exc}")

--- a/rheojax/gui/workspace/fit/step5_visualize.py
+++ b/rheojax/gui/workspace/fit/step5_visualize.py
@@ -102,13 +102,19 @@ class VisualizeStep(QWidget):
         return "⚠ not-converged: " + "; ".join(verdict.get("reasons", []))
 
     def _refresh_overlay(self) -> None:
+        self._overlay.clear()
+        try:
+            self._refresh_overlay_impl()
+        except Exception:
+            logger.exception("Failed to refresh fit overlay")
+
+    def _refresh_overlay_impl(self) -> None:
         result = self._state.nlsq_result or {}
         x, y, y_fit = result.get("x"), result.get("y"), result.get("y_fit")
         if x is None or y is None:
             return
         x = np.asarray(x)
         y = np.asarray(y)
-        self._overlay.clear()
         # PyQtGraph rejects complex dtype arrays outright. Oscillation-mode
         # data/fits carry y = G' + i*G'' as a genuine complex array (see
         # RheoData.is_complex) -- split into separate real/imag traces
@@ -151,13 +157,17 @@ class VisualizeStep(QWidget):
                 self._overlay.plot_line(x, hi, name="Posterior hi", line_style="dash")
 
     def _refresh_residuals(self) -> None:
-        result = self._state.nlsq_result or {}
-        y, y_fit = result.get("y"), result.get("y_fit")
-        if y is None or y_fit is None:
-            return
-        self._residuals.plot_residuals(
-            np.asarray(y), np.asarray(y_fit), result.get("x")
-        )
+        self._residuals.clear()
+        try:
+            result = self._state.nlsq_result or {}
+            y, y_fit = result.get("y"), result.get("y_fit")
+            if y is None or y_fit is None:
+                return
+            self._residuals.plot_residuals(
+                np.asarray(y), np.asarray(y_fit), result.get("x")
+            )
+        except Exception:
+            logger.exception("Failed to refresh residuals")
 
     def _add_diagnostics_tab(self) -> None:
         page = QWidget(self)

--- a/rheojax/io/readers/csv_reader.py
+++ b/rheojax/io/readers/csv_reader.py
@@ -202,8 +202,15 @@ def load_csv(
 
     # Auto-detect comment preamble: if file starts with '#' lines and user
     # hasn't explicitly set a comment character, pass comment='#' to pandas.
+    # Skip this when the requested columns already carry a literal '#'
+    # prefix (e.g. auto-detected from a raw "#time,stress" header): that
+    # means the '#' is part of the header itself, not a preamble marker,
+    # and stripping it here would make usecols/header disagree.
     comment_char = kwargs.pop("comment", None)
-    if comment_char is None and header == 0:
+    has_hash_column = any(
+        isinstance(c, str) and c.startswith("#") for c in (usecols or [])
+    )
+    if comment_char is None and header == 0 and not has_hash_column:
         try:
             with open(filepath, encoding=default_encoding, errors="replace") as _f:
                 first_line = _f.readline()

--- a/tests/gui/services/test_data_service_temperature.py
+++ b/tests/gui/services/test_data_service_temperature.py
@@ -1,0 +1,19 @@
+"""Regression check: DataService._extract_scalar_temperature must detect
+the file's real delimiter, not assume comma."""
+
+from pathlib import Path
+
+from rheojax.gui.services.data_service import DataService
+
+
+def test_extract_scalar_temperature_tab_delimited(tmp_path: Path):
+    """A tab-delimited file collapses to one column under pandas' default
+    comma separator, so the temperature column lookup silently fails and
+    the metadata is dropped with no user-visible error.
+    """
+    tsv_path = tmp_path / "sweep.tsv"
+    tsv_path.write_text("omega\tGp\tGpp\tTemp\n1\t101\t11\t25.0\n2\t102\t12\t25.0\n")
+
+    value = DataService._extract_scalar_temperature(tsv_path, "Temp")
+
+    assert value == 25.0

--- a/tests/gui/test_column_mapper.py
+++ b/tests/gui/test_column_mapper.py
@@ -1,0 +1,44 @@
+"""Regression check: ColumnMapperDialog auto-detect never maps X and Y to
+the same column."""
+
+import os
+
+os.environ.setdefault("QT_QPA_PLATFORM", "offscreen")
+
+import pytest
+
+pytest.importorskip("PySide6")
+
+from PySide6.QtWidgets import QApplication
+
+from rheojax.gui.dialogs.column_mapper import ColumnMapperDialog
+
+
+@pytest.fixture(scope="module")
+def qapp():
+    """Ensure a QApplication exists."""
+    app = QApplication.instance()
+    if app is None:
+        app = QApplication([])
+    return app
+
+
+def test_auto_detect_does_not_map_x_and_y_to_same_column(qapp):
+    """A single ambiguous column (matches both an X pattern like "shear"
+    and a Y pattern like "stress") must be claimed by only one field --
+    previously both find_match() calls ran independently and could select
+    the identical column for X and Y. Populates the dialog's combos
+    directly (bypassing file I/O/delimiter sniffing) to isolate
+    _auto_detect() itself as the unit under test.
+    """
+    dialog = ColumnMapperDialog(file_path=None)
+    dialog.columns = ["shear stress"]
+    dialog.x_combo.set_items_safely(dialog.columns)
+    dialog.y_combo.set_items_safely(dialog.columns)
+    dialog.y2_combo.set_items_safely(dialog.columns)
+    dialog.temp_combo.set_items_safely(dialog.columns)
+
+    dialog._auto_detect()
+
+    assert dialog.x_combo.currentText() == "shear stress"
+    assert dialog.y_combo.currentText() != "shear stress"

--- a/tests/gui/workspace/fit/test_step3_wiring.py
+++ b/tests/gui/workspace/fit/test_step3_wiring.py
@@ -320,6 +320,30 @@ def test_nlsq_step_loads_parameter_table_and_passes_bounds(monkeypatch):
     assert ip["b"] == {"value": 2.0, "bounds": (0.0, 5.0), "fixed": True}
 
 
+def test_nlsq_step_run_shows_cancelled_not_failed_on_cancellation():
+    """A user cancel must render as "Cancelled.", not be swallowed by the
+    generic except Exception branch and shown as an NLSQ failure."""
+    from rheojax.gui.foundation.state import FitState
+    from rheojax.gui.jobs.cancellation import CancellationError
+    from rheojax.gui.workspace.fit.step3_nlsq import NlsqStep
+
+    def cancelling_fit_fn(
+        model_key,
+        model_config,
+        data_ref,
+        column_map,
+        initial_params=None,
+        multi_start=None,
+        options=None,
+    ):
+        raise CancellationError("Operation cancelled by user")
+
+    st = FitState(model_key="m", model_config={})
+    step = NlsqStep(st, fit_fn=cancelling_fit_fn)
+    step.run()
+    assert step._result.text() == "Cancelled."
+
+
 def test_multistart_forwards_config_to_fit_fn():
     from rheojax.gui.foundation.state import FitState
     from rheojax.gui.workspace.fit.step3_nlsq import NlsqStep

--- a/tests/gui/workspace/fit/test_step4.py
+++ b/tests/gui/workspace/fit/test_step4.py
@@ -41,6 +41,22 @@ def test_nuts_sampler_failure_is_reported_without_escaping_qt_slot(qtbot):
     assert "sampler failed" in step._result.text()
 
 
+def test_nuts_run_shows_cancelled_not_failed_on_cancellation(qtbot):
+    """A user cancel must render as "Cancelled.", not be swallowed by the
+    generic except Exception branch and shown as a NUTS failure."""
+    from rheojax.gui.jobs.cancellation import CancellationError
+
+    st = FitState(nlsq_result={"params": {"G0": 1000.0}})
+
+    def cancelled(*args, **kwargs):
+        raise CancellationError("Operation cancelled by user")
+
+    step = NutsStep(st, sample_fn=cancelled)
+    qtbot.addWidget(step)
+    step.run()
+    assert step._result.text() == "Cancelled."
+
+
 def test_reset_skip_clears_stale_skip_decision(qtbot):
     # Regression: skip() sets _skipped=True permanently. If NLSQ is later
     # re-run (invalidating nuts_result via the cascade), is_ready() must not

--- a/tests/gui/workspace/fit/test_step5.py
+++ b/tests/gui/workspace/fit/test_step5.py
@@ -27,6 +27,23 @@ def test_diagnostics_tab_added_by_refresh(qtbot):
     ]
 
 
+def test_refresh_clears_stale_overlay_and_residuals_on_failed_result(qtbot):
+    """A failed re-fit (nlsq_result with no x/y) must blank the overlay and
+    residuals canvases, not leave the previous successful fit's curve on
+    screen looking current."""
+    x = np.array([1.0, 2.0, 3.0])
+    y = np.array([10.0, 20.0, 30.0])
+    y_fit = np.array([11.0, 19.0, 31.0])
+    st = FitState(nlsq_result={"x": x, "y": y, "y_fit": y_fit, "success": True})
+    v = VisualizeStep(st)
+    qtbot.addWidget(v)
+    assert len(v._overlay._data_items) > 0
+
+    st.nlsq_result = {"success": False, "message": "failed"}
+    v.refresh()
+    assert v._overlay._data_items == []
+
+
 def test_diagnostics_builds_with_real_nuts_result(qtbot):
     # Shaped like the worker output: NlsqStep normalizes FitResult to a plain
     # dict (see step3_nlsq.py); by analogy the NUTS sample_fn wired in

--- a/tests/io/test_csv_detection.py
+++ b/tests/io/test_csv_detection.py
@@ -82,6 +82,21 @@ def test_load_csv_comment_preamble_autodetect(tmp_path: Path):
     np.testing.assert_allclose(data.y, [100.0, 200.0], rtol=1e-10)
 
 
+def test_load_csv_hash_prefixed_header_is_not_stripped_as_preamble(tmp_path: Path):
+    """A '#'-prefixed header row (numpy.savetxt style, e.g. "#time,stress")
+    is real column data, not a metadata preamble -- the auto-comment
+    detector must not enable comment='#' when the caller's usecols already
+    carry that literal '#' prefix, or pandas strips the very header row
+    usecols expects to find.
+    """
+    csv_path = tmp_path / "hashheader.csv"
+    csv_path.write_text("#time,stress\n0.1,100\n0.2,95\n")
+
+    data = auto_load(str(csv_path))
+    np.testing.assert_allclose(data.x, [0.1, 0.2], rtol=1e-10)
+    np.testing.assert_allclose(data.y, [100.0, 95.0], rtol=1e-10)
+
+
 def test_load_csv_semicolon_values(tmp_path: Path):
     """Test that column values are correctly extracted after delimiter detection."""
     csv_path = tmp_path / "simple.csv"


### PR DESCRIPTION
## Summary

Second GUI end-to-end audit pass (data loading / fitting / visualization), run as three parallel read-only finder agents against the code PR #83 left under-covered, followed by sequential fixes applied and verified in the main thread.

**Data loading**
- `csv_reader.py`: a `#`-prefixed header row (e.g. `numpy.savetxt` output) was being treated as a comment preamble and stripped, breaking `usecols` and raising a `ValueError` on import. Now skipped when the requested columns already carry a literal `#` prefix.
- `data_service.py`: `_extract_scalar_temperature()` read non-comma files (tab/semicolon-delimited) with the pandas default separator, silently collapsing every row into one column and dropping the temperature metadata with no user-visible error. Now detects the real delimiter first, like every other read path in the module.
- `column_mapper.py`: auto-detect could map X and Y to the *same* column (e.g. "shear stress" matches both an X pattern via "shear" and a Y pattern via "stress"). Now tracks claimed columns, mirroring `import_wizard.py`'s existing pattern.

**Fitting**
- `model_service.py` / `bayesian_service.py`: a user-cancelled NLSQ/NUTS run had its `CancellationError` swallowed by a broad `except Exception`, surfacing as `FitResult(success=False)` / `RuntimeError("MCMC failed: ...")` — Cancel looked like an error. Both now re-raise `CancellationError` past the broad except.
- `step3_nlsq.py` / `step4_nuts.py`: added an `except CancellationError` branch before the generic failure handler so a cancel renders "Cancelled." instead of "NLSQ/NUTS failed: ...". Covers the between-restarts cancel path too.
- Not fixed (documented, architectural): standard-model NLSQ never actually polls `cancel_event` (`nlsq_optimize` has no callback param) and NUTS sampling can't be interrupted mid-run (no subprocess to kill) — Cancel is now *reported* correctly but true interruption for these two paths needs routing through the existing `ProcessWorkerAdapter` or threading a callback into `nlsq_optimize`. Real design decision, not a one-line fix.

**Visualization**
- `step5_visualize.py`: `_refresh_overlay`/`_refresh_residuals` only cleared the canvas on the success path — a failed re-fit left the *previous* successful fit's curve/residuals on screen looking current. Now clears unconditionally, and both are wrapped in a try/except so a malformed result degrades gracefully instead of escaping the Qt slot.
- `pyqtgraph_canvas.py`: the scale combo defaulted to "Log-Log" but `currentTextChanged` was connected *after* the combo was populated, so the initial selection never actually called `setLogMode` — the plot stayed lin-lin while the UI claimed log-log. Now synced explicitly once after wiring.
- `plot_canvas.py`: missing the `destroyed → cleanup()` wiring already present on `ResidualsPanel`/`BaseArviZWidget` (PR #48/#83) — latent (currently unused widget) but would reproduce the FT_Render_Glyph crash class if ever embedded.
- Not fixed (documented, architectural): the Diagnostics tab renders 8 ArviZ figures synchronously on the GUI thread right when NUTS finishes — a multi-second UI freeze, not a crash. Left as a follow-up; a safe lazy-render fix is more invasive than this pass's risk budget.

## Test plan
- [x] `tests/gui/` + `tests/io/` full suite: 1409 passed, 0 failed (both before and after fixes)
- [x] `ruff check` clean on all touched files
- [x] New/updated regression tests: cancellation (NLSQ + NUTS), stale-overlay-clear, `#`-header CSV, tab-delimited temperature extraction, column-mapper collision
- [ ] Manual UI drive not performed (background job, offscreen Qt only) — static review + suite is the honest ceiling here

🤖 Generated with [Claude Code](https://claude.com/claude-code)