### PR TITLE
feat(deps): remove interpax, raise jax ceiling to unpinned

### DIFF
--- a/docs/tech-stack.md
+++ b/docs/tech-stack.md
@@ -26,7 +26,6 @@
 |---------|---------|---------|
 | **jax** | >=0.8.3 | Functional numerical computing (JIT, vmap, grad) |
 | **jaxlib** | >=0.8.3 | XLA compiler backend |
-| **interpax** | >=0.3.12 | JIT-safe interpolation (replaces scipy.interpolate) |
 | **diffrax** | >=0.7.1 | JAX-native ODE/SDE solver (Tsit5, Kvaerno5, etc.) |
 | **nlsq** | >=0.6.10 | GPU-accelerated non-linear least squares (imported before JAX) |
 | **optimistix** | (via diffrax) | Root-finding and optimization |

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -86,9 +86,13 @@ dependencies = [
     # JAX ecosystem (CPU-only - works on all platforms)
     # GPU users: see installation instructions above
     "jax>=0.8.3,<0.11.0",     # JAX 0.8.0+ for CUDA 12/13 support. numpyro's xla_pmap_p import
-                              # is now try/except-guarded (resolved). JAX 0.11.0 will change
-                              # jnp.empty to return uninitialized memory instead of zero-fill --
-                              # audit for reliance on zero-init before raising this ceiling.
+                              # is now try/except-guarded (resolved). Ceiling matches interpax's
+                              # own cap (interpax==0.3.14 depends on jax<0.11 -- confirmed via
+                              # `uv add jax==0.11.0` conflict trace, 2026-07-17); interpax has not
+                              # released jax-0.11 support yet, so this is a real, not redundant, cap.
+                              # rheojax's own code has zero jnp.empty call sites (host-side np.empty
+                              # only, all fully written before read), so 0.11.0's zero-fill removal
+                              # is a non-issue here once interpax unblocks.
     "jaxlib>=0.8.3,<0.11.0",  # jaxlib must match JAX version
 
     # JAX-compatible scientific computing (§2 Technical Guidelines)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -85,18 +85,15 @@ dependencies = [
 
     # JAX ecosystem (CPU-only - works on all platforms)
     # GPU users: see installation instructions above
-    "jax>=0.8.3,<0.11.0",     # JAX 0.8.0+ for CUDA 12/13 support. numpyro's xla_pmap_p import
-                              # is now try/except-guarded (resolved). Ceiling matches interpax's
-                              # own cap (interpax==0.3.14 depends on jax<0.11 -- confirmed via
-                              # `uv add jax==0.11.0` conflict trace, 2026-07-17); interpax has not
-                              # released jax-0.11 support yet, so this is a real, not redundant, cap.
-                              # rheojax's own code has zero jnp.empty call sites (host-side np.empty
-                              # only, all fully written before read), so 0.11.0's zero-fill removal
-                              # is a non-issue here once interpax unblocks.
-    "jaxlib>=0.8.3,<0.11.0",  # jaxlib must match JAX version
+    "jax>=0.8.3",     # JAX 0.8.0+ for CUDA 12/13 support. numpyro's xla_pmap_p import
+                      # is now try/except-guarded (resolved). Ceiling formerly capped at
+                      # <0.11.0 to match interpax's own jax<0.11 pin (2026-07-17); interpax
+                      # was replaced by rheojax.utils.jax_cubic_spline (pure-JAX cubic spline,
+                      # numerically validated against interpax/scipy to ~1e-8), which has no
+                      # jax version constraint, so the ceiling is no longer needed.
+    "jaxlib>=0.8.3",  # jaxlib must match JAX version
 
     # JAX-compatible scientific computing (§2 Technical Guidelines)
-    "interpax>=0.3.12",   # JIT-safe interpolation (replaces scipy.interpolate)
     "diffrax>=0.7.1",     # JAX-native ODE solver (replaces jax.experimental.ode)
 
     # Probabilistic programming

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -89,8 +89,8 @@ dependencies = [
                       # is now try/except-guarded (resolved). Ceiling formerly capped at
                       # <0.11.0 to match interpax's own jax<0.11 pin (2026-07-17); interpax
                       # was replaced by rheojax.utils.jax_cubic_spline (pure-JAX cubic spline,
-                      # numerically validated against interpax/scipy to ~1e-8), which has no
-                      # jax version constraint, so the ceiling is no longer needed.
+                      # see tests/utils/test_jax_cubic_spline.py for scipy-validated parity),
+                      # which has no jax version constraint, so the ceiling is no longer needed.
     "jaxlib>=0.8.3",  # jaxlib must match JAX version
 
     # JAX-compatible scientific computing (§2 Technical Guidelines)

--- a/rheojax/models/sgr/sgr_conventional.py
+++ b/rheojax/models/sgr/sgr_conventional.py
@@ -1656,9 +1656,8 @@ class SGRConventional(BaseModel):
         def vector_field(t_val, x_val, args):
             """ODE vector field: dx/dt = f(t, x)."""
             # Interpolate gamma_dot at current time t_val
-            # Use linear interpolation (jnp.interp is acceptable for
-            # piecewise-linear interpolation; interpax would be preferred
-            # for JIT-safe differentiable interpolation if imported).
+            # jnp.interp gives JIT-safe piecewise-linear interpolation,
+            # which is sufficient here (no need for a cubic spline).
             gamma_dot_current = jnp.interp(t_val, t_jax, gamma_dot_jax)
 
             # Compute x_ss at current shear rate using args, not self.parameters,

--- a/rheojax/transforms/fft_analysis.py
+++ b/rheojax/transforms/fft_analysis.py
@@ -8,7 +8,6 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING, Literal
 
-import interpax
 import numpy as np
 
 from rheojax.core.base import BaseTransform
@@ -244,7 +243,7 @@ class FFTAnalysis(BaseTransform):
             # Every step must be strictly positive: a majority-positive median
             # (e.g. one backward step buried in an otherwise increasing array)
             # would pass a median-only check yet still be non-monotonic, which
-            # feeds unsorted knots into interpax's interpolator below.
+            # feeds unsorted knots into the interpolation below.
             if np.any(dt_values <= 0):
                 raise ValueError(
                     "Time array must be strictly monotonically increasing for "
@@ -260,12 +259,11 @@ class FFTAnalysis(BaseTransform):
                 t_np = np.asarray(t)
                 y_np = np.asarray(y)
                 t_uniform = np.linspace(float(t_np[0]), float(t_np[-1]), n)
-                # R9-FFT-001: interpax.Interpolator1D (JIT-safe) replaces np.interp.
-                # extrap defaults to False (out-of-bounds -> nan, unlike np.interp's
-                # clamping), but np.linspace(start, stop, n) guarantees t_uniform[0]
-                # and t_uniform[-1] are bit-exact to t_np[0]/t_np[-1], so the strict
-                # </> bounds check in interpax never trips here.
-                y = interpax.Interpolator1D(t_np, y_np, method="linear")(t_uniform)
+                # R9-FFT-001: jnp.interp (JIT-safe) replaces np.interp for JAX
+                # compatibility. np.linspace(start, stop, n) guarantees
+                # t_uniform[0]/t_uniform[-1] are bit-exact to t_np[0]/t_np[-1],
+                # so jnp.interp's default out-of-bounds clamping never triggers.
+                y = jnp.interp(t_uniform, t_np, y_np)
                 t = jnp.array(t_uniform)
                 dt = float(t_uniform[1] - t_uniform[0])
             # R9-FFT-002: recompute n after resampling so rfftfreq and window

--- a/rheojax/transforms/smooth_derivative.py
+++ b/rheojax/transforms/smooth_derivative.py
@@ -154,7 +154,7 @@ class SmoothDerivative(BaseTransform):
                 "zero). Increase polyorder or lower deriv."
             )
 
-        # interpax CubicSpline is always degree-3, so any derivative order
+        # The cubic spline is always degree-3, so any derivative order
         # above 3 is identically zero.
         if self.method == "spline" and self.deriv > 3:
             raise ValueError(
@@ -314,7 +314,7 @@ class SmoothDerivative(BaseTransform):
         return dy_dx_sorted[unsort_idx]
 
     def _spline_derivative(self, x: JaxArray, y: JaxArray) -> JaxArray:
-        """Compute derivative using JIT-safe cubic splines via interpax.
+        """Compute derivative using JIT-safe cubic splines.
 
         Parameters
         ----------
@@ -328,22 +328,21 @@ class SmoothDerivative(BaseTransform):
         jnp.ndarray
             Derivative dy/dx
         """
-        from interpax import CubicSpline
+        from rheojax.utils.jax_cubic_spline import NotAKnotCubicSpline
 
         # Ensure JAX arrays
         x_jax = jnp.asarray(x)
         y_jax = jnp.asarray(y)
 
-        # Sort data if needed (interpax requires sorted x)
+        # Sort data if needed (spline requires sorted x)
         sort_idx = jnp.argsort(x_jax)
         x_sorted = x_jax[sort_idx]
         y_sorted = y_jax[sort_idx]
 
         # Fit cubic spline (JIT-compatible)
-        spline = CubicSpline(x_sorted, y_sorted)
+        spline = NotAKnotCubicSpline(x_sorted, y_sorted)
 
         # Compute derivative at original x points
-        # interpax splines have .derivative() method
         deriv_spline = spline.derivative(nu=self.deriv)
         dy_dx = deriv_spline(x_sorted)
 

--- a/rheojax/transforms/smooth_derivative.py
+++ b/rheojax/transforms/smooth_derivative.py
@@ -339,6 +339,19 @@ class SmoothDerivative(BaseTransform):
         x_sorted = x_jax[sort_idx]
         y_sorted = y_jax[sort_idx]
 
+        # R7-DERIV-006: Guard against duplicate/near-duplicate x (zero
+        # spacing), matching _savgol_derivative/_finite_diff_derivative.
+        # The spline's tridiagonal solve divides by spacing-derived terms
+        # and would otherwise silently produce NaN/Inf.
+        dx = np.diff(np.asarray(x_sorted))
+        if dx.size and np.any(np.abs(dx) < 1e-30):
+            raise ValueError(
+                "SmoothDerivative: spline method requires distinct x "
+                "values; data contains duplicate/near-duplicate x, which "
+                "causes division by zero. Remove duplicates before "
+                "computing derivatives."
+            )
+
         # Fit cubic spline (JIT-compatible)
         spline = NotAKnotCubicSpline(x_sorted, y_sorted)
 

--- a/rheojax/utils/jax_cubic_spline.py
+++ b/rheojax/utils/jax_cubic_spline.py
@@ -16,6 +16,19 @@ call site's output changes:
   system below is transcribed directly from
   ``scipy.interpolate._cubic.CubicSpline.__init__`` and solved with a JAX
   Thomas algorithm (O(n), not a dense O(n^3) solve).
+
+Numerically validated in ``tests/utils/test_jax_cubic_spline.py`` (random
+arrays, edge cases n=2/3, derivative orders 0-3, exact cubic reproduction)
+against ``scipy.interpolate.CubicSpline``/``CubicHermiteSpline`` -- interpax
+itself is no longer a dependency, so scipy is the committed oracle. Matches
+to ~1e-8 for values/1st derivatives, looser (~1e-4) for the noisier 3rd
+derivative.
+
+One deliberate behavioral difference from interpax: query points outside
+``[x[0], x[-1]]`` are cubically extrapolated here (clipped to the boundary
+segment), whereas interpax's default ``extrap=False`` returns NaN outside the
+domain. No current call site queries out-of-bounds points, so this is latent;
+a future caller relying on NaN-on-out-of-bounds should clamp/mask explicitly.
 """
 
 from rheojax.core.jax_config import safe_import_jax
@@ -28,6 +41,10 @@ def _thomas_solve(sub, diag, sup, rhs):
 
     ``sub[i]``/``sup[i]`` are the coefficients of ``x[i-1]``/``x[i+1]`` in
     row ``i``; ``sub[0]`` and ``sup[-1]`` are unused padding.
+
+    # ponytail: unpivoted (unlike scipy's solve_banded), valid for the
+    # diagonally-dominant systems well-conditioned monotone grids produce;
+    # add partial pivoting if ever fed extreme non-uniform spacing.
     """
     sup0 = sup[0] / diag[0]
     rhs0 = rhs[0] / diag[0]
@@ -58,10 +75,21 @@ def _thomas_solve(sub, diag, sup, rhs):
     return jnp.concatenate([x_rest_rev, x_last[None]])
 
 
+def _safe_slope(x, y):
+    """``diff(y)/diff(x)``, matching interpax's zero-spacing guard.
+
+    interpax's own ``_cubic1``/``_cubic2`` use
+    ``jnp.where(dx == 0, 0, 1/dx)`` rather than dividing directly, so a
+    duplicate x value yields a finite (zero) slope instead of inf/NaN.
+    """
+    dx = jnp.diff(x)
+    dxi = jnp.where(dx == 0, 0.0, 1.0 / dx)
+    return jnp.diff(y) * dxi
+
+
 def _local_cubic_slopes(x, y):
     """Node tangents matching interpax's ``_cubic1`` (centered secant average)."""
-    dx = jnp.diff(x)
-    slope = jnp.diff(y) / dx
+    slope = _safe_slope(x, y)
     interior = 0.5 * (slope[:-1] + slope[1:])
     return jnp.concatenate([slope[:1], interior, slope[-1:]])
 
@@ -75,7 +103,7 @@ def _not_a_knot_slopes(x, y):
     """
     n = x.shape[0]
     dx = jnp.diff(x)
-    slope = jnp.diff(y) / dx
+    slope = _safe_slope(x, y)
 
     if n == 2:
         return jnp.array([slope[0], slope[0]])
@@ -172,6 +200,16 @@ class NotAKnotCubicSpline:
     def __init__(self, x, y):
         self.x = jnp.asarray(x)
         self.y = jnp.asarray(y)
+        # Matches scipy.interpolate.CubicSpline: a duplicate/non-monotonic x
+        # makes the not-a-knot boundary rows singular (e.g. diag[0] = dx[1]
+        # is exactly zero for a duplicate at index 1), so reject upfront
+        # rather than silently returning NaN/Inf from a singular solve.
+        if not bool(jnp.all(jnp.diff(self.x) > 0)):
+            raise ValueError(
+                "NotAKnotCubicSpline requires strictly increasing x (no "
+                "duplicate or non-monotonic values); the not-a-knot system "
+                "is singular otherwise."
+            )
         self.s = _not_a_knot_slopes(self.x, self.y)
 
     def __call__(self, xq, nu=0):

--- a/rheojax/utils/jax_cubic_spline.py
+++ b/rheojax/utils/jax_cubic_spline.py
@@ -1,0 +1,192 @@
+"""Pure-JAX cubic spline interpolation, replacing interpax.
+
+interpax pins ``jax<0.11`` in its own dependencies (unreleased upstream fix as
+of 2026-07-17), which blocks raising rheojax's own jax ceiling. This module
+reproduces the exact numerics of the two interpax schemes rheojax used, so no
+call site's output changes:
+
+- :func:`local_cubic_eval` matches ``interpax.Interpolator1D(method="cubic")``
+  / ``interpax.interp1d(method="cubic")``: a C1 Catmull-Rom-style cubic
+  Hermite spline whose node tangents are the average of adjacent secant
+  slopes (see ``interpax._fd_derivs._cubic1``). No linear solve -- O(n)
+  closed form.
+- :class:`NotAKnotCubicSpline` matches ``interpax.CubicSpline`` (default
+  ``bc_type="not-a-knot"``), which is itself the same algorithm as
+  ``scipy.interpolate.CubicSpline(bc_type="not-a-knot")``. The tridiagonal
+  system below is transcribed directly from
+  ``scipy.interpolate._cubic.CubicSpline.__init__`` and solved with a JAX
+  Thomas algorithm (O(n), not a dense O(n^3) solve).
+"""
+
+from rheojax.core.jax_config import safe_import_jax
+
+jax, jnp = safe_import_jax()
+
+
+def _thomas_solve(sub, diag, sup, rhs):
+    """Solve a tridiagonal system via the Thomas algorithm.
+
+    ``sub[i]``/``sup[i]`` are the coefficients of ``x[i-1]``/``x[i+1]`` in
+    row ``i``; ``sub[0]`` and ``sup[-1]`` are unused padding.
+    """
+    sup0 = sup[0] / diag[0]
+    rhs0 = rhs[0] / diag[0]
+
+    def forward(carry, row):
+        sup_prev, rhs_prev = carry
+        sub_i, diag_i, sup_i, rhs_i = row
+        w = 1.0 / (diag_i - sub_i * sup_prev)
+        sup_star = sup_i * w
+        rhs_star = (rhs_i - sub_i * rhs_prev) * w
+        return (sup_star, rhs_star), (sup_star, rhs_star)
+
+    _, (sup_star_rest, rhs_star_rest) = jax.lax.scan(
+        forward, (sup0, rhs0), (sub[1:], diag[1:], sup[1:], rhs[1:])
+    )
+    sup_star = jnp.concatenate([sup0[None], sup_star_rest])
+    rhs_star = jnp.concatenate([rhs0[None], rhs_star_rest])
+
+    def backward(x_next, row):
+        sup_star_i, rhs_star_i = row
+        x_i = rhs_star_i - sup_star_i * x_next
+        return x_i, x_i
+
+    x_last = rhs_star[-1]
+    _, x_rest_rev = jax.lax.scan(
+        backward, x_last, (sup_star[:-1], rhs_star[:-1]), reverse=True
+    )
+    return jnp.concatenate([x_rest_rev, x_last[None]])
+
+
+def _local_cubic_slopes(x, y):
+    """Node tangents matching interpax's ``_cubic1`` (centered secant average)."""
+    dx = jnp.diff(x)
+    slope = jnp.diff(y) / dx
+    interior = 0.5 * (slope[:-1] + slope[1:])
+    return jnp.concatenate([slope[:1], interior, slope[-1:]])
+
+
+def _not_a_knot_slopes(x, y):
+    """Node slopes for the not-a-knot C2 cubic spline.
+
+    Transcribed from ``scipy.interpolate._cubic.CubicSpline.__init__``
+    (BSD-3-Clause), restricted to the ``bc_type="not-a-knot"`` (both ends)
+    case that interpax's ``CubicSpline`` default uses.
+    """
+    n = x.shape[0]
+    dx = jnp.diff(x)
+    slope = jnp.diff(y) / dx
+
+    if n == 2:
+        return jnp.array([slope[0], slope[0]])
+
+    if n == 3:
+        a = jnp.array(
+            [
+                [1.0, 1.0, 0.0],
+                [dx[1], 2 * (dx[0] + dx[1]), dx[0]],
+                [0.0, 1.0, 1.0],
+            ]
+        )
+        b = jnp.array(
+            [
+                2 * slope[0],
+                3 * (dx[0] * slope[1] + dx[1] * slope[0]),
+                2 * slope[1],
+            ]
+        )
+        return jnp.linalg.solve(a, b)
+
+    sub = jnp.zeros(n)
+    diag = jnp.zeros(n)
+    sup = jnp.zeros(n)
+    rhs = jnp.zeros(n)
+
+    sub = sub.at[1:-1].set(dx[1:])
+    diag = diag.at[1:-1].set(2 * (dx[:-1] + dx[1:]))
+    sup = sup.at[1:-1].set(dx[:-1])
+    rhs = rhs.at[1:-1].set(3 * (dx[1:] * slope[:-1] + dx[:-1] * slope[1:]))
+
+    d0 = x[2] - x[0]
+    diag = diag.at[0].set(dx[1])
+    sup = sup.at[0].set(d0)
+    rhs = rhs.at[0].set(
+        ((dx[0] + 2 * d0) * dx[1] * slope[0] + dx[0] ** 2 * slope[1]) / d0
+    )
+
+    dn = x[-1] - x[-3]
+    sub = sub.at[-1].set(dn)
+    diag = diag.at[-1].set(dx[-2])
+    rhs = rhs.at[-1].set(
+        (dx[-1] ** 2 * slope[-2] + (2 * dn + dx[-1]) * dx[-2] * slope[-1]) / dn
+    )
+
+    return _thomas_solve(sub, diag, sup, rhs)
+
+
+def _hermite_eval(x, y, s, xq, nu=0):
+    """Evaluate a cubic Hermite spline (or its ``nu``-th derivative) at ``xq``."""
+    n = x.shape[0]
+    idx = jnp.clip(jnp.searchsorted(x, xq, side="right") - 1, 0, n - 2)
+    x0, x1 = x[idx], x[idx + 1]
+    y0, y1 = y[idx], y[idx + 1]
+    m0, m1 = s[idx], s[idx + 1]
+    dx = x1 - x0
+    t = (xq - x0) / dx
+
+    if nu == 0:
+        h00 = 2 * t**3 - 3 * t**2 + 1
+        h10 = t**3 - 2 * t**2 + t
+        h01 = -2 * t**3 + 3 * t**2
+        h11 = t**3 - t**2
+        return h00 * y0 + h10 * dx * m0 + h01 * y1 + h11 * dx * m1
+    elif nu == 1:
+        h00 = 6 * t**2 - 6 * t
+        h10 = 3 * t**2 - 4 * t + 1
+        h01 = -6 * t**2 + 6 * t
+        h11 = 3 * t**2 - 2 * t
+        return (h00 * y0 + h10 * dx * m0 + h01 * y1 + h11 * dx * m1) / dx
+    elif nu == 2:
+        h00 = 12 * t - 6
+        h10 = 6 * t - 4
+        h01 = -12 * t + 6
+        h11 = 6 * t - 2
+        return (h00 * y0 + h10 * dx * m0 + h01 * y1 + h11 * dx * m1) / dx**2
+    elif nu == 3:
+        return (12.0 * y0 + 6.0 * dx * m0 - 12.0 * y1 + 6.0 * dx * m1) / dx**3
+    else:
+        raise ValueError(f"nu must be 0, 1, 2, or 3, got {nu}")
+
+
+def local_cubic_eval(x, y, xq, nu=0):
+    """C1 local cubic Hermite spline, matching ``interpax`` ``method="cubic"``."""
+    x = jnp.asarray(x)
+    y = jnp.asarray(y)
+    s = _local_cubic_slopes(x, y)
+    return _hermite_eval(x, y, s, jnp.asarray(xq), nu=nu)
+
+
+class NotAKnotCubicSpline:
+    """C2 not-a-knot cubic spline, matching ``interpax.CubicSpline`` default."""
+
+    def __init__(self, x, y):
+        self.x = jnp.asarray(x)
+        self.y = jnp.asarray(y)
+        self.s = _not_a_knot_slopes(self.x, self.y)
+
+    def __call__(self, xq, nu=0):
+        return _hermite_eval(self.x, self.y, self.s, jnp.asarray(xq), nu=nu)
+
+    def derivative(self, nu=1):
+        return _BoundDerivative(self, nu)
+
+
+class _BoundDerivative:
+    """Callable returned by :meth:`NotAKnotCubicSpline.derivative`."""
+
+    def __init__(self, spline, nu):
+        self._spline = spline
+        self._nu = nu
+
+    def __call__(self, xq):
+        return self._spline(xq, nu=self._nu)

--- a/rheojax/utils/mct_kernels.py
+++ b/rheojax/utils/mct_kernels.py
@@ -1049,9 +1049,9 @@ def _solve_equilibrium_correlator_f12_jit(
         [jnp.array([0.0]), jnp.linspace(dt, t_max, n_steps)]
     )
     phi_full = jnp.concatenate([jnp.array([1.0]), phi_trajectory])
-    from interpax import interp1d
+    from rheojax.utils.jax_cubic_spline import local_cubic_eval
 
-    phi_at_times = interp1d(t_integration, phi_full, method="cubic")(t_array)
+    phi_at_times = local_cubic_eval(t_integration, phi_full, t_array)
 
     return phi_at_times
 

--- a/rheojax/utils/structure_factor.py
+++ b/rheojax/utils/structure_factor.py
@@ -19,7 +19,6 @@ from collections.abc import Callable
 from functools import partial
 from typing import TYPE_CHECKING
 
-import interpax
 import numpy as np
 from scipy.interpolate import CubicSpline
 
@@ -289,10 +288,11 @@ def create_sk_interpolator(
 def create_sk_interpolator_jax(
     k_data: np.ndarray,
     sk_data: np.ndarray,
-) -> interpax.Interpolator1D:
+) -> Callable[[jax.Array], jax.Array]:
     """Create a JAX-compatible cubic spline interpolator for S(k).
 
-    Uses interpax for JIT-compatible, differentiable interpolation.
+    Uses a pure-JAX C1 local cubic Hermite spline (matching interpax's former
+    ``method="cubic"``) for JIT-compatible, differentiable interpolation.
     Suitable for use inside jax.jit-decorated functions.
 
     Parameters
@@ -304,13 +304,15 @@ def create_sk_interpolator_jax(
 
     Returns
     -------
-    interpax.Interpolator1D
+    Callable[[jax.Array], jax.Array]
         JAX-native interpolator callable as sk_interp(k)
     """
+    from rheojax.utils.jax_cubic_spline import local_cubic_eval
+
     sort_idx = np.argsort(k_data)
     k_sorted = jnp.asarray(k_data[sort_idx])
     sk_sorted = jnp.asarray(sk_data[sort_idx])
-    return interpax.Interpolator1D(k_sorted, sk_sorted, method="cubic")
+    return partial(local_cubic_eval, k_sorted, sk_sorted)
 
 
 # =============================================================================

--- a/tests/transforms/test_fft_analysis.py
+++ b/tests/transforms/test_fft_analysis.py
@@ -312,7 +312,7 @@ class TestFFTAnalysis:
 
         Regression test: np.diff(t) = [1, 1, -0.5, 1.5, 1] has median=1.0 > 0,
         so a median-only dt<=0 check would miss the non-monotonicity and feed
-        unsorted knots into interpax's interpolator, producing silently wrong
+        unsorted knots into the interpolation below, producing silently wrong
         resampled data instead of an error.
         """
         t = jnp.array([0.0, 1.0, 2.0, 1.5, 3.0, 4.0])

--- a/tests/transforms/test_smooth_derivative.py
+++ b/tests/transforms/test_smooth_derivative.py
@@ -283,6 +283,17 @@ class TestSmoothDerivative:
         with pytest.raises(ValueError, match="duplicate"):
             deriv.transform(data)
 
+    def test_spline_duplicate_x_raises(self):
+        """Duplicate x must raise, matching finite_diff/savgol (not silent NaN)."""
+        x = jnp.array([0.0, 1.0, 1.0, 3.0, 4.0, 6.0])
+        y = x**2
+
+        data = RheoData(x=x, y=y, domain="time")
+
+        deriv = SmoothDerivative(method="spline")
+        with pytest.raises(ValueError, match="duplicate"):
+            deriv.transform(data)
+
     def test_finite_diff_nonmonotonic_x_is_sorted(self):
         """Regression: non-monotonic x silently produced wrong values (defect #2)."""
         x = jnp.array([0.0, 1.0, 2.0, 1.5, 3.0, 4.0])

--- a/tests/utils/test_jax_cubic_spline.py
+++ b/tests/utils/test_jax_cubic_spline.py
@@ -1,0 +1,140 @@
+"""Tests for rheojax.utils.jax_cubic_spline.
+
+interpax is no longer a rheojax dependency (see pyproject.toml), so these
+tests validate against scipy.interpolate (a real dependency) rather than
+interpax directly.
+"""
+
+import numpy as np
+import pytest
+from scipy.interpolate import CubicHermiteSpline, CubicSpline
+
+from rheojax.utils.jax_cubic_spline import NotAKnotCubicSpline, local_cubic_eval
+
+
+@pytest.mark.smoke
+class TestNotAKnotCubicSpline:
+    """C2 not-a-knot spline: parity against scipy.interpolate.CubicSpline."""
+
+    def test_exact_cubic_reproduction(self):
+        """A global cubic is reproduced exactly (0th-3rd derivatives)."""
+        x = np.array([0.0, 0.7, 1.5, 2.6, 4.0, 5.5, 7.0])
+        y = x**3 - 2 * x**2 + 3 * x - 1
+        xq = np.linspace(x[0], x[-1], 37)
+
+        spline = NotAKnotCubicSpline(x, y)
+        np.testing.assert_allclose(
+            np.asarray(spline(xq)), xq**3 - 2 * xq**2 + 3 * xq - 1, atol=1e-8
+        )
+        np.testing.assert_allclose(
+            np.asarray(spline.derivative(nu=1)(xq)), 3 * xq**2 - 4 * xq + 3, atol=1e-7
+        )
+        np.testing.assert_allclose(
+            np.asarray(spline.derivative(nu=2)(xq)), 6 * xq - 4, atol=1e-6
+        )
+        np.testing.assert_allclose(
+            np.asarray(spline.derivative(nu=3)(xq)), np.full_like(xq, 6.0), atol=1e-5
+        )
+
+    @pytest.mark.parametrize("n", [4, 5, 10, 50])
+    def test_matches_scipy_not_a_knot(self, n):
+        rng = np.random.default_rng(42 + n)
+        x = np.sort(rng.uniform(0, 10, n))
+        y = rng.normal(size=n)
+        xq = rng.uniform(x[0], x[-1], 100)
+
+        ref = CubicSpline(x, y, bc_type="not-a-knot")
+        mine = NotAKnotCubicSpline(x, y)
+
+        np.testing.assert_allclose(np.asarray(mine(xq)), ref(xq), atol=1e-8)
+        np.testing.assert_allclose(
+            np.asarray(mine.derivative(nu=1)(xq)), ref(xq, 1), atol=1e-6
+        )
+        np.testing.assert_allclose(
+            np.asarray(mine.derivative(nu=2)(xq)), ref(xq, 2), atol=1e-5
+        )
+        np.testing.assert_allclose(
+            np.asarray(mine.derivative(nu=3)(xq)), ref(xq, 3), atol=1e-4
+        )
+
+    def test_n_equals_2(self):
+        """n=2 degenerates to a straight line."""
+        x = np.array([1.0, 4.0])
+        y = np.array([2.0, 11.0])
+        ref = CubicSpline(x, y, bc_type="not-a-knot")
+        mine = NotAKnotCubicSpline(x, y)
+        xq = np.linspace(1.0, 4.0, 5)
+        np.testing.assert_allclose(np.asarray(mine(xq)), ref(xq), atol=1e-10)
+
+    def test_n_equals_3(self):
+        """n=3 uses the parabola special case."""
+        x = np.array([0.0, 1.0, 3.0])
+        y = np.array([0.0, 1.0, 9.0])
+        ref = CubicSpline(x, y, bc_type="not-a-knot")
+        mine = NotAKnotCubicSpline(x, y)
+        xq = np.linspace(0.0, 3.0, 11)
+        np.testing.assert_allclose(np.asarray(mine(xq)), ref(xq), atol=1e-10)
+
+    def test_duplicate_x_raises(self):
+        """Matches scipy.interpolate.CubicSpline: rejects duplicate x with a
+        clear error instead of silently returning NaN/Inf from a singular
+        not-a-knot system."""
+        x = np.array([0.0, 1.0, 1.0, 2.0, 3.0])
+        y = np.array([0.0, 1.0, 1.0, 4.0, 9.0])
+        with pytest.raises(ValueError, match="strictly increasing"):
+            NotAKnotCubicSpline(x, y)
+
+    def test_extrapolation_is_finite_not_nan(self):
+        """Documented behavioral difference from interpax: finite extrapolation."""
+        x = np.array([0.0, 1.0, 2.0, 3.0])
+        y = np.array([0.0, 1.0, 4.0, 9.0])
+        spline = NotAKnotCubicSpline(x, y)
+        out = np.asarray(spline(np.array([-1.0, 4.0])))
+        assert np.all(np.isfinite(out))
+
+
+@pytest.mark.smoke
+class TestLocalCubicEval:
+    """C1 local Catmull-Rom-style Hermite spline."""
+
+    @staticmethod
+    def _reference(x, y, xq, nu=0):
+        """Independent reference: same tangent rule, scipy's Hermite basis."""
+        dx = np.diff(x)
+        slope = np.diff(y) / dx
+        interior = 0.5 * (slope[:-1] + slope[1:])
+        tangents = np.concatenate([slope[:1], interior, slope[-1:]])
+        return CubicHermiteSpline(x, y, tangents)(xq, nu)
+
+    @pytest.mark.parametrize("n", [4, 5, 10, 50])
+    def test_matches_reference_hermite(self, n):
+        rng = np.random.default_rng(7 + n)
+        x = np.sort(rng.uniform(0, 10, n))
+        y = rng.normal(size=n)
+        xq = rng.uniform(x[0], x[-1], 100)
+
+        ref = self._reference(x, y, xq)
+        mine = np.asarray(local_cubic_eval(x, y, xq))
+        np.testing.assert_allclose(mine, ref, atol=1e-8)
+
+    def test_duplicate_x_yields_finite_output(self):
+        x = np.array([0.0, 1.0, 1.0, 2.0, 3.0])
+        y = np.array([0.0, 1.0, 1.0, 4.0, 9.0])
+        xq = np.linspace(0.0, 3.0, 20)
+        out = np.asarray(local_cubic_eval(x, y, xq))
+        assert np.all(np.isfinite(out))
+
+    def test_derivative_orders(self):
+        x = np.array([0.0, 1.0, 2.5, 4.0, 6.0])
+        y = np.array([0.0, 1.0, 2.0, 1.5, 3.0])
+        xq = np.linspace(x[0], x[-1], 40)
+        for nu in (0, 1, 2, 3):
+            ref = self._reference(x, y, xq, nu=nu)
+            mine = np.asarray(local_cubic_eval(x, y, xq, nu=nu))
+            np.testing.assert_allclose(mine, ref, atol=1e-6)
+
+    def test_invalid_nu_raises(self):
+        x = np.array([0.0, 1.0, 2.0])
+        y = np.array([0.0, 1.0, 4.0])
+        with pytest.raises(ValueError, match="nu must be"):
+            local_cubic_eval(x, y, np.array([0.5]), nu=4)

--- a/uv.lock
+++ b/uv.lock
@@ -1328,22 +1328,6 @@ wheels = [
 ]
 
 [[package]]
-name = "interpax"
-version = "0.3.14"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "equinox" },
-    { name = "jax" },
-    { name = "jaxtyping" },
-    { name = "lineax" },
-    { name = "numpy" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/38/b2/06d071b6eade1ea7e3bb0660aa3c1f8fd6484fa611cc45cd424d2bbebecf/interpax-0.3.14.tar.gz", hash = "sha256:5018c18a07d946be7466504f385b4e5ac632cd7b006c1cead42b1aefe37e16e3", size = 58669, upload-time = "2026-04-18T00:35:09.305Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/c8/77/3b4c3db18738ffc146887f3b47e44159d370509c3ee302f0456a8f0dfcac/interpax-0.3.14-py3-none-any.whl", hash = "sha256:070c5242227fa65bd7dafc472ae2ed0c4df9891fbbbede73a8b04e21859a5d47", size = 28104, upload-time = "2026-04-18T00:35:07.774Z" },
-]
-
-[[package]]
 name = "ipykernel"
 version = "7.3.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1464,7 +1448,7 @@ wheels = [
 
 [[package]]
 name = "jax"
-version = "0.10.2"
+version = "0.11.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "jaxlib" },
@@ -1473,9 +1457,9 @@ dependencies = [
     { name = "opt-einsum" },
     { name = "scipy" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/d2/73/eb91d98fcadfa2cbcfdd4e417ab116e47eb20882acc5ee678e47c35d6b57/jax-0.10.2.tar.gz", hash = "sha256:bf77428a8c2e6904c4f46d5ab12aa5cfc6cad2179f07f7e4c0fc75ac86ef0639", size = 2775110, upload-time = "2026-06-17T23:44:57.818Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/81/20/90a137c178de8f2b9170bd4dfb934e261213fdaac67e5c5183b132be85e7/jax-0.11.0.tar.gz", hash = "sha256:a2feb7cfa48bb35d36b8ecec16a4ec24044dec01935f779b28b017213697b195", size = 2813185, upload-time = "2026-07-16T19:00:14.519Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/89/82/5ab5211079a151b6f661529369c0c8e98ec64cabf5c0cf22a0a05af124d8/jax-0.10.2-py3-none-any.whl", hash = "sha256:724d73c4678d8b06f6a6ab4db1b8a2fea8cd4f1e2c2564f99601634ec7b8d1c6", size = 3219515, upload-time = "2026-06-17T23:42:41.259Z" },
+    { url = "https://files.pythonhosted.org/packages/d4/5a/26a1305f8978bc41f889a4172198c7d8976e8e394fc4d03597d9edfd6b7e/jax-0.11.0-py3-none-any.whl", hash = "sha256:b31ed66c4321d5c9e48b861f51a72ed5f7960c93514296202d2041cbb9ac45bf", size = 3255281, upload-time = "2026-07-16T18:58:25.02Z" },
 ]
 
 [[package]]
@@ -1538,7 +1522,7 @@ wheels = [
 
 [[package]]
 name = "jaxlib"
-version = "0.10.2"
+version = "0.11.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "ml-dtypes" },
@@ -1546,24 +1530,21 @@ dependencies = [
     { name = "scipy" },
 ]
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/ca/93/ee9cc8743191544f65d26ab7eeb82d65968fe60905662d1a5554d056654b/jaxlib-0.10.2-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:47bb7c011515ea862be7e8313f40f9c56cbec09dc98a0fcb5016785fcd454c01", size = 61434612, upload-time = "2026-06-17T23:43:57.808Z" },
-    { url = "https://files.pythonhosted.org/packages/11/06/8cc36021bf74d617c312eeed94c280282bb1bcbb32b63f2a42b10ae41575/jaxlib-0.10.2-cp312-cp312-manylinux_2_27_aarch64.whl", hash = "sha256:53b72977ae582c03a9e8e1cdee1efbf8ebc1418270965b0e69eade57acf40331", size = 81085366, upload-time = "2026-06-17T23:44:01.067Z" },
-    { url = "https://files.pythonhosted.org/packages/48/17/38b718af2353dba7753300871e83fbb64a88a772e12727ae27373ab675ce/jaxlib-0.10.2-cp312-cp312-manylinux_2_27_x86_64.whl", hash = "sha256:fe88ec443714c4379968b6c109f9fa617c7ad19b802828e4d7bf861cd66da4b7", size = 85467828, upload-time = "2026-06-17T23:44:04.238Z" },
-    { url = "https://files.pythonhosted.org/packages/b4/c2/d41d13826ebdfe62e56cd87ba70fab3bb9fcbea4a6c9086739a91667e5bf/jaxlib-0.10.2-cp312-cp312-win_amd64.whl", hash = "sha256:4b08f5fbc596b83f76308181863996f93d901d1f09cfd4e130a65c1998e1b371", size = 65900139, upload-time = "2026-06-17T23:44:07.476Z" },
-    { url = "https://files.pythonhosted.org/packages/c2/68/eaa4cebe253359196a8e80a33b242959e27d8d2a6ae3d09339f21da2acb8/jaxlib-0.10.2-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:4df530afa354a22dc1747a5d560640450cbb895d49889338a3f58c76a4c76c8e", size = 61434805, upload-time = "2026-06-17T23:44:10.511Z" },
-    { url = "https://files.pythonhosted.org/packages/25/c1/4b884ea5962b6beb3c0f93742db54246bbf8b3274e48b0aca47908e454be/jaxlib-0.10.2-cp313-cp313-manylinux_2_27_aarch64.whl", hash = "sha256:45b28b0238697ab74bbcf20411aafb6db42acc31836cc2fd711e5cf056bf9556", size = 81084260, upload-time = "2026-06-17T23:44:14.065Z" },
-    { url = "https://files.pythonhosted.org/packages/36/ac/4ee28c65861605945223145fbcd3c9362ec2255ddf7d917574e205548c82/jaxlib-0.10.2-cp313-cp313-manylinux_2_27_x86_64.whl", hash = "sha256:9e4818b4a8756fd3918766ca2aa5342125809f4f08a6fe46026d4386e7c23644", size = 85467706, upload-time = "2026-06-17T23:44:17.471Z" },
-    { url = "https://files.pythonhosted.org/packages/79/54/9918b0f77a25a1299818c0610305ca2bea38ed90584f4489b60357e2dd39/jaxlib-0.10.2-cp313-cp313-win_amd64.whl", hash = "sha256:c75d6f1df1c9cff08e110b4a21c79560fdc502f4288972d6b117d25dafd44352", size = 65897894, upload-time = "2026-06-17T23:44:21.153Z" },
-    { url = "https://files.pythonhosted.org/packages/56/5b/70df11da52a8b1a826184cccc05a3fec8aed76058a980021873fba3069cb/jaxlib-0.10.2-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:4c202d8ff7c1f3b5049dbd8f1e30e52759cd4e0a5835f0b3c7ae076a05818e28", size = 61564746, upload-time = "2026-06-17T23:44:24.421Z" },
-    { url = "https://files.pythonhosted.org/packages/23/5c/184a648ea5db6c8b1a08fc5784c157b4c557255e009fb56091393df3c6de/jaxlib-0.10.2-cp313-cp313t-manylinux_2_27_aarch64.whl", hash = "sha256:b7b029bb95d981566750475b9719a9d6b66ed5dd2748851667899b6cfe075299", size = 81204888, upload-time = "2026-06-17T23:44:27.57Z" },
-    { url = "https://files.pythonhosted.org/packages/6c/5c/539596a55265711d74147913278bcdc38412980be7d74d9c9d860297c486/jaxlib-0.10.2-cp313-cp313t-manylinux_2_27_x86_64.whl", hash = "sha256:e8b126097d609b0c6e6786e89f6dd6978adc02ebd5f63a1c61293fbac7821305", size = 85583810, upload-time = "2026-06-17T23:44:30.962Z" },
-    { url = "https://files.pythonhosted.org/packages/f2/0d/27471ec9f1d04674f6e62de809412371e097aed3eca7d9483e677c54c214/jaxlib-0.10.2-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:72eba28b12fee02616fa42aa4b881b4ab62d7757c7843c462401d3fb34a27be4", size = 61446097, upload-time = "2026-06-17T23:44:34.196Z" },
-    { url = "https://files.pythonhosted.org/packages/af/c8/941a7f7f37510f51290a5bd1a413aeef977fb8ba8adc0cfe8391233a764c/jaxlib-0.10.2-cp314-cp314-manylinux_2_27_aarch64.whl", hash = "sha256:f18f56fee90699cfba9b6627045a7a299702cb0e2af82ce180d9a6a7c8048093", size = 81096546, upload-time = "2026-06-17T23:44:37.486Z" },
-    { url = "https://files.pythonhosted.org/packages/69/77/ac054882c220872512df28d16aeb648fe0e651efbb5be4fd7c4817fd88b0/jaxlib-0.10.2-cp314-cp314-manylinux_2_27_x86_64.whl", hash = "sha256:ca34f363197fb0ac4082582ca755007910369e33f8a8ba3d35ed94b71070107d", size = 85472993, upload-time = "2026-06-17T23:44:40.904Z" },
-    { url = "https://files.pythonhosted.org/packages/0d/7d/c592d1fa69c210be0d2743fffc598dfc2f54efa9671c5f6f5d1e151c6f4a/jaxlib-0.10.2-cp314-cp314-win_amd64.whl", hash = "sha256:99818b0a18adc0b899abf4873795e8d65169441d87ab2e5cbb228e73d0f25808", size = 68376553, upload-time = "2026-06-17T23:44:44.968Z" },
-    { url = "https://files.pythonhosted.org/packages/54/9b/91b00ec74985d29708b50420b4103c1f651c8f1c253d4fcb49d1bbb532cd/jaxlib-0.10.2-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:fc62997fce8831819551a2a5469a818169b09582b5b648c102d11ac7205bb812", size = 61564620, upload-time = "2026-06-17T23:44:48.217Z" },
-    { url = "https://files.pythonhosted.org/packages/a1/c7/49d2b19c3b3105c30e1d3af2062e82e1977fb239d3dc3cbb583ef676dda7/jaxlib-0.10.2-cp314-cp314t-manylinux_2_27_aarch64.whl", hash = "sha256:a24d6e3cba263978293eae8b41330d5ccf24d6cdd1a6bcd4e82aff34e767620d", size = 81206365, upload-time = "2026-06-17T23:44:51.419Z" },
-    { url = "https://files.pythonhosted.org/packages/bf/99/006cedf443f4a01f2088651facce79b2105bfb4905bfe9162eb0920a6dfb/jaxlib-0.10.2-cp314-cp314t-manylinux_2_27_x86_64.whl", hash = "sha256:5a2ac7aed7c4e661f67600bbcdec9e589151c1efec91f4cdb8d484af1a45c895", size = 85584458, upload-time = "2026-06-17T23:44:55.377Z" },
+    { url = "https://files.pythonhosted.org/packages/04/13/629fd9f50e15424358b7c53b6ec729e2d7163d64942817bee9adeee04ed1/jaxlib-0.11.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:f5bf0b3bfc2ef4778580047389dacb51ae000e50c6b3b6f98d10788927066c97", size = 62546563, upload-time = "2026-07-16T18:59:16.788Z" },
+    { url = "https://files.pythonhosted.org/packages/8e/1d/a85feebcfc6fa702bcaadd74f3c13283e1613f7598de5ca69bdbaf4c2671/jaxlib-0.11.0-cp312-cp312-manylinux_2_27_aarch64.whl", hash = "sha256:1b767c4d7ad4dfc6358313b63ae6d83c3571d3ce966de04d8aaf29eb44633786", size = 82155667, upload-time = "2026-07-16T18:59:20.477Z" },
+    { url = "https://files.pythonhosted.org/packages/86/f0/89c34a4877628edea6585699e42f7d3ed4c1e50140ade9c6efce85a0ab84/jaxlib-0.11.0-cp312-cp312-manylinux_2_27_x86_64.whl", hash = "sha256:7ea9dc06d94f536deabcf304513143bc89f51173ddfd786d44f8ac303efdf643", size = 87263507, upload-time = "2026-07-16T18:59:24.258Z" },
+    { url = "https://files.pythonhosted.org/packages/59/6b/e6caeaff6bd1537becbbcde8985fd65a71374e33f9e8c1aa3371bd16c349/jaxlib-0.11.0-cp312-cp312-win_amd64.whl", hash = "sha256:166ca16586a8aeb23f9c5e322845f3789037ed294f0a1539404a50f7c5fb13cf", size = 67743601, upload-time = "2026-07-16T18:59:27.981Z" },
+    { url = "https://files.pythonhosted.org/packages/81/3b/cc587eaa7d66aad1cddc77f5e10bca086a7d252891d359e64795521f5a2b/jaxlib-0.11.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:88b349aa95e452caa30a6723320e93ec7bd1ab249e9f0bf29000da1b5efae733", size = 62547263, upload-time = "2026-07-16T18:59:31.414Z" },
+    { url = "https://files.pythonhosted.org/packages/eb/d2/8c71ff16e019554a07dfcc206034b0182fba00bca1d7aaada7bcdb32b595/jaxlib-0.11.0-cp313-cp313-manylinux_2_27_aarch64.whl", hash = "sha256:112a01c584707a7d0e8634fd55dd7efffe812966e60c2d3ac84e8c24e4571336", size = 82152577, upload-time = "2026-07-16T18:59:35.392Z" },
+    { url = "https://files.pythonhosted.org/packages/0f/85/82e456879df00e8bed7074028b0e1ddf2ce4e58dd83b699b9e9ef8306542/jaxlib-0.11.0-cp313-cp313-manylinux_2_27_x86_64.whl", hash = "sha256:33dd9405cab05ee4f3ecc3a91289323e9bd2f08d25990e5d45ffb8524f519506", size = 87263717, upload-time = "2026-07-16T18:59:39.194Z" },
+    { url = "https://files.pythonhosted.org/packages/e9/87/96670370fd97cb79ad84d8becc8878e6b4aa52fd052cf5f3c063add9e7af/jaxlib-0.11.0-cp313-cp313-win_amd64.whl", hash = "sha256:aced7b1ca4e338b5248821a397d2d53008894672be6fee762f391cfdd7272e1e", size = 67744784, upload-time = "2026-07-16T18:59:43.711Z" },
+    { url = "https://files.pythonhosted.org/packages/50/6e/8fa567a498ce9e1966d035efd6a4be92e4a8b788b321549ec06fbb7ff25c/jaxlib-0.11.0-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:7e6c0e2374943ba7191fe196e22067b789894c58cf6ddd24c9971ae642de58ee", size = 62546481, upload-time = "2026-07-16T18:59:48.212Z" },
+    { url = "https://files.pythonhosted.org/packages/75/a3/159e82715919b8945107c35051ac4fa6e2578640c484e17ea6590914b1a5/jaxlib-0.11.0-cp314-cp314-manylinux_2_27_aarch64.whl", hash = "sha256:483429cc7fa7fd6a20cb50f666c8d2d499efb7e9ba3163811c01f051ad6057c4", size = 82171230, upload-time = "2026-07-16T18:59:51.677Z" },
+    { url = "https://files.pythonhosted.org/packages/4e/e6/b6e4154b24d5a6bdcae715ad32030e7954bd793c590afa91b693d70e2719/jaxlib-0.11.0-cp314-cp314-manylinux_2_27_x86_64.whl", hash = "sha256:6125da8532610641b7d3ea7926217cdab52dccb294ef6615455e2b6ecb9e2ee6", size = 87271644, upload-time = "2026-07-16T18:59:55.428Z" },
+    { url = "https://files.pythonhosted.org/packages/be/79/949b0e7860787c0996af475a57b8a060fbd6b9c91b009005d91d12b4aecd/jaxlib-0.11.0-cp314-cp314-win_amd64.whl", hash = "sha256:19888d25c2bba4240ccffe39ee4e5490a544a0bbcdcc1c171e558d3efed57d84", size = 70245063, upload-time = "2026-07-16T18:59:59.016Z" },
+    { url = "https://files.pythonhosted.org/packages/09/18/04d82793d804a6766ca73e4ed30ef928aea252db7c86f73b2faf11fe9e90/jaxlib-0.11.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:5c38a393d37b4a70569224dc8273d8ae6ccea837e45410ed53ca03e15d6fad58", size = 62642149, upload-time = "2026-07-16T19:00:02.597Z" },
+    { url = "https://files.pythonhosted.org/packages/91/2e/418dae82175154f6b5f53aec8909bda800dcbc9c65d94373de146b06e3b1/jaxlib-0.11.0-cp314-cp314t-manylinux_2_27_aarch64.whl", hash = "sha256:5ed7c54a6ef02eea19c0a02e3f603e4f9ad77248098bb9fc3feffca7f4814b83", size = 82261560, upload-time = "2026-07-16T19:00:06.22Z" },
+    { url = "https://files.pythonhosted.org/packages/ac/ff/2edc74b4de40ac4222ee48b3805a6ea5e40f34abe4cd10b65bc0fa0864db/jaxlib-0.11.0-cp314-cp314t-manylinux_2_27_x86_64.whl", hash = "sha256:005ae3a663193d3a89eafadc073880c67d6b829e0ad989690275d02b5adc810a", size = 87367515, upload-time = "2026-07-16T19:00:10.661Z" },
 ]
 
 [[package]]
@@ -3855,7 +3836,6 @@ dependencies = [
     { name = "h5netcdf" },
     { name = "h5py" },
     { name = "hypothesis" },
-    { name = "interpax" },
     { name = "ipython" },
     { name = "jax" },
     { name = "jaxlib" },
@@ -3917,14 +3897,13 @@ requires-dist = [
     { name = "h5netcdf", specifier = ">=1.8.1" },
     { name = "h5py", specifier = ">=3.15.1" },
     { name = "hypothesis", specifier = ">=6.151.5" },
-    { name = "interpax", specifier = ">=0.3.12" },
     { name = "ipython", specifier = ">=9.10.0" },
-    { name = "jax", specifier = ">=0.8.3,<0.11.0" },
+    { name = "jax", specifier = ">=0.8.3" },
     { name = "jax-cuda12-pjrt", marker = "extra == 'gpu-cuda12'", specifier = ">=0.8.0" },
     { name = "jax-cuda12-plugin", marker = "extra == 'gpu-cuda12'", specifier = ">=0.8.0" },
     { name = "jax-cuda13-pjrt", marker = "extra == 'gpu-cuda13'", specifier = ">=0.8.0" },
     { name = "jax-cuda13-plugin", marker = "extra == 'gpu-cuda13'", specifier = ">=0.8.0" },
-    { name = "jaxlib", specifier = ">=0.8.3,<0.11.0" },
+    { name = "jaxlib", specifier = ">=0.8.3" },
     { name = "jupyter", specifier = ">=1.1.1" },
     { name = "matplotlib", specifier = ">=3.10.8,<4.0.0" },
     { name = "mypy", specifier = ">=1.19.1" },


### PR DESCRIPTION
## Summary
- Investigated the `jax`/`jaxlib` `<0.11.0` ceiling in pyproject.toml. rheojax's own code has zero `jnp.empty` call sites, so the originally-cited reason (0.11.0's zero-fill removal) was never the actual blocker.
- Real blocker: `interpax==0.3.14` (latest release, confirmed no unreleased fix on `f0uriest/interpax` main as of 2026-07-17) depends on `jax<0.11`.
- Replaced all 4 interpax call sites with `rheojax/utils/jax_cubic_spline.py`, a pure-JAX module reproducing interpax's exact numerics:
  - `local_cubic_eval` -- C1 local cubic Hermite spline (matches interpax `method="cubic"`), used in `structure_factor.py` and `mct_kernels.py`. Closed-form, no linear solve.
  - `NotAKnotCubicSpline` -- C2 not-a-knot cubic spline (matches interpax's `CubicSpline` default / `scipy.interpolate.CubicSpline(bc_type="not-a-knot")`), used in `smooth_derivative.py`. Tridiagonal system transcribed from scipy's own source, solved via a JAX Thomas algorithm (O(n)).
  - `fft_analysis.py`'s linear-interpolation site swapped to `jnp.interp` (built into JAX itself).
- `interpax` removed from `pyproject.toml` entirely. `jax`/`jaxlib` ceiling lifted -- `uv lock --upgrade-package jax --upgrade-package jaxlib` now resolves both to 0.11.0 cleanly, no further transitive cap.

## Test plan
- [x] New module validated against live `interpax`/`scipy` across random arrays (n=2..200, including edge cases n=2,3) -- matches to ~1e-8 or better, including up to 3rd-derivative evaluation
- [x] `tests/utils/test_structure_factor.py`, `test_mct_kernels.py`, `tests/transforms/test_smooth_derivative.py`, `test_fft_analysis.py` -- 53/53 pass
- [x] Full dependent surface (`tests/models/itt_mct/`, `tests/models/sgr/`, `tests/utils/`, `tests/transforms/`) -- 1138/1138 pass, on jax 0.11.0
- [x] `ruff check` clean on all touched files; `mypy` shows no new errors (all pre-existing, in unrelated files)