### PR TITLE
fix(gui): resolve setTabOrder cross-window warning in NutsStep

### DIFF
--- a/rheojax/gui/workspace/fit/step4_nuts.py
+++ b/rheojax/gui/workspace/fit/step4_nuts.py
@@ -248,11 +248,15 @@ class NutsStep(QWidget):
         # a field is added or reordered, rather than fixing a live bug.
         self.setTabOrder(self._warmup, self._samples)
         self.setTabOrder(self._samples, self._chains)
-        self.setTabOrder(self._chains, self._seed)
-        self.setTabOrder(self._seed, self._target)
-        self.setTabOrder(self._target, self._max_tree_depth)
-        self.setTabOrder(self._max_tree_depth, self._skip_btn)
+        self.setTabOrder(self._chains, self._options_btn)
+        self.setTabOrder(self._options_btn, self._skip_btn)
         self.setTabOrder(self._skip_btn, self._run_btn)
+        # _seed/_target/_max_tree_depth live in self._sampler_dialog (a
+        # separate top-level window, since dialog_form was added to
+        # dialog_layout), not in self -- setTabOrder requires both widgets
+        # share a window, so their chain must run on the dialog itself.
+        self._sampler_dialog.setTabOrder(self._seed, self._target)
+        self._sampler_dialog.setTabOrder(self._target, self._max_tree_depth)
         self._skip_btn.clicked.connect(self.skip)
         self._run_btn.clicked.connect(self._on_sample_clicked)
         for spin in (

--- a/rheojax/gui/workspace/fit/step4_nuts.py
+++ b/rheojax/gui/workspace/fit/step4_nuts.py
@@ -254,7 +254,8 @@ class NutsStep(QWidget):
         # _seed/_target/_max_tree_depth live in self._sampler_dialog (a
         # separate top-level window, since dialog_form was added to
         # dialog_layout), not in self -- setTabOrder requires both widgets
-        # share a window, so their chain must run on the dialog itself.
+        # share a window, so these pairs can't cross into self's chain
+        # above (the receiver below is cosmetic; Qt keys off the args).
         self._sampler_dialog.setTabOrder(self._seed, self._target)
         self._sampler_dialog.setTabOrder(self._target, self._max_tree_depth)
         self._skip_btn.clicked.connect(self.skip)


### PR DESCRIPTION
## Summary
- Root cause of the repeated `QWidget::setTabOrder: 'first' and 'second' must be in the same window` warning: `NutsStep.__init__` (`step4_nuts.py`) chains tab order across two different top-level windows. `_seed`/`_target`/`_max_tree_depth` are added to `dialog_form`, which is added to `self._sampler_dialog` — a separate `QDialog` window — while `_chains`/`_skip_btn` stay in `self` (the `NutsStep` widget). The old chain crossed that boundary twice (`_chains -> _seed`, `_max_tree_depth -> _skip_btn`), matching the exact 2 warnings reported.
- Fix: split into two per-window `setTabOrder` chains — one on `self` for the main widget's fields, one on `self._sampler_dialog` for the dialog's fields.

## Test plan
- [x] `uv run pytest tests/gui/workspace/fit/test_step4.py tests/gui/workspace/fit/test_step4_priors.py -q` — 11 passed
- [x] Checked sibling `step3_nlsq.py` for the same pattern — its dialog is built lazily on click, not sharing `__init__`'s tab-order widgets, so it's unaffected.