### PR TITLE
fix(types): resolve all 30 mypy errors surfaced by full type-check

### DIFF
--- a/rheojax/core/base.py
+++ b/rheojax/core/base.py
@@ -9,7 +9,7 @@ from __future__ import annotations
 import copy
 from abc import ABC, abstractmethod
 from collections import OrderedDict
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, Self
 
 import numpy as np
 
@@ -110,7 +110,7 @@ class BaseModel(BayesianMixin, ABC):
         default_test_mode=None,
         normalize: bool = True,
         **kwargs,
-    ) -> BaseModel:
+    ) -> Self:
         """Standard NLSQ fitting pipeline for models with a stateless model_fn.
 
         Handles: RheoData unpacking, test_mode resolution/caching,

--- a/rheojax/core/data.py
+++ b/rheojax/core/data.py
@@ -531,6 +531,12 @@ class RheoData:
         if self.y is None:
             raise ValueError("RheoData.y_real requires non-None y data")
         y = self.y
+        # Invariant: __post_init__ always converts x/y via _ensure_array, so y is
+        # never a bare list/tuple here — narrow for mypy, raise loudly if violated.
+        if not isinstance(y, (np.ndarray, jnp.ndarray)):
+            raise TypeError(
+                f"RheoData.y_real: expected a converted ndarray, got {type(y).__name__}"
+            )
         y_np = _coerce_ndarray(y)
         if np.iscomplexobj(y_np):
             if isinstance(y, jnp.ndarray):
@@ -539,12 +545,6 @@ class RheoData:
         if y_np.ndim == 2 and y_np.shape[1] == 2:
             # (N,2) DMTA/GMM convention: column 0 is G' (storage modulus)
             return y[:, 0]
-        # Invariant: __post_init__ always converts x/y via _ensure_array, so y is
-        # never a bare list/tuple here — narrow for mypy, raise loudly if violated.
-        if not isinstance(y, (np.ndarray, jnp.ndarray)):
-            raise TypeError(
-                f"RheoData.y_real: expected a converted ndarray, got {type(y).__name__}"
-            )
         return y
 
     @property
@@ -567,6 +567,12 @@ class RheoData:
         if self.y is None:
             raise ValueError("RheoData.y_imag requires non-None y data")
         y = self.y
+        # Invariant: __post_init__ always converts x/y via _ensure_array, so y is
+        # never a bare list/tuple here — narrow for mypy, raise loudly if violated.
+        if not isinstance(y, (np.ndarray, jnp.ndarray)):
+            raise TypeError(
+                f"RheoData.y_imag: expected a converted ndarray, got {type(y).__name__}"
+            )
         y_np = _coerce_ndarray(y)
         if np.iscomplexobj(y_np):
             if isinstance(y, jnp.ndarray):

--- a/rheojax/core/registry.py
+++ b/rheojax/core/registry.py
@@ -206,7 +206,7 @@ class Registry:
             # abstract methods (e.g. BaseModel._fit/_predict never
             # overridden).
             if inspect.isabstract(plugin_class):
-                missing = sorted(plugin_class.__abstractmethods__)
+                missing = sorted(getattr(plugin_class, "__abstractmethods__", ()))
                 raise ValueError(
                     f"Model plugin '{plugin_class.__name__}' is abstract; "
                     f"missing implementation for: {', '.join(missing)}"
@@ -219,7 +219,7 @@ class Registry:
                     "Transform plugin does not implement required interface: missing 'transform' method"
                 )
             if inspect.isabstract(plugin_class):
-                missing = sorted(plugin_class.__abstractmethods__)
+                missing = sorted(getattr(plugin_class, "__abstractmethods__", ()))
                 raise ValueError(
                     f"Transform plugin '{plugin_class.__name__}' is abstract; "
                     f"missing implementation for: {', '.join(missing)}"

--- a/rheojax/io/readers/_utils.py
+++ b/rheojax/io/readers/_utils.py
@@ -858,11 +858,11 @@ def normalize_units(
     if key not in UNIFIED_UNIT_CONVERSIONS:
         return values, source_unit
 
-    target_unit, factor = UNIFIED_UNIT_CONVERSIONS[key]
+    target_unit, unit_factor = UNIFIED_UNIT_CONVERSIONS[key]
     values = np.asarray(values, dtype=np.float64)
 
-    if factor is not None:
-        return values * factor, target_unit
+    if unit_factor is not None:
+        return values * unit_factor, target_unit
 
     # Additive temperature conversion
     if key in ("°c", "c"):

--- a/rheojax/io/readers/csv_reader.py
+++ b/rheojax/io/readers/csv_reader.py
@@ -351,6 +351,7 @@ def load_csv(
 
     # Extract y data (single column or complex modulus)
     is_complex = y_cols is not None
+    y_data: np.ndarray
     if is_complex:
         if y_cols is None:  # pragma: no cover — guarded by is_complex
             raise ValueError("y_cols must not be None for complex data")
@@ -437,7 +438,9 @@ def load_csv(
                 imag_part, _ = normalize_units(y_data.imag, extracted_y_units)
                 y_data = real_part + 1j * imag_part
             else:
-                y_data, y_units = normalize_units(y_data, extracted_y_units)
+                y_data, y_units = normalize_units(
+                    np.asarray(y_data, dtype=np.float64), extracted_y_units
+                )
         else:
             y_units = extracted_y_units
 

--- a/rheojax/io/readers/excel_reader.py
+++ b/rheojax/io/readers/excel_reader.py
@@ -227,6 +227,7 @@ def load_excel(
 
     # Extract y data (single column or complex modulus)
     is_complex = y_cols is not None
+    y_data: np.ndarray
     if is_complex:
         if y_cols is None:  # pragma: no cover — guarded by is_complex
             raise ValueError("y_cols must not be None for complex data")
@@ -316,7 +317,9 @@ def load_excel(
                 imag_part, _ = normalize_units(y_data.imag, extracted_y_units)
                 y_data = real_part + 1j * imag_part
             else:
-                y_data, y_units = normalize_units(y_data, extracted_y_units)
+                y_data, y_units = normalize_units(
+                    np.asarray(y_data, dtype=np.float64), extracted_y_units
+                )
         else:
             y_units = extracted_y_units
 

--- a/rheojax/models/dmt/nonlocal_model.py
+++ b/rheojax/models/dmt/nonlocal_model.py
@@ -511,7 +511,7 @@ class DMTNonlocal(DMTBase):
             band_location = self.y[band_indices].mean()
         else:
             band_width = self.gap_width
-            band_location = self.gap_width / 2
+            band_location = np.float64(self.gap_width / 2)
 
         return {
             "is_banding": is_banding,

--- a/rheojax/models/multimode/generalized_maxwell.py
+++ b/rheojax/models/multimode/generalized_maxwell.py
@@ -2130,6 +2130,8 @@ class GeneralizedMaxwell(BaseModel):
         symbol = "G"
 
         E_inf = self.parameters.get_value(f"{symbol}_inf")
+        if E_inf is None:
+            raise ValueError(f"Parameter '{symbol}_inf' is not set")
         E_i = jnp.array(
             [
                 self.parameters.get_value(f"{symbol}_{i + 1}")

--- a/rheojax/models/spp/spp_yield_stress.py
+++ b/rheojax/models/spp/spp_yield_stress.py
@@ -685,6 +685,8 @@ class SPPYieldStress(BaseModel):
         sigma_dy_exp = self.parameters.get_value("sigma_dy_exp")
         G_cage = self.parameters.get_value("G_cage")
         K_flow = self.parameters.get_value("K_flow")
+        if G_cage is None or K_flow is None:
+            raise ValueError("Parameters 'G_cage' and 'K_flow' must be set")
 
         result = {"gamma_0": gamma_0_array}
 

--- a/rheojax/models/vlb/nonlocal_model.py
+++ b/rheojax/models/vlb/nonlocal_model.py
@@ -744,7 +744,7 @@ class VLBNonlocal(VLBBase):
             band_location = self.y[band_indices].mean()
         else:
             band_width = self.gap_width
-            band_location = self.gap_width / 2
+            band_location = np.float64(self.gap_width / 2)
 
         return {
             "is_banding": is_banding,

--- a/rheojax/transforms/spectrum_inversion.py
+++ b/rheojax/transforms/spectrum_inversion.py
@@ -397,6 +397,7 @@ def _max_entropy_inversion(
         grad_chi2_at_m = 2.0 * A.T @ (A @ m - b)
         lam = max(float(np.mean(np.abs(grad_chi2_at_m))), 1e-30)
         lam_lo, lam_hi = lam * 1e-3, lam * 1e3
+    assert lam is not None  # guaranteed by the auto_lam branch above or the caller
 
     max_iter = 200
     tol = 1e-6

--- a/rheojax/transforms/srfs.py
+++ b/rheojax/transforms/srfs.py
@@ -29,7 +29,7 @@ References:
 from __future__ import annotations
 
 import warnings
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, NoReturn
 
 import numpy as np
 
@@ -332,7 +332,7 @@ class SRFS(BaseTransform):
 
         return self.create_mastercurve(data, x, tau0, return_shifts=return_shifts)
 
-    def _raise_missing_sgr_params(self) -> None:
+    def _raise_missing_sgr_params(self) -> NoReturn:
         """Raise the appropriate error when x/tau0 are not supplied.
 
         auto_shift=True is documented as a way to skip explicit x/tau0, but

--- a/rheojax/utils/mct_kernels.py
+++ b/rheojax/utils/mct_kernels.py
@@ -322,7 +322,7 @@ def prony_decompose_memory(
             f"Only {valid_mask.sum()} valid points for {n_modes} modes. "
             "Reducing n_modes."
         )
-        n_modes = max(2, valid_mask.sum() // 2)
+        n_modes = max(2, int(valid_mask.sum() // 2))
 
     t_valid = t[valid_mask]
     m_valid = m_t[valid_mask]


### PR DESCRIPTION
## Summary
- \`make verify\`'s mypy step only tails the last line (advisory), so real type errors were silently accumulating. Ran \`uv run mypy rheojax\` directly and found 30 errors across 13 files.
- Fixed each at the root cause rather than suppressing: `Self` return type on `BaseModel._standard_nlsq_fit` (fixes 5 flow-model subclasses at once), earlier type narrowing in `RheoData.y_real`/`y_imag`, `NoReturn` annotation on `SRFS._raise_missing_sgr_params`, `getattr` for `__abstractmethods__` (not in typeshed), and None-guards/explicit casts at the remaining `float | None` boundary crossings (dmt/vlb nonlocal models, generalized_maxwell, spp_yield_stress, spectrum_inversion, mct_kernels, csv/excel readers).
- No behavior changes.

## Test plan
- [x] `uv run mypy rheojax` → 0 errors (was 30)
- [x] `make verify` → lint clean, mypy clean, 2037 tests passed, 76 pre-existing/intentional test warnings unchanged (Bayesian convergence diagnostics tests, parameter-clamp tests, matplotlib tight-layout cosmetics)

🤖 Generated with [Claude Code](https://claude.com/claude-code)