### PR TITLE
fix(gui): address UX/a11y audit findings across WorkspaceWindow

### DIFF
--- a/rheojax/gui/dialogs/preferences.py
+++ b/rheojax/gui/dialogs/preferences.py
@@ -185,7 +185,9 @@ class PreferencesDialog(QDialog):
         self.max_undo_spin.setSuffix(" steps")
         self.max_undo_spin.setToolTip(
             "Maximum number of undo steps kept in memory. "
-            "Larger values use more memory when fitting large datasets."
+            "Larger values use more memory when fitting large datasets.\n"
+            "Not yet implemented -- no undo history is currently kept. "
+            "Delete Dataset always asks for confirmation instead."
         )
         self.max_undo_spin.valueChanged.connect(
             lambda value: logger.debug(

--- a/rheojax/gui/resources/styles/base.qss
+++ b/rheojax/gui/resources/styles/base.qss
@@ -107,6 +107,11 @@ QToolButton:checked {
     border-color: @tool_checked_border;
 }
 
+QToolButton:focus {
+    border: 2px solid @border_focus;
+    padding: 5px;
+}
+
 /* ========== Input Widgets ========== */
 
 QLineEdit, QSpinBox, QDoubleSpinBox {
@@ -311,6 +316,11 @@ QToolButton[class="icon-button"]:pressed {
     background-color: @bg_pressed;
 }
 
+QToolButton[class="icon-button"]:focus {
+    border: 2px solid @border_focus;
+    padding: 6px;
+}
+
 QToolButton[class="icon-button-primary"] {
     background-color: @icon_btn_primary_bg;
     border: none;
@@ -322,6 +332,11 @@ QToolButton[class="icon-button-primary"] {
 
 QToolButton[class="icon-button-primary"]:hover {
     background-color: @icon_btn_primary_hover;
+}
+
+QToolButton[class="icon-button-primary"]:focus {
+    border: 2px solid @border_focus;
+    padding: 6px;
 }
 
 /* ========== Page Containers ========== */
@@ -725,13 +740,13 @@ QMenuBar::item:selected {
 /* ========== Empty State Labels ========== */
 
 QLabel[class="empty-message"] {
-    color: @text_disabled;
+    color: @text_secondary;
     font-size: 12pt;
     padding: 0;
 }
 
 QLabel[class="empty-desc"] {
-    color: @text_disabled;
+    color: @text_secondary;
     font-size: 10pt;
     padding: 0;
 }

--- a/rheojax/gui/resources/styles/tokens.py
+++ b/rheojax/gui/resources/styles/tokens.py
@@ -42,8 +42,8 @@ class ColorPalette:
     SUCCESS_HOVER: ClassVar[str] = "#047857"
     SUCCESS_LIGHT: ClassVar[str] = "#D1FAE5"
 
-    WARNING: ClassVar[str] = "#D97706"
-    WARNING_HOVER: ClassVar[str] = "#B45309"
+    WARNING: ClassVar[str] = "#92400E"  # amber-800 (4.5:1+ on BG_SURFACE/WARNING_LIGHT, was #D97706 at 3.05:1)
+    WARNING_HOVER: ClassVar[str] = "#78350F"  # amber-900
     WARNING_LIGHT: ClassVar[str] = "#FEF3C7"
 
     ERROR: ClassVar[str] = "#DC2626"

--- a/rheojax/gui/widgets/log_dock.py
+++ b/rheojax/gui/widgets/log_dock.py
@@ -23,6 +23,7 @@ from rheojax.gui.compat import (
     QVBoxLayout,
     QWidget,
 )
+from rheojax.gui.resources.styles.tokens import themed
 from rheojax.gui.utils.layout_helpers import set_compact_margins
 from rheojax.gui.widgets.dropdown import RheoComboBox
 
@@ -30,12 +31,15 @@ _MAX_RECORDS = 2000
 
 _LEVEL_NAMES = ("DEBUG", "INFO", "WARNING", "ERROR", "CRITICAL")
 
-_LEVEL_COLORS = {
-    logging.DEBUG: "#8a8a8a",
+# Resolved via themed() at render time (not a frozen dict) so log lines stay
+# WCAG AA-contrast (>=4.5:1) and repaint correctly after a light/dark theme
+# switch, instead of the fixed hex values this used to hardcode.
+_LEVEL_TOKENS = {
+    logging.DEBUG: "TEXT_SECONDARY",
     logging.INFO: None,  # default text color
-    logging.WARNING: "#b8860b",
-    logging.ERROR: "#cc3333",
-    logging.CRITICAL: "#cc3333",
+    logging.WARNING: "WARNING",
+    logging.ERROR: "ERROR",
+    logging.CRITICAL: "ERROR",
 }
 
 
@@ -88,7 +92,8 @@ class LogDockWidget(QDockWidget):
             self._append_line(levelno, message)
 
     def _append_line(self, levelno: int, message: str) -> None:
-        color = _LEVEL_COLORS.get(levelno)
+        token = _LEVEL_TOKENS.get(levelno)
+        color = themed(token) if token else None
         escaped = html.escape(message)
         if color:
             self.text_edit.append(f'<span style="color:{color};">{escaped}</span>')

--- a/rheojax/gui/workspace/fit/fit_controller.py
+++ b/rheojax/gui/workspace/fit/fit_controller.py
@@ -129,24 +129,30 @@ def _run_on_thread(fn, *, progress_queue=None, on_progress=None):
     return outcome["result"]
 
 
-def _make_progress_reporter(active_jobs, job_id):
+def _make_progress_reporter(active_jobs, job_id, status_bar=None):
     """Build an on_progress callback that stashes the latest progress
-    message on the job's active_jobs.by_id entry, so anything reading
-    active_jobs (e.g. a future status-bar/progress widget) can see it.
+    message on the job's active_jobs.by_id entry, and -- if *status_bar* is
+    given -- forwards it to StatusBar.show_progress() so a running NLSQ/NUTS
+    job is actually visible (previously this only wrote to active_jobs,
+    which nothing read: the run showed no feedback beyond a disabled
+    button for its whole duration).
     GUI-thread only -- no lock needed, see ActiveJobsState.lock's docstring.
     """
 
     def _on_progress(msg) -> None:
-        if active_jobs is None:
-            return
-        job = active_jobs.by_id.get(job_id)
-        if job is not None:
-            job["progress"] = msg
+        if active_jobs is not None:
+            job = active_jobs.by_id.get(job_id)
+            if job is not None:
+                job["progress"] = msg
+        if status_bar is not None and isinstance(msg, dict):
+            status_bar.show_progress(
+                msg.get("percent", 0), msg.get("total", 100), msg.get("message", "")
+            )
 
     return _on_progress
 
 
-def _make_fit_fn(library, fit_state, active_jobs=None):
+def _make_fit_fn(library, fit_state, active_jobs=None, status_bar=None):
     """Build the real fit_fn NlsqStep.run() calls."""
 
     def _fit_fn(
@@ -186,6 +192,8 @@ def _make_fit_fn(library, fit_state, active_jobs=None):
         # while the loop is still suspended waiting on the worker thread.
         if active_jobs is not None:
             active_jobs.by_id[job_id] = {"status": "running", "worker": token}
+        if status_bar is not None:
+            status_bar.show_progress(0, 100, "Fitting...")
         try:
             return _fit_fn_body(
                 library,
@@ -199,10 +207,13 @@ def _make_fit_fn(library, fit_state, active_jobs=None):
                 token.event,
                 active_jobs,
                 job_id,
+                status_bar,
             )
         finally:
             if active_jobs is not None:
                 active_jobs.by_id.pop(job_id, None)
+            if status_bar is not None:
+                status_bar.hide_progress()
 
     return _fit_fn
 
@@ -219,6 +230,7 @@ def _fit_fn_body(
     cancel_event,
     active_jobs=None,
     job_id=None,
+    status_bar=None,
 ):
     rheo_data = library.load_payload(data_ref)
     # ponytail: Step 1's protocol combo uses the same vocabulary as
@@ -277,7 +289,9 @@ def _fit_fn_body(
                     metadata=metadata,
                 ),
                 progress_queue=progress_queue,
-                on_progress=_make_progress_reporter(active_jobs, job_id or data_ref),
+                on_progress=_make_progress_reporter(
+                    active_jobs, job_id or data_ref, status_bar
+                ),
             )
         finally:
             # Release the queue's feeder thread/fds/semaphore -- mirrors
@@ -309,7 +323,7 @@ def _fit_fn_body(
     return best
 
 
-def _make_sample_fn(library, fit_state, active_jobs=None):
+def _make_sample_fn(library, fit_state, active_jobs=None, status_bar=None):
     """Build the real sample_fn NutsStep.run() calls."""
 
     def _sample_fn(priors, warm_start, config):
@@ -329,6 +343,8 @@ def _make_sample_fn(library, fit_state, active_jobs=None):
                 "status": "running",
                 "worker": token,
             }
+        if status_bar is not None:
+            status_bar.show_progress(0, 100, "Sampling...")
         progress_queue = multiprocessing.Queue()
         try:
             return _run_on_thread(
@@ -352,7 +368,7 @@ def _make_sample_fn(library, fit_state, active_jobs=None):
                     max_tree_depth=config.get("max_tree_depth"),
                 ),
                 progress_queue=progress_queue,
-                on_progress=_make_progress_reporter(active_jobs, job_id),
+                on_progress=_make_progress_reporter(active_jobs, job_id, status_bar),
             )
         finally:
             # Release the queue's feeder thread/fds/semaphore -- mirrors
@@ -364,20 +380,30 @@ def _make_sample_fn(library, fit_state, active_jobs=None):
                 pass
             if active_jobs is not None:
                 active_jobs.by_id.pop(job_id, None)
+            if status_bar is not None:
+                status_bar.hide_progress()
 
     return _sample_fn
 
 
-def build_fit_controller(app_state: AppState):
+def build_fit_controller(app_state: AppState, status_bar=None):
     st = app_state.fit
     bodies = [
         ProtocolModelStep(st),
         DataStep(st, app_state.library),
         NlsqStep(
-            st, fit_fn=_make_fit_fn(app_state.library, st, app_state.active_jobs)
+            st,
+            fit_fn=_make_fit_fn(
+                app_state.library, st, app_state.active_jobs, status_bar
+            ),
+            active_jobs=app_state.active_jobs,
         ),
         NutsStep(
-            st, sample_fn=_make_sample_fn(app_state.library, st, app_state.active_jobs)
+            st,
+            sample_fn=_make_sample_fn(
+                app_state.library, st, app_state.active_jobs, status_bar
+            ),
+            active_jobs=app_state.active_jobs,
         ),
         VisualizeStep(st),
         ExportStep(st, app_state.library, app_state.active_jobs),

--- a/rheojax/gui/workspace/fit/step3_nlsq.py
+++ b/rheojax/gui/workspace/fit/step3_nlsq.py
@@ -19,6 +19,9 @@ from rheojax.gui.foundation.state import FitState, ParameterState
 from rheojax.gui.jobs.cancellation import CancellationError
 from rheojax.gui.utils.layout_helpers import set_panel_margins
 from rheojax.gui.widgets.parameter_table import ParameterTable
+from rheojax.logging import get_logger
+
+logger = get_logger(__name__)
 
 
 def _default_fit_fn(
@@ -55,6 +58,7 @@ class NlsqStep(QWidget):
         self._state = state
         self._fit_fn = fit_fn or _default_fit_fn
         self._active_jobs = active_jobs
+        self._current_job_id: str | None = None
         self._table = ParameterTable(self)
         self._ms_enabled = QCheckBox("multi-start", self)
         self._ms_count = QSpinBox(self)
@@ -89,12 +93,23 @@ class NlsqStep(QWidget):
         self._run_btn.clicked.connect(self.run)
 
     def _on_cancel_clicked(self) -> None:
-        if self._active_jobs is None:
+        if self._active_jobs is None or self._current_job_id is None:
             return
-        job_id = f"{self._state.data_ref}:nlsq"
-        job = self._active_jobs.by_id.get(job_id)
+        # Look up the job_id captured when THIS run started (not recomputed
+        # from live state.data_ref) -- run()'s own comments document that the
+        # nested event loop lets the user navigate to Step 2 and pick a
+        # different dataset while a fit is in flight, which would otherwise
+        # make this button silently miss and do nothing.
+        job = self._active_jobs.by_id.get(self._current_job_id)
         worker = job.get("worker") if job else None
         if worker is None:
+            # Job already finished (or never registered) -- not an error,
+            # just a stale click, but worth a trace since it's the one path
+            # that makes this button silently do nothing.
+            logger.debug(
+                "Cancel clicked with no live worker",
+                job_id=self._current_job_id,
+            )
             return
         from PySide6.QtCore import QThreadPool
 
@@ -172,7 +187,12 @@ class NlsqStep(QWidget):
         # button must be disabled for the duration or a second click launches
         # an overlapping fit that corrupts shared active_jobs tracking.
         self._run_btn.setEnabled(False)
-        self._cancel_btn.setVisible(True)
+        # job_id mirrors fit_controller._make_fit_fn's own f"{data_ref}:nlsq"
+        # exactly, captured here (not recomputed from live state in
+        # _on_cancel_clicked) so a dataset switch mid-run can't make Cancel
+        # silently miss the job it's actually trying to stop.
+        self._current_job_id = f"{self._state.data_ref}:nlsq"
+        self._cancel_btn.setVisible(self._active_jobs is not None)
         # Snapshot: _fit_fn pumps a nested QEventLoop, so the user can
         # navigate elsewhere/edit Step 1 while this run is in flight --
         # that invalidation bumps FitState.revision (invalidation.py). If it
@@ -276,6 +296,7 @@ class NlsqStep(QWidget):
         finally:
             self._run_btn.setEnabled(True)
             self._cancel_btn.setVisible(False)
+            self._current_job_id = None
 
     def refresh_display(self) -> None:
         """Sync the result label to current state.

--- a/rheojax/gui/workspace/fit/step3_nlsq.py
+++ b/rheojax/gui/workspace/fit/step3_nlsq.py
@@ -48,11 +48,13 @@ class NlsqStep(QWidget):
         self,
         state: FitState,
         fit_fn: Callable | None = None,
+        active_jobs=None,
         parent: QWidget | None = None,
     ) -> None:
         super().__init__(parent)
         self._state = state
         self._fit_fn = fit_fn or _default_fit_fn
+        self._active_jobs = active_jobs
         self._table = ParameterTable(self)
         self._ms_enabled = QCheckBox("multi-start", self)
         self._ms_count = QSpinBox(self)
@@ -60,8 +62,17 @@ class NlsqStep(QWidget):
         self._ms_count.setValue(8)
         self._fit_options: dict = {}
         self._options_btn = QPushButton("⚙ Fit Options", self)
+        self._options_btn.setAccessibleName("Fit Options")
         self._options_btn.clicked.connect(self._on_options_clicked)
         self._run_btn = QPushButton("▶ Run NLSQ", self)
+        self._run_btn.setAccessibleName("Run NLSQ")
+        # Only path to stop a running NLSQ fit used to be Close/New/Open's
+        # heavyweight "Jobs Running -- Cancel them and continue?" dialog.
+        # This reuses the same active_jobs "worker" token + CancelWorkerRunnable
+        # that dialog already dispatches, just from a direct per-step button.
+        self._cancel_btn = QPushButton("Cancel", self)
+        self._cancel_btn.setVisible(False)
+        self._cancel_btn.clicked.connect(self._on_cancel_clicked)
         self._result = QLabel("", self)
         lay = QVBoxLayout(self)
         set_panel_margins(lay)
@@ -71,10 +82,27 @@ class NlsqStep(QWidget):
             self._ms_count,
             self._options_btn,
             self._run_btn,
+            self._cancel_btn,
             self._result,
         ):
             lay.addWidget(w)
         self._run_btn.clicked.connect(self.run)
+
+    def _on_cancel_clicked(self) -> None:
+        if self._active_jobs is None:
+            return
+        job_id = f"{self._state.data_ref}:nlsq"
+        job = self._active_jobs.by_id.get(job_id)
+        worker = job.get("worker") if job else None
+        if worker is None:
+            return
+        from PySide6.QtCore import QThreadPool
+
+        from rheojax.gui.workspace.pipeline.cancel_runnable import (
+            CancelWorkerRunnable,
+        )
+
+        QThreadPool.globalInstance().start(CancelWorkerRunnable(worker))
 
     def parameter_table(self) -> ParameterTable:
         return self._table
@@ -144,6 +172,7 @@ class NlsqStep(QWidget):
         # button must be disabled for the duration or a second click launches
         # an overlapping fit that corrupts shared active_jobs tracking.
         self._run_btn.setEnabled(False)
+        self._cancel_btn.setVisible(True)
         # Snapshot: _fit_fn pumps a nested QEventLoop, so the user can
         # navigate elsewhere/edit Step 1 while this run is in flight --
         # that invalidation bumps FitState.revision (invalidation.py). If it
@@ -246,6 +275,7 @@ class NlsqStep(QWidget):
             self.finished.emit()
         finally:
             self._run_btn.setEnabled(True)
+            self._cancel_btn.setVisible(False)
 
     def refresh_display(self) -> None:
         """Sync the result label to current state.

--- a/rheojax/gui/workspace/fit/step4_nuts.py
+++ b/rheojax/gui/workspace/fit/step4_nuts.py
@@ -21,6 +21,9 @@ from rheojax.gui.foundation.state import FitState
 from rheojax.gui.jobs.cancellation import CancellationError
 from rheojax.gui.utils.layout_helpers import set_panel_margins
 from rheojax.gui.widgets.priors_editor import PriorsEditor
+from rheojax.logging import get_logger
+
+logger = get_logger(__name__)
 
 _R_HAT_THRESHOLD = 1.05
 _ESS_MIN = 400
@@ -123,6 +126,7 @@ class NutsStep(QWidget):
         self._state = state
         self._sample_fn = sample_fn or _default_sample_fn
         self._active_jobs = active_jobs
+        self._current_job_id: str | None = None
         self._skipped = False
         self._banner = QLabel("⚡ warm-started from NLSQ MAP", self)
         self._banner.setAccessibleName("Warm-started from NLSQ MAP")
@@ -204,12 +208,19 @@ class NutsStep(QWidget):
         cfg.max_tree_depth = self._max_tree_depth.value() or None
 
     def _on_cancel_clicked(self) -> None:
-        if self._active_jobs is None:
+        if self._active_jobs is None or self._current_job_id is None:
             return
-        job_id = f"{self._state.data_ref}:nuts"
-        job = self._active_jobs.by_id.get(job_id)
+        # See NlsqStep._on_cancel_clicked's matching comment: uses the job_id
+        # captured when THIS run started, not recomputed from live
+        # state.data_ref, so a dataset switch mid-run can't make Cancel
+        # silently miss the job it's actually trying to stop.
+        job = self._active_jobs.by_id.get(self._current_job_id)
         worker = job.get("worker") if job else None
         if worker is None:
+            logger.debug(
+                "Cancel clicked with no live worker",
+                job_id=self._current_job_id,
+            )
             return
         from PySide6.QtCore import QThreadPool
 
@@ -274,7 +285,10 @@ class NutsStep(QWidget):
         # completes. Mirrors NlsqStep.run()'s identical guard.
         self._run_btn.setEnabled(False)
         self._skip_btn.setEnabled(False)
-        self._cancel_btn.setVisible(True)
+        # job_id mirrors fit_controller._make_sample_fn's own
+        # f"{data_ref}:nuts" exactly -- see NlsqStep.run()'s matching comment.
+        self._current_job_id = f"{self._state.data_ref}:nuts"
+        self._cancel_btn.setVisible(self._active_jobs is not None)
         # See NlsqStep.run()'s matching comment: discard a result that no
         # longer corresponds to the current selection if state moved on
         # while this run was in flight.
@@ -324,6 +338,7 @@ class NutsStep(QWidget):
             self._run_btn.setEnabled(True)
             self._skip_btn.setEnabled(True)
             self._cancel_btn.setVisible(False)
+            self._current_job_id = None
 
     def is_ready(self) -> bool:
         return self._skipped or self._state.nuts_result is not None

--- a/rheojax/gui/workspace/fit/step4_nuts.py
+++ b/rheojax/gui/workspace/fit/step4_nuts.py
@@ -116,13 +116,16 @@ class NutsStep(QWidget):
         self,
         state: FitState,
         sample_fn: Callable | None = None,
+        active_jobs=None,
         parent: QWidget | None = None,
     ) -> None:
         super().__init__(parent)
         self._state = state
         self._sample_fn = sample_fn or _default_sample_fn
+        self._active_jobs = active_jobs
         self._skipped = False
         self._banner = QLabel("⚡ warm-started from NLSQ MAP", self)
+        self._banner.setAccessibleName("Warm-started from NLSQ MAP")
         self._priors_editor = PriorsEditor(self)
 
         # Sampler settings (previously hardcoded in fit_controller.py's
@@ -162,13 +165,21 @@ class NutsStep(QWidget):
 
         self._skip_btn = QPushButton("Skip NUTS", self)
         self._run_btn = QPushButton("▶ Sample", self)
+        self._run_btn.setAccessibleName("Sample")
+        # Only path to stop a running NUTS sample used to be Close/New/Open's
+        # heavyweight "Jobs Running -- Cancel them and continue?" dialog.
+        # This reuses the same active_jobs "worker" token + CancelWorkerRunnable
+        # that dialog already dispatches, just from a direct per-step button.
+        self._cancel_btn = QPushButton("Cancel", self)
+        self._cancel_btn.setVisible(False)
+        self._cancel_btn.clicked.connect(self._on_cancel_clicked)
         self._result = QLabel("", self)
         lay = QVBoxLayout(self)
         set_panel_margins(lay)
         lay.addWidget(self._banner)
         lay.addWidget(self._priors_editor)
         lay.addLayout(settings_form)
-        for w in (self._skip_btn, self._run_btn, self._result):
+        for w in (self._skip_btn, self._run_btn, self._cancel_btn, self._result):
             lay.addWidget(w)
         lay.addStretch()  # see step1_protocol_model.py's addStretch() comment
         self._skip_btn.clicked.connect(self.skip)
@@ -191,6 +202,22 @@ class NutsStep(QWidget):
         cfg.seed = self._seed.value()
         cfg.target_accept = self._target.value()
         cfg.max_tree_depth = self._max_tree_depth.value() or None
+
+    def _on_cancel_clicked(self) -> None:
+        if self._active_jobs is None:
+            return
+        job_id = f"{self._state.data_ref}:nuts"
+        job = self._active_jobs.by_id.get(job_id)
+        worker = job.get("worker") if job else None
+        if worker is None:
+            return
+        from PySide6.QtCore import QThreadPool
+
+        from rheojax.gui.workspace.pipeline.cancel_runnable import (
+            CancelWorkerRunnable,
+        )
+
+        QThreadPool.globalInstance().start(CancelWorkerRunnable(worker))
 
     def priors_editor(self) -> PriorsEditor:
         return self._priors_editor
@@ -247,6 +274,7 @@ class NutsStep(QWidget):
         # completes. Mirrors NlsqStep.run()'s identical guard.
         self._run_btn.setEnabled(False)
         self._skip_btn.setEnabled(False)
+        self._cancel_btn.setVisible(True)
         # See NlsqStep.run()'s matching comment: discard a result that no
         # longer corresponds to the current selection if state moved on
         # while this run was in flight.
@@ -295,6 +323,7 @@ class NutsStep(QWidget):
         finally:
             self._run_btn.setEnabled(True)
             self._skip_btn.setEnabled(True)
+            self._cancel_btn.setVisible(False)
 
     def is_ready(self) -> bool:
         return self._skipped or self._state.nuts_result is not None

--- a/rheojax/gui/workspace/pipeline/step1_configure_run.py
+++ b/rheojax/gui/workspace/pipeline/step1_configure_run.py
@@ -97,6 +97,7 @@ class PipelineConfigureRunStep(QWidget):
         )
 
         self._run_all_btn = QPushButton("▶ Run All", self)
+        self._run_all_btn.setAccessibleName("Run All")
         self._run_all_btn.clicked.connect(self.run_requested.emit)
 
         layout = QVBoxLayout(self)

--- a/rheojax/gui/workspace/transform/step3_run.py
+++ b/rheojax/gui/workspace/transform/step3_run.py
@@ -34,6 +34,7 @@ class RunStep(QWidget):
         self._state = state
         self._run_fn = run_fn or _default_run_fn
         self._btn = QPushButton("▶ Run transform", self)
+        self._btn.setAccessibleName("Run transform")
         self._status = QLabel("", self)
         lay = QVBoxLayout(self)
         set_panel_margins(lay)

--- a/rheojax/gui/workspace/window.py
+++ b/rheojax/gui/workspace/window.py
@@ -182,6 +182,7 @@ class _WindowChrome:
 <tr><td><b>Ctrl+S</b></td><td>Save Project</td></tr>
 <tr><td><b>Ctrl+Shift+S</b></td><td>Save Project As</td></tr>
 <tr><td><b>Ctrl+K</b></td><td>Command Palette</td></tr>
+<tr><td><b>Ctrl+1..9</b></td><td>Jump to Step 1..9 (current mode)</td></tr>
 </table>
         """
         QMessageBox.information(self, "Keyboard Shortcuts", shortcuts)
@@ -433,7 +434,7 @@ class WorkspaceWindow(QMainWindow, _WindowChrome):
         self._mode = initial_mode if initial_mode in self.MODES else "fit"
         from rheojax.gui.workspace.pipeline.controller import build_pipeline_controller
 
-        fit_ctl, self._fit_bodies = build_fit_controller(state)
+        fit_ctl, self._fit_bodies = build_fit_controller(state, self.statusBar())
         transform_ctl, self._transform_bodies = build_transform_controller(state)
         pipeline_ctl, self._pipeline_bodies = build_pipeline_controller(
             state,

--- a/tests/gui/workspace/fit/test_cancel_and_progress.py
+++ b/tests/gui/workspace/fit/test_cancel_and_progress.py
@@ -1,0 +1,229 @@
+"""Regression tests for the NLSQ/NUTS Cancel button and status-bar progress
+wiring added to close a PR #100 review gap: neither had any coverage, and
+both have real "silently does nothing" / "stuck forever" failure modes.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+pytest.importorskip("PySide6")
+
+from rheojax.gui.foundation.library import DatasetRef
+from rheojax.gui.foundation.state import ActiveJobsState, AppState
+from rheojax.gui.workspace.fit.fit_controller import _make_fit_fn, _make_sample_fn
+from rheojax.gui.workspace.fit.step3_nlsq import NlsqStep
+from rheojax.gui.workspace.fit.step4_nuts import NutsStep
+
+
+class _FakeWorker:
+    def __init__(self):
+        self.cancel_called = False
+
+    def cancel(self):
+        self.cancel_called = True
+
+
+class _FakeStatusBar:
+    def __init__(self):
+        self.progress_calls: list[tuple[int, int, str]] = []
+        self.hide_calls = 0
+
+    def show_progress(self, value, maximum, text=""):
+        self.progress_calls.append((value, maximum, text))
+
+    def hide_progress(self):
+        self.hide_calls += 1
+
+
+def _run_qthreadpool_tasks(qtbot):
+    from PySide6.QtCore import QThreadPool
+
+    QThreadPool.globalInstance().waitForDone(2000)
+    qtbot.wait(50)
+
+
+def test_nlsq_cancel_button_hidden_without_active_jobs(qtbot):
+    step = NlsqStep(state=AppState().fit, active_jobs=None)
+    qtbot.addWidget(step)
+    step._current_job_id = "d1:nlsq"  # simulate a run() in flight
+    step._cancel_btn.setVisible(step._active_jobs is not None)
+    assert step._cancel_btn.isVisible() is False
+
+
+def test_nlsq_cancel_noop_when_no_active_jobs(qtbot):
+    step = NlsqStep(state=AppState().fit, active_jobs=None)
+    qtbot.addWidget(step)
+    step._current_job_id = "d1:nlsq"
+    step._on_cancel_clicked()  # must not raise
+
+
+def test_nlsq_cancel_noop_when_job_not_registered(qtbot):
+    active_jobs = ActiveJobsState()
+    step = NlsqStep(state=AppState().fit, active_jobs=active_jobs)
+    qtbot.addWidget(step)
+    step._current_job_id = "d1:nlsq"  # no matching entry in active_jobs.by_id
+    step._on_cancel_clicked()  # must not raise, must not crash on missing job
+
+
+def test_nlsq_cancel_dispatches_to_registered_worker(qtbot):
+    active_jobs = ActiveJobsState()
+    worker = _FakeWorker()
+    active_jobs.by_id["d1:nlsq"] = {"status": "running", "worker": worker}
+    step = NlsqStep(state=AppState().fit, active_jobs=active_jobs)
+    qtbot.addWidget(step)
+    step._current_job_id = "d1:nlsq"
+
+    step._on_cancel_clicked()
+    _run_qthreadpool_tasks(qtbot)
+
+    assert worker.cancel_called is True
+
+
+def test_nuts_cancel_dispatches_to_registered_worker(qtbot):
+    active_jobs = ActiveJobsState()
+    worker = _FakeWorker()
+    active_jobs.by_id["d1:nuts"] = {"status": "running", "worker": worker}
+    step = NutsStep(state=AppState().fit, active_jobs=active_jobs)
+    qtbot.addWidget(step)
+    step._current_job_id = "d1:nuts"
+
+    step._on_cancel_clicked()
+    _run_qthreadpool_tasks(qtbot)
+
+    assert worker.cancel_called is True
+
+
+def test_nlsq_run_shows_and_hides_progress_via_status_bar(monkeypatch, qtbot):
+    def fake_run_fit_isolated(
+        model_name,
+        x_data,
+        y_data,
+        test_mode,
+        initial_params,
+        options,
+        progress_queue,
+        cancel_event,
+        y2_data=None,
+        metadata=None,
+        dataset_id="",
+        model_config=None,
+    ):
+        progress_queue.put(
+            {"type": "progress", "percent": 50, "total": 100, "message": "halfway"}
+        )
+        return {"params": {"a": 1.0}, "r_squared": 0.9, "success": True}
+
+    monkeypatch.setattr(
+        "rheojax.gui.workspace.fit.fit_controller.run_fit_isolated",
+        fake_run_fit_isolated,
+    )
+
+    app = AppState()
+    app.library.add(
+        DatasetRef(
+            id="d1",
+            name="d1",
+            protocol_type="flow_curve",
+            origin="imported",
+            units={},
+            row_count=2,
+            hash="h",
+            provenance={},
+            lineage=[],
+        )
+    )
+
+    class _RheoData:
+        x = [1.0, 2.0]
+        y = [1.0, 2.0]
+
+    app.library.store_payload("d1", _RheoData())
+    app.fit.protocol = "flow_curve"
+    app.fit.model_key = "power_law"
+    app.fit.model_config = {}
+    app.fit.data_ref = "d1"
+
+    status_bar = _FakeStatusBar()
+    fit_fn = _make_fit_fn(app.library, app.fit, app.active_jobs, status_bar)
+    step = NlsqStep(state=app.fit, fit_fn=fit_fn, active_jobs=app.active_jobs)
+    qtbot.addWidget(step)
+
+    step.run()
+
+    # Initial "Fitting..." message, then the forwarded 50% progress message --
+    # both must have reached the status bar, not just been computed and
+    # silently discarded (the original bug this wiring fixes).
+    assert status_bar.progress_calls[0] == (0, 100, "Fitting...")
+    assert (50, 100, "halfway") in status_bar.progress_calls
+    # hide_progress must fire exactly once when the run completes, or the
+    # status bar is left showing a stale progress bar forever.
+    assert status_bar.hide_calls == 1
+    # Cancel button must not be left visible after a completed run.
+    assert step._cancel_btn.isVisible() is False
+    assert step._current_job_id is None
+
+
+def test_nuts_run_shows_and_hides_progress_via_status_bar(monkeypatch, qtbot):
+    def fake_run_bayesian_isolated(
+        model_name,
+        x_data,
+        y_data,
+        test_mode,
+        num_warmup,
+        num_samples,
+        num_chains,
+        warm_start,
+        priors,
+        seed,
+        progress_queue,
+        cancel_event,
+        y2_data=None,
+        metadata=None,
+        fitted_model_state=None,
+        dataset_id="",
+        target_accept=0.8,
+        model_config=None,
+        max_tree_depth=None,
+    ):
+        return {"posterior_samples": {"a": [1.0, 1.1]}, "r_hat": {"a": 1.0}}
+
+    monkeypatch.setattr(
+        "rheojax.gui.workspace.fit.fit_controller.run_bayesian_isolated",
+        fake_run_bayesian_isolated,
+    )
+
+    app = AppState()
+    app.library.add(
+        DatasetRef(
+            id="d1",
+            name="d1",
+            protocol_type="oscillation",
+            origin="imported",
+            units={},
+            row_count=2,
+            hash="h",
+            provenance={},
+            lineage=[],
+        )
+    )
+
+    class _RheoData:
+        x = [1.0, 2.0]
+        y = [1.0, 2.0]
+
+    app.library.store_payload("d1", _RheoData())
+    app.fit.data_ref = "d1"
+    app.fit.model_key = "power_law"
+
+    status_bar = _FakeStatusBar()
+    sample_fn = _make_sample_fn(app.library, app.fit, app.active_jobs, status_bar)
+    step = NutsStep(state=app.fit, sample_fn=sample_fn, active_jobs=app.active_jobs)
+    qtbot.addWidget(step)
+
+    step.run()
+
+    assert status_bar.progress_calls[0] == (0, 100, "Sampling...")
+    assert status_bar.hide_calls == 1
+    assert step._cancel_btn.isVisible() is False
+    assert step._current_job_id is None


### PR DESCRIPTION
## Summary

Addresses all findings from a Qt UI design audit (WCAG 2.2, motion, typography, keyboard nav, semantic color, AI-latency patterns) of the WorkspaceWindow shell.

**Critical**
- Visible `:focus` ring for `QToolButton` (mode switcher, step rail, icon buttons) -- previously Tab-focusable but invisible (WCAG 2.4.7)
- `WARNING` token contrast fixed (3.05:1 -> 6.8:1+ on `BG_SURFACE`), fixing status bar Float64 label and NLSQ/NUTS convergence badges; `log_dock.py` colors now theme-aware via `themed()` instead of hardcoded, theme-blind hex
- NLSQ/NUTS fit-job progress now reaches `StatusBar.show_progress()` -- previously computed by `fit_controller.py` and silently discarded, leaving only a disabled Run button with zero feedback during multi-minute runs

**Warning**
- Per-step Cancel button added to NLSQ/NUTS steps, reusing the existing `active_jobs` worker-token + `CancelWorkerRunnable` cancellation path (previously only reachable via the heavyweight "Jobs Running" close/open confirmation)
- `setAccessibleName()` added to glyph-prefixed controls (Run NLSQ, Sample, Run All, Run transform, Fit Options, warm-started banner) so screen readers don't read raw decorative glyphs
- Shortcuts help dialog now lists the `Ctrl+1..9` step-jump bindings
- "Max Undo Steps" preference tooltip now discloses it isn't wired up yet (no `QUndoStack` exists in the app) instead of implying a safety net for Delete Dataset

**Opportunity**
- Empty-state label CSS class no longer reuses the disabled-state color token (2.41:1 -> passing contrast)

## Test plan
- [x] `ruff check` clean on all changed Python files
- [x] `pytest tests/gui/workspace/fit/` (33 tests) -- fit_controller/step3/step4 wiring
- [x] `pytest tests/gui/test_gui_smoke.py tests/gui/workspace/` (413 tests) -- full GUI suite
- [x] Manual contrast math verified for all token changes (WCAG AA >=4.5:1 text / >=3:1 UI)
- [x] Manual smoke test of `_make_progress_reporter` -> `StatusBar.show_progress()` wiring

🤖 Generated with [Claude Code](https://claude.com/claude-code)