### PR TITLE
fix(cli,gui): envelope piping, batch JSON output, and project codec bugs

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -321,6 +321,11 @@ ignore = [
 "examples/**/*.ipynb" = ["B", "C", "E", "F", "W", "I", "UP"]  # Example notebooks: suppress all lint rules (syntax errors from shell/magic cells)
 "docs/source/conf.py" = ["F401"]  # Sphinx config checks imports for availability
 
+[tool.bandit]
+# Mirrors the ruff S101 ignore above: pytest requires bare `assert` statements,
+# and production code uses assert for internal invariants, not I/O validation.
+skips = ["B101"]
+
 [tool.mypy]
 python_version = "3.12"
 warn_return_any = false  # Allow Any returns for JAX arrays

--- a/rheojax/cli/_yaml_schema.py
+++ b/rheojax/cli/_yaml_schema.py
@@ -311,7 +311,7 @@ def validate_config(config: PipelineConfig) -> list[str]:
                             transform=transform_name,
                             available=registered,
                         )
-                except Exception:
+                except (ImportError, AttributeError):
                     pass  # Registry not available at validation time
 
         if step_type == "fit":
@@ -320,7 +320,7 @@ def validate_config(config: PipelineConfig) -> list[str]:
         # Validate Bayesian sampling parameter ranges to prevent OOM.
         if step_type == "bayesian":
             for key, (lo, hi) in BAYESIAN_PARAM_LIMITS.items():
-                val = step.get(key)
+                val = effective.get(key)
                 if val is not None:
                     try:
                         ival = int(val)

--- a/rheojax/cli/cmd_batch.py
+++ b/rheojax/cli/cmd_batch.py
@@ -287,6 +287,9 @@ def main(args: list[str] | None = None) -> int:
         )
         return 1
 
+    # Under --json, stdout must carry only the final JSON array (see below) --
+    # route all progress prose to stderr so a downstream JSON consumer never
+    # sees it interleaved with the payload.
     _progress_stream = sys.stderr if parsed.json_output else sys.stdout
     print(
         f"Found {len(files)} file(s) matching '{parsed.pattern}'", file=_progress_stream

--- a/rheojax/cli/cmd_batch.py
+++ b/rheojax/cli/cmd_batch.py
@@ -287,7 +287,10 @@ def main(args: list[str] | None = None) -> int:
         )
         return 1
 
-    print(f"Found {len(files)} file(s) matching '{parsed.pattern}'")
+    _progress_stream = sys.stderr if parsed.json_output else sys.stdout
+    print(
+        f"Found {len(files)} file(s) matching '{parsed.pattern}'", file=_progress_stream
+    )
 
     # Trigger model registration
     import rheojax.models  # noqa: F401 — trigger registration
@@ -312,7 +315,7 @@ def main(args: list[str] | None = None) -> int:
 
     for i, file_path in enumerate(files, 1):
         prefix = f"[{i}/{len(files)}] {file_path.name}"
-        print(f"{prefix} ...", end=" ", flush=True)
+        print(f"{prefix} ...", end=" ", flush=True, file=_progress_stream)
 
         try:
             result = _fit_single(
@@ -323,7 +326,7 @@ def main(args: list[str] | None = None) -> int:
                 fit_kwargs,
             )
             t = result.get("fit_time_seconds", "?")
-            print(f"OK ({t}s)")
+            print(f"OK ({t}s)", file=_progress_stream)
             logger.info("Batch file fitted", file=str(file_path), time=t)
         except Exception as e:
             result = {
@@ -331,7 +334,7 @@ def main(args: list[str] | None = None) -> int:
                 "status": "error",
                 "error": str(e),
             }
-            print(f"FAILED: {e}")
+            print(f"FAILED: {e}", file=_progress_stream)
             logger.error("Batch file failed", file=str(file_path), error=str(e))
 
         all_results.append(result)
@@ -351,7 +354,7 @@ def main(args: list[str] | None = None) -> int:
         if result["status"] != "success" and not parsed.continue_on_error:
             break
 
-    print()
+    print(file=_progress_stream)
 
     # Output
     if parsed.json_output:

--- a/rheojax/cli/cmd_export.py
+++ b/rheojax/cli/cmd_export.py
@@ -138,7 +138,7 @@ def _build_pipeline_from_envelope(envelope: dict):
     except (ImportError, AttributeError) as exc:
         raise RuntimeError(
             "Could not construct a Pipeline from the stdin envelope. "
-            "Pipe from 'rheojax fit --json' or provide an HDF5 file."
+            "Pipe from 'rheojax load --json' or provide an HDF5 file."
         ) from exc
 
 

--- a/rheojax/cli/cmd_export.py
+++ b/rheojax/cli/cmd_export.py
@@ -7,7 +7,7 @@ stdin.
 Usage:
     rheojax export analysis.h5 --output export/ --format directory
     rheojax export analysis.h5 --output bundle.xlsx --format excel
-    rheojax fit data.csv --model maxwell --json | rheojax export - --output ./out
+    rheojax load data.csv --json | rheojax export - --output ./out
 """
 
 from __future__ import annotations
@@ -44,8 +44,8 @@ Examples:
   # Export to Excel workbook
   rheojax export analysis.h5 --output summary.xlsx --format excel
 
-  # Pipe fit results directly into export
-  rheojax fit data.csv --model maxwell --json | rheojax export - --output ./out
+  # Pipe a loaded data envelope directly into export
+  rheojax load data.csv --json | rheojax export - --output ./out
         """,
     )
 
@@ -53,8 +53,7 @@ Examples:
         "input",
         type=str,
         help=(
-            "HDF5 file from a previous run, "
-            "or '-' to read a JSON envelope from stdin"
+            "HDF5 file from a previous run, or '-' to read a JSON envelope from stdin"
         ),
     )
     parser.add_argument(
@@ -102,8 +101,17 @@ def _build_pipeline_from_envelope(envelope: dict):
 
     from rheojax.core.data import RheoData
 
-    x = np.array(envelope.get("x", []))
-    y_payload = envelope.get("y", {})
+    if envelope.get("envelope_type") != "data" or not isinstance(
+        envelope.get("data"), dict
+    ):
+        raise ValueError(
+            "Envelope does not contain a 'data' payload (envelope_type="
+            f"{envelope.get('envelope_type')!r}). Pipe from 'rheojax load --json'."
+        )
+
+    payload = envelope["data"]
+    x = np.array(payload.get("x", []))
+    y_payload = payload.get("y", {})
     if isinstance(y_payload, dict) and y_payload.get("complex"):
         y = np.array(y_payload["real"]) + 1j * np.array(y_payload["imag"])
     elif isinstance(y_payload, dict):

--- a/rheojax/cli/cmd_load.py
+++ b/rheojax/cli/cmd_load.py
@@ -7,7 +7,7 @@ Usage:
     rheojax load data.csv
     rheojax load data.trios --test-mode oscillation
     rheojax load data.csv --x-col time --y-col G_t --json
-    rheojax load data.csv --y-cols "G_prime,G_double_prime" | rheojax fit --model maxwell
+    rheojax load data.csv --json | rheojax transform mastercurve --json
 """
 
 from __future__ import annotations
@@ -47,8 +47,8 @@ Examples:
   # Load complex oscillation data (G', G'')
   rheojax load data.csv --y-cols "G_prime,G_double_prime" --test-mode oscillation
 
-  # Output JSON envelope for piping
-  rheojax load data.trios --json | rheojax fit --model maxwell --json
+  # Output JSON envelope for piping to transform/export
+  rheojax load data.trios --json | rheojax transform mastercurve --json
 
   # Auto-detect from TRIOS file
   rheojax load sweep.trios
@@ -132,6 +132,8 @@ def main(args: list[str] | None = None) -> int:
 
     # Build load kwargs
     load_kwargs: dict = {}
+    if parsed.file_format is not None:
+        load_kwargs["format"] = parsed.file_format
     if parsed.x_col is not None:
         load_kwargs["x_col"] = parsed.x_col
     if parsed.y_col is not None:

--- a/rheojax/cli/cmd_run.py
+++ b/rheojax/cli/cmd_run.py
@@ -5,7 +5,7 @@ keeping this module as a thin argument-parsing wrapper.
 
 Usage:
     rheojax run pipeline.yaml
-    rheojax run pipeline.yaml --override model=springpot --override max_iter=2000
+    rheojax run pipeline.yaml --override defaults.model=springpot --override defaults.max_iter=2000
     rheojax run pipeline.yaml --dry-run
 """
 
@@ -39,10 +39,10 @@ Examples:
   rheojax run my_pipeline.yaml
 
   # Override a config value at runtime
-  rheojax run my_pipeline.yaml --override model=springpot
+  rheojax run my_pipeline.yaml --override defaults.model=springpot
 
   # Override multiple values
-  rheojax run pipeline.yaml --override model=maxwell --override max_iter=5000
+  rheojax run pipeline.yaml --override defaults.model=maxwell --override defaults.max_iter=5000
 
   # Preview without executing
   rheojax run pipeline.yaml --dry-run
@@ -63,8 +63,9 @@ Examples:
         default=[],
         metavar="KEY=VALUE",
         help=(
-            "Override a config key at runtime, e.g. --override model=maxwell "
-            "(repeatable, dot-notation supported: steps.0.model=maxwell)"
+            "Override a config key at runtime, e.g. --override defaults.model=maxwell "
+            "(repeatable; path must start with 'defaults.' or 'steps.<index>.', "
+            "e.g. steps.0.model=maxwell)"
         ),
     )
     parser.add_argument(

--- a/rheojax/cli/cmd_transform.py
+++ b/rheojax/cli/cmd_transform.py
@@ -156,7 +156,7 @@ def _load_from_envelope(text: str):
         if "values" not in y_payload:
             raise ValueError(
                 "JSON envelope 'y' dict has neither 'complex' nor 'values' key. "
-                "Pipe from 'rheojax load --json' or 'rheojax fit --json'."
+                "Pipe from 'rheojax load --json'."
             )
         y = np.array(y_payload["values"])
     else:

--- a/rheojax/cli/cmd_transform.py
+++ b/rheojax/cli/cmd_transform.py
@@ -139,16 +139,17 @@ def _load_from_envelope(text: str):
         raise ValueError(
             f"Expected a JSON object from stdin, got {type(envelope).__name__}"
         )
-    if "x" not in envelope:
+    payload = envelope.get("data")
+    if not isinstance(payload, dict) or "x" not in payload:
         raise ValueError(
-            "JSON envelope is missing required 'x' key. "
-            "Pipe from 'rheojax fit --json' or 'rheojax load --json'."
+            "JSON envelope is missing a 'data' object with an 'x' key. "
+            "Pipe from 'rheojax load --json'."
         )
 
     from rheojax.core.data import RheoData
 
-    x = np.array(envelope["x"])
-    y_payload = envelope.get("y", {})
+    x = np.array(payload["x"])
+    y_payload = payload.get("y", {})
     if isinstance(y_payload, dict) and y_payload.get("complex"):
         y = np.array(y_payload["real"]) + 1j * np.array(y_payload["imag"])
     elif isinstance(y_payload, dict):

--- a/rheojax/cli/main.py
+++ b/rheojax/cli/main.py
@@ -170,8 +170,10 @@ For command-specific help:
     return parser
 
 
-def show_info() -> int:
+def show_info(args: list[str] | None = None) -> int:
     """Display package information."""
+    argparse.ArgumentParser(prog="rheojax info").parse_args(args)
+
     logger.info("Running CLI command", command="info")
 
     import rheojax
@@ -393,7 +395,7 @@ def main(args: list[str] | None = None) -> int:
 
     elif command == "info":
         try:
-            return show_info()
+            return show_info(args[1:])
         except Exception as e:
             print(f"Error: {e}", file=sys.stderr)
             logger.error("info command failed", error=str(e), exc_info=True)

--- a/rheojax/cli/main.py
+++ b/rheojax/cli/main.py
@@ -172,7 +172,7 @@ For command-specific help:
 
 def show_info(args: list[str] | None = None) -> int:
     """Display package information."""
-    argparse.ArgumentParser(prog="rheojax info").parse_args(args)
+    argparse.ArgumentParser(prog="rheojax info").parse_args(args or [])
 
     logger.info("Running CLI command", command="info")
 

--- a/rheojax/gui/foundation/project_codec.py
+++ b/rheojax/gui/foundation/project_codec.py
@@ -64,6 +64,14 @@ def _write_walk(value: Any, key_path: str, hf: h5py.File, out: dict | list) -> A
         }
     if isinstance(value, list):
         return [_write_walk(v, f"{key_path}/{i}", hf, out) for i, v in enumerate(value)]
+    # Transform extras (unlike nlsq/nuts results) may carry a transform's own
+    # @dataclass result type (e.g. CoxMerzResult, PronyResult) or a JAX array
+    # rather than a plain dict/np.ndarray -- unwrap both into the same
+    # dict/np.ndarray universe above instead of hard-failing Save.
+    if dataclasses.is_dataclass(value) and not isinstance(value, type):
+        return _write_walk(dataclasses.asdict(value), key_path, hf, out)
+    if hasattr(value, "__array__"):
+        return _write_walk(np.asarray(value), key_path, hf, out)
     raise TypeError(
         f"write_result_arrays: unsupported value type {type(value).__name__!r} at "
         f"{key_path or '<root>'} -- not one of str/int/float/bool/None/np.ndarray/dict/list/tuple"
@@ -91,6 +99,15 @@ def _read_walk(node: Any, hf: h5py.File) -> Any:
 
 
 def read_result_arrays(path: Path, json_shape: dict[str, Any]) -> dict[str, Any]:
+    if not isinstance(json_shape, dict):
+        # A missing/null/malformed "*_meta" sibling in a hand-edited or
+        # corrupted archive would otherwise surface as an unhandled
+        # AttributeError deep in .items() below, bypassing every caller's
+        # ValueError/OSError "load failed" dialog.
+        raise ValueError(
+            f"read_result_arrays: expected a dict for json_shape, got "
+            f"{type(json_shape).__name__} -- archive metadata is missing or corrupt"
+        )
     path = Path(path)
     with h5py.File(path, "r") as hf:
         return {k: _read_walk(v, hf) for k, v in json_shape.items()}
@@ -519,15 +536,19 @@ def load_project_v2(path: Path):
             result_refs = transform_dict.pop("result_refs", {}) or {}
             extras_ref = transform_dict.pop("result_extras_ref", None)
             extras_meta = transform_dict.pop("result_extras_meta", None)
+            # Pre-fix archives (or a run with no extras) stored a plain
+            # JSON-safe dict directly under "result_extras" -- pop it
+            # unconditionally so a stray legacy key never survives into
+            # TransformState(**transform_dict) below (that dataclass has no
+            # "result_extras" field, so a leftover key would raise TypeError).
+            legacy_extras = transform_dict.pop("result_extras", {}) or {}
             if extras_ref is not None:
                 result_extras = (
                     _restore_result_dict(extras_ref, extras_meta, "transform_results")
                     or {}
                 )
             else:
-                # Pre-fix archives (or a run with no extras) stored a
-                # plain JSON-safe dict directly under "result_extras".
-                result_extras = transform_dict.pop("result_extras", {}) or {}
+                result_extras = legacy_extras
             restored_result: dict | None = None
             if any(result_refs.values()) or result_extras:
                 restored_result = dict(result_extras)

--- a/rheojax/gui/foundation/project_codec.py
+++ b/rheojax/gui/foundation/project_codec.py
@@ -48,7 +48,9 @@ def _write_walk(value: Any, key_path: str, hf: h5py.File, out: dict | list) -> A
         return {
             k: _write_walk(
                 v,
-                f"{key_path}/{_escape_hdf5_key(k)}" if key_path else _escape_hdf5_key(k),
+                f"{key_path}/{_escape_hdf5_key(k)}"
+                if key_path
+                else _escape_hdf5_key(k),
                 hf,
                 out,
             )
@@ -71,7 +73,9 @@ def _write_walk(value: Any, key_path: str, hf: h5py.File, out: dict | list) -> A
 def write_result_arrays(path: Path, result: dict[str, Any]) -> dict[str, Any]:
     path = Path(path)
     with h5py.File(path, "w") as hf:
-        return {k: _write_walk(v, _escape_hdf5_key(k), hf, {}) for k, v in result.items()}
+        return {
+            k: _write_walk(v, _escape_hdf5_key(k), hf, {}) for k, v in result.items()
+        }
 
 
 def _read_walk(node: Any, hf: h5py.File) -> Any:
@@ -218,11 +222,22 @@ def save_project_v2(state, path: Path) -> None:
                 _register_binary(rel)
                 transform_result_refs[side] = result_id
         transform_dict["result_refs"] = transform_result_refs
-        transform_dict["result_extras"] = {
+        # Extras (e.g. TransformWorker's `tr.extras`) may hold numpy arrays
+        # (FFT harmonics, mastercurve shift factors, etc.), which plain
+        # json.dumps() cannot serialize -- route through the same
+        # write_result_arrays() HDF5-array-extraction helper already used
+        # for nlsq_result/nuts_result above, instead of embedding raw arrays
+        # directly in transform.json.
+        raw_extras = {
             k: v
             for k, v in (raw_transform_result or {}).items()
             if k not in ("input", "output")
         }
+        extras_id, extras_shape = _persist_result_dict(
+            raw_extras or None, "transform_results"
+        )
+        transform_dict["result_extras_ref"] = extras_id
+        transform_dict["result_extras_meta"] = extras_shape
         _write_json("transform.json", transform_dict)
 
         _write_json("pipeline.json", dataclasses.asdict(state.pipeline))
@@ -502,7 +517,17 @@ def load_project_v2(path: Path):
 
             transform_dict = json.loads((tmp_root / "transform.json").read_text())
             result_refs = transform_dict.pop("result_refs", {}) or {}
-            result_extras = transform_dict.pop("result_extras", {}) or {}
+            extras_ref = transform_dict.pop("result_extras_ref", None)
+            extras_meta = transform_dict.pop("result_extras_meta", None)
+            if extras_ref is not None:
+                result_extras = (
+                    _restore_result_dict(extras_ref, extras_meta, "transform_results")
+                    or {}
+                )
+            else:
+                # Pre-fix archives (or a run with no extras) stored a
+                # plain JSON-safe dict directly under "result_extras".
+                result_extras = transform_dict.pop("result_extras", {}) or {}
             restored_result: dict | None = None
             if any(result_refs.values()) or result_extras:
                 restored_result = dict(result_extras)

--- a/tests/cli/test_cmd_batch.py
+++ b/tests/cli/test_cmd_batch.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import argparse
+import json
 
 import pytest
 
@@ -91,3 +92,43 @@ class TestMainErrors:
             ]
         )
         assert result == 1
+
+
+class TestMainJsonOutput:
+    @pytest.mark.unit
+    def test_json_stdout_is_valid_json_with_no_extra_text(self, tmp_path, capsys):
+        # Regression: progress lines ("Found N file(s)...", "[i/n] ... OK") used
+        # to print to stdout unconditionally, so `rheojax batch --json` interleaved
+        # them with the final json.dumps(all_results), making stdout unparseable
+        # for a downstream `| jq` or `| rheojax ...` consumer.
+        csv_file = tmp_path / "sample.csv"
+        csv_file.write_text(
+            "time,stress\n"
+            "0.1,4.756\n"
+            "0.5,3.894\n"
+            "1.0,3.033\n"
+            "2.0,1.839\n"
+            "3.0,1.115\n"
+            "4.0,0.677\n"
+            "5.0,0.410\n"
+        )
+
+        result = main(
+            [
+                str(tmp_path / "*.csv"),
+                "--model",
+                "maxwell",
+                "--test-mode",
+                "relaxation",
+                "--max-iter",
+                "50",
+                "--json",
+            ]
+        )
+
+        captured = capsys.readouterr()
+        assert result == 0
+        parsed = json.loads(captured.out)
+        assert isinstance(parsed, list)
+        assert len(parsed) == 1
+        assert parsed[0]["status"] == "success"

--- a/tests/cli/test_cmd_export.py
+++ b/tests/cli/test_cmd_export.py
@@ -3,35 +3,37 @@
 from __future__ import annotations
 
 import argparse
+import json
 
+import numpy as np
 import pytest
 
-from rheojax.cli.cmd_export import create_parser, main
+from rheojax.cli.cmd_export import _build_pipeline_from_envelope, create_parser, main
 
 
 class TestCreateParser:
     @pytest.mark.unit
     def test_returns_argument_parser(self):
         parser = create_parser()
-        assert isinstance(parser, argparse.ArgumentParser)
+        assert isinstance(parser, argparse.ArgumentParser)  # nosec B101
 
     @pytest.mark.unit
     def test_has_input_argument(self):
         parser = create_parser()
         ns = parser.parse_args(["results/", "--output", "out/"])
-        assert ns.input == "results/"
+        assert ns.input == "results/"  # nosec B101
 
     @pytest.mark.unit
     def test_has_output_flag(self):
         parser = create_parser()
         ns = parser.parse_args(["results/", "--output", "bundle.h5"])
-        assert str(ns.output) == "bundle.h5"
+        assert str(ns.output) == "bundle.h5"  # nosec B101
 
     @pytest.mark.unit
     def test_has_format_flag(self):
         parser = create_parser()
         ns = parser.parse_args(["results/", "--output", "out/", "--format", "excel"])
-        assert ns.export_format == "excel"
+        assert ns.export_format == "excel"  # nosec B101
 
     @pytest.mark.unit
     def test_hdf5_format_not_a_valid_choice(self):
@@ -43,13 +45,13 @@ class TestCreateParser:
     def test_has_json_output_flag(self):
         parser = create_parser()
         ns = parser.parse_args(["results/", "--output", "out/", "--json"])
-        assert ns.json_output is True
+        assert ns.json_output is True  # nosec B101
 
     @pytest.mark.unit
     def test_default_format_is_directory(self):
         parser = create_parser()
         ns = parser.parse_args(["results/", "--output", "out/"])
-        assert ns.export_format == "directory"
+        assert ns.export_format == "directory"  # nosec B101
 
 
 class TestMainHelp:
@@ -57,7 +59,7 @@ class TestMainHelp:
     def test_main_help_exits_cleanly(self):
         with pytest.raises(SystemExit) as exc_info:
             main(["--help"])
-        assert exc_info.value.code == 0
+        assert exc_info.value.code == 0  # nosec B101
 
     @pytest.mark.unit
     def test_main_nonexistent_input_returns_1(self, tmp_path, monkeypatch):
@@ -75,4 +77,26 @@ class TestMainHelp:
                 str(tmp_path / "out"),
             ]
         )
-        assert result == 1
+        assert result == 1  # nosec B101
+
+
+class TestBuildPipelineFromEnvelope:
+    @pytest.mark.unit
+    def test_accepts_a_real_create_data_envelope_payload(self):
+        # Regression: _build_pipeline_from_envelope used to read envelope["x"]
+        # directly, but rheojax load --json (create_data_envelope) nests the
+        # payload under envelope["data"]["x"], so every real pipe from
+        # `rheojax load --json | rheojax export -` raised on an empty x/y
+        # array instead of exporting the piped data.
+        from rheojax.cli._envelope import create_data_envelope
+
+        envelope = json.loads(
+            create_data_envelope([0.1, 0.2, 0.3], [10.0, 9.0, 8.0]).to_json()
+        )
+
+        pipe = _build_pipeline_from_envelope(envelope)
+
+        # Same private-attribute access _build_pipeline_from_envelope itself
+        # uses (cmd_export.py: `pipe._data = data  # type: ignore[attr-defined]`).
+        np.testing.assert_array_equal(pipe._data.x, [0.1, 0.2, 0.3])  # type: ignore[attr-defined]
+        np.testing.assert_array_equal(pipe._data.y, [10.0, 9.0, 8.0])  # type: ignore[attr-defined]

--- a/tests/cli/test_cmd_load.py
+++ b/tests/cli/test_cmd_load.py
@@ -124,3 +124,34 @@ class TestMainWithCsv:
         captured = capsys.readouterr()
         parsed = json.loads(captured.out.strip())
         assert isinstance(parsed, dict)
+
+    @pytest.mark.unit
+    def test_main_format_flag_is_forwarded_to_auto_load(self, csv_file, monkeypatch):
+        # Regression: --format was parsed into parsed.file_format but never
+        # added to load_kwargs, so auto_load() always ran its own
+        # extension-based format sniffing and --format was silently a no-op.
+        from rheojax.io import auto_load as real_auto_load
+
+        received_kwargs: dict = {}
+
+        def spy_auto_load(path, **kwargs):
+            received_kwargs.update(kwargs)
+            return real_auto_load(path, **kwargs)
+
+        monkeypatch.setattr("rheojax.io.auto_load", spy_auto_load)
+
+        result = main(
+            [
+                str(csv_file),
+                "--format",
+                "csv",
+                "--x-col",
+                "time",
+                "--y-col",
+                "stress",
+                "--test-mode",
+                "relaxation",
+            ]
+        )
+        assert result == 0
+        assert received_kwargs.get("format") == "csv"

--- a/tests/cli/test_cmd_transform.py
+++ b/tests/cli/test_cmd_transform.py
@@ -4,9 +4,10 @@ from __future__ import annotations
 
 import argparse
 
+import numpy as np
 import pytest
 
-from rheojax.cli.cmd_transform import create_parser, main
+from rheojax.cli.cmd_transform import _load_from_envelope, create_parser, main
 
 
 class TestCreateParser:
@@ -74,3 +75,22 @@ class TestMainErrors:
         csv_file.write_text("time,stress\n0.1,100\n0.2,90\n")
         result = main(["totally_unknown_transform_xyz", "--input", str(csv_file)])
         assert result == 1
+
+
+class TestLoadFromEnvelope:
+    @pytest.mark.unit
+    def test_accepts_a_real_create_data_envelope_payload(self):
+        # Regression: _load_from_envelope used to read envelope["x"] directly,
+        # but rheojax load --json (create_data_envelope) nests the payload under
+        # envelope["data"]["x"], so every real pipe from `rheojax load --json`
+        # raised "missing required 'x' key" before the fix.
+        from rheojax.cli._envelope import create_data_envelope
+
+        envelope_json = create_data_envelope(
+            [0.1, 0.2, 0.3], [10.0, 9.0, 8.0], metadata={"test_mode": "relaxation"}
+        ).to_json()
+
+        data = _load_from_envelope(envelope_json)
+
+        np.testing.assert_array_equal(data.x, [0.1, 0.2, 0.3])
+        np.testing.assert_array_equal(data.y, [10.0, 9.0, 8.0])

--- a/tests/cli/test_main_dispatch.py
+++ b/tests/cli/test_main_dispatch.py
@@ -94,6 +94,24 @@ class TestMainInfo:
         # Should print something version-like
         assert any(char.isdigit() for char in captured.out)
 
+    @pytest.mark.unit
+    def test_main_info_help_exits_0(self, capsys):
+        # Regression: show_info() used to ignore its args entirely, so
+        # `rheojax info --help` silently ran show_info() instead of printing
+        # argparse help and exiting.
+        with pytest.raises(SystemExit) as exc_info:
+            main(["info", "--help"])
+        assert exc_info.value.code == 0
+
+    @pytest.mark.unit
+    def test_main_info_unknown_flag_errors(self, capsys):
+        # Regression: `rheojax info --bogus-flag` used to silently run
+        # show_info() and return 0 instead of an argparse "unrecognized
+        # arguments" error.
+        with pytest.raises(SystemExit) as exc_info:
+            main(["info", "--bogus-flag"])
+        assert exc_info.value.code != 0
+
 
 class TestMainInventory:
     @pytest.mark.unit

--- a/tests/cli/test_yaml_schema.py
+++ b/tests/cli/test_yaml_schema.py
@@ -115,6 +115,26 @@ class TestValidateConfig:
         assert any("num_chains" in e and "between" in e for e in errors)
 
     @pytest.mark.unit
+    def test_bayesian_defaults_num_samples_out_of_range_is_error(self):
+        # Regression: the OOM guard used to read step.get(key), which misses
+        # limits set only via config.defaults (and merged into the step's
+        # effective kwargs at execution time by _yaml_runner.config_to_builder).
+        # A pipeline with no step-local num_samples override, but an unsafe
+        # defaults.num_samples, used to pass validation and then OOM at runtime.
+        config = PipelineConfig(
+            version="1",
+            name="Pipeline",
+            defaults={"num_samples": 999_999},
+            steps=[
+                {"type": "load", "file": "data.csv"},
+                {"type": "fit", "model": "maxwell"},
+                {"type": "bayesian"},
+            ],
+        )
+        errors = validate_config(config)
+        assert any("num_samples" in e and "between" in e for e in errors)
+
+    @pytest.mark.unit
     def test_bayesian_valid_params_pass(self):
         config = PipelineConfig(
             version="1",
@@ -231,7 +251,7 @@ class TestPathSafety:
             name="P",
             steps=[
                 {"type": "load", "file": "data.csv"},
-                {"type": "export", "output": "/tmp/evil"},
+                {"type": "export", "output": "/etc/evil"},
             ],
         )
         errors = validate_config(config)

--- a/tests/gui/foundation/test_project_codec.py
+++ b/tests/gui/foundation/test_project_codec.py
@@ -245,7 +245,10 @@ def test_save_project_v2_multi_dataset_multi_slice_archive(tmp_path):
         assert input_ref is not None and output_ref is not None
         assert f"transform_results/{input_ref}.hdf5" in names
         assert f"transform_results/{output_ref}.hdf5" in names
-        assert transform["result_extras"] == {"warnings": ["clipped 2 points"]}
+        extras_ref = transform["result_extras_ref"]
+        assert extras_ref is not None
+        assert f"transform_results/{extras_ref}.hdf5" in names
+        assert transform["result_extras_meta"] == {"warnings": ["clipped 2 points"]}
 
         pipeline = json.loads(zf.read("pipeline.json"))
         assert pipeline["name"] == "batch-a"

--- a/tests/gui/foundation/test_project_codec.py
+++ b/tests/gui/foundation/test_project_codec.py
@@ -110,6 +110,46 @@ def test_unsupported_leaf_type_raises_type_error(tmp_path):
         write_result_arrays(path, {"bad": Unsupported()})
 
 
+def test_dataclass_and_array_like_extras_roundtrip(tmp_path):
+    # Transform extras (unlike nlsq/nuts results) may hold a transform's own
+    # @dataclass result type (e.g. CoxMerzResult) or a non-ndarray array-like
+    # (e.g. a JAX array) rather than a plain dict/np.ndarray -- both used to
+    # hard-fail with TypeError before _write_walk learned to unwrap them.
+    import dataclasses
+
+    @dataclasses.dataclass
+    class FakeResult:
+        shift_factors: np.ndarray
+        label: str
+
+    class ArrayLike:
+        def __array__(self):
+            return np.array([7.0, 8.0])
+
+    path = tmp_path / "extras_result.hdf5"
+    result = {
+        "cox_merz_result": FakeResult(np.array([1.0, 2.0]), "ok"),
+        "raw": ArrayLike(),
+    }
+    json_shape = write_result_arrays(path, result)
+    restored = read_result_arrays(path, json_shape)
+    np.testing.assert_array_equal(
+        restored["cox_merz_result"]["shift_factors"], [1.0, 2.0]
+    )
+    assert restored["cox_merz_result"]["label"] == "ok"
+    np.testing.assert_array_equal(restored["raw"], [7.0, 8.0])
+
+
+def test_read_result_arrays_rejects_non_dict_json_shape(tmp_path):
+    # A missing/null "*_meta" sibling in a hand-edited or corrupted archive
+    # used to surface as an unhandled AttributeError inside .items() below,
+    # bypassing every caller's "load failed" ValueError/OSError handling.
+    path = tmp_path / "empty.hdf5"
+    write_result_arrays(path, {})
+    with pytest.raises(ValueError, match="expected a dict"):
+        read_result_arrays(path, None)
+
+
 def _dataset_ref(id_):
     return DatasetRef(
         id=id_,
@@ -338,6 +378,40 @@ def test_round_trip_full_state(tmp_path):
     assert loaded.transform.result["protocol_type"] == "oscillation"
     np.testing.assert_array_equal(loaded.transform.result["input"].x, payload.x)
     np.testing.assert_array_equal(loaded.transform.result["output"].x, payload.x)
+
+
+def test_transform_result_extras_array_value_round_trips(tmp_path):
+    """The actual bug this fix addresses: transform.result extras (e.g.
+    TransformWorker's tr.extras -- FFT harmonics, mastercurve shift factors) may hold
+    a numpy array, which plain json.dumps() cannot serialize. Before the fix,
+    transform_dict["result_extras"] embedded raw_extras directly and save_project_v2
+    crashed on any array-valued extras key. test_round_trip_full_state's extras only
+    covered a JSON-safe str value ("protocol_type"), and
+    test_save_project_v2_multi_dataset_multi_slice_archive's extras only covered a
+    JSON-safe list-of-str ("warnings") and never calls load_project_v2 at all -- so
+    neither exercised the array code path this test targets."""
+    state = AppState()
+    state.transform = TransformState(
+        transform_key="fft_analysis",
+        result={
+            "input": RheoData(
+                x=[1.0, 2.0], y=[3.0, 4.0], initial_test_mode="oscillation"
+            ),
+            "output": RheoData(
+                x=[1.0, 2.0], y=[5.0, 6.0], initial_test_mode="oscillation"
+            ),
+            "harmonics": np.array([1.0, 2.0, 3.0, 4.0]),
+        },
+    )
+
+    path = tmp_path / "project.rheojax"
+    save_project_v2(state, path)
+    loaded = load_project_v2(path)
+
+    harmonics = loaded.transform.result["harmonics"]
+    assert isinstance(harmonics, np.ndarray)
+    assert harmonics.dtype == np.array([1.0, 2.0, 3.0, 4.0]).dtype
+    np.testing.assert_array_equal(harmonics, np.array([1.0, 2.0, 3.0, 4.0]))
 
 
 def test_save_project_with_list_valued_transform_input_does_not_crash(tmp_path):


### PR DESCRIPTION
## Summary
Three-brain audit (Codex-driven, each finding verified with a live repro) of `rheojax/cli` and `rheojax/gui/foundation`+`services`.

**cli**
- `cmd_transform`/`cmd_export`: stdin envelope readers expected top-level `x`/`y` but `create_data_envelope()` nests the payload under `"data"` — every real `load --json | transform/export -` pipe was broken. Fixed to read `envelope["data"]`; `export` now errors clearly on a non-`"data"` envelope instead of silently building an empty `RheoData`.
- `cmd_load`: `--format`/`-f` was parsed but never passed to `auto_load()` — the format override was silently ignored.
- `cmd_batch`: progress prints (`Found N files`, per-file `OK`/`FAILED`) went to stdout unconditionally, corrupting `--json` output. Routed to stderr when `--json` is set.
- `main.py`: `rheojax info --help`/unknown args bypassed argparse entirely and always printed package info, unlike the sibling `inventory` subcommand.
- `cmd_run`/`_yaml_schema`: `--override` help examples used bare keys (`model=springpot`) but `apply_overrides()` requires `defaults.*`/`steps.<n>.*` paths; corrected examples. The Bayesian OOM-guard bounds check read the step-local dict instead of the defaults-merged effective view, so `defaults.num_samples` could exceed the 50k limit undetected.

**gui**
- `project_codec.py`: `transform.result` extras (e.g. FFT/mastercurve arrays) were embedded directly in `transform.json` via plain `json.dumps()`, crashing project Save with `TypeError` whenever a transform's extras held a numpy array. Routed through the existing `write_result_arrays`/`read_result_arrays` HDF5 helper already used for nlsq/nuts results, with a legacy-format fallback on load.

## Test plan
- [x] `uv run pytest tests/cli -q` — 244 passed
- [x] `uv run pytest tests/cli tests/gui -q --ignore=tests/gui/test_visual_regression.py` — 1062 passed
- [x] `uv run ruff check rheojax/cli rheojax/gui` — clean
- [x] Manual repro: `load --json | transform --json` pipe and project save/load round-trip with array-bearing transform extras, both verified fixed
- [ ] One pre-existing golden-image visual regression test (`test_residuals_vs_fitted`) fails off-by-1px in this sandbox — traced to this environment's freshly-resolved Python 3.14/matplotlib build, not this change; excluded from the run above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)