### PR TITLE
refactor(gui): remove 2 dead-code parameters found by vulture

### DIFF
--- a/rheojax/gui/services/export_service.py
+++ b/rheojax/gui/services/export_service.py
@@ -794,7 +794,7 @@ class ExportService:
                 import matplotlib.pyplot as plt
                 from matplotlib.backends.backend_pdf import PdfPages
 
-                def _new_page(pdf_handle, figures):
+                def _new_page(figures):
                     """Create a new blank axes page and append to figures list."""
                     _fig, _ax = plt.subplots(figsize=(8.5, 11))
                     _ax.axis("off")
@@ -803,7 +803,7 @@ class ExportService:
 
                 with PdfPages(path) as pdf:
                     figures = []
-                    fig, ax, y = _new_page(pdf, figures)
+                    fig, ax, y = _new_page(figures)
                     for line in report_lines:
                         for subline in line.split("\n"):
                             # GUI-IO-019: page-break when near bottom margin.
@@ -814,7 +814,7 @@ class ExportService:
                                 pdf.savefig(fig, bbox_inches="tight")
                                 plt.close(fig)
                                 figures.pop()
-                                fig, ax, y = _new_page(pdf, figures)
+                                fig, ax, y = _new_page(figures)
                             if not subline:
                                 y -= 0.03
                                 continue

--- a/rheojax/gui/services/plot_service.py
+++ b/rheojax/gui/services/plot_service.py
@@ -270,7 +270,7 @@ class PlotService:
                 )
 
                 # Helper: compute uncertainty band for real-valued fits
-                def _compute_band(x_vals, y_vals):
+                def _compute_band(y_vals):
                     """Compute +/-1.96*sigma band if pcov available (RSS approximation).
 
                     GUI-IO-017 NOTE: This uncertainty band uses the root-sum-square
@@ -382,7 +382,7 @@ class PlotService:
                         )
 
                         # Add uncertainty band
-                        y_lo, y_hi = _compute_band(x, y_fit)
+                        y_lo, y_hi = _compute_band(y_fit)
                         if y_lo is not None and y_hi is not None:
                             y_lo = np.maximum(
                                 y_lo, 1e-30
@@ -407,7 +407,7 @@ class PlotService:
                     )
 
                     # Add uncertainty band
-                    y_lo, y_hi = _compute_band(x, y_fit)
+                    y_lo, y_hi = _compute_band(y_fit)
                     if y_lo is not None and y_hi is not None:
                         y_lo = np.maximum(y_lo, 1e-30)  # Ensure positive for log scale
                         ax.fill_between(
@@ -430,7 +430,7 @@ class PlotService:
                     )
 
                     # Add uncertainty band
-                    y_lo, y_hi = _compute_band(x, y_fit)
+                    y_lo, y_hi = _compute_band(y_fit)
                     if y_lo is not None and y_hi is not None:
                         y_lo = np.maximum(y_lo, 1e-30)  # Ensure positive for log scale
                         ax.fill_between(
@@ -453,7 +453,7 @@ class PlotService:
                     )
 
                     # Add uncertainty band
-                    y_lo, y_hi = _compute_band(x, y_fit)
+                    y_lo, y_hi = _compute_band(y_fit)
                     if y_lo is not None and y_hi is not None:
                         y_lo = np.maximum(y_lo, 1e-30)  # Ensure positive for log scale
                         ax.fill_between(


### PR DESCRIPTION
## Summary
`/ecc:refactor-clean` pass using `vulture` (Python dead-code detector, `--min-confidence 80`).

11 findings total, all "unused variable" at 100% confidence. Investigated each:
- **2 genuinely dead** (private nested closures, unused first param, no external caller): `_new_page(pdf_handle, figures)` in `export_service.py`, `_compute_band(x_vals, y_vals)` in `plot_service.py`. Removed and updated all call sites (2 + 4 respectively).
- **9 false positives for deletion** — each is a required signature contract vulture can't see: sklearn-style `get_params(deep=...)`, a documented-unimplemented public style-token param, a callback registered by exact arity (`NutsStep._default_sample_fn`), `logging.Formatter.formatTime`'s override signature, `scipy.integrate.solve_ivp`'s `fun(t, y)` contract, `multiprocessing.Process` target args, a documented forward-compat placeholder (`compare_models(return_results=...)`), `signal.signal`'s `handler(signum, frame)` contract, and a JIT+doctest-referenced public function's positional parameter. Left untouched.

## Test plan
- [x] Baseline: 24 tests across `test_export_service_netcdf.py`, `test_plot_service_golden.py`, `test_pipeline_execution_service_execute.py`, `test_step5_writers.py`, `test_export_and_project.py` — all passing before the change
- [x] Same 24 tests re-run after the change — still all passing
- [x] `ruff check` clean
- [x] Re-ran vulture — the 2 fixed findings are gone, the 9 left-alone findings are unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)