### PR TITLE
fix(gui): address UX/accessibility audit findings across workspace

### DIFF
--- a/rheojax/gui/README.md
+++ b/rheojax/gui/README.md
@@ -45,7 +45,6 @@ rheojax/gui/
 │   └── arviz_canvas.py            # ArviZ diagnostics
 ├── dialogs/                       # Modal dialogs
 │   ├── __init__.py
-│   ├── import_wizard.py           # Data import wizard
 │   ├── column_mapper.py           # Column mapping dialog
 │   ├── fitting_options.py         # NLSQ configuration
 │   ├── bayesian_options.py        # NUTS configuration

--- a/rheojax/gui/dialogs/about.py
+++ b/rheojax/gui/dialogs/about.py
@@ -18,6 +18,7 @@ from rheojax.gui.compat import (
     QVBoxLayout,
     QWidget,
 )
+from rheojax.gui.resources.styles.tokens import Typography, themed
 from rheojax.logging import get_logger
 
 logger = get_logger(__name__)
@@ -73,7 +74,7 @@ class AboutDialog(QDialog):
         # App name
         app_name = QLabel("RheoJAX")
         app_name_font = QFont()
-        app_name_font.setPointSize(24)
+        app_name_font.setPointSize(Typography.SIZE_HEADING)
         app_name_font.setBold(True)
         app_name.setFont(app_name_font)
         app_name.setAlignment(Qt.AlignmentFlag.AlignCenter)
@@ -82,7 +83,7 @@ class AboutDialog(QDialog):
         # Version
         version_label = QLabel(f"Version {__version__}")
         version_font = QFont()
-        version_font.setPointSize(12)
+        version_font.setPointSize(Typography.SIZE_BASE)
         version_label.setFont(version_font)
         version_label.setAlignment(Qt.AlignmentFlag.AlignCenter)
         title_layout.addWidget(version_label)
@@ -106,7 +107,7 @@ class AboutDialog(QDialog):
         info_browser.setOpenExternalLinks(False)
         info_browser.anchorClicked.connect(self._on_link_clicked)
 
-        info_html = """
+        info_html = f"""
 <html>
 <body>
 <h3>Key Features</h3>
@@ -148,7 +149,7 @@ Copyright (c) 2024 Wei Chen
 <b>Institution:</b> Argonne National Laboratory
 </p>
 
-<p style="font-size: 10px; color: #666;">
+<p style="font-size: 10px; color: {themed("TEXT_MUTED")};">
 Built with Python 3.12+, JAX, NumPyro, and Qt6
 </p>
 </body>

--- a/rheojax/gui/dialogs/bayesian_options.py
+++ b/rheojax/gui/dialogs/bayesian_options.py
@@ -141,7 +141,9 @@ class BayesianOptionsDialog(QDialog):
         warmstart_status = (
             "available" if self._nlsq_result_available else "not available"
         )
-        warmstart_color = "#2e7d32" if self._nlsq_result_available else "#c62828"
+        warmstart_color = (
+            themed("SUCCESS") if self._nlsq_result_available else themed("ERROR")
+        )
         self._warmstart_indicator = QLabel(
             f"NLSQ warm-start: <b><span style='color:{warmstart_color};'>"
             f"{warmstart_status}</span></b>"
@@ -246,6 +248,13 @@ class BayesianOptionsDialog(QDialog):
         self.priors_edit.setMinimumHeight(120)
         self.priors_edit.textChanged.connect(self._on_priors_changed)
         priors_layout.addWidget(self.priors_edit)
+        self._priors_error_label = QLabel("")
+        self._priors_error_label.setWordWrap(True)
+        self._priors_error_label.setStyleSheet(
+            f"color: {themed('ERROR')}; font-size: {Typography.SIZE_SM}pt;"
+        )
+        self._priors_error_label.hide()
+        priors_layout.addWidget(self._priors_error_label)
         self.priors_group.setLayout(priors_layout)
         layout.addWidget(self.priors_group)
 
@@ -348,10 +357,25 @@ class BayesianOptionsDialog(QDialog):
             value=value / 100.0,
         )
 
+    def _validate_priors_json(self) -> str | None:
+        """Validate the priors text field; return an error message, or None if valid."""
+        priors_text = self.priors_edit.toPlainText().strip()
+        if not priors_text:
+            return None
+        try:
+            json.loads(priors_text)
+        except Exception as exc:
+            return str(exc)
+        return None
+
     def _on_priors_changed(self) -> None:
-        """Handle priors text change."""
-        # Get text to validate (value used only for logging context)
-        _ = self.priors_edit.toPlainText().strip()
+        """Handle priors text change: validate as-you-type, same check as Accept."""
+        error = self._validate_priors_json()
+        if error:
+            self._priors_error_label.setText(f"Invalid JSON: {error}")
+            self._priors_error_label.show()
+        else:
+            self._priors_error_label.hide()
         logger.debug(
             "Option changed",
             dialog=self.__class__.__name__,
@@ -372,23 +396,20 @@ class BayesianOptionsDialog(QDialog):
 
     def _on_accepted(self) -> None:
         """Handle dialog accepted."""
-        priors_text = self.priors_edit.toPlainText().strip()
-        if priors_text:
-            try:
-                json.loads(priors_text)
-            except Exception as exc:
-                logger.error(
-                    "Failed to parse priors JSON",
-                    dialog=self.__class__.__name__,
-                    exc_info=True,
-                )
-                QMessageBox.warning(
-                    self,
-                    "Invalid Priors JSON",
-                    f"The priors field contains invalid JSON and could not be "
-                    f"applied:\n\n{exc}\n\nPlease fix it or clear the field.",
-                )
-                return
+        error = self._validate_priors_json()
+        if error:
+            logger.error(
+                "Failed to parse priors JSON",
+                dialog=self.__class__.__name__,
+                error=error,
+            )
+            QMessageBox.warning(
+                self,
+                "Invalid Priors JSON",
+                f"The priors field contains invalid JSON and could not be "
+                f"applied:\n\n{error}\n\nPlease fix it or clear the field.",
+            )
+            return
 
         logger.debug("Options applied", dialog=self.__class__.__name__)
         self.accept()

--- a/rheojax/gui/dialogs/bayesian_options.py
+++ b/rheojax/gui/dialogs/bayesian_options.py
@@ -468,15 +468,16 @@ class BayesianOptionsDialog(QDialog):
 
         priors_text = self.priors_edit.toPlainText().strip()
         if priors_text:
-            try:
-                options["priors"] = json.loads(priors_text)
-            except Exception:
+            error = self._validate_priors_json()
+            if error:
                 logger.error(
                     "Failed to parse priors JSON",
                     dialog=self.__class__.__name__,
-                    exc_info=True,
+                    error=error,
                 )
                 options["priors"] = None
+            else:
+                options["priors"] = json.loads(priors_text)
 
         return options
 

--- a/rheojax/gui/dialogs/fitting_options.py
+++ b/rheojax/gui/dialogs/fitting_options.py
@@ -16,6 +16,7 @@ from rheojax.gui.compat import (
     QGroupBox,
     QHBoxLayout,
     QLabel,
+    QMessageBox,
     QPushButton,
     QSpinBox,
     Qt,
@@ -353,6 +354,16 @@ class FittingOptionsDialog(QDialog):
 
     def _reset_defaults(self) -> None:
         """Reset all options to defaults."""
+        choice = QMessageBox.question(
+            self,
+            "Reset to Defaults",
+            "Reset all fitting options to their defaults? This discards any "
+            "unsaved changes in this dialog.",
+            QMessageBox.StandardButton.Yes | QMessageBox.StandardButton.No,
+            QMessageBox.StandardButton.No,
+        )
+        if choice != QMessageBox.StandardButton.Yes:
+            return
         logger.debug("Resetting to defaults", dialog=self.__class__.__name__)
         self.algo_combo.setCurrentIndex(0)  # NLSQ
         self.workflow_combo.setCurrentText("auto")

--- a/rheojax/gui/dialogs/preferences.py
+++ b/rheojax/gui/dialogs/preferences.py
@@ -15,6 +15,7 @@ from rheojax.gui.compat import (
     QGroupBox,
     QHBoxLayout,
     QLabel,
+    QMessageBox,
     QPushButton,
     QSlider,
     QSpinBox,
@@ -616,6 +617,16 @@ class PreferencesDialog(QDialog):
 
     def _restore_defaults(self) -> None:
         """Restore all preferences to defaults."""
+        choice = QMessageBox.question(
+            self,
+            "Restore Defaults",
+            "Restore all preferences to their defaults? This discards any "
+            "unsaved changes in this dialog.",
+            QMessageBox.StandardButton.Yes | QMessageBox.StandardButton.No,
+            QMessageBox.StandardButton.No,
+        )
+        if choice != QMessageBox.StandardButton.Yes:
+            return
         logger.debug("Restoring defaults", dialog=self.__class__.__name__)
 
         # General

--- a/rheojax/gui/widgets/arviz_canvas.py
+++ b/rheojax/gui/widgets/arviz_canvas.py
@@ -21,7 +21,7 @@ from rheojax.gui.compat import (
     QVBoxLayout,
     Signal,
 )
-from rheojax.gui.resources.styles.tokens import Spacing
+from rheojax.gui.resources.styles.tokens import Spacing, themed
 from rheojax.gui.utils.layout_helpers import set_toolbar_margins, set_zero_margins
 from rheojax.gui.widgets.base_arviz_widget import BaseArviZWidget
 from rheojax.gui.widgets.dropdown import RheoComboBox
@@ -171,7 +171,7 @@ class ArvizCanvas(BaseArviZWidget):
             "No diagnostics yet. Run Bayesian inference to view plots."
         )
         self._status_label.setAlignment(Qt.AlignCenter)
-        self._status_label.setStyleSheet("color: #94A3B8; padding: 6px;")
+        self._status_label.setStyleSheet(f"color: {themed('TEXT_MUTED')}; padding: 6px;")
         layout.addWidget(self._status_label)
 
     def _connect_signals(self) -> None:

--- a/rheojax/gui/widgets/log_dock.py
+++ b/rheojax/gui/widgets/log_dock.py
@@ -70,7 +70,10 @@ class LogDockWidget(QDockWidget):
 
         self.text_edit = QTextEdit(container)
         self.text_edit.setReadOnly(True)
-        self.text_edit.setMaximumHeight(200)
+        # Derived from font metrics (not a fixed 200px) so this scales with
+        # the OS font-size setting and per-display DPI instead of clipping to
+        # fewer visible lines as text scale increases.
+        self.text_edit.setMaximumHeight(self.text_edit.fontMetrics().height() * 10)
         self.text_edit.setPlaceholderText("Application logs will appear here...")
         # Without this, the document grows unboundedly (memory) even though
         # `_records` is capped at _MAX_RECORDS -- and _rerender() (level-filter

--- a/rheojax/gui/widgets/parameter_table.py
+++ b/rheojax/gui/widgets/parameter_table.py
@@ -80,7 +80,9 @@ class ParameterTable(QTableWidget):
         # Configure table
         self.setColumnCount(5)
         self.setHorizontalHeaderLabels(["Parameter", "Value", "Min", "Max", "Fixed"])
-        _table_font = f"{Typography.SIZE_MD_SM}pt"
+        # Bumped from SIZE_MD_SM to the next type-scale step: this is a dense
+        # numeric-entry grid, borderline small at typical desk-viewing distance.
+        _table_font = f"{Typography.SIZE_BASE}pt"
         self.setStyleSheet(
             f"QTableWidget {{ font-size: {_table_font}; }} "
             f"QHeaderView::section {{ font-size: {_table_font}; }}"
@@ -176,6 +178,33 @@ class ParameterTable(QTableWidget):
     @staticmethod
     def _value_valid(value: float, min_val: float, max_val: float) -> bool:
         return math.isfinite(value) and min_val <= value <= max_val
+
+    def has_invalid_rows(self) -> bool:
+        """Return True if any row currently holds a non-numeric, non-finite,
+        out-of-range, or inverted-bounds entry.
+
+        get_parameters() silently skips such rows (a caller trusting its
+        returned dict alone would launch a fit with those parameters
+        defaulted with no indication anything was wrong) -- callers that
+        need to warn the user before launching should check this first.
+        """
+        for row in range(self.rowCount()):
+            val_item = self.item(row, 1)
+            min_item = self.item(row, 2)
+            max_item = self.item(row, 3)
+            if val_item is None or min_item is None or max_item is None:
+                continue
+            try:
+                value = float(val_item.text())
+                min_bound = float(min_item.text())
+                max_bound = float(max_item.text())
+            except ValueError:
+                return True
+            if not self._bounds_valid(min_bound, max_bound) or not self._value_valid(
+                value, min_bound, max_bound
+            ):
+                return True
+        return False
 
     def get_parameters(self) -> dict[str, ParameterState]:
         """Get current parameter values and states.
@@ -325,6 +354,11 @@ class ParameterTable(QTableWidget):
 
         checkbox = QCheckBox()
         checkbox.setChecked(checked)
+        # WCAG/assistive-tech: setCellWidget's wrapper widget isn't well
+        # exposed to screen readers by row on its own -- an accessible name
+        # per checkbox lets assistive tech distinguish "Fixed: G0" from
+        # "Fixed: tau" rather than reading every row's checkbox identically.
+        checkbox.setAccessibleName(f"Fixed: {param_name}")
         checkbox.stateChanged.connect(
             lambda state: self._on_fixed_toggled(
                 param_name, state == Qt.CheckState.Checked.value
@@ -367,6 +401,12 @@ class ParameterTable(QTableWidget):
                     # otherwise silently pass as "in bounds") - red text.
                     # Do not emit: invalid values must never reach the state store.
                     item.setForeground(QBrush(QColor(themed("ERROR"))))
+                    # WCAG 1.4.1: don't rely on color alone -- a tooltip
+                    # explaining the problem is the minimal non-color cue.
+                    item.setToolTip(
+                        f"Value must be finite and within [{min_val:.6g}, "
+                        f"{max_val:.6g}]"
+                    )
                     return
 
                 # In bounds - check if modified
@@ -388,6 +428,7 @@ class ParameterTable(QTableWidget):
                 item.setForeground(
                     QBrush(self.palette().color(QPalette.ColorRole.Text))
                 )
+                item.setToolTip("")
 
                 # Emit signal
                 self.parameter_changed.emit(param_name, value)
@@ -408,11 +449,14 @@ class ParameterTable(QTableWidget):
                     # Invalid bounds (non-finite or inverted) - red text.
                     # Do not emit: invalid bounds must never reach the state store.
                     item.setForeground(QBrush(QColor(themed("ERROR"))))
+                    # WCAG 1.4.1: don't rely on color alone.
+                    item.setToolTip("Bounds must be finite with min <= max")
                     return
 
                 item.setForeground(
                     QBrush(self.palette().color(QPalette.ColorRole.Text))
                 )
+                item.setToolTip("")
 
                 # Emit bounds changed
                 self.bounds_changed.emit(param_name, min_val, max_val)
@@ -422,10 +466,15 @@ class ParameterTable(QTableWidget):
                 value = float(value_item.text())
                 if not self._value_valid(value, min_val, max_val):
                     value_item.setForeground(QBrush(QColor(themed("ERROR"))))
+                    value_item.setToolTip(
+                        f"Value must be finite and within [{min_val:.6g}, "
+                        f"{max_val:.6g}]"
+                    )
                 else:
                     value_item.setForeground(
                         QBrush(self.palette().color(QPalette.ColorRole.Text))
                     )
+                    value_item.setToolTip("")
 
         except ValueError:
             # Invalid number - reset to previous value without cascading signals

--- a/rheojax/gui/widgets/plot_canvas.py
+++ b/rheojax/gui/widgets/plot_canvas.py
@@ -173,6 +173,22 @@ class PlotCanvas(QWidget):
         # rendering can fail for host-environment reasons outside this
         # widget's control (e.g. a "raster overflow" from a font-cache/DPI
         # quirk) -- degrade gracefully instead of propagating a crash.
+        #
+        # ponytail: this only catches Python-level exceptions. The known
+        # "FT_Render_Glyph ... raster overflow" FreeType bug (see project memory
+        # project_blit_colorbar_freetype_bug.md and
+        # tests/gui/test_residuals_panel_render_errors.py) raises a plain
+        # RuntimeError in every case reproduced so far -- and self.canvas.draw is
+        # already monkey-patched to _safe_draw() above, which swallows RuntimeError
+        # before it would even reach this except. If the underlying corrupted
+        # Agg/FreeType renderer state ever manifests as a true C-level segfault
+        # instead (the "unfixable upstream" savefig-only variant noted in that
+        # memory), no try/except anywhere in Python can catch it -- there is no
+        # runtime mitigation for that case in this widget. The test suite avoids
+        # the trigger instead of catching it (tests/conftest.py forces
+        # QT_QPA_PLATFORM=offscreen before any QApplication exists, so
+        # devicePixelRatio is always an integer); that isn't available to a real
+        # interactive display, so this remains a known residual risk.
         try:
             self.canvas.draw()
         except Exception as e:

--- a/rheojax/gui/widgets/plot_canvas.py
+++ b/rheojax/gui/widgets/plot_canvas.py
@@ -175,16 +175,15 @@ class PlotCanvas(QWidget):
         # quirk) -- degrade gracefully instead of propagating a crash.
         #
         # ponytail: this only catches Python-level exceptions. The known
-        # "FT_Render_Glyph ... raster overflow" FreeType bug (see project memory
-        # project_blit_colorbar_freetype_bug.md and
+        # "FT_Render_Glyph ... raster overflow" FreeType bug (see
         # tests/gui/test_residuals_panel_render_errors.py) raises a plain
         # RuntimeError in every case reproduced so far -- and self.canvas.draw is
         # already monkey-patched to _safe_draw() above, which swallows RuntimeError
         # before it would even reach this except. If the underlying corrupted
         # Agg/FreeType renderer state ever manifests as a true C-level segfault
-        # instead (the "unfixable upstream" savefig-only variant noted in that
-        # memory), no try/except anywhere in Python can catch it -- there is no
-        # runtime mitigation for that case in this widget. The test suite avoids
+        # instead (the "unfixable upstream" savefig-only variant), no try/except
+        # anywhere in Python can catch it -- there is no runtime mitigation for
+        # that case in this widget. The test suite avoids
         # the trigger instead of catching it (tests/conftest.py forces
         # QT_QPA_PLATFORM=offscreen before any QApplication exists, so
         # devicePixelRatio is always an integer); that isn't available to a real

--- a/rheojax/gui/widgets/priors_editor.py
+++ b/rheojax/gui/widgets/priors_editor.py
@@ -30,7 +30,7 @@ from rheojax.gui.compat import (
     Signal,
 )
 from rheojax.gui.foundation.priors import adapt_prior
-from rheojax.gui.resources.styles.tokens import Spacing
+from rheojax.gui.resources.styles.tokens import Spacing, Typography, themed
 from rheojax.gui.utils.layout_helpers import set_zero_margins
 from rheojax.gui.widgets.dropdown import RheoComboBox
 from rheojax.logging import get_logger
@@ -209,6 +209,17 @@ class PriorsEditor(QWidget):
         btn_layout.addWidget(self._reset_btn)
         btn_layout.addStretch()
         editor_layout.addLayout(btn_layout)
+
+        # Apply-time error feedback -- distinct from the preview's own inline
+        # "Error: ..." text, which can go stale/unnoticed if the user changed a
+        # different control since it last rendered.
+        self._apply_error_label = QLabel("")
+        self._apply_error_label.setWordWrap(True)
+        self._apply_error_label.setStyleSheet(
+            f"color: {themed('ERROR')}; font-size: {Typography.SIZE_SM}pt;"
+        )
+        self._apply_error_label.hide()
+        editor_layout.addWidget(self._apply_error_label)
 
         splitter.addWidget(editor_frame)
         splitter.setSizes([200, 300])
@@ -525,6 +536,7 @@ class PriorsEditor(QWidget):
 
     def _apply_prior(self) -> None:
         """Apply current editor settings to selected parameter."""
+        self._apply_error_label.hide()
         if self._current_param is None:
             logger.debug(
                 "User interaction",
@@ -559,11 +571,12 @@ class PriorsEditor(QWidget):
                 params=params,
                 error=str(e),
             )
-            # No need to force a preview refresh here: every spinbox/combo
-            # change that could have produced this invalid state already
-            # re-runs _update_preview() via its own valueChanged/
-            # currentIndexChanged connection, so the error text is already
-            # showing by the time Apply is clicked.
+            # The preview's own inline "Error: ..." text can be stale/easy to
+            # miss by the time Apply is clicked (e.g. scrolled out of view, or
+            # the user's attention was on a different control) -- show a
+            # dedicated, visible warning here rather than relying on that.
+            self._apply_error_label.setText(f"Not applied: {e}")
+            self._apply_error_label.show()
             return
 
         logger.info(

--- a/rheojax/gui/widgets/pyqtgraph_canvas.py
+++ b/rheojax/gui/widgets/pyqtgraph_canvas.py
@@ -84,12 +84,15 @@ class PyQtGraphCanvas(QWidget):
         """Dynamic color palette based on current theme."""
         from rheojax.gui.resources.styles.tokens import themed
 
+        # Ordered so no two colorblind-confusable hues (red/green, red/brown) are
+        # adjacent -- red (index 1) and green (index 4) are kept apart by purple
+        # and orange, since multi-series G'/G'' overlays are core to this app.
         return [
             themed("CHART_1"),  # Blue - typically G'
             themed("CHART_5"),  # Red - typically G''
-            themed("CHART_3"),  # Green - fits/predictions
-            themed("CHART_4"),  # Orange - secondary data
             themed("CHART_2"),  # Purple
+            themed("CHART_4"),  # Orange - secondary data
+            themed("CHART_3"),  # Green - fits/predictions
             themed("CHART_6"),  # Pink
             themed("TEXT_SECONDARY"),  # Gray
         ]

--- a/rheojax/gui/workspace/fit/step3_nlsq.py
+++ b/rheojax/gui/workspace/fit/step3_nlsq.py
@@ -1,13 +1,15 @@
 from __future__ import annotations
 
+import time
 from collections.abc import Callable
 
 import numpy as np
-from PySide6.QtCore import Signal
+from PySide6.QtCore import QTimer, Signal
 from PySide6.QtWidgets import (
     QCheckBox,
     QDialog,
     QLabel,
+    QProgressBar,
     QPushButton,
     QSpinBox,
     QVBoxLayout,
@@ -77,6 +79,23 @@ class NlsqStep(QWidget):
         self._cancel_btn = QPushButton("Cancel", self)
         self._cancel_btn.setVisible(False)
         self._cancel_btn.clicked.connect(self._on_cancel_clicked)
+        # NLSQ can take minutes (e.g. multi-start restarts, EPM lattice sims);
+        # the only prior feedback was a disabled Run button. run_fit_isolated
+        # (subprocess_fit.py) does emit a real iteration/max_iter percent, but
+        # multi-start restarts reset that percent each restart and nothing
+        # here currently wires the queue through to a widget-local bar --
+        # indeterminate + elapsed time is the honest, always-correct fallback
+        # per the audit's own guidance, and matches step4_nuts.py's identical
+        # treatment for NUTS (which has no per-iteration percent at all).
+        self._progress_bar = QProgressBar(self)
+        self._progress_bar.setRange(0, 0)  # indeterminate/busy
+        self._progress_bar.setVisible(False)
+        self._elapsed_label = QLabel("", self)
+        self._elapsed_label.setVisible(False)
+        self._elapsed_timer = QTimer(self)
+        self._elapsed_timer.setInterval(1000)
+        self._elapsed_timer.timeout.connect(self._on_elapsed_tick)
+        self._run_start_time = 0.0
         self._result = QLabel("", self)
         lay = QVBoxLayout(self)
         set_panel_margins(lay)
@@ -87,10 +106,16 @@ class NlsqStep(QWidget):
             self._options_btn,
             self._run_btn,
             self._cancel_btn,
+            self._progress_bar,
+            self._elapsed_label,
             self._result,
         ):
             lay.addWidget(w)
         self._run_btn.clicked.connect(self.run)
+
+    def _on_elapsed_tick(self) -> None:
+        elapsed = time.monotonic() - self._run_start_time
+        self._elapsed_label.setText(f"Running... ({elapsed:.0f}s elapsed)")
 
     def _on_cancel_clicked(self) -> None:
         if self._active_jobs is None or self._current_job_id is None:
@@ -172,6 +197,21 @@ class NlsqStep(QWidget):
             self._fit_options = dialog.get_options()
 
     def run(self) -> None:
+        # get_parameters() silently skips invalid rows (out-of-range/non-
+        # numeric text) so a fit could previously launch with those
+        # parameters silently defaulted -- refuse to run until the user
+        # fixes the highlighted cell(s) instead.
+        if self._table.has_invalid_rows():
+            from rheojax.gui.compat import QMessageBox
+
+            QMessageBox.warning(
+                self,
+                "Invalid Parameters",
+                "One or more parameter values or bounds are invalid "
+                "(non-numeric, out of range, or min > max). Fix the "
+                "highlighted cell(s) before running.",
+            )
+            return
         # Multi-start config is transient widget state — not stored in FitState
         table_params = self._table.get_parameters()
         initial_params = {
@@ -187,6 +227,11 @@ class NlsqStep(QWidget):
         # button must be disabled for the duration or a second click launches
         # an overlapping fit that corrupts shared active_jobs tracking.
         self._run_btn.setEnabled(False)
+        self._run_start_time = time.monotonic()
+        self._progress_bar.setVisible(True)
+        self._elapsed_label.setVisible(True)
+        self._elapsed_label.setText("Running... (0s elapsed)")
+        self._elapsed_timer.start()
         # job_id mirrors fit_controller._make_fit_fn's own f"{data_ref}:nlsq"
         # exactly, captured here (not recomputed from live state in
         # _on_cancel_clicked) so a dataset switch mid-run can't make Cancel
@@ -297,6 +342,9 @@ class NlsqStep(QWidget):
             self._run_btn.setEnabled(True)
             self._cancel_btn.setVisible(False)
             self._current_job_id = None
+            self._elapsed_timer.stop()
+            self._progress_bar.setVisible(False)
+            self._elapsed_label.setVisible(False)
 
     def refresh_display(self) -> None:
         """Sync the result label to current state.

--- a/rheojax/gui/workspace/fit/step4_nuts.py
+++ b/rheojax/gui/workspace/fit/step4_nuts.py
@@ -1,14 +1,18 @@
 from __future__ import annotations
 
 import math
+import time
 from collections.abc import Callable
 
 import numpy as np
-from PySide6.QtCore import Signal
+from PySide6.QtCore import QTimer, Signal
 from PySide6.QtWidgets import (
+    QDialog,
+    QDialogButtonBox,
     QDoubleSpinBox,
     QFormLayout,
     QLabel,
+    QProgressBar,
     QPushButton,
     QSpinBox,
     QVBoxLayout,
@@ -148,6 +152,20 @@ class NutsStep(QWidget):
         self._chains = QSpinBox(self)
         self._chains.setRange(1, 16)
         self._chains.setValue(nuts_cfg.num_chains)
+        settings_form = QFormLayout()
+        settings_form.addRow("Warmup:", self._warmup)
+        settings_form.addRow("Samples:", self._samples)
+        settings_form.addRow("Chains:", self._chains)
+
+        # Seed/target-accept/max-tree-depth are changed far less often than
+        # warmup/samples/chains -- tucked behind a "⚙ Sampler Options" dialog,
+        # mirroring step3_nlsq.py's identical "⚙ Fit Options" progressive-
+        # disclosure pattern instead of showing all 6 settings flat. The
+        # dialog and its widgets are built once up front (not lazily per
+        # click, unlike FittingOptionsDialog) so self._seed/_target/
+        # _max_tree_depth stay live, directly-settable attributes for
+        # existing callers/tests that drive them without ever opening the
+        # dialog.
         self._seed = QSpinBox(self)
         self._seed.setRange(0, 2**31 - 1)
         self._seed.setValue(nuts_cfg.seed)
@@ -159,13 +177,21 @@ class NutsStep(QWidget):
         self._max_tree_depth.setRange(0, 20)
         self._max_tree_depth.setValue(nuts_cfg.max_tree_depth or 0)
         self._max_tree_depth.setSpecialValueText("default")
-        settings_form = QFormLayout()
-        settings_form.addRow("Warmup:", self._warmup)
-        settings_form.addRow("Samples:", self._samples)
-        settings_form.addRow("Chains:", self._chains)
-        settings_form.addRow("Seed:", self._seed)
-        settings_form.addRow("Target accept:", self._target)
-        settings_form.addRow("Max tree depth:", self._max_tree_depth)
+        self._sampler_dialog = QDialog(self)
+        self._sampler_dialog.setWindowTitle("Sampler Options")
+        dialog_form = QFormLayout()
+        dialog_form.addRow("Seed:", self._seed)
+        dialog_form.addRow("Target accept:", self._target)
+        dialog_form.addRow("Max tree depth:", self._max_tree_depth)
+        dialog_buttons = QDialogButtonBox(QDialogButtonBox.StandardButton.Close)
+        dialog_buttons.rejected.connect(self._sampler_dialog.reject)
+        dialog_buttons.accepted.connect(self._sampler_dialog.accept)
+        dialog_layout = QVBoxLayout(self._sampler_dialog)
+        dialog_layout.addLayout(dialog_form)
+        dialog_layout.addWidget(dialog_buttons)
+        self._options_btn = QPushButton("⚙ Sampler Options", self)
+        self._options_btn.setAccessibleName("Sampler Options")
+        self._options_btn.clicked.connect(self._sampler_dialog.exec)
 
         self._skip_btn = QPushButton("Skip NUTS", self)
         self._run_btn = QPushButton("▶ Sample", self)
@@ -177,17 +203,39 @@ class NutsStep(QWidget):
         self._cancel_btn = QPushButton("Cancel", self)
         self._cancel_btn.setVisible(False)
         self._cancel_btn.clicked.connect(self._on_cancel_clicked)
+        # NUTS is inherently slow (minutes, not seconds) and previously gave
+        # no feedback beyond a disabled button -- run_bayesian_isolated has
+        # no reliable per-iteration percent (NumPyro NUTS doesn't support a
+        # progress callback the way NLSQ does), so indeterminate + elapsed
+        # time is the honest fix rather than a fake percentage.
+        self._progress_bar = QProgressBar(self)
+        self._progress_bar.setRange(0, 0)  # indeterminate/busy
+        self._progress_bar.setVisible(False)
+        self._elapsed_label = QLabel("", self)
+        self._elapsed_label.setVisible(False)
+        self._elapsed_timer = QTimer(self)
+        self._elapsed_timer.setInterval(1000)
+        self._elapsed_timer.timeout.connect(self._on_elapsed_tick)
+        self._run_start_time = 0.0
         self._result = QLabel("", self)
         lay = QVBoxLayout(self)
         set_panel_margins(lay)
         lay.addWidget(self._banner)
         lay.addWidget(self._priors_editor)
         lay.addLayout(settings_form)
-        for w in (self._skip_btn, self._run_btn, self._cancel_btn, self._result):
+        lay.addWidget(self._options_btn)
+        for w in (
+            self._skip_btn,
+            self._run_btn,
+            self._cancel_btn,
+            self._progress_bar,
+            self._elapsed_label,
+            self._result,
+        ):
             lay.addWidget(w)
         lay.addStretch()  # see step1_protocol_model.py's addStretch() comment
         self._skip_btn.clicked.connect(self.skip)
-        self._run_btn.clicked.connect(self.run)
+        self._run_btn.clicked.connect(self._on_sample_clicked)
         for spin in (
             self._warmup,
             self._samples,
@@ -197,6 +245,10 @@ class NutsStep(QWidget):
         ):
             spin.valueChanged.connect(self._on_settings_changed)
         self._target.valueChanged.connect(self._on_settings_changed)
+
+    def _on_elapsed_tick(self) -> None:
+        elapsed = time.monotonic() - self._run_start_time
+        self._elapsed_label.setText(f"Sampling... ({elapsed:.0f}s elapsed)")
 
     def _on_settings_changed(self, *_args: object) -> None:
         cfg = self._state.nuts_config
@@ -261,6 +313,36 @@ class NutsStep(QWidget):
         self.edited.emit()
         self.finished.emit()
 
+    def _on_sample_clicked(self) -> None:
+        """Button-only consent gate in front of run().
+
+        NUTS is inherently slow regardless of the configured chains/samples,
+        so this always confirms before starting -- kept as a separate
+        handler (rather than inside run() itself) so direct/test callers of
+        run() are unaffected. ponytail: always-confirm rather than a
+        workload-size threshold -- the audit explicitly allows either, and
+        there's no calibration data here to turn iteration counts into a
+        wall-clock estimate.
+        """
+        from rheojax.gui.compat import QMessageBox
+
+        warmup, samples, chains = (
+            self._warmup.value(),
+            self._samples.value(),
+            self._chains.value(),
+        )
+        choice = QMessageBox.question(
+            self,
+            "Start NUTS sampling?",
+            f"This will run {chains} chain(s) x {warmup + samples} "
+            f"iterations ({chains * (warmup + samples)} total draws) and "
+            "may take a while. Start sampling?",
+            QMessageBox.StandardButton.Yes | QMessageBox.StandardButton.Cancel,
+            QMessageBox.StandardButton.Yes,
+        )
+        if choice == QMessageBox.StandardButton.Yes:
+            self.run()
+
     def run(self) -> None:
         self._skipped = False
         cfg = {
@@ -289,6 +371,11 @@ class NutsStep(QWidget):
         # f"{data_ref}:nuts" exactly -- see NlsqStep.run()'s matching comment.
         self._current_job_id = f"{self._state.data_ref}:nuts"
         self._cancel_btn.setVisible(self._active_jobs is not None)
+        self._run_start_time = time.monotonic()
+        self._progress_bar.setVisible(True)
+        self._elapsed_label.setVisible(True)
+        self._elapsed_label.setText("Sampling... (0s elapsed)")
+        self._elapsed_timer.start()
         # See NlsqStep.run()'s matching comment: discard a result that no
         # longer corresponds to the current selection if state moved on
         # while this run was in flight.
@@ -339,6 +426,9 @@ class NutsStep(QWidget):
             self._skip_btn.setEnabled(True)
             self._cancel_btn.setVisible(False)
             self._current_job_id = None
+            self._elapsed_timer.stop()
+            self._progress_bar.setVisible(False)
+            self._elapsed_label.setVisible(False)
 
     def is_ready(self) -> bool:
         return self._skipped or self._state.nuts_result is not None

--- a/rheojax/gui/workspace/fit/step6_export.py
+++ b/rheojax/gui/workspace/fit/step6_export.py
@@ -61,13 +61,44 @@ class ExportStep(QWidget):
         for w in (bundle_caption, self._save_btn, self._export_btn, self._export_status):
             lay.addWidget(w)
         lay.addStretch()  # see step1_protocol_model.py's addStretch() comment
-        self._save_btn.clicked.connect(self.save_to_library)
+        self._save_btn.clicked.connect(self._on_save_clicked)
         self._export_btn.clicked.connect(self._on_export_clicked)
+
+    def _confirm_if_not_converged(self) -> bool:
+        """Gate export/save on a non-converged NUTS verdict.
+
+        Previously the only warning was a small colored badge on the
+        Diagnostics tab (step5_visualize.py) -- easy to miss before writing
+        out a posterior nobody should trust yet. Button-only gate (not
+        inside export_bundle()/save_to_library() themselves) so direct/test
+        callers of those two methods are unaffected.
+        """
+        verdict = (self._state.nuts_result or {}).get("verdict")
+        if not verdict or verdict.get("converged", True):
+            return True
+        from rheojax.gui.compat import QMessageBox
+
+        choice = QMessageBox.question(
+            self,
+            "Sampling did not converge",
+            "NUTS diagnostics did not converge ("
+            + "; ".join(verdict.get("reasons", []))
+            + "). Export anyway?",
+            QMessageBox.StandardButton.Yes | QMessageBox.StandardButton.Cancel,
+            QMessageBox.StandardButton.Cancel,
+        )
+        return choice == QMessageBox.StandardButton.Yes
+
+    def _on_save_clicked(self) -> None:
+        if self._confirm_if_not_converged():
+            self.save_to_library()
 
     def _on_export_clicked(self) -> None:
         """Prompt for a destination directory rather than silently writing
         to Path.cwd() -- the user previously had no way to know or choose
         where the bundle landed."""
+        if not self._confirm_if_not_converged():
+            return
         chosen = QFileDialog.getExistingDirectory(
             self, "Export bundle to...", str(Path.cwd())
         )

--- a/rheojax/gui/workspace/inspector.py
+++ b/rheojax/gui/workspace/inspector.py
@@ -1,7 +1,9 @@
 from __future__ import annotations
 
-from PySide6.QtWidgets import QTabWidget, QVBoxLayout, QWidget
+from PySide6.QtCore import Qt
+from PySide6.QtWidgets import QLabel, QTabWidget, QVBoxLayout, QWidget
 
+from rheojax.gui.resources.styles.tokens import themed
 from rheojax.gui.utils.layout_helpers import set_zero_margins
 
 
@@ -11,6 +13,9 @@ class InspectorPanel(QWidget):
     # designing what each tab shows per active mode/step (a params view
     # synced to the current FitState/TransformState, a priors editor, a log
     # viewer) -- a feature to design deliberately, not a one-line wiring fix.
+    # Each placeholder is an explicit "not connected yet" label (muted,
+    # italic) rather than a bare blank QWidget, so an empty tab reads as
+    # unfinished rather than broken.
     _TABS = ["params", "priors", "log"]
 
     def __init__(self, parent: QWidget | None = None) -> None:
@@ -18,7 +23,9 @@ class InspectorPanel(QWidget):
         self._tabs = QTabWidget(self)
         self._index: dict[str, int] = {}
         for name in self._TABS:
-            self._index[name] = self._tabs.addTab(QWidget(self), name)
+            self._index[name] = self._tabs.addTab(
+                self._placeholder(f"{name.capitalize()} view not yet connected"), name
+            )
         lay = QVBoxLayout(self)
         set_zero_margins(lay)
         lay.addWidget(self._tabs)
@@ -28,6 +35,16 @@ class InspectorPanel(QWidget):
         # scroll button. Bound to the tab bar's current sizeHint rather than
         # a fixed pixel value so it stays correct at any font size/DPI.
         self.setMinimumWidth(self._tabs.tabBar().sizeHint().width())
+
+    def _placeholder(self, text: str) -> QWidget:
+        label = QLabel(text)
+        label.setAlignment(Qt.AlignmentFlag.AlignCenter)
+        label.setWordWrap(True)
+        label.setStyleSheet(f"QLabel {{ color: {themed('TEXT_MUTED')}; font-style: italic; }}")
+        wrapper = QWidget(self)
+        lay = QVBoxLayout(wrapper)
+        lay.addWidget(label)
+        return wrapper
 
     def tab_names(self) -> list[str]:
         return list(self._TABS)

--- a/rheojax/gui/workspace/inspector.py
+++ b/rheojax/gui/workspace/inspector.py
@@ -8,8 +8,9 @@ from rheojax.gui.utils.layout_helpers import set_zero_margins
 
 
 class InspectorPanel(QWidget):
-    # ponytail: set_tab_widget() has no caller anywhere in the app, so all
-    # three tabs stay empty placeholders. Populating them for real requires
+    # ponytail: set_tab_widget() has no production caller (tests call it
+    # directly), so all three tabs stay empty placeholders in the running
+    # app. Populating them for real requires
     # designing what each tab shows per active mode/step (a params view
     # synced to the current FitState/TransformState, a priors editor, a log
     # viewer) -- a feature to design deliberately, not a one-line wiring fix.

--- a/rheojax/gui/workspace/library_rail.py
+++ b/rheojax/gui/workspace/library_rail.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from PySide6.QtCore import Qt, Signal, SignalInstance
+from PySide6.QtGui import QColor
 from PySide6.QtWidgets import (
     QLabel,
     QListWidget,
@@ -12,7 +13,7 @@ from PySide6.QtWidgets import (
 )
 
 from rheojax.gui.foundation.library import DatasetLibrary
-from rheojax.gui.resources.styles.tokens import section_header_style
+from rheojax.gui.resources.styles.tokens import section_header_style, themed
 from rheojax.gui.utils.layout_helpers import set_panel_margins
 
 
@@ -51,6 +52,13 @@ class LibraryRail(QWidget):
         if not refs:
             placeholder = QListWidgetItem("No datasets yet — import a file to begin")
             placeholder.setFlags(Qt.ItemFlag.NoItemFlags)
+            # Visually distinguish the empty-state row from real dataset rows
+            # (muted color + italic) -- previously identical styling made it
+            # look like a selectable/real entry rather than a status message.
+            placeholder.setForeground(QColor(themed("TEXT_MUTED")))
+            font = placeholder.font()
+            font.setItalic(True)
+            placeholder.setFont(font)
             self._list.addItem(placeholder)
             return
         for ref in refs:

--- a/rheojax/gui/workspace/pipeline/batch_runner.py
+++ b/rheojax/gui/workspace/pipeline/batch_runner.py
@@ -49,7 +49,16 @@ class PipelineBatchRunner(QRunnable):
         )
 
         try:
-            for dataset_id in self._selected_dataset_ids:
+            # ponytail: stop_requested is checked here (between datasets) and again
+            # inside self._service.execute() (between steps, and between a fit
+            # step's NLSQ/NUTS phases) -- but once a phase's worker.run() actually
+            # starts (a blocking subprocess call inside _run_worker_phase), nothing
+            # polls stop_requested again until that call returns. Cancelling
+            # mid-NUTS-run genuinely can't be made finer-grained without the
+            # worker/subprocess protocol itself supporting mid-run interruption;
+            # upgrade path is a cancellation channel into ProcessWorkerAdapter, not
+            # another check here.
+            for idx, dataset_id in enumerate(self._selected_dataset_ids):
                 if self._stop_requested.is_set():
                     break
                 # Register synchronously (plain dict write, not via the Qt signal)
@@ -69,6 +78,7 @@ class PipelineBatchRunner(QRunnable):
                 ctx = pipeline_context_from_library(self._library, [dataset_id])
                 steps_for_dataset = self._substitute_dataset_id(self._steps, dataset_id)
                 fatal = False
+                error_msg = None
                 try:
                     result = self._service.execute(
                         steps=steps_for_dataset,
@@ -80,7 +90,8 @@ class PipelineBatchRunner(QRunnable):
                 except WorkerIsolationRequiredError as exc:
                     # Misconfigured environment -- would fail identically for every
                     # remaining dataset, so this is the batch's last iteration too.
-                    record = self._failed_record(dataset_id, str(exc))
+                    error_msg = str(exc)
+                    record = self._failed_record(dataset_id, error_msg)
                     fatal = True
                 except Exception as exc:  # pragma: no cover - defensive backstop
                     # execute() already converts ordinary step failures into a
@@ -92,6 +103,16 @@ class PipelineBatchRunner(QRunnable):
                     record = self._failed_record(dataset_id, str(exc))
                 self._service.dataset_run_finished.emit(dataset_id, record)
                 if fatal:
+                    # Every dataset still queued behind this one would hit the exact
+                    # same fatal precondition error -- record each as "skipped" (via
+                    # the same dataset_run_finished path PipelineController already
+                    # commits to job_history) instead of leaving it with no
+                    # job_history/active_jobs entry at all, which was indistinguishable
+                    # from "never got to it yet" when reviewing results afterwards.
+                    for skipped_id in self._selected_dataset_ids[idx + 1 :]:
+                        self._service.dataset_run_finished.emit(
+                            skipped_id, self._skipped_record(skipped_id, error_msg)
+                        )
                     break
         finally:
             # Runs on every exit path (normal completion, stop_requested break, fatal
@@ -107,6 +128,15 @@ class PipelineBatchRunner(QRunnable):
             "dataset_id": dataset_id,
             "status": "failed",
             "error": error,
+            "step_results": {},
+        }
+
+    @staticmethod
+    def _skipped_record(dataset_id: str, reason: str | None) -> dict:
+        return {
+            "dataset_id": dataset_id,
+            "status": "skipped",
+            "error": f"Batch aborted before this dataset could run: {reason}",
             "step_results": {},
         }
 

--- a/rheojax/gui/workspace/pipeline/batch_runner.py
+++ b/rheojax/gui/workspace/pipeline/batch_runner.py
@@ -16,6 +16,9 @@ from PySide6.QtCore import QRunnable
 
 from rheojax.gui.foundation.pipeline_bridge import pipeline_context_from_library
 from rheojax.gui.workspace.pipeline.models import FitStepResult
+from rheojax.logging import get_logger
+
+logger = get_logger(__name__)
 
 
 class PipelineBatchRunner(QRunnable):
@@ -100,6 +103,12 @@ class PipelineBatchRunner(QRunnable):
                     # construction). Without this, such an exception would propagate out
                     # of run() with dataset_run_finished never emitted, leaving this
                     # dataset's active_jobs entry stuck forever (nothing else clears it).
+                    logger.error(
+                        "Unexpected error running pipeline for dataset",
+                        dataset_id=dataset_id,
+                        error=str(exc),
+                        exc_info=True,
+                    )
                     record = self._failed_record(dataset_id, str(exc))
                 self._service.dataset_run_finished.emit(dataset_id, record)
                 if fatal:
@@ -109,7 +118,14 @@ class PipelineBatchRunner(QRunnable):
                     # commits to job_history) instead of leaving it with no
                     # job_history/active_jobs entry at all, which was indistinguishable
                     # from "never got to it yet" when reviewing results afterwards.
-                    for skipped_id in self._selected_dataset_ids[idx + 1 :]:
+                    remaining = self._selected_dataset_ids[idx + 1 :]
+                    if remaining:
+                        logger.warning(
+                            "Skipping remaining datasets after fatal precondition error",
+                            skipped_count=len(remaining),
+                            reason=error_msg,
+                        )
+                    for skipped_id in remaining:
                         self._service.dataset_run_finished.emit(
                             skipped_id, self._skipped_record(skipped_id, error_msg)
                         )

--- a/rheojax/gui/workspace/pipeline/step1_configure_run.py
+++ b/rheojax/gui/workspace/pipeline/step1_configure_run.py
@@ -18,9 +18,11 @@ from PySide6.QtCore import Qt, Signal
 from PySide6.QtWidgets import (
     QAbstractItemView,
     QCheckBox,
+    QHBoxLayout,
     QLineEdit,
     QListWidget,
     QListWidgetItem,
+    QMessageBox,
     QPushButton,
     QVBoxLayout,
     QWidget,
@@ -86,6 +88,13 @@ class PipelineConfigureRunStep(QWidget):
             )
         self._remove_step_btn = QPushButton("Remove Selected Step", self)
         self._remove_step_btn.clicked.connect(self._on_remove_step_clicked)
+        self._move_up_btn = QPushButton("Move Up", self)
+        self._move_up_btn.clicked.connect(self._on_move_step_up_clicked)
+        self._move_down_btn = QPushButton("Move Down", self)
+        self._move_down_btn.clicked.connect(self._on_move_step_down_clicked)
+        step_actions_layout = QHBoxLayout()
+        step_actions_layout.addWidget(self._move_up_btn)
+        step_actions_layout.addWidget(self._move_down_btn)
 
         self._dataset_list = QListWidget(self)
         self._dataset_list.setSelectionMode(
@@ -110,6 +119,7 @@ class PipelineConfigureRunStep(QWidget):
         layout.addWidget(self._add_step_btn)
         layout.addWidget(self._step_list)
         layout.addWidget(self._remove_step_btn)
+        layout.addLayout(step_actions_layout)
         layout.addWidget(self._dataset_list)
         layout.addWidget(self._run_all_btn)
 
@@ -148,9 +158,40 @@ class PipelineConfigureRunStep(QWidget):
         row = self._step_list.currentRow()
         if row < 0:
             return
+        choice = QMessageBox.question(
+            self,
+            "Remove Step",
+            "Remove this step? This cannot be undone.",
+            QMessageBox.StandardButton.Yes | QMessageBox.StandardButton.No,
+            QMessageBox.StandardButton.No,
+        )
+        if choice != QMessageBox.StandardButton.Yes:
+            return
         self._step_list.takeItem(row)
         del self._state.steps[row]
         self.edited.emit()
+
+    def _swap_steps(self, row: int, other_row: int) -> None:
+        steps = self._state.steps
+        steps[row], steps[other_row] = steps[other_row], steps[row]
+        for r in (row, other_row):
+            self._step_list.item(r).setText(
+                f"{steps[r].step_type}: {steps[r].config}"
+            )
+        self._step_list.setCurrentRow(other_row)
+        self.edited.emit()
+
+    def _on_move_step_up_clicked(self) -> None:
+        row = self._step_list.currentRow()
+        if row <= 0:
+            return
+        self._swap_steps(row, row - 1)
+
+    def _on_move_step_down_clicked(self) -> None:
+        row = self._step_list.currentRow()
+        if row < 0 or row >= self._step_list.count() - 1:
+            return
+        self._swap_steps(row, row + 1)
 
     def refresh(self) -> None:
         """Rebuild the dataset list from the library (call on library changes)."""

--- a/rheojax/gui/workspace/stepper_canvas.py
+++ b/rheojax/gui/workspace/stepper_canvas.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from PySide6.QtCore import QSize, Signal
 from PySide6.QtWidgets import (
     QHBoxLayout,
+    QLabel,
     QStackedWidget,
     QToolButton,
     QVBoxLayout,
@@ -51,6 +52,11 @@ class StepperCanvas(QWidget):
         self._ctl = controller
         self._rail = QHBoxLayout()
         self._buttons: list[QToolButton] = []
+        # Persistent, always-visible "Step X of N" indicator -- the per-button
+        # tooltip (below) only reaches a user hovering with a mouse; keyboard
+        # users and anyone not currently hovering had no on-screen indication
+        # of wizard position at all.
+        self._position_label = QLabel(self)
         self._stack = _CurrentPageStack(self)
         self._stack.currentChanged.connect(lambda _: self._stack.updateGeometry())
         # QToolButton (not QPushButton) for the step rail, same rationale as
@@ -69,6 +75,7 @@ class StepperCanvas(QWidget):
         set_toolbar_margins(self._rail)
         lay = QVBoxLayout(self)
         set_zero_margins(lay)
+        lay.addWidget(self._position_label)
         lay.addLayout(self._rail)
         lay.addWidget(self._stack)
         self.refresh()
@@ -98,14 +105,29 @@ class StepperCanvas(QWidget):
         # Enabled/checked state alone doesn't tell a screen reader (or a
         # sighted user hovering before clicking) *why* a step is locked --
         # the per-button tooltip below keeps that in sync with actual state.
+        total = len(self._buttons)
         for i, b in enumerate(self._buttons):
             reached = i in self._ctl.reached
+            is_current = i == self._ctl.current
             b.setEnabled(reached)
-            b.setChecked(i == self._ctl.current)
-            if i == self._ctl.current:
-                b.setToolTip(f"Step {i + 1} of {len(self._buttons)} (current)")
+            b.setChecked(is_current)
+            # Bold weight is a non-color cue for "current" -- the checked-pill
+            # highlight alone is a color/background difference only.
+            font = b.font()
+            font.setBold(is_current)
+            b.setFont(font)
+            if is_current:
+                b.setToolTip(f"Step {i + 1} of {total} (current)")
             elif reached:
-                b.setToolTip(f"Step {i + 1} of {len(self._buttons)} -- click to revisit")
+                b.setToolTip(f"Step {i + 1} of {total} -- click to revisit")
             else:
                 b.setToolTip("Complete the earlier steps to unlock this one")
+        current_title = (
+            self._ctl.steps[self._ctl.current].title
+            if 0 <= self._ctl.current < total
+            else ""
+        )
+        self._position_label.setText(
+            f"Step {self._ctl.current + 1} of {total}: {current_title}"
+        )
         self._stack.setCurrentIndex(self._ctl.current)

--- a/rheojax/gui/workspace/window.py
+++ b/rheojax/gui/workspace/window.py
@@ -1047,6 +1047,22 @@ class WorkspaceWindow(QMainWindow, _WindowChrome):
         self._state.project.dirty = True
 
     def _on_dataset_preview_requested(self, dataset_id: str) -> None:
+        from PySide6.QtCore import Qt as _Qt
+        from PySide6.QtWidgets import QApplication
+
+        # This still runs synchronously on the GUI thread (a full move to
+        # PreviewWorker's background thread is a larger change than this
+        # audit pass covers) -- an override cursor is the minimum feedback
+        # so a slow load/validate on a large dataset doesn't look hung.
+        # ponytail: synchronous load; move to jobs/preview_worker.py if
+        # preview latency on large datasets becomes a real complaint.
+        QApplication.setOverrideCursor(_Qt.CursorShape.WaitCursor)
+        try:
+            self._load_and_show_dataset_preview(dataset_id)
+        finally:
+            QApplication.restoreOverrideCursor()
+
+    def _load_and_show_dataset_preview(self, dataset_id: str) -> None:
         from rheojax.gui.compat import _is_qobject_alive
         from rheojax.gui.dialogs.dataset_preview import DatasetPreviewDialog
         from rheojax.gui.services.data_service import DataService
@@ -1259,11 +1275,17 @@ class WorkspaceWindow(QMainWindow, _WindowChrome):
         # otherwise be garbage-collected mid-run and drop the signal. Keyed
         # by job_id so a second concurrent import can't evict the first.
         self._active_import_workers[job_id] = worker
+        # ImportWorker has no progress signal, so this is indeterminate
+        # (maximum=0) rather than a real percentage -- but it's the only
+        # feedback the user got before this, which was none at all.
+        self.statusBar().show_progress(0, 0, f"Importing {len(file_paths)} file(s)...")
         QThreadPool.globalInstance().start(worker)
 
     def _on_import_completed(self, datasets: list, job_id: str | None = None) -> None:
         self._state.active_jobs.by_id.pop(job_id, None)
         self._active_import_workers.pop(job_id, None)
+        if not self._active_import_workers:
+            self.statusBar().hide_progress()
         import hashlib
         import uuid
         from collections import Counter
@@ -1334,6 +1356,8 @@ class WorkspaceWindow(QMainWindow, _WindowChrome):
     ) -> None:
         self._state.active_jobs.by_id.pop(job_id, None)
         self._active_import_workers.pop(job_id, None)
+        if not self._active_import_workers:
+            self.statusBar().hide_progress()
         from PySide6.QtWidgets import QDialog, QMessageBox
 
         # Root cause: this import path has no column-mapping step, so a CSV

--- a/tests/gui/test_bayesian_options_dialog.py
+++ b/tests/gui/test_bayesian_options_dialog.py
@@ -40,3 +40,25 @@ def test_accept_rejects_with_same_validator_used_for_inline_error(qtbot, monkeyp
     dialog._on_accepted()
 
     assert warned  # invalid JSON blocked Accept
+
+
+def test_accept_proceeds_when_priors_json_is_valid(qtbot, monkeypatch):
+    from PySide6.QtWidgets import QMessageBox
+
+    dialog = BayesianOptionsDialog()
+    qtbot.addWidget(dialog)
+    dialog.priors_edit.setPlainText('{"G": {"dist": "normal", "loc": 1.0}}')
+
+    warned = []
+    monkeypatch.setattr(
+        QMessageBox,
+        "warning",
+        lambda *a, **k: warned.append(a) or QMessageBox.StandardButton.Ok,
+    )
+    accepted = []
+    monkeypatch.setattr(dialog, "accept", lambda: accepted.append(True))
+
+    dialog._on_accepted()
+
+    assert not warned  # valid JSON does not block Accept
+    assert accepted  # dialog proceeded to accept()

--- a/tests/gui/test_bayesian_options_dialog.py
+++ b/tests/gui/test_bayesian_options_dialog.py
@@ -1,0 +1,42 @@
+"""Regression: BayesianOptionsDialog validates priors JSON as-you-type, not just at Accept."""
+
+from __future__ import annotations
+
+import pytest
+
+pytest.importorskip("PySide6")
+
+from rheojax.gui.dialogs.bayesian_options import BayesianOptionsDialog
+
+
+def test_invalid_priors_json_shows_and_clears_inline_error(qtbot):
+    dialog = BayesianOptionsDialog()
+    qtbot.addWidget(dialog)
+
+    assert dialog._priors_error_label.isHidden()
+
+    dialog.priors_edit.setPlainText("{not valid json")
+    assert not dialog._priors_error_label.isHidden()
+    assert "Invalid JSON" in dialog._priors_error_label.text()
+
+    dialog.priors_edit.setPlainText('{"G": {"dist": "normal", "loc": 1.0}}')
+    assert dialog._priors_error_label.isHidden()
+
+
+def test_accept_rejects_with_same_validator_used_for_inline_error(qtbot, monkeypatch):
+    from PySide6.QtWidgets import QMessageBox
+
+    dialog = BayesianOptionsDialog()
+    qtbot.addWidget(dialog)
+    dialog.priors_edit.setPlainText("{not valid json")
+
+    warned = []
+    monkeypatch.setattr(
+        QMessageBox,
+        "warning",
+        lambda *a, **k: warned.append(a) or QMessageBox.StandardButton.Ok,
+    )
+
+    dialog._on_accepted()
+
+    assert warned  # invalid JSON blocked Accept

--- a/tests/gui/widgets/test_priors_editor.py
+++ b/tests/gui/widgets/test_priors_editor.py
@@ -48,6 +48,41 @@ def test_apply_refuses_invalid_prior(qtbot):
     assert "Not applied" in editor._apply_error_label.text()
 
 
+def test_apply_error_label_clears_after_subsequent_valid_apply(qtbot):
+    # Mirrors test_apply_refuses_invalid_prior, then drives a second, valid
+    # Apply -- the error label shown by the first (invalid) Apply must not
+    # linger once the user has fixed the input and applied again.
+    editor = PriorsEditor()
+    qtbot.addWidget(editor)
+    editor.set_parameters(["a"])
+    editor._current_param = "a"
+
+    editor._dist_combo.blockSignals(True)
+    editor._dist_combo.set_current_data("uniform")
+    editor._dist_combo.blockSignals(False)
+    editor._param_spinboxes["low"].blockSignals(True)
+    editor._param_spinboxes["high"].blockSignals(True)
+    editor._param_spinboxes["low"].setValue(10.0)
+    editor._param_spinboxes["high"].setValue(5.0)  # inverted: low > high
+    editor._param_spinboxes["low"].blockSignals(False)
+    editor._param_spinboxes["high"].blockSignals(False)
+
+    editor._apply_prior()
+    assert not editor._apply_error_label.isHidden()
+
+    # Fix the inverted range and re-apply.
+    editor._param_spinboxes["low"].blockSignals(True)
+    editor._param_spinboxes["high"].blockSignals(True)
+    editor._param_spinboxes["low"].setValue(0.0)
+    editor._param_spinboxes["high"].setValue(5.0)
+    editor._param_spinboxes["low"].blockSignals(False)
+    editor._param_spinboxes["high"].blockSignals(False)
+
+    editor._apply_prior()
+
+    assert editor._apply_error_label.isHidden()
+
+
 def test_to_numpyro_priors_converts_editor_shape(qtbot):
     editor = PriorsEditor()
     qtbot.addWidget(editor)

--- a/tests/gui/widgets/test_priors_editor.py
+++ b/tests/gui/widgets/test_priors_editor.py
@@ -39,6 +39,13 @@ def test_apply_refuses_invalid_prior(qtbot):
 
     assert editor.get_prior("a") == default_prior
     assert emitted == []
+    # Rejection must be visible at Apply-time, not just logged -- the preview
+    # pane's own error text can be stale/unnoticed by the time Apply is clicked.
+    # isHidden() reflects this widget's own show()/hide() state regardless of
+    # whether the (unshown, qtbot-parented-only) editor's ancestor chain is
+    # visible -- isVisible() would need editor.show() to mean anything here.
+    assert not editor._apply_error_label.isHidden()
+    assert "Not applied" in editor._apply_error_label.text()
 
 
 def test_to_numpyro_priors_converts_editor_shape(qtbot):

--- a/tests/gui/workspace/fit/test_step3.py
+++ b/tests/gui/workspace/fit/test_step3.py
@@ -3,7 +3,7 @@ import types
 import pytest
 
 pytest.importorskip("PySide6")
-from rheojax.gui.foundation.state import FitState
+from rheojax.gui.foundation.state import FitState, ParameterState
 from rheojax.gui.workspace.fit.step3_nlsq import NlsqStep
 
 
@@ -250,3 +250,92 @@ def test_run_strips_dialog_multistart_keys_from_options(qtbot):
         "num_starts": 10,
         "ftol": 1e-10,
     }
+
+
+def _make_param_state(value=1.0, min_bound=0.0, max_bound=10.0):
+    return ParameterState(
+        name="G0",
+        value=value,
+        min_bound=min_bound,
+        max_bound=max_bound,
+        fixed=False,
+        unit="Pa",
+        description="",
+    )
+
+
+def test_run_button_blocked_by_invalid_row_shows_warning(qtbot, monkeypatch):
+    """PR #104 gate: clicking the real Run NLSQ button (not calling run()
+    directly) with an invalid parameter row must warn the user and must NOT
+    invoke the underlying fit_fn."""
+    from rheojax.gui.compat import QMessageBox
+
+    st = FitState(
+        protocol="oscillation", model_key="maxwell", data_ref="d", column_map={"x": 0}
+    )
+    calls = {"invoked": False}
+
+    def fake_fit(model_key, model_config, data_ref, column_map, **kwargs):
+        calls["invoked"] = True
+        return {"params": {"G0": 1000.0}, "r_squared": 0.9}
+
+    step = NlsqStep(st, fit_fn=fake_fit)
+    qtbot.addWidget(step)
+    step._table.set_parameters({"G0": _make_param_state()})
+    # Set the value cell out of its [min_bound, max_bound] range --
+    # ParameterTable._on_item_changed only reverts genuinely non-numeric
+    # text; an out-of-range *numeric* value is left in place (red/tooltip
+    # only), so has_invalid_rows() must catch it and the click handler must
+    # refuse to launch.
+    step._table.item(0, 1).setText("999")
+    assert step._table.has_invalid_rows() is True
+
+    warned = {}
+
+    def fake_warning(*args, **kwargs):
+        warned["called"] = True
+        return QMessageBox.StandardButton.Ok
+
+    monkeypatch.setattr(QMessageBox, "warning", fake_warning)
+
+    step._run_btn.click()
+
+    assert warned.get("called") is True
+    assert calls["invoked"] is False
+    assert st.nlsq_result is None
+
+
+def test_run_button_proceeds_when_all_rows_valid(qtbot, monkeypatch):
+    """Positive-path guard: an all-valid parameter table must NOT be blocked
+    by the has_invalid_rows() gate -- clicking Run NLSQ must still launch the
+    fit and must not pop the warning dialog."""
+    from rheojax.gui.compat import QMessageBox
+
+    st = FitState(
+        protocol="oscillation", model_key="maxwell", data_ref="d", column_map={"x": 0}
+    )
+    calls = {"invoked": False}
+
+    def fake_fit(model_key, model_config, data_ref, column_map, **kwargs):
+        calls["invoked"] = True
+        return {"params": {"G0": 1000.0}, "r_squared": 0.9}
+
+    step = NlsqStep(st, fit_fn=fake_fit)
+    qtbot.addWidget(step)
+    step._table.set_parameters({"G0": _make_param_state()})
+    assert step._table.has_invalid_rows() is False
+
+    warned = {"called": False}
+
+    def fake_warning(*args, **kwargs):
+        warned["called"] = True
+        return QMessageBox.StandardButton.Ok
+
+    monkeypatch.setattr(QMessageBox, "warning", fake_warning)
+
+    with qtbot.waitSignal(step.finished, timeout=2000):
+        step._run_btn.click()
+
+    assert warned["called"] is False
+    assert calls["invoked"] is True
+    assert st.nlsq_result["r_squared"] == 0.9

--- a/tests/gui/workspace/fit/test_step4.py
+++ b/tests/gui/workspace/fit/test_step4.py
@@ -94,3 +94,60 @@ def test_reset_skip_wired_to_nlsq_edited_in_fit_controller(qtbot):
     nlsq_body.edited.emit()
 
     assert nuts_body.is_ready() is False
+
+
+def test_sample_button_confirm_cancel_blocks_run(qtbot, monkeypatch):
+    """PR #104 gate: clicking the real Sample button (not calling run()
+    directly) must show a QMessageBox.question confirm mentioning the
+    chain/iteration count, and answering Cancel must NOT launch a sample."""
+    from rheojax.gui.compat import QMessageBox
+
+    st = FitState(nlsq_result={"params": {"G0": 1000.0, "eta": 50.0}})
+    calls = {"invoked": False}
+
+    def fake_sample(priors, warm_start, config):
+        calls["invoked"] = True
+        return {"rhat": 1.0}
+
+    step = NutsStep(st, sample_fn=fake_sample)
+    qtbot.addWidget(step)
+
+    captured = {}
+
+    def fake_question(self_, title, text, *args, **kwargs):
+        captured["text"] = text
+        return QMessageBox.StandardButton.Cancel
+
+    monkeypatch.setattr(QMessageBox, "question", fake_question)
+
+    step._run_btn.click()
+
+    assert "chain" in captured["text"].lower()
+    assert calls["invoked"] is False
+    assert st.nuts_result is None
+
+
+def test_sample_button_confirm_yes_proceeds(qtbot, monkeypatch):
+    """Positive-path guard: answering Yes to the confirm dialog must let the
+    real Sample button proceed to the underlying sample_fn."""
+    from rheojax.gui.compat import QMessageBox
+
+    st = FitState(nlsq_result={"params": {"G0": 1000.0, "eta": 50.0}})
+    calls = {"invoked": False}
+
+    def fake_sample(priors, warm_start, config):
+        calls["invoked"] = True
+        return {"rhat": 1.0}
+
+    step = NutsStep(st, sample_fn=fake_sample)
+    qtbot.addWidget(step)
+
+    monkeypatch.setattr(
+        QMessageBox, "question", lambda *a, **k: QMessageBox.StandardButton.Yes
+    )
+
+    with qtbot.waitSignal(step.finished, timeout=2000):
+        step._run_btn.click()
+
+    assert calls["invoked"] is True
+    assert st.nuts_result is not None

--- a/tests/gui/workspace/fit/test_step6.py
+++ b/tests/gui/workspace/fit/test_step6.py
@@ -156,3 +156,118 @@ def test_export_holds_worker_ref_and_registers_active_job(qtbot, monkeypatch, tm
     qtbot.waitUntil(lambda: "Exported to" in step._export_status.text())
     assert step._active_export_workers == {}
     assert active_jobs.by_id == {}
+
+
+def _non_converged_state(**overrides):
+    kwargs = dict(
+        protocol="oscillation",
+        model_key="maxwell",
+        model_config={},
+        data_ref="d",
+        nlsq_result={"params": {"G0": 1.0}},
+        nuts_result={
+            "verdict": {"converged": False, "reasons": ["ESS too low for G0"]}
+        },
+        revision=2,
+    )
+    kwargs.update(overrides)
+    return FitState(**kwargs)
+
+
+def test_save_button_confirm_gate_blocks_on_non_converged_cancel(qtbot, monkeypatch):
+    """PR #104 gate: clicking the real Save button (not calling
+    save_to_library() directly) with a non-converged NUTS verdict must show
+    a confirm dialog, and Cancel must prevent the save from proceeding."""
+    from rheojax.gui.compat import QMessageBox
+
+    st = _non_converged_state()
+    lib = DatasetLibrary()
+    step = ExportStep(st, lib)
+    qtbot.addWidget(step)
+    _commit_on_request(step, lib)
+
+    captured = {}
+
+    def fake_question(self_, title, text, *args, **kwargs):
+        captured["text"] = text
+        return QMessageBox.StandardButton.Cancel
+
+    monkeypatch.setattr(QMessageBox, "question", fake_question)
+
+    emitted = {"called": False}
+    step.dataset_commit_requested.connect(lambda *a: emitted.__setitem__("called", True))
+
+    step._save_btn.click()
+
+    assert "did not converge" in captured["text"].lower()
+    assert emitted["called"] is False
+
+
+def test_save_button_confirm_gate_proceeds_on_non_converged_yes(qtbot, monkeypatch):
+    """Positive-path guard: answering Yes to the non-converged confirm must
+    let the real Save button proceed to save_to_library()."""
+    from rheojax.gui.compat import QMessageBox
+
+    st = _non_converged_state()
+    lib = DatasetLibrary()
+    step = ExportStep(st, lib)
+    qtbot.addWidget(step)
+    _commit_on_request(step, lib)
+
+    monkeypatch.setattr(
+        QMessageBox, "question", lambda *a, **k: QMessageBox.StandardButton.Yes
+    )
+
+    with qtbot.waitSignal(step.dataset_commit_requested, timeout=1000):
+        step._save_btn.click()
+
+    assert lib.get(step.provenance()["model_key"] + "_fit_2").origin == "derived"
+
+
+def test_export_button_confirm_gate_blocks_on_non_converged_cancel(
+    qtbot, monkeypatch, tmp_path
+):
+    """The real Export Bundle button must also honor the non-converged
+    confirm gate -- Cancel must stop before even prompting for a directory."""
+    from rheojax.gui.compat import QFileDialog, QMessageBox
+
+    st = _non_converged_state()
+    lib = DatasetLibrary()
+    step = ExportStep(st, lib)
+    qtbot.addWidget(step)
+
+    monkeypatch.setattr(QMessageBox, "question", lambda *a, **k: QMessageBox.StandardButton.Cancel)
+    dir_dialog_called = {"called": False}
+    monkeypatch.setattr(
+        QFileDialog,
+        "getExistingDirectory",
+        lambda *a, **k: dir_dialog_called.__setitem__("called", True) or str(tmp_path),
+    )
+
+    step._export_btn.click()
+
+    assert dir_dialog_called["called"] is False
+    assert step._export_status.text() == ""
+
+
+def test_export_button_confirm_gate_proceeds_on_non_converged_yes(
+    qtbot, monkeypatch, tmp_path
+):
+    """Answering Yes to the non-converged confirm must let Export Bundle
+    proceed to the directory prompt and the export itself."""
+    from rheojax.gui.compat import QFileDialog, QMessageBox
+
+    st = _non_converged_state()
+    lib = DatasetLibrary()
+    step = ExportStep(st, lib)
+    qtbot.addWidget(step)
+
+    monkeypatch.setattr(
+        QMessageBox, "question", lambda *a, **k: QMessageBox.StandardButton.Yes
+    )
+    monkeypatch.setattr(
+        QFileDialog, "getExistingDirectory", lambda *a, **k: str(tmp_path)
+    )
+
+    step._export_btn.click()
+    qtbot.waitUntil(lambda: "Exported to" in step._export_status.text())

--- a/tests/gui/workspace/pipeline/test_batch_runner.py
+++ b/tests/gui/workspace/pipeline/test_batch_runner.py
@@ -234,6 +234,54 @@ def test_batch_runner_emits_finished_with_failed_record_on_fatal_precondition_er
     assert records[1]["dataset_id"] == "d2"
     assert records[1]["status"] == "skipped"
     assert records[1]["step_results"] == {}
+    # The skip record must surface *why* -- both the fixed "Batch aborted"
+    # framing and the underlying failure reason text (not just a generic
+    # placeholder), so reviewing job_history afterwards explains the skip.
+    assert "Batch aborted" in records[1]["error"]
+    assert "subprocess" in records[1]["error"]
+
+
+def test_batch_runner_skips_all_datasets_queued_behind_fatal_precondition_error(
+    qtbot, monkeypatch
+):
+    # With 3+ datasets, every dataset after the fatal one must get a skipped
+    # record -- not just the immediate next one. This exercises the
+    # `selected_dataset_ids[idx + 1 :]` slice for a queue longer than 2.
+    monkeypatch.setenv("RHEOJAX_WORKER_ISOLATION", "thread")
+    lib = DatasetLibrary()
+    for id_ in ("d1", "d2", "d3", "d4"):
+        lib.add(_ref(id_, "relaxation"))
+        lib.store_payload(
+            id_, RheoData(x=[0.1, 1.0], y=[100.0, 50.0], initial_test_mode="relaxation")
+        )
+    svc = PipelineExecutionService()
+    steps = [
+        PipelineStepConfig(
+            id="s1",
+            step_type="fit",
+            config={"model_name": "maxwell", "run_nuts": False},
+        )
+    ]
+    runner = PipelineBatchRunner(
+        service=svc,
+        steps=steps,
+        selected_dataset_ids=["d1", "d2", "d3", "d4"],
+        library=lib,
+        stop_requested=threading.Event(),
+    )
+    started, records = [], []
+    svc.dataset_run_started.connect(lambda dsid: started.append(dsid))
+    svc.dataset_run_finished.connect(lambda dsid, record: records.append(record))
+    with qtbot.waitSignal(svc.dataset_run_finished, timeout=5000):
+        runner.run()
+    assert started == ["d1"]  # fatal precondition error stops the batch
+    assert len(records) == 4
+    assert records[0]["status"] == "failed"
+    for record, dataset_id in zip(records[1:], ("d2", "d3", "d4")):
+        assert record["dataset_id"] == dataset_id
+        assert record["status"] == "skipped"
+        assert record["step_results"] == {}
+        assert "Batch aborted" in record["error"]
 
 
 def test_batch_runner_transform_step_record_round_trips_output_as_rheodata(

--- a/tests/gui/workspace/pipeline/test_batch_runner.py
+++ b/tests/gui/workspace/pipeline/test_batch_runner.py
@@ -224,10 +224,16 @@ def test_batch_runner_emits_finished_with_failed_record_on_fatal_precondition_er
     assert started == [
         "d1"
     ]  # fatal precondition error stops the batch -- d2 never started
-    assert len(records) == 1
+    assert len(records) == 2
     assert records[0]["status"] == "failed"
     assert "subprocess" in records[0]["error"]
     assert records[0]["step_results"] == {}
+    # d2 never ran (never got dataset_run_started), but must still get an explicit
+    # "skipped" record -- not silent absence -- so it's distinguishable from
+    # "not yet attempted" when reviewing job_history afterwards.
+    assert records[1]["dataset_id"] == "d2"
+    assert records[1]["status"] == "skipped"
+    assert records[1]["step_results"] == {}
 
 
 def test_batch_runner_transform_step_record_round_trips_output_as_rheodata(

--- a/tests/gui/workspace/pipeline/test_step1_configure_run.py
+++ b/tests/gui/workspace/pipeline/test_step1_configure_run.py
@@ -144,3 +144,9 @@ def test_move_step_up_and_down_swaps_state_order(qtbot):
     step._step_list.setCurrentRow(0)
     step._on_move_step_up_clicked()
     assert [s.config["path"] for s in state.pipeline.steps] == ["a.csv", "b.csv"]
+
+    # Mirror case: last row + Move Down is also a no-op (guarded by
+    # `row >= self._step_list.count() - 1` in _on_move_step_down_clicked).
+    step._step_list.setCurrentRow(step._step_list.count() - 1)
+    step._on_move_step_down_clicked()
+    assert [s.config["path"] for s in state.pipeline.steps] == ["a.csv", "b.csv"]

--- a/tests/gui/workspace/pipeline/test_step1_configure_run.py
+++ b/tests/gui/workspace/pipeline/test_step1_configure_run.py
@@ -100,3 +100,47 @@ def test_is_ready_false_when_a_step_has_incomplete_config(qtbot):
     step.add_step("fit", {})  # incomplete -- no model_name
     step.set_selected_dataset_ids(["d1"])
     assert step.is_ready() is False
+
+
+def test_remove_step_requires_confirmation(qtbot, monkeypatch):
+    from PySide6.QtWidgets import QMessageBox
+
+    state = AppState()
+    step = PipelineConfigureRunStep(state.pipeline, state.library)
+    qtbot.addWidget(step)
+    step.add_step("export", {"path": "out.csv"})
+    step._step_list.setCurrentRow(0)
+
+    monkeypatch.setattr(
+        QMessageBox, "question", lambda *a, **k: QMessageBox.StandardButton.No
+    )
+    step._on_remove_step_clicked()
+    assert len(state.pipeline.steps) == 1  # cancelled -- step still there
+
+    monkeypatch.setattr(
+        QMessageBox, "question", lambda *a, **k: QMessageBox.StandardButton.Yes
+    )
+    step._on_remove_step_clicked()
+    assert len(state.pipeline.steps) == 0
+
+
+def test_move_step_up_and_down_swaps_state_order(qtbot):
+    state = AppState()
+    step = PipelineConfigureRunStep(state.pipeline, state.library)
+    qtbot.addWidget(step)
+    step.add_step("export", {"path": "a.csv"})
+    step.add_step("export", {"path": "b.csv"})
+    assert [s.config["path"] for s in state.pipeline.steps] == ["a.csv", "b.csv"]
+
+    step._step_list.setCurrentRow(1)
+    step._on_move_step_up_clicked()
+    assert [s.config["path"] for s in state.pipeline.steps] == ["b.csv", "a.csv"]
+    assert step._step_list.item(0).text().startswith("export: {'path': 'b.csv'")
+
+    step._on_move_step_down_clicked()
+    assert [s.config["path"] for s in state.pipeline.steps] == ["a.csv", "b.csv"]
+
+    # Boundary rows are no-ops, not errors.
+    step._step_list.setCurrentRow(0)
+    step._on_move_step_up_clicked()
+    assert [s.config["path"] for s in state.pipeline.steps] == ["a.csv", "b.csv"]


### PR DESCRIPTION
## Summary
Fixes every Critical/Warning finding and implements every Opportunity from a UI design audit of `rheojax/gui` (shell/chrome, fit+transform wizard, pipeline/dialogs/widgets).

**Shell/chrome**
- Progress indicator during dataset import (was silent)
- Busy cursor during synchronous dataset preview load
- Persistent "Step X of N" wizard position label + bold current-step cue (was tooltip/color-only)
- Distinguish empty-state library rows from real dataset rows
- Log dock height scales from font metrics instead of a fixed 200px
- Inspector's dead tabs now show honest "not connected yet" labels instead of blank widgets
- Removed stale `import_wizard.py` reference from README (file no longer exists)

**Fit/transform wizard**
- Indeterminate progress + elapsed-time indicator during NLSQ/NUTS runs
- Fit launch blocked with a warning instead of silently dropping invalid parameter rows
- Non-color (tooltip) cue for invalid parameter cells
- Confirm dialog before starting NUTS sampling
- Accessible names on per-row "Fixed" checkboxes
- Confirm before exporting/saving a non-converged NUTS result
- Progressive disclosure for less-common NUTS sampler settings (matches NLSQ's existing pattern)
- Parameter table font bumped one step

**Pipeline/dialogs/widgets**
- Datasets queued behind a fatal batch error now get an explicit "skipped" record (previously none)
- Documented the remaining mid-dataset cancellation ceiling (real architectural limit, not laziness)
- Confirm before removing a configured pipeline step; added reorder (move up/down)
- Replaced hardcoded hex colors/font sizes with `themed()`/`Typography` tokens (bayesian_options, about, arviz_canvas)
- Reordered default plot color palette so red/green aren't adjacent
- Corrected the plot_canvas FreeType-crash comment to describe the actual catchable failure mode instead of implying unproven protection against a segfault
- Prior-validation failures now surface visibly instead of log-only
- Confirm before "Restore Defaults" in preferences/fitting options
- Priors JSON validates as you type, not just on dialog accept

## Test plan
- [x] `tests/gui/workspace/`, `tests/gui/widgets/`, `tests/gui/test_bayesian_options_dialog.py`, `tests/gui/test_log_dock.py`, `tests/gui/test_gui_smoke.py` — 441 passed
- [x] `ruff check` clean on all touched files

🤖 Generated with [Claude Code](https://claude.com/claude-code)