### PR TITLE
fix(gui): theme-aware float64 status color, add LibraryRail section header

### DIFF
--- a/rheojax/gui/workspace/library_rail.py
+++ b/rheojax/gui/workspace/library_rail.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from PySide6.QtCore import Qt, Signal
 from PySide6.QtWidgets import (
+    QLabel,
     QListWidget,
     QListWidgetItem,
     QMenu,
@@ -11,6 +12,7 @@ from PySide6.QtWidgets import (
 )
 
 from rheojax.gui.foundation.library import DatasetLibrary
+from rheojax.gui.resources.styles.tokens import section_header_style
 from rheojax.gui.utils.layout_helpers import set_panel_margins
 
 
@@ -23,10 +25,13 @@ class LibraryRail(QWidget):
     def __init__(self, library: DatasetLibrary, parent: QWidget | None = None) -> None:
         super().__init__(parent)
         self._library = library
+        self._header = QLabel("Datasets", self)
+        self._header.setStyleSheet(section_header_style())
         self._list = QListWidget(self)
         self._import = QPushButton("+ Import data…", self)
         lay = QVBoxLayout(self)
         set_panel_margins(lay)
+        lay.addWidget(self._header)
         lay.addWidget(self._list)
         lay.addWidget(self._import)
         self._list.itemClicked.connect(

--- a/rheojax/gui/workspace/status_bar.py
+++ b/rheojax/gui/workspace/status_bar.py
@@ -13,6 +13,7 @@ from rheojax.gui.compat import (
     QWidget,
     _is_qobject_alive,
 )
+from rheojax.gui.resources.styles.tokens import themed
 from rheojax.logging import get_logger
 
 logger = get_logger(__name__)
@@ -172,16 +173,21 @@ class StatusBar(QStatusBar):
         self.memory_label.setText(f"Memory: {int(memory_used)}/{int(memory_total)} MB")
 
         # Update float64 indicator (ASCII to avoid macOS rendering issues)
-        if float64_enabled:
+        self._set_float64_label(float64_enabled)
+
+    def _set_float64_label(self, enabled: bool) -> None:
+        # themed("SUCCESS")/themed("WARNING") (not literal "green"/"orange") --
+        # same pattern already used for pass/fail coloring in
+        # workspace/fit/step5_visualize.py -- so this label tracks the active
+        # theme instead of a fixed CSS color name clashing with the app's
+        # indigo/slate "Precision Laboratory" palette in dark mode.
+        if enabled:
             self.float64_label.setText("Float64: [OK]")
-            self.float64_label.setStyleSheet(
-                "QLabel { padding: 0 10px; color: green; }"
-            )
+            color = themed("SUCCESS")
         else:
             self.float64_label.setText("Float64: [X]")
-            self.float64_label.setStyleSheet(
-                "QLabel { padding: 0 10px; color: orange; }"
-            )
+            color = themed("WARNING")
+        self.float64_label.setStyleSheet(f"QLabel {{ padding: 0 10px; color: {color}; }}")
 
     def update_memory(self, used_mb: float, total_mb: float) -> None:
         """Update memory usage indicator.
@@ -216,14 +222,4 @@ class StatusBar(QStatusBar):
             Whether float64 is enabled
         """
         logger.debug("Float64 status set", enabled=enabled)
-        # ASCII characters to avoid macOS CoreText rendering issues
-        if enabled:
-            self.float64_label.setText("Float64: [OK]")
-            self.float64_label.setStyleSheet(
-                "QLabel { padding: 0 10px; color: green; }"
-            )
-        else:
-            self.float64_label.setText("Float64: [X]")
-            self.float64_label.setStyleSheet(
-                "QLabel { padding: 0 10px; color: orange; }"
-            )
+        self._set_float64_label(enabled)


### PR DESCRIPTION
## Summary
- **StatusBar**: float64 indicator hardcoded literal `color: green;`/`color: orange;` CSS, duplicated in `update_jax_status()` and `set_float64_status()`. No `@success`/`@warning` QSS token existed to reuse, but `tokens.py`'s `ColorPalette`/`DarkColorPalette` already define `SUCCESS`/`WARNING` with a `themed()` accessor — the same pattern already used in `workspace/fit/step5_visualize.py`. Swapped to `themed("SUCCESS")`/`themed("WARNING")`, deduped both call sites into one `_set_float64_label()` helper.
- **LibraryRail**: no section header above the dataset list. Added one using `section_header_style()` (already exported from `tokens.py`, zero prior call sites).

## Context
Continuation of the WorkspaceWindow polish work (see #87). Gemini backend still unavailable this session, so Ideation was done via `codex exec --dangerously-bypass-approvals-and-sandbox` and `agy --dangerously-skip-permissions` per user's explicit redirect, both read-only/analysis-only. Cross-checked their claims against the actual source (`tokens.py`, `base.qss`) before acting on them — confirmed `themed()`/`section_header_style()` are real, already-idiomatic helpers rather than inventing new QSS tokens as both externals initially suggested.

## Test plan
- [x] `tests/gui/workspace/test_library_rail.py`, `test_widgets.py`, `test_window_chrome.py`, `tests/gui/test_crash_prevention.py` — 71/71 passed
- [x] Visually verified via offscreen `QWidget.grab()` render in both light and dark themes — float64 label now uses theme-correct emerald/amber (brighter, readable in dark mode vs. the old flat CSS colors), "Datasets" header renders with proper hierarchy in both themes