### PR TITLE
fix(gui): close 5 click-path state bugs found by behavioral audit

### DIFF
--- a/rheojax/gui/workspace/fit/step2_data.py
+++ b/rheojax/gui/workspace/fit/step2_data.py
@@ -154,7 +154,17 @@ class DataStep(QWidget):
             # valid for the new protocol/model). Re-derive them here via the
             # same logic _on_select uses for a fresh pick, since signals were
             # blocked above and _on_select was never triggered for `current`.
-            self._on_select(current)
+            #
+            # Only do this when state was actually cleared: refresh() is also
+            # invoked from DatasetLibraryNotifier.changed on events unrelated
+            # to this step (e.g. "Save fit to library", another dataset
+            # import) where data_ref/column_map are still intact. Calling
+            # _on_select unconditionally there re-emits `edited` for a
+            # selection that never changed, which cascades through
+            # invalidate_downstream("column_map") and silently wipes
+            # nlsq_result/nuts_result out from under the user.
+            if self._state.data_ref != current or not self._state.column_map:
+                self._on_select(current)
         else:
             # Regression: in the real wired app, the upstream cascade
             # (fit_controller.py's _cascade_and_relock, connected BEFORE

--- a/rheojax/gui/workspace/pipeline/controller.py
+++ b/rheojax/gui/workspace/pipeline/controller.py
@@ -36,38 +36,20 @@ class PipelineController(WorkflowController):
         super().__init__(steps=[])
         on_started = self._on_dataset_run_started
         on_finished = self._commit_job_result
-        on_worker_ready = self._on_phase_worker_ready
         # guard() no-ops these handlers once WorkspaceWindow._epoch advances past
         # `epoch` (a rebuild happened), so a stale controller left connected to the
         # persistent PipelineExecutionService can't write into a discarded AppState.
         if guard is not None:
             on_started = guard(epoch, on_started)
             on_finished = guard(epoch, on_finished)
-            on_worker_ready = guard(epoch, on_worker_ready)
         self._service.dataset_run_started.connect(on_started)
         self._service.dataset_run_finished.connect(on_finished)
-        self._service.phase_worker_ready.connect(on_worker_ready)
         # Keep the exact connected callables so WorkspaceWindow._dispose_workspace
         # can disconnect them from the persistent service on rebuild -- without
         # this, every New/Open leaves the old controller (and the AppState it
         # closed over) connected and reachable for the life of the window.
         self._started_slot = on_started
         self._finished_slot = on_finished
-        self._worker_ready_slot = on_worker_ready
-
-    def _on_phase_worker_ready(
-        self, dataset_id: str, step_id: str, phase: str, worker
-    ) -> None:
-        # Stashes the actual cancellable worker (ProcessWorkerAdapter/FitWorker)
-        # into this dataset's active_jobs entry, mirroring fit_controller.py's
-        # {"status": "running", "worker": token} pattern. Without this, no
-        # Pipeline active_jobs entry ever carried a "worker" key, so window.py's
-        # "Cancel them and continue?" dialog (which reads job.get("worker")) could
-        # never actually stop an in-flight NLSQ/NUTS phase -- it only prevented
-        # the batch from starting the NEXT dataset.
-        job = self._state.active_jobs.by_id.get(dataset_id)
-        if job is not None:
-            job["worker"] = worker
 
     def _on_dataset_run_started(self, dataset_id: str) -> None:
         # Registers ONE dataset's active_jobs entry right before it starts running -- not the

--- a/rheojax/gui/workspace/pipeline/controller.py
+++ b/rheojax/gui/workspace/pipeline/controller.py
@@ -36,20 +36,38 @@ class PipelineController(WorkflowController):
         super().__init__(steps=[])
         on_started = self._on_dataset_run_started
         on_finished = self._commit_job_result
+        on_worker_ready = self._on_phase_worker_ready
         # guard() no-ops these handlers once WorkspaceWindow._epoch advances past
         # `epoch` (a rebuild happened), so a stale controller left connected to the
         # persistent PipelineExecutionService can't write into a discarded AppState.
         if guard is not None:
             on_started = guard(epoch, on_started)
             on_finished = guard(epoch, on_finished)
+            on_worker_ready = guard(epoch, on_worker_ready)
         self._service.dataset_run_started.connect(on_started)
         self._service.dataset_run_finished.connect(on_finished)
+        self._service.phase_worker_ready.connect(on_worker_ready)
         # Keep the exact connected callables so WorkspaceWindow._dispose_workspace
         # can disconnect them from the persistent service on rebuild -- without
         # this, every New/Open leaves the old controller (and the AppState it
         # closed over) connected and reachable for the life of the window.
         self._started_slot = on_started
         self._finished_slot = on_finished
+        self._worker_ready_slot = on_worker_ready
+
+    def _on_phase_worker_ready(
+        self, dataset_id: str, step_id: str, phase: str, worker
+    ) -> None:
+        # Stashes the actual cancellable worker (ProcessWorkerAdapter/FitWorker)
+        # into this dataset's active_jobs entry, mirroring fit_controller.py's
+        # {"status": "running", "worker": token} pattern. Without this, no
+        # Pipeline active_jobs entry ever carried a "worker" key, so window.py's
+        # "Cancel them and continue?" dialog (which reads job.get("worker")) could
+        # never actually stop an in-flight NLSQ/NUTS phase -- it only prevented
+        # the batch from starting the NEXT dataset.
+        job = self._state.active_jobs.by_id.get(dataset_id)
+        if job is not None:
+            job["worker"] = worker
 
     def _on_dataset_run_started(self, dataset_id: str) -> None:
         # Registers ONE dataset's active_jobs entry right before it starts running -- not the

--- a/rheojax/gui/workspace/transform/transform_controller.py
+++ b/rheojax/gui/workspace/transform/transform_controller.py
@@ -81,6 +81,15 @@ def _make_run_fn(library, active_jobs=None):
         # (e.g. for protocol_type) could see a different selection than the
         # one `data` was actually resolved from.
         slots = dict(slots)
+        # Same reasoning as the slots snapshot above: config is the live,
+        # mutable TransformState.config dict, and step2_slots.py's
+        # _on_params_changed() mutates it in place from the GUI thread while
+        # loop.exec() below pumps events. Without a copy, TransformWorker
+        # (and TransformService.apply_transform()'s multiple params.get()
+        # reads + the later provenance record) can observe a dict changing
+        # mid-run -- a single run silently computing with an inconsistent
+        # mix of pre-/post-edit parameter values.
+        config = dict(config)
         data = _resolve_slot_data(library, transform_key, slots)
         # A real, cancellable token registered in active_jobs -- mirrors
         # fit_controller.py's _make_fit_fn/_make_sample_fn. Without this,

--- a/rheojax/gui/workspace/window.py
+++ b/rheojax/gui/workspace/window.py
@@ -653,7 +653,9 @@ class WorkspaceWindow(QMainWindow):
             lambda: self._maybe_confirm_unsaved_changes(_open)
         )
 
-    def _blocked_by_active_jobs(self, action: str, on_unblocked=None) -> bool:
+    def _blocked_by_active_jobs(
+        self, action: str, on_unblocked: Callable[[], None] | None = None
+    ) -> bool:
         # Spec §3.3: "Save snapshots job_history only; blocked while active_jobs is
         # non-empty" -- a running Pipeline batch mutates DatasetLibrary/job_history from
         # a worker thread, so a concurrent Save could serialize a torn, inconsistent

--- a/rheojax/gui/workspace/window.py
+++ b/rheojax/gui/workspace/window.py
@@ -9,6 +9,7 @@ from typing import Any
 from rheojax.gui.compat import (
     QAction,
     QApplication,
+    QButtonGroup,
     QCloseEvent,
     QDialog,
     QInputDialog,
@@ -85,6 +86,15 @@ class WorkspaceWindow(QMainWindow):
         self._fit_btn.setCheckable(True)
         self._tx_btn.setCheckable(True)
         self._pipeline_btn.setCheckable(True)
+        # Exclusive group so Qt itself refuses to uncheck the sole checked
+        # button on a re-click. Without this, clicking the already-active
+        # mode pill toggles it unchecked before set_mode()'s no-op early
+        # return (mode == self._mode) ever reaches _sync_mode_buttons() --
+        # the pill goes visually unselected while the app stays in that mode.
+        self._mode_btn_group = QButtonGroup(self)
+        self._mode_btn_group.setExclusive(True)
+        for btn in (self._fit_btn, self._tx_btn, self._pipeline_btn):
+            self._mode_btn_group.addButton(btn)
         self._fit_btn.clicked.connect(lambda: self.set_mode("fit"))
         self._tx_btn.clicked.connect(lambda: self.set_mode("transform"))
         self._pipeline_btn.clicked.connect(lambda: self.set_mode("pipeline"))
@@ -497,6 +507,12 @@ class WorkspaceWindow(QMainWindow):
                 )
             except (RuntimeError, TypeError):
                 pass
+            try:
+                self._pipeline_service.phase_worker_ready.disconnect(
+                    pipeline_ctl._worker_ready_slot
+                )
+            except (RuntimeError, TypeError):
+                pass
         # Disconnect only the handler each body list actually wired in
         # __init__ -- attempting to disconnect a slot that was never
         # connected to a given body (e.g. _on_transform_body_edited from a
@@ -643,16 +659,25 @@ class WorkspaceWindow(QMainWindow):
             lambda: self._maybe_confirm_unsaved_changes(_open)
         )
 
-    def _blocked_by_active_jobs(self, action: str) -> bool:
+    def _blocked_by_active_jobs(self, action: str, on_unblocked=None) -> bool:
         # Spec §3.3: "Save snapshots job_history only; blocked while active_jobs is
         # non-empty" -- a running Pipeline batch mutates DatasetLibrary/job_history from
         # a worker thread, so a concurrent Save could serialize a torn, inconsistent
         # snapshot. Unlike Close/New/Open (which offer to cancel jobs and proceed), Save
         # is a hard block: there is no safe "discard the running job" option here.
+        #
+        # on_unblocked, if given, runs while active_jobs.lock is still held --
+        # closes the gap between "is anything running?" and the caller's own
+        # save I/O that a worker thread could otherwise slip a new job
+        # registration into (the exact race Save is meant to prevent). Any
+        # exception on_unblocked raises propagates to the caller after the
+        # lock is released (the `with` block's __exit__ still runs).
         with self._state.active_jobs.lock:
             job_count = len(self._state.active_jobs.by_id)
-        if job_count == 0:
-            return False
+            if job_count == 0:
+                if on_unblocked is not None:
+                    on_unblocked()
+                return False
         from PySide6.QtWidgets import QMessageBox
 
         QMessageBox.information(
@@ -664,8 +689,6 @@ class WorkspaceWindow(QMainWindow):
         return True
 
     def _on_save(self) -> None:
-        if self._blocked_by_active_jobs("save"):
-            return
         if self._state.project.path is None:
             self._on_save_as()
             return
@@ -673,7 +696,13 @@ class WorkspaceWindow(QMainWindow):
         from rheojax.gui.foundation.project_codec import save_project_v2
 
         try:
-            save_project_v2(self._state, self._state.project.path)
+            if self._blocked_by_active_jobs(
+                "save",
+                on_unblocked=lambda: save_project_v2(
+                    self._state, self._state.project.path
+                ),
+            ):
+                return
         except (ValueError, FileNotFoundError, OSError) as exc:
             QMessageBox.critical(self, "Save Failed", str(exc))
             return
@@ -681,8 +710,6 @@ class WorkspaceWindow(QMainWindow):
         self.statusBar().show_message("Project saved", 2000)
 
     def _on_save_as(self) -> None:
-        if self._blocked_by_active_jobs("save"):
-            return
         from rheojax.gui.compat import QFileDialog, QMessageBox
 
         path, _ = QFileDialog.getSaveFileName(
@@ -692,7 +719,10 @@ class WorkspaceWindow(QMainWindow):
             from rheojax.gui.foundation.project_codec import save_project_v2
 
             try:
-                save_project_v2(self._state, path)
+                if self._blocked_by_active_jobs(
+                    "save", on_unblocked=lambda: save_project_v2(self._state, path)
+                ):
+                    return
             except (ValueError, FileNotFoundError, OSError) as exc:
                 QMessageBox.critical(self, "Save Failed", str(exc))
                 return
@@ -1422,8 +1452,16 @@ class WorkspaceWindow(QMainWindow):
             self._state.active_jobs.by_id[batch_job_id] = {"status": "starting"}
         runner = PipelineBatchRunner(
             service=self._pipeline_service,
-            steps=pipeline_state.steps,
-            selected_dataset_ids=pipeline_state.selected_dataset_ids,
+            # Shallow-copy both lists: PipelineBatchRunner.run() iterates
+            # them on a worker thread across the whole (potentially long)
+            # batch, while Add/Remove Step and the dataset picker in
+            # step1_configure_run.py stay clickable on the GUI thread and
+            # mutate `pipeline_state.steps`/`.selected_dataset_ids` in place
+            # -- without a copy, an in-flight batch can silently skip,
+            # duplicate, or misconfigure steps for whichever dataset happens
+            # to be substituting when the GUI thread's edit lands.
+            steps=list(pipeline_state.steps),
+            selected_dataset_ids=list(pipeline_state.selected_dataset_ids),
             library=self._state.library,
             stop_requested=self._pipeline_stop_event,
             app_state=self._state,

--- a/rheojax/gui/workspace/window.py
+++ b/rheojax/gui/workspace/window.py
@@ -507,12 +507,6 @@ class WorkspaceWindow(QMainWindow):
                 )
             except (RuntimeError, TypeError):
                 pass
-            try:
-                self._pipeline_service.phase_worker_ready.disconnect(
-                    pipeline_ctl._worker_ready_slot
-                )
-            except (RuntimeError, TypeError):
-                pass
         # Disconnect only the handler each body list actually wired in
         # __init__ -- attempting to disconnect a slot that was never
         # connected to a given body (e.g. _on_transform_body_edited from a
@@ -1454,12 +1448,14 @@ class WorkspaceWindow(QMainWindow):
             service=self._pipeline_service,
             # Shallow-copy both lists: PipelineBatchRunner.run() iterates
             # them on a worker thread across the whole (potentially long)
-            # batch, while Add/Remove Step and the dataset picker in
-            # step1_configure_run.py stay clickable on the GUI thread and
-            # mutate `pipeline_state.steps`/`.selected_dataset_ids` in place
-            # -- without a copy, an in-flight batch can silently skip,
-            # duplicate, or misconfigure steps for whichever dataset happens
-            # to be substituting when the GUI thread's edit lands.
+            # batch. Add/Remove Step in step1_configure_run.py mutate
+            # `pipeline_state.steps` in place (append/del) while staying
+            # clickable on the GUI thread -- without a copy, an in-flight
+            # batch can silently skip, duplicate, or misconfigure steps for
+            # whichever dataset happens to be substituting when the edit
+            # lands. `selected_dataset_ids` is only ever wholesale-reassigned
+            # today (never mutated in place), so this copy is precautionary
+            # for it rather than closing a currently-reachable race.
             steps=list(pipeline_state.steps),
             selected_dataset_ids=list(pipeline_state.selected_dataset_ids),
             library=self._state.library,

--- a/tests/gui/workspace/fit/test_fit_controller.py
+++ b/tests/gui/workspace/fit/test_fit_controller.py
@@ -150,6 +150,53 @@ def test_model_only_edit_restores_still_valid_dataset_selection(qtbot):
     assert bodies[1]._source.currentText() == "osc1"
 
 
+def test_refresh_on_unrelated_notify_preserves_fit_results(qtbot):
+    # End-to-end regression: DataStep.refresh() also runs when
+    # WorkspaceWindow wires DatasetLibraryNotifier.changed -> refresh() for
+    # events unrelated to Step 1 (e.g. "Save fit to library", another
+    # dataset import) -- not just via the Step-1 edit cascade exercised by
+    # test_model_only_edit_restores_still_valid_dataset_selection above.
+    # Before the fix, refresh() unconditionally re-ran _on_select(), which
+    # unconditionally emits `edited`; through this real controller's wiring
+    # (body.edited -> _cascade_and_relock(1, "column_map") ->
+    # invalidate_downstream), that silently wiped nlsq_result/nuts_result
+    # for a selection that never changed. This drives the actual wired
+    # cascade (unlike test_step2.py's DataStep-in-isolation test, which
+    # only proves `edited` doesn't fire and can't see this invalidation).
+    app = AppState()
+    app.library.add(
+        DatasetRef(
+            id="osc1",
+            name="osc1",
+            protocol_type="oscillation",
+            origin="imported",
+            units={"x": "rad/s"},
+            row_count=64,
+            hash="h",
+            provenance={},
+            lineage=[],
+        )
+    )
+    app.library.store_payload(
+        "osc1", _RheoData(np.linspace(0.1, 10.0, 64), np.linspace(1.0, 5.0, 64))
+    )
+    ctl, bodies = build_fit_controller(app)
+    for b in bodies:
+        qtbot.addWidget(b)
+
+    bodies[0].set_protocol("oscillation")
+    bodies[0].set_model("maxwell")
+    bodies[1].select_dataset("osc1")
+    app.fit.nlsq_result = {"success": True, "params": {}}
+    app.fit.nuts_result = {"success": True}
+
+    bodies[1].refresh()  # simulates DatasetLibraryNotifier.changed -> refresh()
+
+    assert app.fit.data_ref == "osc1"
+    assert app.fit.nlsq_result is not None
+    assert app.fit.nuts_result is not None
+
+
 def test_export_step_unlocked_once_visualize_reached(qtbot):
     # Regression: ExportStep (index 5) was structurally unreachable.
     # WorkflowController.advance() is only ever invoked from

--- a/tests/gui/workspace/fit/test_step2.py
+++ b/tests/gui/workspace/fit/test_step2.py
@@ -92,6 +92,35 @@ def test_data_step_refresh_clears_stale_selection(qtbot):
     assert step.available_datasets() == ["c1"]
 
 
+def test_data_step_refresh_preserves_result_when_selection_unchanged(qtbot):
+    # Regression: refresh() used to unconditionally re-run _on_select() even
+    # when the selected dataset hadn't changed -- e.g. when called from
+    # DatasetLibraryNotifier.changed on an unrelated event like "Save fit to
+    # library" or another dataset import. That re-emitted `edited`, which
+    # cascades through invalidate_downstream("column_map") and silently
+    # wiped nlsq_result/nuts_result for a selection that never changed.
+    st = FitState(protocol="oscillation", model_key="generalized_maxwell")
+    lib = DatasetLibrary()
+    lib.add(_ref("osc1", "oscillation"))
+    step = DataStep(st, lib)
+    qtbot.addWidget(step)
+    step.select_dataset("osc1")
+    assert st.data_ref == "osc1"
+    assert st.column_map
+
+    st.nlsq_result = {"success": True, "params": {}}
+    st.nuts_result = {"success": True}
+
+    edited_calls = []
+    step.edited.connect(lambda: edited_calls.append(1))
+    step.refresh()  # same protocol/model/dataset -- nothing actually changed
+
+    assert edited_calls == []
+    assert st.data_ref == "osc1"
+    assert st.nlsq_result is not None
+    assert st.nuts_result is not None
+
+
 def test_data_step_flags_viscosity_data_for_stress_model(qtbot):
     # Regression: MIKH (flow_quantity="stress") silently fit raw viscosity
     # values as stress when a flow_curve CSV had no explicit unit conversion.

--- a/tests/gui/workspace/fit/test_step2.py
+++ b/tests/gui/workspace/fit/test_step2.py
@@ -97,8 +97,12 @@ def test_data_step_refresh_preserves_result_when_selection_unchanged(qtbot):
     # when the selected dataset hadn't changed -- e.g. when called from
     # DatasetLibraryNotifier.changed on an unrelated event like "Save fit to
     # library" or another dataset import. That re-emitted `edited`, which
+    # (via the real fit_controller.py wiring, exercised end-to-end in
+    # test_fit_controller.py::test_refresh_on_unrelated_notify_preserves_fit_results)
     # cascades through invalidate_downstream("column_map") and silently
-    # wiped nlsq_result/nuts_result for a selection that never changed.
+    # wipes nlsq_result/nuts_result for a selection that never changed. This
+    # widget-level test pins the root cause DataStep in isolation controls:
+    # `edited` must not fire when nothing changed.
     st = FitState(protocol="oscillation", model_key="generalized_maxwell")
     lib = DatasetLibrary()
     lib.add(_ref("osc1", "oscillation"))
@@ -108,17 +112,13 @@ def test_data_step_refresh_preserves_result_when_selection_unchanged(qtbot):
     assert st.data_ref == "osc1"
     assert st.column_map
 
-    st.nlsq_result = {"success": True, "params": {}}
-    st.nuts_result = {"success": True}
-
     edited_calls = []
     step.edited.connect(lambda: edited_calls.append(1))
     step.refresh()  # same protocol/model/dataset -- nothing actually changed
 
     assert edited_calls == []
     assert st.data_ref == "osc1"
-    assert st.nlsq_result is not None
-    assert st.nuts_result is not None
+    assert st.column_map
 
 
 def test_data_step_flags_viscosity_data_for_stress_model(qtbot):

--- a/tests/gui/workspace/test_window_chrome.py
+++ b/tests/gui/workspace/test_window_chrome.py
@@ -227,6 +227,25 @@ def test_preferences_dialog_restores_current_theme_selection(qtbot):
     assert dialog.theme_combo.currentText() == "Dark"
 
 
+def test_mode_switcher_button_stays_checked_on_reclick(qtbot):
+    # Regression: the three mode-switcher pills had no exclusive QButtonGroup,
+    # so Qt would uncheck the already-active pill on a re-click before
+    # set_mode()'s no-op early return (mode == self._mode) ever reached
+    # _sync_mode_buttons() -- the toolbar could show no mode selected while
+    # the app stayed in that mode. QButtonGroup(exclusive=True) makes Qt
+    # itself refuse to uncheck the sole checked button.
+    from PySide6.QtCore import Qt
+
+    win = _win(qtbot)
+    assert win.mode() == "fit"
+    assert win._fit_btn.isChecked() is True
+
+    qtbot.mouseClick(win._fit_btn, Qt.MouseButton.LeftButton)
+
+    assert win.mode() == "fit"
+    assert win._fit_btn.isChecked() is True
+
+
 def test_command_palette_action_list_has_expected_labels(qtbot):
     win = _win(qtbot)
     actions = win._command_palette_actions()

--- a/tests/gui/workspace/test_window_file_menu.py
+++ b/tests/gui/workspace/test_window_file_menu.py
@@ -160,6 +160,29 @@ def test_on_save_holds_active_jobs_lock_during_save(qtbot, monkeypatch, tmp_path
     assert lock_held_during_save == [True]
 
 
+def test_on_save_as_holds_active_jobs_lock_during_save(qtbot, monkeypatch, tmp_path):
+    # Same regression as test_on_save_holds_active_jobs_lock_during_save
+    # above, for the _on_save_as call site specifically -- it received the
+    # identical on_unblocked-holds-the-lock fix, on a separate code path
+    # that a revert scoped to just _on_save could silently leave broken.
+    win = _win(qtbot)
+    path = str(tmp_path / "proj.rheojax")
+
+    lock_held_during_save = []
+
+    def _fake_save(state, save_path):
+        lock_held_during_save.append(state.active_jobs.lock.locked())
+
+    monkeypatch.setattr(
+        "rheojax.gui.foundation.project_codec.save_project_v2", _fake_save
+    )
+    monkeypatch.setattr(QFileDialog, "getSaveFileName", lambda *a, **k: (path, ""))
+
+    win._on_save_as()
+
+    assert lock_held_during_save == [True]
+
+
 def test_on_save_as_shows_critical_dialog_on_os_error(qtbot, monkeypatch):
     win = _win(qtbot)
 

--- a/tests/gui/workspace/test_window_file_menu.py
+++ b/tests/gui/workspace/test_window_file_menu.py
@@ -136,6 +136,30 @@ def test_on_save_shows_critical_dialog_on_value_error(qtbot, monkeypatch):
     assert win._state.project.dirty is True
 
 
+def test_on_save_holds_active_jobs_lock_during_save(qtbot, monkeypatch, tmp_path):
+    # Regression: _blocked_by_active_jobs used to check active_jobs.by_id
+    # under lock, release the lock, then call save_project_v2() unlocked --
+    # a worker thread could register a job in that TOCTOU gap and produce a
+    # torn save, exactly the race Save is meant to prevent (see its own
+    # Spec S3.3 comment). The save I/O must now run while active_jobs.lock
+    # is still held.
+    win = _win(qtbot)
+    win._state.project.path = str(tmp_path / "proj.rheojax")
+
+    lock_held_during_save = []
+
+    def _fake_save(state, path):
+        lock_held_during_save.append(state.active_jobs.lock.locked())
+
+    monkeypatch.setattr(
+        "rheojax.gui.foundation.project_codec.save_project_v2", _fake_save
+    )
+
+    win._on_save()
+
+    assert lock_held_during_save == [True]
+
+
 def test_on_save_as_shows_critical_dialog_on_os_error(qtbot, monkeypatch):
     win = _win(qtbot)
 

--- a/tests/gui/workspace/test_window_pipeline_mode.py
+++ b/tests/gui/workspace/test_window_pipeline_mode.py
@@ -74,6 +74,54 @@ def test_run_all_populates_active_jobs(qtbot, tmp_path, monkeypatch):
     assert "d1" in captured["d1"]
 
 
+def test_pipeline_run_requested_passes_step_list_copies_not_live_refs(
+    qtbot, monkeypatch
+):
+    # Regression: PipelineBatchRunner used to receive the live
+    # pipeline_state.steps/.selected_dataset_ids list objects by reference
+    # and iterate them on a worker thread across the whole (potentially
+    # long) batch, while Add/Remove Step and the dataset picker in
+    # step1_configure_run.py stayed clickable on the GUI thread and mutated
+    # those same lists in place -- an in-flight batch could silently skip,
+    # duplicate, or misconfigure steps for whichever dataset happened to be
+    # substituting when the edit landed. The window must now pass shallow
+    # copies at construction time.
+    from PySide6.QtCore import QThreadPool
+
+    state = AppState()
+    win = WorkspaceWindow(state)
+    qtbot.addWidget(win)
+    win.set_mode("pipeline")
+    pipeline_body = win._pipeline_bodies[0]
+    pipeline_body.add_step(
+        "export", {"path": "out.csv", "format": "csv"}
+    )
+    pipeline_body.set_selected_dataset_ids(["d1"])
+
+    started_runners = []
+    monkeypatch.setattr(
+        QThreadPool.globalInstance(),
+        "start",
+        lambda runner: started_runners.append(runner),
+    )
+
+    win._on_pipeline_run_requested()
+
+    assert len(started_runners) == 1
+    runner = started_runners[0]
+    assert runner._steps is not state.pipeline.steps
+    assert runner._selected_dataset_ids is not state.pipeline.selected_dataset_ids
+    assert runner._steps == state.pipeline.steps  # same content, distinct object
+    assert runner._selected_dataset_ids == state.pipeline.selected_dataset_ids
+
+    # Mutating the live state after the runner was constructed must not
+    # reach the runner's copies.
+    state.pipeline.steps.clear()
+    state.pipeline.selected_dataset_ids.clear()
+    assert len(runner._steps) == 1
+    assert runner._selected_dataset_ids == ["d1"]
+
+
 def test_run_all_ignored_while_batch_already_running(qtbot, monkeypatch):
     from PySide6.QtCore import QThreadPool
 

--- a/tests/gui/workspace/transform/test_run_step_wiring.py
+++ b/tests/gui/workspace/transform/test_run_step_wiring.py
@@ -99,6 +99,43 @@ def test_run_fn_registers_active_job_during_run(qapp, monkeypatch):
     assert app.active_jobs.by_id == {}
 
 
+def test_run_fn_snapshots_config_before_worker_starts(qapp, monkeypatch):
+    # Regression: the run closure snapshotted `slots` but not `config`,
+    # leaving TransformWorker holding a live reference into
+    # TransformState.config. step2_slots.py's _on_params_changed() mutates
+    # that same dict in place from the GUI thread while loop.exec() pumps
+    # events during the run -- a single run could compute with an
+    # inconsistent mix of pre-/post-edit parameter values. config must be
+    # snapshotted the same way slots already was.
+    captured_params = {}
+
+    def fake_apply_transform(self, name, data, params):
+        captured_params["params"] = params
+        # Simulate a concurrent GUI-thread edit to the live config dict
+        # while the worker is "in flight" -- must not be visible below.
+        app.transform.config["threshold"] = "mutated-mid-run"
+        return _RheoData([1.0], [2.0])
+
+    monkeypatch.setattr(
+        "rheojax.gui.services.transform_service.TransformService.apply_transform",
+        fake_apply_transform,
+    )
+
+    app = AppState()
+    app.library.add(_ref("d1", "flow_curve"))
+    app.library.store_payload("d1", _RheoData([0.0], [0.0]))
+    app.transform.transform_key = "smooth_derivative"
+    app.transform.slots = {"input": "d1"}
+    app.transform.config = {"threshold": "original"}
+
+    ctl, bodies = build_transform_controller(app)
+    run_step = bodies[2]
+    run_step.run()
+
+    assert captured_params["params"]["threshold"] == "original"
+    assert captured_params["params"] is not app.transform.config
+
+
 def test_run_fn_raises_on_worker_failure(qapp, monkeypatch):
     def fake_apply_transform(self, name, data, params):
         raise ValueError("bad params")


### PR DESCRIPTION
## Summary

Ran a click-path audit (`/click-path-audit`) across the whole GUI workspace — wizard nav shell plus fit/transform/pipeline tabs — tracing every button handler against the Redux-style/foundation state layer's side-effect map to find actions that silently undo each other. 9 candidate bugs found; 5 confirmed and fixed here, 1 was a false positive (caught by `/review-pr`, see below), 2 deliberately skipped (documented, not silently dropped).

**Fixed:**
- **fit tab (Critical/High):** `DataStep.refresh()` unconditionally re-ran `_on_select()` on every `DatasetLibraryNotifier.changed` event, even when the selected dataset hadn't changed — re-emitting `edited`, which cascades through `invalidate_downstream("column_map")` and wipes `nlsq_result`/`nuts_result`. Clicking "Save fit to library" (or any unrelated dataset import) silently discarded the fit just produced. Fixed by guarding the re-derive on actual state change.
- **wizard nav (Medium):** mode-switcher pills had no exclusive button group, so re-clicking the already-active pill let Qt uncheck it before `set_mode()`'s no-op early return could resync it — the toolbar could show no mode selected while the app stayed in that mode. Fixed via `QButtonGroup(exclusive=True)`.
- **wizard nav (Medium-High):** Save checked `active_jobs.by_id` under lock, released it, then wrote the project snapshot unlocked — a worker thread could register a job in that TOCTOU gap and produce a torn save, exactly what the guard's own comment says it prevents. Fixed by running the write inside the same locked section.
- **transform tab (High):** the run closure snapshotted `slots` but not `config`, which stayed a live reference into `TransformState.config` while `step2_slots.py` mutated it in place mid-run — a single run could compute with an inconsistent mix of pre-/post-edit parameter values. Fixed by snapshotting `config` the same way `slots` already was.
- **pipeline tab (High):** `PipelineBatchRunner` iterated the live `pipeline_state.steps`/`selected_dataset_ids` lists across a whole (potentially long) batch while Add/Remove Step and the dataset picker stayed clickable on the GUI thread and mutated those same lists in place. Fixed by passing shallow copies at construction time.

**Not fixed (flagged, not dropped):**
- fit tab (Low): background NLSQ/NUTS completion can snap stepper navigation back to the running step if the user navigated elsewhere mid-run. UX-only, no data corruption (the `revision_at_start` guard already discards stale results correctly). No canvas/controller handle currently exists inside `NlsqStep`/`NutsStep` to gate on — wiring one in is disproportionate to a cosmetic issue.
- pipeline tab (Low): `PipelineState.job_id` collapses a multi-dataset batch's per-dataset job IDs to whichever finished last. Currently write-only with zero readers (one test only asserts non-null) — changing the data model speculatively for a bug with no live consumer isn't a fix, it's scope creep.

## `/review-pr` findings and corrections

Ran the full ECC review stack (code-reviewer, comment-analyzer, pr-test-analyzer, silent-failure-hunter, type-design-analyzer, code-simplifier) against this branch. Two independent agents (code-reviewer, comment-analyzer) caught a real defect in the original "pipeline cancel doesn't work" fix:

- **False premise, reverted:** `WorkspaceWindow._on_phase_worker_ready` (added in #31, an ancestor of this branch's base) already wires `phase_worker_ready` → stashes the cancellable worker into `active_jobs.by_id[dataset_id]["worker"]` under `active_jobs.lock`. Pipeline cancel was never actually broken on `main`. The handler this PR originally added to `PipelineController` was a second, **unlocked** writer to the same dict entry on the same signal — redundant at best, and it violated the exact lock invariant the existing handler documents. Reverted entirely rather than reconciling two handlers doing the same job. 34 targeted tests re-verified green after the revert.
- **Comment accuracy fix:** the `PipelineBatchRunner` list-snapshot comment overstated the hazard — it claimed `selected_dataset_ids` is mutated in place, but it's actually only ever wholesale-reassigned. Corrected to avoid future rot (a reader trusting the stale claim could introduce a real in-place-mutation bug elsewhere believing this comment already covered it).
- **No other Critical/High findings.** type-design-analyzer and code-simplifier found nothing to change (no new types in this diff; current implementation already the simplest correct option, including a latent improvement where `_on_save` now checks `project.path is None` before the active-jobs check, avoiding a double-dialog the old code had).

**Regression tests added.** pr-test-analyzer flagged that none of the 5 fixed bugs had a dedicated regression test — the 121 passing tests proved no *unrelated* regression, not that these specific fixes stay fixed. Added one targeted test per fix (`tests/gui/workspace/fit/test_step2.py`, `test_window_chrome.py`, `test_window_file_menu.py`, `transform/test_run_step_wiring.py`, `test_window_pipeline_mode.py`) — 126 passed, 0 failed.

## Test plan

- [x] Ran targeted GUI suite covering all touched files: `tests/gui/workspace/fit/{test_step2,test_step2_validation,test_fit_controller,test_end_to_end_fit_to_export}.py`, `tests/gui/workspace/{test_window_file_menu,test_window_chrome,test_window_active_jobs_dialog,test_window_pipeline_mode}.py`, `tests/gui/workspace/transform/{test_transform_controller,test_run_step_wiring}.py`, `tests/gui/workspace/pipeline/{test_controller,test_batch_runner}.py` — 121 passed, 0 failed (pre-revert); re-ran pipeline/window subset (34 tests) post-revert — all passed.
- [ ] Manual smoke test in the running GUI (not done here — background job, no display).
- [x] Regression tests for the 5 fixed bugs — one per fix, 126 passed total.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
