### PR TITLE
fix(gui): close gaps where invalid input silently reaches the compute engine

### DIFF
--- a/rheojax/gui/widgets/parameter_table.py
+++ b/rheojax/gui/widgets/parameter_table.py
@@ -218,6 +218,31 @@ class ParameterTable(QTableWidget):
                 )
                 continue
 
+            # PTBL-002: same invariant _on_item_changed enforces on live edits
+            # ("invalid values must never reach the state store") also applies
+            # here, since a fit can be launched without ever triggering that
+            # per-cell signal (e.g. paste, or a row never focused after edit).
+            if (
+                not math.isfinite(value)
+                or not math.isfinite(min_bound)
+                or not math.isfinite(max_bound)
+                or min_bound > max_bound
+                or value < min_bound
+                or value > max_bound
+            ):
+                logger.warning(
+                    "Skipping row with invalid value/bounds — parameter will "
+                    "use model default; check the table for out-of-range or "
+                    "non-finite entries",
+                    widget=self.__class__.__name__,
+                    row=row,
+                    param_name=param_name,
+                    value=value,
+                    min_bound=min_bound,
+                    max_bound=max_bound,
+                )
+                continue
+
             # Get fixed state from checkbox
             checkbox_widget = self.cellWidget(row, 4)
             checkbox = checkbox_widget.findChild(QCheckBox) if checkbox_widget else None

--- a/rheojax/gui/widgets/priors_editor.py
+++ b/rheojax/gui/widgets/priors_editor.py
@@ -543,6 +543,28 @@ class PriorsEditor(QWidget):
                     params[name] = self._param_spinboxes[name].value()
                 break
 
+        # PRED-001: _compute_pdf is the same validation the live preview runs
+        # (rejects non-positive scale, inverted uniform bounds, etc.). Apply
+        # must not skip it — a prior it would reject here otherwise reaches
+        # NUTS unfiltered and fails there with an opaque NumPyro/JAX error.
+        try:
+            self._compute_pdf(dist)
+        except Exception as e:
+            logger.warning(
+                "Refusing to apply invalid prior",
+                widget=self.__class__.__name__,
+                parameter=self._current_param,
+                distribution=dist,
+                params=params,
+                error=str(e),
+            )
+            # No need to force a preview refresh here: every spinbox/combo
+            # change that could have produced this invalid state already
+            # re-runs _update_preview() via its own valueChanged/
+            # currentIndexChanged connection, so the error text is already
+            # showing by the time Apply is clicked.
+            return
+
         logger.info(
             "Prior applied",
             widget=self.__class__.__name__,

--- a/rheojax/gui/workspace/fit/step2_data.py
+++ b/rheojax/gui/workspace/fit/step2_data.py
@@ -39,13 +39,19 @@ def _classify_y_unit(unit: str) -> str | None:
 
 
 def _validate_shape_and_values(rheo_data) -> list[str]:
-    """Shape/NaN/monotonicity checks against a loaded RheoData. Empty = valid."""
+    """Shape/NaN/monotonicity checks against a loaded RheoData."""
     errors: list[str] = []
     x = np.asarray(rheo_data.x)
     y = np.asarray(rheo_data.y)
     if x.shape[0] != y.shape[0]:
         errors.append(f"x/y length mismatch: {x.shape[0]} vs {y.shape[0]}")
         return errors  # remaining checks assume matching length
+    if x.shape[0] == 0:
+        # A 0-row dataset used to pass validation vacuously and only fail
+        # deep inside NLSQ with a cryptic scipy/JAX error. Report it here,
+        # where it's actually knowable, instead.
+        errors.append("dataset has no rows")
+        return errors
     x_has_nan = bool(np.isnan(x).any())
     if x_has_nan:
         errors.append("x contains NaN values")

--- a/rheojax/gui/workspace/library_rail.py
+++ b/rheojax/gui/workspace/library_rail.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from PySide6.QtCore import Qt, Signal
+from PySide6.QtCore import Qt, Signal, SignalInstance
 from PySide6.QtWidgets import (
     QLabel,
     QListWidget,
@@ -35,12 +35,10 @@ class LibraryRail(QWidget):
         lay.addWidget(self._list)
         lay.addWidget(self._import)
         self._list.itemClicked.connect(
-            lambda it: self.dataset_selected.emit(it.data(Qt.ItemDataRole.UserRole))
+            lambda it: self._emit_if_dataset(self.dataset_selected, it)
         )
         self._list.itemDoubleClicked.connect(
-            lambda it: self.dataset_preview_requested.emit(
-                it.data(Qt.ItemDataRole.UserRole)
-            )
+            lambda it: self._emit_if_dataset(self.dataset_preview_requested, it)
         )
         self._list.setContextMenuPolicy(Qt.ContextMenuPolicy.CustomContextMenu)
         self._list.customContextMenuRequested.connect(self._on_context_menu_requested)
@@ -49,14 +47,35 @@ class LibraryRail(QWidget):
 
     def refresh(self) -> None:
         self._list.clear()
-        for ref in self._library.all():
-            it = QListWidgetItem(f"{ref.name}   [{ref.protocol_type}]")
+        refs = self._library.all()
+        if not refs:
+            placeholder = QListWidgetItem("No datasets yet — import a file to begin")
+            placeholder.setFlags(Qt.ItemFlag.NoItemFlags)
+            self._list.addItem(placeholder)
+            return
+        for ref in refs:
+            label = f"{ref.name}   [{ref.protocol_type}]"
+            it = QListWidgetItem(label)
+            # QListWidget does not elide item text; a long dataset name (common
+            # for TRIOS exports) is otherwise clipped with no way to recover it.
+            it.setToolTip(label)
             it.setData(Qt.ItemDataRole.UserRole, ref.id)
             self._list.addItem(it)
 
+    def _emit_if_dataset(self, signal: SignalInstance, item: QListWidgetItem) -> None:
+        # The empty-state placeholder item has no UserRole data; skip it so
+        # clicking/double-clicking the "No datasets yet" row is a no-op.
+        dataset_id = item.data(Qt.ItemDataRole.UserRole)
+        if dataset_id is not None:
+            signal.emit(dataset_id)
+
     def _on_context_menu_requested(self, pos) -> None:
         item = self._list.itemAt(pos)
-        if item is None:
+        # itemAt() is a pure geometry hit-test and ignores item flags, so the
+        # empty-state placeholder (NoItemFlags, no UserRole data) still gets
+        # returned here; treat it the same as "no item under the cursor" so
+        # we don't open a context menu with actions that have no target.
+        if item is None or item.data(Qt.ItemDataRole.UserRole) is None:
             return
         menu = QMenu(self)
         preview_action = menu.addAction("Preview…")

--- a/rheojax/gui/workspace/status_bar.py
+++ b/rheojax/gui/workspace/status_bar.py
@@ -92,6 +92,10 @@ class StatusBar(QStatusBar):
         """
         logger.debug("Status updated", message=message, timeout=timeout)
         self.message_label.setText(message)
+        # QLabel doesn't elide/wrap here, so a long message (a file path, a
+        # dataset name) can be visually clipped by the fixed-width indicators
+        # to its right; the tooltip is the only way to recover the full text.
+        self.message_label.setToolTip(message)
         self._message_token += 1
         if timeout > 0:
             # NOTE: deliberately NOT calling super().showMessage(message, timeout) --

--- a/tests/gui/test_parameter_table_validation.py
+++ b/tests/gui/test_parameter_table_validation.py
@@ -40,6 +40,19 @@ def test_invalid_bounds_are_not_emitted(qapp):
     assert emitted == []
 
 
+def test_get_parameters_skips_invalid_rows(qapp):
+    # Regression test: get_parameters() is the read path a Run click uses
+    # (fit/step3_nlsq.py), separate from the itemChanged signal path the
+    # tests above cover. A cell can hold invalid text without ever emitting
+    # (e.g. "-5" is out of [0, 10] bounds -- itemChanged blocks the signal
+    # but leaves the cell text as "-5"), so get_parameters() must re-check
+    # rather than trust that "no signal fired" means "no invalid state".
+    table = _make_table(qapp)
+    table.item(0, 1).setText("-5")  # out of bounds, itemChanged already saw this
+
+    assert table.get_parameters() == {}
+
+
 def test_valid_value_and_bounds_are_emitted(qapp):
     table = _make_table(qapp)
     values = []

--- a/tests/gui/widgets/test_priors_editor.py
+++ b/tests/gui/widgets/test_priors_editor.py
@@ -1,0 +1,41 @@
+"""Regression test: PriorsEditor.Apply must not store an invalid prior."""
+
+from __future__ import annotations
+
+from rheojax.gui.widgets.priors_editor import PriorsEditor
+
+
+def test_apply_refuses_invalid_prior(qtbot):
+    # _compute_pdf() (used by the live preview) already rejects an inverted
+    # uniform range, but _apply_prior() used to store it anyway -- an
+    # invalid prior would then reach NUTS unfiltered and fail there with an
+    # opaque NumPyro/JAX error instead of being caught at the Apply button.
+    editor = PriorsEditor()
+    qtbot.addWidget(editor)
+    editor.set_parameters(["a"])
+    default_prior = editor.get_prior("a")
+    emitted = []
+    editor.prior_changed.connect(lambda *args: emitted.append(args))
+
+    editor._current_param = "a"
+    # blockSignals on both the combo and spinboxes: driving these through
+    # their real signals would fire _on_dist_changed()/_update_preview(),
+    # which renders a matplotlib Figure -- a documented, environment-specific
+    # FreeType crash in this sandbox unrelated to what this test checks (see
+    # tests/conftest.py's FT_Render_Glyph note). _apply_prior() itself never
+    # renders, so blocking these signals sidesteps the crash without
+    # weakening the assertion below.
+    editor._dist_combo.blockSignals(True)
+    editor._dist_combo.set_current_data("uniform")
+    editor._dist_combo.blockSignals(False)
+    editor._param_spinboxes["low"].blockSignals(True)
+    editor._param_spinboxes["high"].blockSignals(True)
+    editor._param_spinboxes["low"].setValue(10.0)
+    editor._param_spinboxes["high"].setValue(5.0)  # inverted: low > high
+    editor._param_spinboxes["low"].blockSignals(False)
+    editor._param_spinboxes["high"].blockSignals(False)
+
+    editor._apply_prior()
+
+    assert editor.get_prior("a") == default_prior
+    assert emitted == []

--- a/tests/gui/workspace/fit/test_step2_validation.py
+++ b/tests/gui/workspace/fit/test_step2_validation.py
@@ -41,6 +41,7 @@ def test_validate_shape_and_values_catches_mismatch_nan_nonmonotonic():
         "x is not monotonic"
     ]
     assert _validate_shape_and_values(_RheoData([1, 2, 3], [1, 2, 3])) == []
+    assert _validate_shape_and_values(_RheoData([], [])) == ["dataset has no rows"]
 
 
 def test_data_step_blocks_advance_on_invalid_data(qtbot):

--- a/tests/gui/workspace/test_library_rail.py
+++ b/tests/gui/workspace/test_library_rail.py
@@ -4,6 +4,8 @@ import pytest
 
 pytest.importorskip("PySide6")
 
+from PySide6.QtCore import Qt
+
 from rheojax.gui.foundation.library import DatasetLibrary, DatasetRef
 from rheojax.gui.workspace.library_rail import LibraryRail
 
@@ -116,3 +118,25 @@ def test_context_menu_delete_action_emits_dataset_delete_requested(qtbot, monkey
         rail._on_context_menu_requested(pos)
 
     assert blocker.args == ["d1"]
+
+
+def test_empty_library_shows_placeholder_that_ignores_interaction(qtbot):
+    # Regression test: the empty-state placeholder item occupies the same
+    # list geometry a real dataset row would. itemAt() is a pure hit-test
+    # and does not consult item flags, so without an explicit UserRole guard
+    # a click/context-menu on the placeholder would reach the real
+    # (unmocked) _exec_context_menu / emit a None dataset id instead of
+    # being a no-op like empty space.
+    library = DatasetLibrary()
+    rail = LibraryRail(library)
+    qtbot.addWidget(rail)
+
+    assert rail._list.count() == 1
+    placeholder = rail._list.item(0)
+    assert placeholder.data(Qt.ItemDataRole.UserRole) is None
+
+    pos = rail._list.visualItemRect(placeholder).center()
+    # Must not raise, hang, or emit -- same contract as clicking empty space.
+    rail._on_context_menu_requested(pos)
+    rail._list.itemClicked.emit(placeholder)
+    rail._list.itemDoubleClicked.emit(placeholder)


### PR DESCRIPTION
## Summary
`/impeccable harden` audit of the PySide6 GUI (`rheojax/gui/`) surfaced two P0 gaps where invalid user input bypassed validation and reached the fit/sampling engine unfiltered, plus a few smaller resilience fixes:

- **`ParameterTable.get_parameters()`** (the Run button's read path) didn't run the same finite/bounds check the live `itemChanged` handler enforces — a pasted or never-focused NaN/inf/inverted-bounds cell shipped straight into the NLSQ subprocess despite a code comment claiming otherwise.
- **`PriorsEditor._apply_prior()`** stored a prior without the validation the live preview already runs — an invalid distribution (negative scale, inverted uniform range) could reach NUTS and fail there with an opaque NumPyro/JAX error instead of being caught at Apply.
- **`step2_data._validate_shape_and_values()`**: a 0-row dataset passed validation vacuously; now caught at Step 2 instead of failing deep inside NLSQ.
- **`LibraryRail`**: tooltip fallback for long dataset names, empty-state placeholder for an empty library. Fixing the empty state introduced (and I then fixed) a real bug: the placeholder's list geometry made `itemAt()` return non-`None` over empty space, so a context-menu click there reached the real (unmocked in one existing test) blocking `QMenu.exec()` — caught by rerunning the existing test suite with a hard timeout.
- **`StatusBar`**: tooltip on long status messages so they aren't silently clipped by the fixed-width JAX/memory indicators.

Not touched: a dead/untested `BayesianOptionsDialog` seed-field gap (confirmed via grep it's never instantiated anywhere in the real wizard flow) and a centralized-numeric-formatter refactor (speculative, 8+ call sites, no concrete bug) — both out of scope for a minimal hardening pass.

## Test plan
- [x] `pytest tests/gui/test_parameter_table_validation.py tests/gui/workspace/fit/test_step4_priors.py tests/gui/workspace/fit/test_step2.py tests/gui/workspace/fit/test_step2_validation.py tests/gui/workspace/test_library_rail.py` — 44 passed
- [x] `ruff check` on all touched files — clean
- [x] Added regression tests: `get_parameters()` skipping an out-of-bounds row, empty-dataset validation error, empty-library placeholder ignoring click/context-menu interaction (the exact scenario that hung in manual testing before the `itemAt()` guard was added)

🤖 Generated with [Claude Code](https://claude.com/claude-code)