### PR TITLE
fix(gui): stop export/status-bar blocking the Qt main thread

### DIFF
--- a/.reports/codemap-diff.txt
+++ b/.reports/codemap-diff.txt
@@ -1,0 +1,36 @@
+Codemap Update Report — 2026-07-18
+====================================
+
+Baseline: none (first run — no prior docs/CODEMAPS/ existed in this repo).
+
+Files created:
+  docs/CODEMAPS/architecture.md   (~650 tokens)
+  docs/CODEMAPS/backend.md        (~550 tokens)  [adapted: core/pipeline/CLI, no HTTP server]
+  docs/CODEMAPS/frontend.md       (~700 tokens)  [adapted: PySide6 GUI, no web frontend]
+  docs/CODEMAPS/data.md           (~500 tokens)  [adapted: RheoData + file I/O, no DB]
+  docs/CODEMAPS/dependencies.md   (~450 tokens)
+
+Source: root CLAUDE.md's 2026-07-17 architect scan (already verified against source in that
+scan) plus direct source reads from this session's own PR #90 work (rheojax/gui/workspace/
+window.py, stepper_canvas.py, fit/step6_export.py, transform/step5_export.py, jobs/
+export_worker.py, core/registry.py). No fresh full-repo scan was run — cost was already over
+budget for this session ($50+), so this update leans on already-verified, recent context rather
+than re-deriving structure from scratch. GRAPH_REPORT.md (graphify-out/, 3999 lines, built from
+commit a87f8101) exists as a lower-level cross-reference if deeper detail is needed later.
+
+Architecture changes noted (from this session's own PR #90, not yet merged — branch
+worktree-wiggly-watching-hamster):
+  - ExportWorker (rheojax/gui/jobs/export_worker.py) now actually wired into ExportStep/
+    TransformExportStep, and registered in AppState.active_jobs.by_id.
+  - New pattern: GUI background workers must (a) hold a Python reference to the worker for its
+    run duration, (b) register/deregister via active_jobs.by_id keyed by job_id — documented in
+    frontend.md's "Background Jobs" section.
+
+Staleness warnings: none — this is the initial baseline, nothing to compare against yet. Re-run
+after merging PR #90 (or any subsequent GUI/core structural change) to keep these current.
+
+Not scanned (out of scope for this pass, cost-constrained):
+  - Full per-file line counts / function signatures within each module.
+  - models/ (105 files, 22 families) — root CLAUDE.md's existing module index already covers
+    this at the same altitude these codemaps target; not duplicated here.
+  - tests/ tree — codemaps target source structure per the command's own scope.

--- a/docs/CODEMAPS/architecture.md
+++ b/docs/CODEMAPS/architecture.md
@@ -1,0 +1,59 @@
+<!-- Generated: 2026-07-18 | Files scanned: ~342 source (excl. tests) | Token estimate: ~650 -->
+
+# RheoJAX Architecture
+
+JAX-accelerated rheology analysis framework: 53 constitutive models (22 families), 11 data
+transforms, NLSQ+Bayesian(NumPyro) dual-track fitting, scikit-learn-style API + PySide6 GUI.
+
+## Module Graph
+
+```
+rheojax/
+├── core/        (17 src)  BaseModel/BaseTransform, RheoData, Registry, FitOrchestrator, NumPyro builder
+├── models/      (105 src) 53 models / 22 families, lazy __getattr__ registration
+├── transforms/  (12 src)  FFT, mastercurve/TTS-SRFS, SPP decomposition, Prony — eager-imported
+├── io/          (27 src)  TRIOS/Anton Paar/CSV/Excel/HDF5 readers+writers, format auto-detect
+├── pipeline/    (6 src)   Pipeline/BayesianPipeline fluent API, PipelineBuilder, BatchPipeline
+├── cli/         (17 src)  `rheojax`/`rj` entry point: fit/bayesian/spp/pipeline/batch/info
+├── gui/         (115 src) PySide6 desktop app (`rheojax-gui`) — see frontend.md
+├── utils/       (33 src)  Mittag-Leffler, Prony series, NLSQ helpers, uncertainty, init heuristics
+├── parallel/    (4 src)   Process-pool fit/bayesian/batch parallelism
+└── logging/     (6 src)   Structured logging shared by core/cli/gui
+```
+
+Dependency direction: everything → `core`. `models`/`transforms` register into `core.Registry` via
+decorators. `pipeline` and `cli` orchestrate `core` + `models`/`transforms`. `gui` calls `core`/
+`pipeline`/`io` through a service layer (never touches JAX directly — see frontend.md).
+
+## Data Flow (fit path)
+
+```
+file (CSV/HDF5/TRIOS) --io.readers--> RheoData --core.FitOrchestrator--
+    --> NLSQ (utils.optimization) --warm-start--> NumPyro NUTS (core.numpyro_model_builder)
+    --> FitResult (params + ArviZ diagnostics: R-hat/ESS/BFMI)
+```
+
+Same RheoData container flows through `transforms` (FFT/mastercurve/SPP/...) independently of the
+fit path; `pipeline.Pipeline`/`BayesianPipeline` chain transform → fit steps declaratively.
+
+## Key Invariants (see root CLAUDE.md for full detail)
+
+- **float64 forced** at package import (`rheojax/__init__.py`); internal code must use
+  `core.jax_config.safe_import_jax()`, never bare `import jax`.
+- **Lazy registration**: `models`, `PersistentProcessPool`, and the root package's `models`
+  attribute all use `__getattr__` — `_ensure_all_registered()` forces eager load when needed
+  (CLI, GUI model-selection step, tests).
+- **NLSQ → NUTS handoff** is the standard Bayesian path (`core/fit_orchestrator.py`).
+- **Single GUI shell**: `WorkspaceWindow` (`gui/workspace/window.py`) is the only entry point;
+  legacy `RheoJAXMainWindow`/`--legacy` CLI flag removed (BREAKING, see CHANGELOG `[Unreleased]`).
+
+## Entry Points
+
+| Command | File |
+|---|---|
+| `rheojax` / `rj` (CLI) | `rheojax/cli/main.py` |
+| `rheojax-gui` / `rj-gui` | `rheojax/gui/main.py` → `WorkspaceWindow` |
+| Library import | `import rheojax` → `rheojax/__init__.py` (triggers x64 config) |
+
+See `backend.md` (core/pipeline/cli), `frontend.md` (gui), `data.md` (RheoData/io), and
+`dependencies.md` (external stack).

--- a/docs/CODEMAPS/backend.md
+++ b/docs/CODEMAPS/backend.md
@@ -1,0 +1,55 @@
+<!-- Generated: 2026-07-18 | Files scanned: ~40 (core+pipeline+cli) | Token estimate: ~550 -->
+
+# Core / Pipeline / CLI ("backend" layer — no HTTP server; library + CLI)
+
+No web routes. Equivalent surface: CLI subcommands and the fluent Pipeline API, both sitting on
+`core`'s Registry + FitOrchestrator.
+
+## CLI Commands → Core Call Chain
+
+```
+rheojax fit <file>       → cli.fit         → core.Registry.get(model) → FitOrchestrator.fit_nlsq
+rheojax bayesian <file>  → cli.bayesian    → FitOrchestrator.fit_nlsq → fit_bayesian (NUTS warm-start)
+rheojax spp <file>       → cli.spp         → transforms.SPPDecomposer
+rheojax load/transform   → cli.load/transform → io.readers.auto_load → transforms.Registry
+rheojax export           → cli.export      → io.writers (HDF5/Excel/NPZ, SPP MATLAB-compat)
+rheojax pipeline <yaml>  → cli.pipeline    → pipeline.PipelineBuilder.from_yaml
+rheojax batch            → cli.batch       → pipeline.BatchPipeline (+ parallel.PersistentProcessPool)
+rheojax info/inventory   → cli.info        → core.Registry introspection
+```
+
+## Core Registry
+
+`core/registry.py` — `Registry` (singleton), `ModelRegistry`, `TransformRegistry`. Models/
+transforms self-register via `@ModelRegistry.register`/`@TransformRegistry.register` decorators.
+`PluginInfo.doc` = `inspect.getdoc(plugin_class)`, used for CLI `info` output and (as of PR #90)
+GUI model-picker tooltips.
+
+## FitOrchestrator (`core/fit_orchestrator.py`)
+
+- `fit_nlsq(model, data)` → NLSQ-wrapped optimizer (`utils/optimization.py`)
+- `fit_bayesian(model, data, nlsq_result=...)` → warm-starts NumPyro NUTS via
+  `core/numpyro_model_builder.py`; diagnostics via `core/arviz_utils.py` (arviz 1.x kwarg shim)
+
+## Pipeline API (`pipeline/`)
+
+- `Pipeline`/`BayesianPipeline` — fluent, chainable transform→fit steps
+- `PipelineBuilder` — YAML → Pipeline (used by `cli pipeline` and `cli batch`)
+- `BatchPipeline` — multi-dataset batch execution, routes through `parallel/pool.py`
+- Preset workflows: mastercurve, model comparison, creep transforms (`pipeline/workflows.py`)
+
+## Key Files
+
+- `core/base.py` — `BaseModel`/`BaseTransform` abstract contracts
+- `core/data.py` — `RheoData` container (see data.md)
+- `core/registry.py` — plugin registry (722+ lines)
+- `core/fit_orchestrator.py` — NLSQ↔Bayesian orchestration
+- `core/numpyro_model_builder.py` — NumPyro model construction
+- `core/arviz_utils.py` — ArviZ 1.x compat shim
+- `cli/main.py` — argparse entry, subcommand dispatch
+- `pipeline/builder.py` — YAML pipeline loader
+
+## Envelope I/O
+
+CLI pipeline/batch runs read/write a JSON "envelope" format (input config + output results) —
+see `cli/` for envelope schema, not a database.

--- a/docs/CODEMAPS/data.md
+++ b/docs/CODEMAPS/data.md
@@ -1,0 +1,43 @@
+<!-- Generated: 2026-07-18 | Files scanned: ~30 (core/data + io) | Token estimate: ~500 -->
+
+# Data Model & I/O (no relational database)
+
+RheoJAX has no DB. "Data" = the `RheoData` container + file formats it round-trips through.
+
+## RheoData (`core/data.py`)
+
+Core container: `x`/`y` arrays (protocol-typed, e.g. time/G(t), freq/G'+G''), `protocol_type`,
+`metadata` dict, provenance/lineage tracking. Runtime-validated at I/O boundaries (shape, dtype,
+NaN, monotonicity — per root CLAUDE.md §3). Flows unchanged through both the fit path and the
+transform path (see architecture.md).
+
+## Readers (`io/readers/`)
+
+| Format | Reader |
+|---|---|
+| TRIOS (TA Instruments) | `trios.py` |
+| Anton Paar | `anton_paar.py` |
+| CSV / Excel | `csv.py`, `excel.py` |
+| Auto-detect | `auto.py` → `auto_load()` |
+
+## Writers (`io/writers/`)
+
+| Format | Writer | Used by |
+|---|---|---|
+| HDF5 | `hdf5_writer.py` | `cli export`, batch pipeline |
+| Excel / NPZ | `excel_writer.py`, `npz_writer.py` | `cli export` |
+| SPP MATLAB-compat | (SPP export module) | `spp` transform export |
+| CSV/NetCDF/JSON bundle | `gui/services/export_service.py` | GUI wizard "Export Bundle..." (Fit/Transform step) |
+
+## GUI Project File (v2 schema)
+
+`gui/foundation/project_codec.py` — `save_project_v2()`/`load_project_v2()`. Serializes
+`AppState` (fit/transform/pipeline state, dataset library refs, UI prefs) to a single project
+file for GUI "Save"/"Open". Distinct from the CLI's JSON "envelope" format (backend.md).
+
+## Provenance
+
+Every fit/transform result carries a `provenance` dict (model_key, config, protocol, data_ref,
+revision, convergence_verdict when Bayesian) — written into export bundles' `provenance.json` and
+into the project file, so results are traceable back to the exact inputs/config that produced
+them (research-reproducibility requirement, root CLAUDE.md §Principles).

--- a/docs/CODEMAPS/dependencies.md
+++ b/docs/CODEMAPS/dependencies.md
@@ -1,0 +1,50 @@
+<!-- Generated: 2026-07-18 | Files scanned: pyproject.toml (not re-parsed; from CLAUDE.md/known stack) | Token estimate: ~450 -->
+
+# Dependencies
+
+## Numerical Core
+
+- **JAX / jaxlib** — computational core, x64 forced at import. GPU via `jax[cuda12/cuda13]`
+  extras (never both installed together).
+- **NLSQ** — GPU-accelerated non-linear least squares.
+- **optimistix** — root-finding.
+- **optax** — optimizer schedules.
+- **diffrax** — ODE solving (used instead of `jax.experimental.ode`).
+- **interpax** — JIT-safe interpolation (never `scipy.interpolate` in JIT paths).
+- **lineax** — linear algebra (recently upgraded, see git log `06f42c25`).
+
+## Bayesian
+
+- **NumPyro** — preferred Bayesian engine (NUTS).
+- **ArviZ** (1.x: `arviz-base`/`arviz-stats`/`arviz-plots` split) — diagnostics (R-hat, ESS,
+  BFMI); `core/arviz_utils.py` shims kwarg differences.
+
+## GUI
+
+- **PySide6** — Qt bindings, desktop shell.
+- **PyQtGraph** — interactive plotting canvas.
+- **matplotlib** — diagnostic canvases (ArviZ, residuals panel).
+
+## I/O
+
+- **pandas** — CSV/Excel read/write.
+- **h5py** (or equivalent) — HDF5 read/write.
+
+## Dev/Test
+
+- **uv** — package/environment manager, `uv.lock` is the lockfile source of truth.
+- **pytest** (+ **pytest-xdist**, **pytest-qt**, **pytest-timeout**, **pytest-benchmark**) — test
+  runner; `--dist=loadgroup` preserves NUTS-test isolation.
+- **ruff** — lint (line-length 88, E/W/F/I/C/B/UP/S rule sets).
+- **mypy** — type check (`rheojax.gui.*`/`rheojax.cli.*` ignored for PySide6 stub gaps).
+
+## Cross-Cutting Constraint
+
+Never install `gpu_cuda12` and `gpu_cuda13` extras simultaneously (`pyproject.toml` optional-deps
+groups are mutually exclusive at the plugin level).
+
+## External Services
+
+None — this is a local-only library/CLI/desktop app. No network calls except optional GPU
+detection and GitHub-hosted docs (`Help > Documentation`/`Tutorials` in the GUI open
+`readthedocs.io` via `webbrowser.open()`).

--- a/docs/CODEMAPS/frontend.md
+++ b/docs/CODEMAPS/frontend.md
@@ -1,0 +1,62 @@
+<!-- Generated: 2026-07-18 | Files scanned: ~115 (rheojax/gui) | Token estimate: ~700 -->
+
+# GUI (PySide6 desktop app, `rheojax-gui`)
+
+Single-shell app. No web frontend — this replaces the template's "page tree"/"component
+hierarchy" with the Qt widget tree + Redux-style state store.
+
+## Shell
+
+`WorkspaceWindow` (`gui/workspace/window.py`) — sole entry point. 3-step-wizard model: Fit /
+Transform / Pipeline modes, switched via toolbar `QToolButton`s (`_fit_btn`/`_tx_btn`/
+`_pipeline_btn`). Each mode owns a `StepperCanvas` (`gui/workspace/stepper_canvas.py`) — a numbered
+step rail + `QStackedWidget` body, gated by `WorkflowController.reached` (forward-locked,
+backward-revisitable). `Ctrl+1..9` jump steps; `Ctrl+K` opens a command palette.
+
+## Wizard Steps
+
+```
+Fit:       1 Protocol&Model → 2 Data → 3 NLSQ → 4 NUTS → 5 Visualize → 6 Export
+Transform: 1 Slots → 2 Config → 3 Run → 4 Visualize → 5 Export
+Pipeline:  1 Configure&Run  (batch execution via PipelineExecutionService)
+```
+Built by `fit_controller.build_fit_controller(AppState)` /
+`transform_controller.build_transform_controller(AppState)` — each returns
+`(WorkflowController, [step widgets])`. All three built eagerly in
+`WorkspaceWindow._build_workspace`, not lazily per mode-switch.
+
+## State (Redux-style, `gui/state/` + `gui/foundation/state.py`)
+
+`AppState` → `FitState` / `TransformState` / `PipelineState` / `DatasetLibrary` /
+`ActiveJobsState` (`by_id: dict[str, dict]`, tracks in-flight background jobs for
+Close/New/Open confirmation) / `UiState` (theme, mode). `StateStore`/`StateSignals`
+(`gui/state/store.py`, `signals.py`) — granular per-domain Qt signals, not one broad
+`state_changed` fan-out.
+
+## Services (`gui/services/`) — GUI's only path to `core`/`pipeline`
+
+`DataService`, `TransformService`, `ModelService` (`FAMILY_LABELS` for model-picker grouping),
+`BayesianService`, `PlotService`, `ExportService`, `PipelineExecutionService`. GUI code never
+imports JAX directly — always through these.
+
+## Background Jobs (`gui/jobs/`)
+
+`QRunnable`+`QThreadPool` workers, dispatched off the GUI thread and registered in
+`AppState.active_jobs.by_id` so window-close waits for them: `FitWorker`, `BayesianWorker`,
+`ImportWorker`, `ExportWorker`, `PipelineBatchRunner`. Established pattern (post-PR-#90): hold a
+Python reference to the worker for its lifetime (parentless `signals` QObject risks GC mid-run
+otherwise), register/deregister via a `job_id` in `active_jobs.by_id`.
+
+## Plotting
+
+`gui/widgets/pyqtgraph_canvas.py` (`RheoPlotCanvas`/`PyQtGraphCanvas`) — interactive PyQtGraph,
+downsampling+clip-to-view enabled (PR #90). `gui/widgets/arviz_canvas.py`/`residuals_panel.py` —
+matplotlib-backed diagnostic plots (separate from the interactive canvas).
+
+## Key Files
+
+- `gui/main.py` — entry point, JAX status probe (deferred via QTimer as of PR #90)
+- `gui/workspace/window.py` — shell, menus, mode/job/theme management (~1400 lines)
+- `gui/workspace/fit/fit_controller.py`, `transform/transform_controller.py` — wizard assembly
+- `gui/foundation/state.py` — dataclass state tree
+- `gui/foundation/project_codec.py` — project save/load (v2 schema)

--- a/rheojax/gui/jobs/export_worker.py
+++ b/rheojax/gui/jobs/export_worker.py
@@ -84,6 +84,14 @@ class ExportWorker(QRunnable):
             )
             self.signals.completed.emit(result)
         except Exception as e:
+            # Broad on purpose: an uncaught exception on a QThreadPool
+            # worker thread is silently dropped by Qt rather than crashing
+            # or propagating anywhere catchable, which would be worse than
+            # over-catching here. The tradeoff: a genuine programming bug
+            # (AttributeError/KeyError from a typo) now reaches the user as
+            # the same generic "Export failed: ..." text as a legitimate
+            # malformed-data failure, instead of surfacing distinctly.
+            # exception_type is still logged below for post-mortem digging.
             error_msg = str(e)
             logger.error(
                 "Export worker failed",

--- a/rheojax/gui/widgets/pyqtgraph_canvas.py
+++ b/rheojax/gui/widgets/pyqtgraph_canvas.py
@@ -199,16 +199,23 @@ class PyQtGraphCanvas(QWidget):
 
         # Auto-range button
         auto_btn = QPushButton("Auto Range")
+        auto_btn.setToolTip("Reset zoom/pan to fit all plotted data")
         auto_btn.clicked.connect(self._plot_widget.autoRange)
         layout.addWidget(auto_btn)
 
         # Clear button
         clear_btn = QPushButton("Clear")
+        clear_btn.setToolTip("Remove all curves from this chart")
         clear_btn.clicked.connect(self.clear)
         layout.addWidget(clear_btn)
 
         # Export button
-        export_btn = QPushButton("Export")
+        # "Chart" (not bare "Export"): the wizard's own Export step writes a
+        # full CSV/NetCDF/JSON bundle -- this button only saves this one
+        # chart as an image, a different scope that a same-labeled button
+        # elsewhere in the same flow could easily be mistaken for.
+        export_btn = QPushButton("Export Chart...")
+        export_btn.setToolTip("Save this chart as an image file")
         export_btn.clicked.connect(self._on_export)
         layout.addWidget(export_btn)
 

--- a/rheojax/gui/widgets/pyqtgraph_canvas.py
+++ b/rheojax/gui/widgets/pyqtgraph_canvas.py
@@ -131,6 +131,13 @@ class PyQtGraphCanvas(QWidget):
         # Enable grid
         self._plot_item.showGrid(x=True, y=True, alpha=0.3)
 
+        # Large series (e.g. LAOS/time-domain sweeps) were rendering every
+        # raw sample; peak-mode downsampling collapses off-screen density
+        # without losing visible curve shape, and clip-to-view skips points
+        # outside the current pan/zoom range.
+        self._plot_widget.setDownsampling(auto=True, mode="peak")
+        self._plot_widget.setClipToView(True)
+
         # Setup axes
         self._plot_item.setLabel("left", "Y")
         self._plot_item.setLabel("bottom", "X")

--- a/rheojax/gui/workspace/fit/fit_controller.py
+++ b/rheojax/gui/workspace/fit/fit_controller.py
@@ -380,7 +380,7 @@ def build_fit_controller(app_state: AppState):
             st, sample_fn=_make_sample_fn(app_state.library, st, app_state.active_jobs)
         ),
         VisualizeStep(st),
-        ExportStep(st, app_state.library),
+        ExportStep(st, app_state.library, app_state.active_jobs),
     ]
     validators = [
         lambda b=bodies[0]: b.is_ready(),

--- a/rheojax/gui/workspace/fit/step1_protocol_model.py
+++ b/rheojax/gui/workspace/fit/step1_protocol_model.py
@@ -4,7 +4,7 @@ import inspect
 import typing
 from typing import Any, Literal, get_args, get_origin
 
-from PySide6.QtCore import Signal
+from PySide6.QtCore import Qt, Signal
 from PySide6.QtWidgets import (
     QCheckBox,
     QComboBox,
@@ -46,6 +46,20 @@ def _grouped_models(protocol: str) -> dict[str, list[str]]:
     if leftover:
         grouped.setdefault("other", []).extend(leftover)
     return grouped
+
+
+def _model_tooltip(name: str) -> str:
+    """First line of the model class's docstring, or "" if it has none.
+
+    Surfaced as a hover tooltip so picking among a protocol-filtered but
+    still potentially long list of models doesn't require already knowing
+    what each one assumes, or leaving the app to check the docs.
+    """
+    info = ModelRegistry.get_info(name)
+    doc = getattr(info, "doc", None) if info is not None else None
+    if not doc:
+        return ""
+    return doc.strip().split("\n")[0]
 
 
 def _constructor_params(model_key: str) -> list[tuple[str, Any, Any]]:
@@ -168,6 +182,11 @@ class ProtocolModelStep(QWidget):
                 self._model.add_group_header(f"── {label} ──")
                 for name in names:
                     self._model.addItem(f"  {name}", name)
+                    tooltip = _model_tooltip(name)
+                    if tooltip:
+                        self._model.setItemData(
+                            self._model.count() - 1, tooltip, Qt.ItemDataRole.ToolTipRole
+                        )
         self._model.blockSignals(False)
         self._on_model(self._model.currentData())
 
@@ -183,6 +202,10 @@ class ProtocolModelStep(QWidget):
     def _on_model(self, key: str | None) -> None:
         self._state.model_key = key or None
         self._state.model_config = {}
+        # Reflect the *selected* model's description on the closed combo box
+        # itself -- the per-item tooltips set in _on_protocol only show
+        # while the dropdown list is open.
+        self._model.setToolTip(_model_tooltip(key) if key else "")
         self._rebuild_config_widgets(key)
         self._refresh_preview()
         self.edited.emit()

--- a/rheojax/gui/workspace/fit/step6_export.py
+++ b/rheojax/gui/workspace/fit/step6_export.py
@@ -8,9 +8,10 @@ import numpy as np
 from PySide6.QtCore import Signal
 from PySide6.QtWidgets import QLabel, QPushButton, QVBoxLayout, QWidget
 
-from rheojax.gui.compat import QFileDialog
+from rheojax.gui.compat import QFileDialog, QThreadPool
 from rheojax.gui.foundation.library import DatasetLibrary, DatasetRef
 from rheojax.gui.foundation.state import FitState
+from rheojax.gui.jobs.export_worker import ExportWorker
 from rheojax.gui.resources.styles.tokens import field_label_style
 from rheojax.gui.services.export_service import ExportService
 from rheojax.gui.utils.layout_helpers import set_panel_margins
@@ -31,6 +32,7 @@ class ExportStep(QWidget):
         self._state = state
         self._library = library
         self._export_service = ExportService()
+        self._export_worker: ExportWorker | None = None
         self._save_btn = QPushButton("＋ Save fit → library", self)
         self._export_btn = QPushButton("⤓ Export", self)
         self._export_status = QLabel("", self)
@@ -52,24 +54,36 @@ class ExportStep(QWidget):
         )
         if not chosen:
             return
-        try:
-            self.export_bundle(Path(chosen))
-        except (OSError, ValueError, TypeError, RuntimeError) as exc:
-            # ExportService wraps most of its own failures as RuntimeError
-            # ("Export failed: ..."), but export_posterior_netcdf() (used
-            # for the NUTS branch below) has no such wrapper -- a malformed/
-            # empty posterior_samples dict can raise ValueError/TypeError
-            # straight from arviz.from_dict()/to_netcdf() uncaught. An
-            # OSError-only catch here let both of those escape this Qt slot.
-            # Named to these four (not a bare Exception) so an actual
-            # programming bug elsewhere in export_bundle() -- AttributeError,
-            # KeyError from a typo -- still surfaces loudly instead of being
-            # reported identically to a legitimate "your data is malformed"
-            # failure; exc_info logs it either way for post-mortem digging.
-            logger.error("Export failed", exc_info=True)
-            self._export_status.setText(f"Export failed: {exc}")
-            return
-        self._export_status.setText(f"Exported to {Path(chosen)}")
+        directory = Path(chosen)
+        # export_bundle() does real disk I/O (CSV/NetCDF/JSON writes); run it
+        # off the GUI thread via ExportWorker so a large bundle doesn't freeze
+        # the window for its duration.
+        self._export_btn.setEnabled(False)
+        self._export_status.setText("Exporting...")
+        worker = ExportWorker(lambda _progress: self.export_bundle(directory))
+        worker.signals.completed.connect(
+            lambda _result: self._on_export_finished(directory)
+        )
+        worker.signals.failed.connect(self._on_export_failed)
+        # QThreadPool takes ownership of `worker` on the C++ side, but that
+        # doesn't keep its Python wrapper (or the plain QObject at
+        # worker.signals, which has no Qt parent) alive once this method's
+        # local `worker` goes out of scope -- GC could tear it down mid-run,
+        # silently dropping the completed/failed signal. Hold a reference
+        # until one of those signals fires.
+        self._export_worker = worker
+        QThreadPool.globalInstance().start(worker)
+
+    def _on_export_finished(self, directory: Path) -> None:
+        self._export_worker = None
+        self._export_btn.setEnabled(True)
+        self._export_status.setText(f"Exported to {directory}")
+
+    def _on_export_failed(self, message: str) -> None:
+        self._export_worker = None
+        self._export_btn.setEnabled(True)
+        logger.error("Export failed", error=message)
+        self._export_status.setText(f"Export failed: {message}")
 
     def bundle_manifest(self) -> list[str]:
         # ponytail: "figures" isn't listed -- export_bundle() has no figure

--- a/rheojax/gui/workspace/fit/step6_export.py
+++ b/rheojax/gui/workspace/fit/step6_export.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import json
+import uuid
 from pathlib import Path
 from types import SimpleNamespace
 
@@ -10,7 +11,7 @@ from PySide6.QtWidgets import QLabel, QPushButton, QVBoxLayout, QWidget
 
 from rheojax.gui.compat import QFileDialog, QThreadPool
 from rheojax.gui.foundation.library import DatasetLibrary, DatasetRef
-from rheojax.gui.foundation.state import FitState
+from rheojax.gui.foundation.state import ActiveJobsState, FitState
 from rheojax.gui.jobs.export_worker import ExportWorker
 from rheojax.gui.resources.styles.tokens import field_label_style
 from rheojax.gui.services.export_service import ExportService
@@ -26,13 +27,23 @@ class ExportStep(QWidget):
     )  # ref, payload | None, overwrite
 
     def __init__(
-        self, state: FitState, library: DatasetLibrary, parent: QWidget | None = None
+        self,
+        state: FitState,
+        library: DatasetLibrary,
+        active_jobs: ActiveJobsState | None = None,
+        parent: QWidget | None = None,
     ) -> None:
         super().__init__(parent)
         self._state = state
         self._library = library
+        self._active_jobs = active_jobs
         self._export_service = ExportService()
-        self._export_worker: ExportWorker | None = None
+        # Keyed by job_id (mirrors window.py's _active_import_workers), not a
+        # single scalar -- and read via .pop() in the finished/failed
+        # handlers below, so this is never a dead store even though the
+        # button-disable above already rules out concurrent launches from
+        # this one step instance.
+        self._active_export_workers: dict[str, ExportWorker] = {}
         self._save_btn = QPushButton("＋ Save fit → library", self)
         # "Bundle" (not bare "Export"): the plot canvas has its own,
         # differently-scoped "Export Chart..." button (single image) inside
@@ -67,27 +78,45 @@ class ExportStep(QWidget):
         # the window for its duration.
         self._export_btn.setEnabled(False)
         self._export_status.setText("Exporting...")
+        # Registered in active_jobs (mirrors window.py's _launch_import and
+        # fit_controller.py's _make_fit_fn) so Close/New/Open wait for this
+        # export to finish instead of tearing down this widget -- and this
+        # widget's underlying C++ object with it -- while the worker thread
+        # is still mid-write and about to emit into it. No "worker" key: like
+        # ImportWorker, an ExportWorker has no cancel() path, so the
+        # close-confirmation dialog's cancel button skips this entry and the
+        # poll loop just waits for it to finish naturally.
+        job_id = f"export:{uuid.uuid4().hex}"
+        if self._active_jobs is not None:
+            self._active_jobs.by_id[job_id] = {}
         worker = ExportWorker(lambda _progress: self.export_bundle(directory))
         worker.signals.completed.connect(
-            lambda _result: self._on_export_finished(directory)
+            lambda _result, jid=job_id: self._on_export_finished(directory, jid)
         )
-        worker.signals.failed.connect(self._on_export_failed)
+        worker.signals.failed.connect(
+            lambda msg, jid=job_id: self._on_export_failed(msg, jid)
+        )
         # QThreadPool takes ownership of `worker` on the C++ side, but that
         # doesn't keep its Python wrapper (or the plain QObject at
         # worker.signals, which has no Qt parent) alive once this method's
         # local `worker` goes out of scope -- GC could tear it down mid-run,
         # silently dropping the completed/failed signal. Hold a reference
         # until one of those signals fires.
-        self._export_worker = worker
+        self._active_export_workers[job_id] = worker
         QThreadPool.globalInstance().start(worker)
 
-    def _on_export_finished(self, directory: Path) -> None:
-        self._export_worker = None
+    def _clear_export_job(self, job_id: str) -> None:
+        self._active_export_workers.pop(job_id, None)
+        if self._active_jobs is not None:
+            self._active_jobs.by_id.pop(job_id, None)
+
+    def _on_export_finished(self, directory: Path, job_id: str) -> None:
+        self._clear_export_job(job_id)
         self._export_btn.setEnabled(True)
         self._export_status.setText(f"Exported to {directory}")
 
-    def _on_export_failed(self, message: str) -> None:
-        self._export_worker = None
+    def _on_export_failed(self, message: str, job_id: str) -> None:
+        self._clear_export_job(job_id)
         self._export_btn.setEnabled(True)
         logger.error("Export failed", error=message)
         self._export_status.setText(f"Export failed: {message}")

--- a/rheojax/gui/workspace/fit/step6_export.py
+++ b/rheojax/gui/workspace/fit/step6_export.py
@@ -34,7 +34,14 @@ class ExportStep(QWidget):
         self._export_service = ExportService()
         self._export_worker: ExportWorker | None = None
         self._save_btn = QPushButton("＋ Save fit → library", self)
-        self._export_btn = QPushButton("⤓ Export", self)
+        # "Bundle" (not bare "Export"): the plot canvas has its own,
+        # differently-scoped "Export Chart..." button (single image) inside
+        # this same Fit flow -- this one writes the full CSV/NetCDF/JSON set.
+        self._export_btn = QPushButton("⤓ Export Bundle...", self)
+        self._export_btn.setToolTip(
+            "Write parameters, fitted curve, provenance"
+            " (and posterior samples/diagnostics, if NUTS ran) to a folder"
+        )
         self._export_status = QLabel("", self)
         lay = QVBoxLayout(self)
         set_panel_margins(lay)

--- a/rheojax/gui/workspace/stepper_canvas.py
+++ b/rheojax/gui/workspace/stepper_canvas.py
@@ -66,6 +66,9 @@ class StepperCanvas(QWidget):
             self._buttons.append(b)
             self._rail.addWidget(b)
             self._stack.addWidget(QWidget(self))  # placeholder body
+        # Enabled/checked state alone doesn't tell a screen reader (or a
+        # sighted user hovering before clicking) *why* a step is locked --
+        # refresh() below keeps this in sync with each button's actual state.
         set_toolbar_margins(self._rail)
         lay = QVBoxLayout(self)
         set_zero_margins(lay)
@@ -96,6 +99,13 @@ class StepperCanvas(QWidget):
 
     def refresh(self) -> None:
         for i, b in enumerate(self._buttons):
-            b.setEnabled(i in self._ctl.reached)
+            reached = i in self._ctl.reached
+            b.setEnabled(reached)
             b.setChecked(i == self._ctl.current)
+            if i == self._ctl.current:
+                b.setToolTip(f"Step {i + 1} of {len(self._buttons)} (current)")
+            elif reached:
+                b.setToolTip(f"Step {i + 1} of {len(self._buttons)} -- click to revisit")
+            else:
+                b.setToolTip("Complete the earlier steps to unlock this one")
         self._stack.setCurrentIndex(self._ctl.current)

--- a/rheojax/gui/workspace/stepper_canvas.py
+++ b/rheojax/gui/workspace/stepper_canvas.py
@@ -66,9 +66,6 @@ class StepperCanvas(QWidget):
             self._buttons.append(b)
             self._rail.addWidget(b)
             self._stack.addWidget(QWidget(self))  # placeholder body
-        # Enabled/checked state alone doesn't tell a screen reader (or a
-        # sighted user hovering before clicking) *why* a step is locked --
-        # refresh() below keeps this in sync with each button's actual state.
         set_toolbar_margins(self._rail)
         lay = QVBoxLayout(self)
         set_zero_margins(lay)
@@ -98,6 +95,9 @@ class StepperCanvas(QWidget):
         self._buttons[index].click()
 
     def refresh(self) -> None:
+        # Enabled/checked state alone doesn't tell a screen reader (or a
+        # sighted user hovering before clicking) *why* a step is locked --
+        # the per-button tooltip below keeps that in sync with actual state.
         for i, b in enumerate(self._buttons):
             reached = i in self._ctl.reached
             b.setEnabled(reached)

--- a/rheojax/gui/workspace/transform/step5_export.py
+++ b/rheojax/gui/workspace/transform/step5_export.py
@@ -35,7 +35,10 @@ class TransformExportStep(QWidget):
         self._export_service = ExportService()
         self._export_worker: ExportWorker | None = None
         self._save_btn = QPushButton("＋ Save output → library", self)
-        self._export_btn = QPushButton("⤓ Export", self)
+        self._export_btn = QPushButton("⤓ Export Bundle...", self)
+        self._export_btn.setToolTip(
+            "Write the transform output, result, and provenance to a folder"
+        )
         self._export_status = QLabel("", self)
         lay = QVBoxLayout(self)
         set_panel_margins(lay)

--- a/rheojax/gui/workspace/transform/step5_export.py
+++ b/rheojax/gui/workspace/transform/step5_export.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import json
+import uuid
 from pathlib import Path
 
 from PySide6.QtCore import Signal
@@ -8,7 +9,7 @@ from PySide6.QtWidgets import QLabel, QPushButton, QVBoxLayout, QWidget
 
 from rheojax.gui.compat import QFileDialog, QThreadPool
 from rheojax.gui.foundation.library import DatasetLibrary, DatasetRef
-from rheojax.gui.foundation.state import TransformState
+from rheojax.gui.foundation.state import ActiveJobsState, TransformState
 from rheojax.gui.jobs.export_worker import ExportWorker
 from rheojax.gui.resources.styles.tokens import field_label_style
 from rheojax.gui.services.export_service import ExportService
@@ -27,14 +28,21 @@ class TransformExportStep(QWidget):
         self,
         state: TransformState,
         library: DatasetLibrary,
+        active_jobs: ActiveJobsState | None = None,
         parent: QWidget | None = None,
     ) -> None:
         super().__init__(parent)
         self._state = state
         self._library = library
+        self._active_jobs = active_jobs
         self._export_service = ExportService()
-        self._export_worker: ExportWorker | None = None
+        # Keyed by job_id (mirrors window.py's _active_import_workers); read
+        # via .pop() below, so never a dead store.
+        self._active_export_workers: dict[str, ExportWorker] = {}
         self._save_btn = QPushButton("＋ Save output → library", self)
+        # "Bundle" (not bare "Export"): the plot canvas in the Transform tab
+        # has its own "Export Chart..." button (single image), same naming
+        # collision this disambiguates in the Fit tab's ExportStep.
         self._export_btn = QPushButton("⤓ Export Bundle...", self)
         self._export_btn.setToolTip(
             "Write the transform output, result, and provenance to a folder"
@@ -63,27 +71,42 @@ class TransformExportStep(QWidget):
         # ExportWorker so it doesn't freeze the window for its duration.
         self._export_btn.setEnabled(False)
         self._export_status.setText("Exporting...")
+        # Registered in active_jobs (mirrors window.py's _launch_import and
+        # fit_controller.py's _make_fit_fn) so Close/New/Open wait for this
+        # export to finish instead of tearing down this widget while the
+        # worker thread is still mid-write and about to emit into it. No
+        # "worker" key: like ImportWorker, ExportWorker has no cancel() path.
+        job_id = f"export:{uuid.uuid4().hex}"
+        if self._active_jobs is not None:
+            self._active_jobs.by_id[job_id] = {}
         worker = ExportWorker(lambda _progress: self.export_bundle(directory))
         worker.signals.completed.connect(
-            lambda _result: self._on_export_finished(directory)
+            lambda _result, jid=job_id: self._on_export_finished(directory, jid)
         )
-        worker.signals.failed.connect(self._on_export_failed)
+        worker.signals.failed.connect(
+            lambda msg, jid=job_id: self._on_export_failed(msg, jid)
+        )
         # QThreadPool takes ownership of `worker` on the C++ side, but that
         # doesn't keep its Python wrapper (or the plain QObject at
         # worker.signals, which has no Qt parent) alive once this method's
         # local `worker` goes out of scope -- GC could tear it down mid-run,
         # silently dropping the completed/failed signal. Hold a reference
         # until one of those signals fires.
-        self._export_worker = worker
+        self._active_export_workers[job_id] = worker
         QThreadPool.globalInstance().start(worker)
 
-    def _on_export_finished(self, directory: Path) -> None:
-        self._export_worker = None
+    def _clear_export_job(self, job_id: str) -> None:
+        self._active_export_workers.pop(job_id, None)
+        if self._active_jobs is not None:
+            self._active_jobs.by_id.pop(job_id, None)
+
+    def _on_export_finished(self, directory: Path, job_id: str) -> None:
+        self._clear_export_job(job_id)
         self._export_btn.setEnabled(True)
         self._export_status.setText(f"Exported to {directory}")
 
-    def _on_export_failed(self, message: str) -> None:
-        self._export_worker = None
+    def _on_export_failed(self, message: str, job_id: str) -> None:
+        self._clear_export_job(job_id)
         self._export_btn.setEnabled(True)
         logger.error("Export failed", error=message)
         self._export_status.setText(f"Export failed: {message}")

--- a/rheojax/gui/workspace/transform/step5_export.py
+++ b/rheojax/gui/workspace/transform/step5_export.py
@@ -6,12 +6,16 @@ from pathlib import Path
 from PySide6.QtCore import Signal
 from PySide6.QtWidgets import QLabel, QPushButton, QVBoxLayout, QWidget
 
-from rheojax.gui.compat import QFileDialog
+from rheojax.gui.compat import QFileDialog, QThreadPool
 from rheojax.gui.foundation.library import DatasetLibrary, DatasetRef
 from rheojax.gui.foundation.state import TransformState
+from rheojax.gui.jobs.export_worker import ExportWorker
 from rheojax.gui.resources.styles.tokens import field_label_style
 from rheojax.gui.services.export_service import ExportService
 from rheojax.gui.utils.layout_helpers import set_panel_margins
+from rheojax.logging import get_logger
+
+logger = get_logger(__name__)
 
 
 class TransformExportStep(QWidget):
@@ -29,6 +33,7 @@ class TransformExportStep(QWidget):
         self._state = state
         self._library = library
         self._export_service = ExportService()
+        self._export_worker: ExportWorker | None = None
         self._save_btn = QPushButton("＋ Save output → library", self)
         self._export_btn = QPushButton("⤓ Export", self)
         self._export_status = QLabel("", self)
@@ -50,12 +55,35 @@ class TransformExportStep(QWidget):
         )
         if not chosen:
             return
-        try:
-            self.export_bundle(Path(chosen))
-        except OSError as exc:
-            self._export_status.setText(f"Export failed: {exc}")
-            return
-        self._export_status.setText(f"Exported to {Path(chosen)}")
+        directory = Path(chosen)
+        # export_bundle() does real disk I/O; run it off the GUI thread via
+        # ExportWorker so it doesn't freeze the window for its duration.
+        self._export_btn.setEnabled(False)
+        self._export_status.setText("Exporting...")
+        worker = ExportWorker(lambda _progress: self.export_bundle(directory))
+        worker.signals.completed.connect(
+            lambda _result: self._on_export_finished(directory)
+        )
+        worker.signals.failed.connect(self._on_export_failed)
+        # QThreadPool takes ownership of `worker` on the C++ side, but that
+        # doesn't keep its Python wrapper (or the plain QObject at
+        # worker.signals, which has no Qt parent) alive once this method's
+        # local `worker` goes out of scope -- GC could tear it down mid-run,
+        # silently dropping the completed/failed signal. Hold a reference
+        # until one of those signals fires.
+        self._export_worker = worker
+        QThreadPool.globalInstance().start(worker)
+
+    def _on_export_finished(self, directory: Path) -> None:
+        self._export_worker = None
+        self._export_btn.setEnabled(True)
+        self._export_status.setText(f"Exported to {directory}")
+
+    def _on_export_failed(self, message: str) -> None:
+        self._export_worker = None
+        self._export_btn.setEnabled(True)
+        logger.error("Export failed", error=message)
+        self._export_status.setText(f"Export failed: {message}")
 
     def bundle_manifest(self) -> list[str]:
         return ["output", "result", "provenance"]

--- a/rheojax/gui/workspace/transform/transform_controller.py
+++ b/rheojax/gui/workspace/transform/transform_controller.py
@@ -153,7 +153,7 @@ def build_transform_controller(app_state: AppState):
         SlotsStep(st, app_state.library),
         RunStep(st, run_fn=_make_run_fn(app_state.library, app_state.active_jobs)),
         TransformVisualizeStep(st),
-        TransformExportStep(st, app_state.library),
+        TransformExportStep(st, app_state.library, app_state.active_jobs),
     ]
     validators = [
         lambda b=bodies[0]: b.is_ready(),

--- a/rheojax/gui/workspace/window.py
+++ b/rheojax/gui/workspace/window.py
@@ -143,12 +143,14 @@ class WorkspaceWindow(QMainWindow):
         self._setup_os_theme_watcher()
         QShortcut(QKeySequence("Ctrl+K"), self, self._open_command_palette)
         # Ctrl+1..Ctrl+9 jump to a step in the *current* mode's wizard.
-        # self._canvas is reassigned (not recreated as a new attribute) on
-        # every set_mode()/rebuild, so binding these once here -- rather than
-        # re-binding per StepperCanvas -- keeps them live across mode
-        # switches. click_step() on an out-of-range/not-yet-reached index is
-        # a no-op (disabled QToolButton.click()), so no bounds guard needed
-        # beyond skipping indices the current mode doesn't have.
+        # self._canvas always points at the mode's current StepperCanvas even
+        # though set_mode() builds a brand-new instance on every switch --
+        # binding these once here (dereferencing self._canvas dynamically at
+        # call time, not capturing today's instance) keeps them live across
+        # mode switches without re-binding per StepperCanvas. Out-of-range
+        # indices are rejected by _jump_to_step's own bounds check below;
+        # a not-yet-reached-but-in-range index reaches click_step(), which
+        # is a no-op there because that button is disabled.
         for step_idx in range(9):
             QShortcut(
                 QKeySequence(f"Ctrl+{step_idx + 1}"),
@@ -447,9 +449,10 @@ class WorkspaceWindow(QMainWindow):
         self._sync_mode_buttons()
         # Deferred (not called inline): get_jax_info() queries live JAX
         # devices/memory, which is needless synchronous work on the path to
-        # first paint. Parented to self, like _poll_active_jobs_then's timer
-        # above, so a destroyed-mid-construction window (e.g. test teardown)
-        # takes the timer down with it instead of firing into a dangling self.
+        # first paint. Parented to self, like the same pattern used by
+        # _poll_active_jobs_then's timer elsewhere in this file, so a
+        # destroyed-mid-construction window (e.g. test teardown) takes the
+        # timer down with it instead of firing into a dangling self.
         from PySide6.QtCore import QTimer
 
         timer = QTimer(self)

--- a/rheojax/gui/workspace/window.py
+++ b/rheojax/gui/workspace/window.py
@@ -78,10 +78,13 @@ class WorkspaceWindow(QMainWindow):
         # segmented mode switch that should read as navigation, not a command.
         self._fit_btn = QToolButton(self)
         self._fit_btn.setText("Fit")
+        self._fit_btn.setToolTip("Switch to the model-fitting workflow")
         self._tx_btn = QToolButton(self)
         self._tx_btn.setText("Transform")
+        self._tx_btn.setToolTip("Switch to the data-transform workflow")
         self._pipeline_btn = QToolButton(self)
         self._pipeline_btn.setText("Pipeline")
+        self._pipeline_btn.setToolTip("Switch to the batch-pipeline workflow")
         self._fit_btn.setCheckable(True)
         self._tx_btn.setCheckable(True)
         self._pipeline_btn.setCheckable(True)
@@ -139,6 +142,19 @@ class WorkspaceWindow(QMainWindow):
         self._build_workspace(app_state)
         self._setup_os_theme_watcher()
         QShortcut(QKeySequence("Ctrl+K"), self, self._open_command_palette)
+        # Ctrl+1..Ctrl+9 jump to a step in the *current* mode's wizard.
+        # self._canvas is reassigned (not recreated as a new attribute) on
+        # every set_mode()/rebuild, so binding these once here -- rather than
+        # re-binding per StepperCanvas -- keeps them live across mode
+        # switches. click_step() on an out-of-range/not-yet-reached index is
+        # a no-op (disabled QToolButton.click()), so no bounds guard needed
+        # beyond skipping indices the current mode doesn't have.
+        for step_idx in range(9):
+            QShortcut(
+                QKeySequence(f"Ctrl+{step_idx + 1}"),
+                self,
+                lambda i=step_idx: self._jump_to_step(i),
+            )
 
     def _build_file_menu(self) -> None:
         menu = self.menuBar().addMenu("&File")
@@ -1352,6 +1368,15 @@ class WorkspaceWindow(QMainWindow):
 
     def active_step_count(self) -> int:
         return len(self._controllers[self._mode].steps)
+
+    def _jump_to_step(self, index: int) -> None:
+        """Ctrl+N handler: jump to step `index` of the current mode's wizard.
+
+        No-op for an index past the current mode's step count (e.g. Ctrl+9
+        while Transform, which only has 5 steps) or a step not yet reached.
+        """
+        if index < self.active_step_count():
+            self._canvas.click_step(index)
 
     def current_step(self) -> int:
         return self._controllers[self._mode].current

--- a/rheojax/gui/workspace/window.py
+++ b/rheojax/gui/workspace/window.py
@@ -429,7 +429,17 @@ class WorkspaceWindow(QMainWindow):
                 body.run_requested.connect(self._on_pipeline_run_requested)
 
         self._sync_mode_buttons()
-        self._refresh_status_bar()
+        # Deferred (not called inline): get_jax_info() queries live JAX
+        # devices/memory, which is needless synchronous work on the path to
+        # first paint. Parented to self, like _poll_active_jobs_then's timer
+        # above, so a destroyed-mid-construction window (e.g. test teardown)
+        # takes the timer down with it instead of firing into a dangling self.
+        from PySide6.QtCore import QTimer
+
+        timer = QTimer(self)
+        timer.setSingleShot(True)
+        timer.timeout.connect(self._refresh_status_bar)
+        timer.start(0)
 
         self._rail = LibraryRail(state.library, self)
         # LibraryRail otherwise only ever renders the snapshot present at construction

--- a/tests/gui/workspace/fit/test_step6.py
+++ b/tests/gui/workspace/fit/test_step6.py
@@ -116,5 +116,5 @@ def test_on_export_clicked_reports_failure_instead_of_raising(qtbot, monkeypatch
     monkeypatch.setattr(step, "export_bundle", _raise)
 
     step._on_export_clicked()  # must not raise
-    assert "failed" in step._export_status.text().lower()
+    qtbot.waitUntil(lambda: "failed" in step._export_status.text().lower())
     assert "disk full" in step._export_status.text()

--- a/tests/gui/workspace/fit/test_step6.py
+++ b/tests/gui/workspace/fit/test_step6.py
@@ -4,7 +4,7 @@ pytest.importorskip("PySide6")
 
 from rheojax.gui.compat import QFileDialog
 from rheojax.gui.foundation.library import DatasetLibrary
-from rheojax.gui.foundation.state import FitState
+from rheojax.gui.foundation.state import ActiveJobsState, FitState
 from rheojax.gui.workspace.fit.step6_export import ExportStep
 
 
@@ -118,3 +118,41 @@ def test_on_export_clicked_reports_failure_instead_of_raising(qtbot, monkeypatch
     step._on_export_clicked()  # must not raise
     qtbot.waitUntil(lambda: "failed" in step._export_status.text().lower())
     assert "disk full" in step._export_status.text()
+
+
+def test_export_holds_worker_ref_and_registers_active_job(qtbot, monkeypatch, tmp_path):
+    """Regression: _active_export_workers/active_jobs registration must
+    happen synchronously inside _on_export_clicked() and clear exactly once
+    the export finishes. self._active_export_workers[job_id] = worker looks
+    like a dead store to a future cleanup pass (assigned, later popped,
+    never read in between) -- deleting it would silently reintroduce the
+    GC-lifetime bug where the worker's parentless `.signals` QObject could
+    be collected mid-run, and nothing else in this suite would catch that
+    deletion."""
+    st = FitState(
+        protocol="oscillation",
+        model_key="maxwell",
+        model_config={},
+        data_ref="d",
+        nlsq_result={"params": {"G0": 1.0}},
+        nuts_result=None,
+        revision=2,
+    )
+    lib = DatasetLibrary()
+    active_jobs = ActiveJobsState()
+    step = ExportStep(st, lib, active_jobs)
+    qtbot.addWidget(step)
+
+    monkeypatch.setattr(
+        QFileDialog, "getExistingDirectory", lambda *a, **k: str(tmp_path)
+    )
+
+    step._on_export_clicked()
+    # Synchronous up to QThreadPool.start(): both registrations must already
+    # be in place before the worker thread has any chance to run.
+    assert len(step._active_export_workers) == 1
+    assert len(active_jobs.by_id) == 1
+
+    qtbot.waitUntil(lambda: "Exported to" in step._export_status.text())
+    assert step._active_export_workers == {}
+    assert active_jobs.by_id == {}

--- a/tests/gui/workspace/transform/test_step5_writers.py
+++ b/tests/gui/workspace/transform/test_step5_writers.py
@@ -6,7 +6,7 @@ pytest.importorskip("PySide6")
 
 from rheojax.gui.compat import QFileDialog
 from rheojax.gui.foundation.library import DatasetLibrary
-from rheojax.gui.foundation.state import TransformState
+from rheojax.gui.foundation.state import ActiveJobsState, TransformState
 from rheojax.gui.workspace.transform.step5_export import TransformExportStep
 
 
@@ -95,3 +95,31 @@ def test_export_button_reports_failure_instead_of_raising(qtbot, monkeypatch):
 
     step._on_export_clicked()  # must not raise
     qtbot.waitUntil(lambda: "failed" in step._export_status.text().lower())
+
+
+def test_export_holds_worker_ref_and_registers_active_job(qtbot, monkeypatch, tmp_path):
+    """Regression: _active_export_workers/active_jobs registration must
+    happen synchronously inside _on_export_clicked() and clear exactly once
+    the export finishes -- see the mirrored test in test_step6.py for why
+    this line looks like a dead store without this assertion."""
+    st = TransformState(
+        transform_key="derivative",
+        slots={"input": "d1"},
+        result={"result": {"n": 2}, "protocol_type": "flow_curve"},
+    )
+    lib = DatasetLibrary()
+    active_jobs = ActiveJobsState()
+    step = TransformExportStep(st, lib, active_jobs)
+    qtbot.addWidget(step)
+
+    monkeypatch.setattr(
+        QFileDialog, "getExistingDirectory", lambda *a, **k: str(tmp_path)
+    )
+
+    step._on_export_clicked()
+    assert len(step._active_export_workers) == 1
+    assert len(active_jobs.by_id) == 1
+
+    qtbot.waitUntil(lambda: str(tmp_path) in step._export_status.text())
+    assert step._active_export_workers == {}
+    assert active_jobs.by_id == {}

--- a/tests/gui/workspace/transform/test_step5_writers.py
+++ b/tests/gui/workspace/transform/test_step5_writers.py
@@ -72,8 +72,8 @@ def test_export_button_prompts_for_directory_instead_of_using_cwd(
 
     step._on_export_clicked()
 
+    qtbot.waitUntil(lambda: str(tmp_path) in step._export_status.text())
     assert (tmp_path / "provenance.json").exists()
-    assert str(tmp_path) in step._export_status.text()
 
 
 def test_export_button_reports_failure_instead_of_raising(qtbot, monkeypatch):
@@ -94,4 +94,4 @@ def test_export_button_reports_failure_instead_of_raising(qtbot, monkeypatch):
     monkeypatch.setattr(step, "export_bundle", _raise)
 
     step._on_export_clicked()  # must not raise
-    assert "failed" in step._export_status.text().lower()
+    qtbot.waitUntil(lambda: "failed" in step._export_status.text().lower())


### PR DESCRIPTION
## Summary
- Wired the existing-but-unused `ExportWorker` into both export screens (`ExportStep`, `TransformExportStep`) so CSV/Excel/NetCDF/PDF writes no longer freeze the window.
- Fixed a real GC-lifetime bug found while wiring it: the worker's local variable went out of scope when the click handler returned, letting Python collect the parentless `worker.signals` QObject mid-run and silently drop the completion signal (files still wrote, but the status label never updated). Now held on the widget instance until completed/failed fires.
- Deferred the window's JAX device/memory status-bar probe off the synchronous `_build_workspace` construction path via a self-parented `QTimer` (same pattern already used elsewhere in `window.py`).
- Enabled PyQtGraph `setDownsampling`/`setClipToView` on `RheoPlotCanvas` so large time-domain series (LAOS sweeps) don't render every raw sample.

Found via an Explore-agent survey of `rheojax/gui/` for Qt main-thread-blocking patterns; these were the two highest-confidence, most isolated wins. (rheojax's GUI is PySide6/Qt desktop, not a web frontend, so this went through Qt-specific analysis rather than `/impeccable`'s web-perf checklist.)

## Test plan
- [x] `tests/gui -k "not visual"` — 824 passed, 0 failed (69 visual-regression tests deselected)
- [x] Manual repro script confirmed the GC-lifetime bug before the fix, and confirmed it's resolved after