### PR TITLE
refactor(io): extract shared column helpers and split load_csv's read block

### DIFF
--- a/rheojax/io/readers/_utils.py
+++ b/rheojax/io/readers/_utils.py
@@ -245,7 +245,7 @@ def get_column_header(df: pd.DataFrame, col: str | int) -> str:
     return str(df.columns[col])
 
 
-def get_column_data(df: pd.DataFrame, col: str | int) -> np.ndarray:
+def get_column_data(df: pd.DataFrame, col: str | int) -> NDArray:
     """Get column data from DataFrame."""
     if isinstance(col, str):
         return df[col].values

--- a/rheojax/io/readers/_utils.py
+++ b/rheojax/io/readers/_utils.py
@@ -41,6 +41,8 @@ __all__ = [
     "normalize_units",
     "normalize_temperature",
     "find_column_by_pattern",
+    "get_column_header",
+    "get_column_data",
 ]
 
 # =============================================================================
@@ -234,6 +236,20 @@ def find_column_by_pattern(
     if len(substring_matches) == 1:
         return substring_matches[0]
     return None
+
+
+def get_column_header(df: pd.DataFrame, col: str | int) -> str:
+    """Get column header string from DataFrame."""
+    if isinstance(col, str):
+        return col
+    return str(df.columns[col])
+
+
+def get_column_data(df: pd.DataFrame, col: str | int) -> np.ndarray:
+    """Get column data from DataFrame."""
+    if isinstance(col, str):
+        return df[col].values
+    return df.iloc[:, col].values
 
 
 # =============================================================================

--- a/rheojax/io/readers/csv_reader.py
+++ b/rheojax/io/readers/csv_reader.py
@@ -20,15 +20,11 @@ from rheojax.io.readers._utils import (
     detect_domain,
     detect_test_mode_from_columns,
     extract_unit_from_header,
+    get_column_data,
+    get_column_header,
     infer_y_unit_from_name,
     normalize_units,
     validate_transform,
-)
-from rheojax.io.readers._utils import (
-    get_column_data as _get_column_data,
-)
-from rheojax.io.readers._utils import (
-    get_column_header as _get_column_header,
 )
 from rheojax.logging import get_logger, log_io
 
@@ -191,11 +187,11 @@ def load_csv(
         logger.debug("Applied column_mapping", mapping=column_mapping)
 
     # Get column headers for detection
-    x_header = _get_column_header(df, x_col)
+    x_header = get_column_header(df, x_col)
 
     # Extract x data
     try:
-        x_data = _get_column_data(df, x_col)
+        x_data = get_column_data(df, x_col)
     except (KeyError, IndexError) as e:
         logger.error("X column not found", x_col=x_col, exc_info=True)
         raise KeyError(f"X column not found: {e}") from e
@@ -206,10 +202,10 @@ def load_csv(
     if is_complex:
         if y_cols is None:  # pragma: no cover — guarded by is_complex
             raise ValueError("y_cols must not be None for complex data")
-        y_headers = [_get_column_header(df, col) for col in y_cols]
+        y_headers = [get_column_header(df, col) for col in y_cols]
         try:
-            g_prime_data = _get_column_data(df, y_cols[0])
-            g_double_prime_data = _get_column_data(df, y_cols[1])
+            g_prime_data = get_column_data(df, y_cols[0])
+            g_double_prime_data = get_column_data(df, y_cols[1])
         except (KeyError, IndexError) as e:
             logger.error("Y column not found", y_cols=y_cols, exc_info=True)
             raise KeyError(f"Y column not found: {e}") from e
@@ -223,9 +219,9 @@ def load_csv(
     else:
         if y_col is None:  # pragma: no cover — guarded by is_complex
             raise ValueError("y_col must not be None for real data")
-        y_headers = [_get_column_header(df, y_col)]
+        y_headers = [get_column_header(df, y_col)]
         try:
-            y_data = _get_column_data(df, y_col)
+            y_data = get_column_data(df, y_col)
         except (KeyError, IndexError) as e:
             logger.error("Y column not found", y_col=y_col, exc_info=True)
             raise KeyError(f"Y column not found: {e}") from e
@@ -395,8 +391,25 @@ def _read_csv_dataframe(
     """Read a CSV/text file into a DataFrame with delimiter/encoding/comment
     auto-detection, tolerant UTF-16 fallback, and corruption checks.
 
+    Args:
+        filepath: Path to the CSV/text file (already confirmed to exist).
+        x_col, y_col, y_cols, column_mapping: Only used to decide whether
+            ``usecols`` can be safely passed to ``pandas.read_csv`` (memory
+            optimization for wide files) -- all column specifiers must be
+            strings and ``column_mapping`` must be None.
+        delimiter: Column delimiter (auto-detected via detect_csv_delimiter
+            if None).
+        encoding: File encoding (BOM/byte-sniffed if None).
+        header: Row number for column headers (None if no header).
+        **kwargs: Additional arguments forwarded to pandas.read_csv.
+
     Returns:
-        (df, used_encoding, default_encoding)
+        (df, used_encoding, default_encoding) -- used_encoding differs from
+        default_encoding only when the UTF-16 fallback path was triggered.
+
+    Raises:
+        ValueError: If the file cannot be parsed under any tried encoding,
+            or if numeric-column encoding corruption is detected.
     """
     # Auto-detect delimiter if not specified
     if delimiter is None:

--- a/rheojax/io/readers/csv_reader.py
+++ b/rheojax/io/readers/csv_reader.py
@@ -24,6 +24,12 @@ from rheojax.io.readers._utils import (
     normalize_units,
     validate_transform,
 )
+from rheojax.io.readers._utils import (
+    get_column_data as _get_column_data,
+)
+from rheojax.io.readers._utils import (
+    get_column_header as _get_column_header,
+)
 from rheojax.logging import get_logger, log_io
 
 logger = get_logger(__name__)
@@ -161,173 +167,17 @@ def load_csv(
             f"Valid options: {sorted(VALID_TRANSFORMS)}"
         )
 
-    # Auto-detect delimiter if not specified
-    if delimiter is None:
-        delimiter = detect_csv_delimiter(filepath)
-        logger.debug("Auto-detected delimiter", delimiter=repr(delimiter))
-
-    # Choose encoding: explicit parameter > BOM/byte sniffing > default
-    if encoding is not None:
-        default_encoding = encoding
-        logger.debug("Using explicit encoding", encoding=encoding)
-    else:
-        default_encoding = "utf-8-sig"
-        try:
-            with open(filepath, "rb") as f:
-                head_bytes = f.read(4)
-            if (
-                b"\xff\xfe" in head_bytes
-                or b"\xfe\xff" in head_bytes
-                or b"\x00" in head_bytes
-            ):
-                default_encoding = "utf-16"
-            logger.debug("Auto-detected encoding", encoding=default_encoding)
-        except FileNotFoundError:
-            raise
-
-    # Build list of columns to load (memory optimization for wide files)
-    # Only use usecols when all column specifiers are strings (not indices)
-    # Skip when column_mapping is provided — file columns differ from target names
-    usecols = None
-    if column_mapping is not None:
-        pass  # Cannot use usecols with column_mapping (file has pre-rename names)
-    elif isinstance(x_col, str):
-        cols_needed = [x_col]
-        if y_col is not None and isinstance(y_col, str):
-            cols_needed.append(y_col)
-        elif y_cols is not None:
-            cols_needed.extend([c for c in y_cols if isinstance(c, str)])
-        # Only set usecols if all columns are strings
-        if len(cols_needed) == (1 + (1 if y_col is not None else len(y_cols or []))):
-            usecols = cols_needed
-
-    # Auto-detect comment preamble: if file starts with '#' lines and user
-    # hasn't explicitly set a comment character, pass comment='#' to pandas.
-    # Skip this when the requested columns already carry a literal '#'
-    # prefix (e.g. auto-detected from a raw "#time,stress" header): that
-    # means the '#' is part of the header itself, not a preamble marker,
-    # and stripping it here would make usecols/header disagree.
-    comment_char = kwargs.pop("comment", None)
-    has_hash_column = any(
-        isinstance(c, str) and c.startswith("#") for c in (usecols or [])
-    )
-    if comment_char is None and header == 0 and not has_hash_column:
-        try:
-            with open(filepath, encoding=default_encoding, errors="replace") as _f:
-                first_line = _f.readline()
-            if first_line.startswith("#"):
-                comment_char = "#"
-                logger.debug("Auto-detected '#' comment preamble")
-        except (OSError, UnicodeDecodeError):
-            logger.debug("Could not peek at file for comment detection")
-
-    # Read CSV file with tolerant encoding/dialect handling.
-    # "replace" kwarg is kept as the tolerant fallback; "strict" is tried first
-    # so that silent corruption is caught and logged before falling back.
-    read_kwargs = dict(
-        sep=delimiter,
+    df, used_encoding, default_encoding = _read_csv_dataframe(
+        filepath,
+        x_col=x_col,
+        y_col=y_col,
+        y_cols=y_cols,
+        column_mapping=column_mapping,
+        delimiter=delimiter,
+        encoding=encoding,
         header=header,
-        encoding=default_encoding,
-        encoding_errors="replace",
-        engine="python",
-        usecols=usecols,
-        comment=comment_char,
         **kwargs,
     )
-    tried_utf16 = False
-
-    used_encoding = default_encoding
-
-    with log_io(logger, "read", filepath=str(filepath)) as io_ctx:
-        try:
-            # Try strict encoding first to detect corruption early
-            logger.debug(
-                "Reading CSV file (strict encoding)", encoding=default_encoding
-            )
-            df = pd.read_csv(filepath, **{**read_kwargs, "encoding_errors": "strict"})
-        except UnicodeDecodeError:
-            # Strict failed — fall back to replacement characters with a warning
-            logger.warning(
-                "Encoding errors in CSV file — using replacement characters",
-                filepath=str(filepath),
-                encoding=default_encoding,
-            )
-            try:
-                df = pd.read_csv(filepath, **read_kwargs)
-            except UnicodeDecodeError:
-                read_kwargs["encoding"] = "utf-16le"
-                tried_utf16 = True
-                logger.info(
-                    "Encoding fallback triggered",
-                    filepath=str(filepath),
-                    from_encoding=default_encoding,
-                    to_encoding="utf-16le",
-                )
-                df = pd.read_csv(filepath, **read_kwargs)
-                used_encoding = "utf-16le"
-        except Exception as e:
-            # If UTF-8 path failed and we haven't tried utf-16, attempt before giving up
-            if not tried_utf16:
-                try:
-                    read_kwargs["encoding"] = "utf-16le"
-                    logger.info(
-                        "Encoding fallback triggered",
-                        filepath=str(filepath),
-                        from_encoding=default_encoding,
-                        to_encoding="utf-16le",
-                    )
-                    df = pd.read_csv(filepath, **read_kwargs)
-                    used_encoding = "utf-16le"
-                except Exception:
-                    logger.error(
-                        "Failed to parse CSV file",
-                        filepath=str(filepath),
-                        tried_encodings=[default_encoding, "utf-16le"],
-                        exc_info=True,
-                    )
-                    raise ValueError(f"Failed to parse CSV file: {e}") from e
-            else:
-                logger.error(
-                    "Failed to parse CSV file",
-                    filepath=str(filepath),
-                    tried_encodings=[default_encoding, "utf-16le"],
-                    exc_info=True,
-                )
-                raise ValueError(f"Failed to parse CSV file: {e}") from e
-
-        # VIS-CSV-001: Check for encoding replacement artifacts without
-        # materialising .astype(str) twice per column. Cache col_str and reuse
-        # it for both the detection pass and the numeric-corruption check.
-        affected_cols: list[str] = []
-        for col in df.columns:
-            col_str = df[col].astype(str)  # single materialisation per column
-            if col_str.str.contains("\ufffd", na=False).any():
-                affected_cols.append(col)
-                # Reuse col_str — no second astype(str) needed
-                sample = col_str.str.replace("\ufffd", "", regex=False)
-                if sample.str.match(r"^[\d.eE+\-,]*\d[\d.eE+\-,]*$", na=False).any():
-                    raise ValueError(
-                        f"Encoding corruption detected in numeric column '{col}'. "
-                        f"The file may need to be re-exported with UTF-8 encoding. "
-                        f"Affected file: {filepath}"
-                    )
-        if affected_cols:
-            logger.warning(
-                "Encoding replacement characters (\\ufffd) detected in CSV file — "
-                "some values may be corrupted",
-                filepath=str(filepath),
-                affected_columns=affected_cols,
-            )
-
-        io_ctx["rows"] = len(df)
-        io_ctx["columns"] = len(df.columns)
-        io_ctx["encoding"] = used_encoding
-        logger.debug(
-            "CSV file read successfully",
-            n_rows=len(df),
-            n_cols=len(df.columns),
-            encoding=used_encoding,
-        )
 
     # Guard: check for tensile/E* columns/units/mode. Must run on the
     # original file headers (before column_mapping renaming) — otherwise
@@ -530,18 +380,193 @@ def load_csv(
     )
 
 
-def _get_column_header(df: pd.DataFrame, col: str | int) -> str:
-    """Get column header string from DataFrame."""
-    if isinstance(col, str):
-        return col
-    return str(df.columns[col])
+def _read_csv_dataframe(
+    filepath: Path,
+    *,
+    x_col: str | int,
+    y_col: str | int | None,
+    y_cols: list[str | int] | None,
+    column_mapping: dict[str, str] | None,
+    delimiter: str | None,
+    encoding: str | None,
+    header: int | None,
+    **kwargs,
+) -> tuple[pd.DataFrame, str, str]:
+    """Read a CSV/text file into a DataFrame with delimiter/encoding/comment
+    auto-detection, tolerant UTF-16 fallback, and corruption checks.
 
+    Returns:
+        (df, used_encoding, default_encoding)
+    """
+    # Auto-detect delimiter if not specified
+    if delimiter is None:
+        delimiter = detect_csv_delimiter(filepath)
+        logger.debug("Auto-detected delimiter", delimiter=repr(delimiter))
 
-def _get_column_data(df: pd.DataFrame, col: str | int) -> np.ndarray:
-    """Get column data from DataFrame."""
-    if isinstance(col, str):
-        return df[col].values
-    return df.iloc[:, col].values
+    # Choose encoding: explicit parameter > BOM/byte sniffing > default
+    if encoding is not None:
+        default_encoding = encoding
+        logger.debug("Using explicit encoding", encoding=encoding)
+    else:
+        default_encoding = "utf-8-sig"
+        try:
+            with open(filepath, "rb") as f:
+                head_bytes = f.read(4)
+            if (
+                b"\xff\xfe" in head_bytes
+                or b"\xfe\xff" in head_bytes
+                or b"\x00" in head_bytes
+            ):
+                default_encoding = "utf-16"
+            logger.debug("Auto-detected encoding", encoding=default_encoding)
+        except FileNotFoundError:
+            raise
+
+    # Build list of columns to load (memory optimization for wide files)
+    # Only use usecols when all column specifiers are strings (not indices)
+    # Skip when column_mapping is provided — file columns differ from target names
+    usecols = None
+    if column_mapping is not None:
+        pass  # Cannot use usecols with column_mapping (file has pre-rename names)
+    elif isinstance(x_col, str):
+        cols_needed = [x_col]
+        if y_col is not None and isinstance(y_col, str):
+            cols_needed.append(y_col)
+        elif y_cols is not None:
+            cols_needed.extend([c for c in y_cols if isinstance(c, str)])
+        # Only set usecols if all columns are strings
+        if len(cols_needed) == (1 + (1 if y_col is not None else len(y_cols or []))):
+            usecols = cols_needed
+
+    # Auto-detect comment preamble: if file starts with '#' lines and user
+    # hasn't explicitly set a comment character, pass comment='#' to pandas.
+    # Skip this when the requested columns already carry a literal '#'
+    # prefix (e.g. auto-detected from a raw "#time,stress" header): that
+    # means the '#' is part of the header itself, not a preamble marker,
+    # and stripping it here would make usecols/header disagree.
+    comment_char = kwargs.pop("comment", None)
+    has_hash_column = any(
+        isinstance(c, str) and c.startswith("#") for c in (usecols or [])
+    )
+    if comment_char is None and header == 0 and not has_hash_column:
+        try:
+            with open(filepath, encoding=default_encoding, errors="replace") as _f:
+                first_line = _f.readline()
+            if first_line.startswith("#"):
+                comment_char = "#"
+                logger.debug("Auto-detected '#' comment preamble")
+        except (OSError, UnicodeDecodeError):
+            logger.debug("Could not peek at file for comment detection")
+
+    # Read CSV file with tolerant encoding/dialect handling.
+    # "replace" kwarg is kept as the tolerant fallback; "strict" is tried first
+    # so that silent corruption is caught and logged before falling back.
+    read_kwargs = dict(
+        sep=delimiter,
+        header=header,
+        encoding=default_encoding,
+        encoding_errors="replace",
+        engine="python",
+        usecols=usecols,
+        comment=comment_char,
+        **kwargs,
+    )
+    tried_utf16 = False
+
+    used_encoding = default_encoding
+
+    with log_io(logger, "read", filepath=str(filepath)) as io_ctx:
+        try:
+            # Try strict encoding first to detect corruption early
+            logger.debug(
+                "Reading CSV file (strict encoding)", encoding=default_encoding
+            )
+            df = pd.read_csv(filepath, **{**read_kwargs, "encoding_errors": "strict"})
+        except UnicodeDecodeError:
+            # Strict failed — fall back to replacement characters with a warning
+            logger.warning(
+                "Encoding errors in CSV file — using replacement characters",
+                filepath=str(filepath),
+                encoding=default_encoding,
+            )
+            try:
+                df = pd.read_csv(filepath, **read_kwargs)
+            except UnicodeDecodeError:
+                read_kwargs["encoding"] = "utf-16le"
+                tried_utf16 = True
+                logger.info(
+                    "Encoding fallback triggered",
+                    filepath=str(filepath),
+                    from_encoding=default_encoding,
+                    to_encoding="utf-16le",
+                )
+                df = pd.read_csv(filepath, **read_kwargs)
+                used_encoding = "utf-16le"
+        except Exception as e:
+            # If UTF-8 path failed and we haven't tried utf-16, attempt before giving up
+            if not tried_utf16:
+                try:
+                    read_kwargs["encoding"] = "utf-16le"
+                    logger.info(
+                        "Encoding fallback triggered",
+                        filepath=str(filepath),
+                        from_encoding=default_encoding,
+                        to_encoding="utf-16le",
+                    )
+                    df = pd.read_csv(filepath, **read_kwargs)
+                    used_encoding = "utf-16le"
+                except Exception:
+                    logger.error(
+                        "Failed to parse CSV file",
+                        filepath=str(filepath),
+                        tried_encodings=[default_encoding, "utf-16le"],
+                        exc_info=True,
+                    )
+                    raise ValueError(f"Failed to parse CSV file: {e}") from e
+            else:
+                logger.error(
+                    "Failed to parse CSV file",
+                    filepath=str(filepath),
+                    tried_encodings=[default_encoding, "utf-16le"],
+                    exc_info=True,
+                )
+                raise ValueError(f"Failed to parse CSV file: {e}") from e
+
+        # VIS-CSV-001: Check for encoding replacement artifacts without
+        # materialising .astype(str) twice per column. Cache col_str and reuse
+        # it for both the detection pass and the numeric-corruption check.
+        affected_cols: list[str] = []
+        for col in df.columns:
+            col_str = df[col].astype(str)  # single materialisation per column
+            if col_str.str.contains("\ufffd", na=False).any():
+                affected_cols.append(col)
+                # Reuse col_str — no second astype(str) needed
+                sample = col_str.str.replace("\ufffd", "", regex=False)
+                if sample.str.match(r"^[\d.eE+\-,]*\d[\d.eE+\-,]*$", na=False).any():
+                    raise ValueError(
+                        f"Encoding corruption detected in numeric column '{col}'. "
+                        f"The file may need to be re-exported with UTF-8 encoding. "
+                        f"Affected file: {filepath}"
+                    )
+        if affected_cols:
+            logger.warning(
+                "Encoding replacement characters (\\ufffd) detected in CSV file — "
+                "some values may be corrupted",
+                filepath=str(filepath),
+                affected_columns=affected_cols,
+            )
+
+        io_ctx["rows"] = len(df)
+        io_ctx["columns"] = len(df.columns)
+        io_ctx["encoding"] = used_encoding
+        logger.debug(
+            "CSV file read successfully",
+            n_rows=len(df),
+            n_cols=len(df.columns),
+            encoding=used_encoding,
+        )
+
+    return df, used_encoding, default_encoding
 
 
 def _looks_like_eu_thousands(val: str) -> bool:

--- a/rheojax/io/readers/excel_reader.py
+++ b/rheojax/io/readers/excel_reader.py
@@ -18,15 +18,11 @@ from rheojax.io.readers._utils import (
     detect_domain,
     detect_test_mode_from_columns,
     extract_unit_from_header,
+    get_column_data,
+    get_column_header,
     infer_y_unit_from_name,
     normalize_units,
     validate_transform,
-)
-from rheojax.io.readers._utils import (
-    get_column_data as _get_column_data,
-)
-from rheojax.io.readers._utils import (
-    get_column_header as _get_column_header,
 )
 from rheojax.io.readers.csv_reader import _to_float
 from rheojax.logging import get_logger
@@ -222,11 +218,11 @@ def load_excel(
         logger.debug("Applied column_mapping", mapping=column_mapping)
 
     # Get column headers for detection
-    x_header = _get_column_header(df, x_col)
+    x_header = get_column_header(df, x_col)
 
     # Extract x data
     try:
-        x_data = _get_column_data(df, x_col)
+        x_data = get_column_data(df, x_col)
     except (KeyError, IndexError) as e:
         logger.error("X column not found", x_col=x_col, exc_info=True)
         raise KeyError(f"X column not found: {e}") from e
@@ -237,10 +233,10 @@ def load_excel(
     if is_complex:
         if y_cols is None:  # pragma: no cover — guarded by is_complex
             raise ValueError("y_cols must not be None for complex data")
-        y_headers = [_get_column_header(df, col) for col in y_cols]
+        y_headers = [get_column_header(df, col) for col in y_cols]
         try:
-            g_prime_data = _get_column_data(df, y_cols[0])
-            g_double_prime_data = _get_column_data(df, y_cols[1])
+            g_prime_data = get_column_data(df, y_cols[0])
+            g_double_prime_data = get_column_data(df, y_cols[1])
         except (KeyError, IndexError) as e:
             logger.error("Y column not found", y_cols=y_cols, exc_info=True)
             raise KeyError(f"Y column not found: {e}") from e
@@ -255,9 +251,9 @@ def load_excel(
     else:
         if y_col is None:  # pragma: no cover — guarded by is_complex
             raise ValueError("y_col must not be None for real data")
-        y_headers = [_get_column_header(df, y_col)]
+        y_headers = [get_column_header(df, y_col)]
         try:
-            y_data = _get_column_data(df, y_col)
+            y_data = get_column_data(df, y_col)
         except (KeyError, IndexError) as e:
             logger.error("Y column not found", y_col=y_col, exc_info=True)
             raise KeyError(f"Y column not found: {e}") from e

--- a/rheojax/io/readers/excel_reader.py
+++ b/rheojax/io/readers/excel_reader.py
@@ -22,6 +22,12 @@ from rheojax.io.readers._utils import (
     normalize_units,
     validate_transform,
 )
+from rheojax.io.readers._utils import (
+    get_column_data as _get_column_data,
+)
+from rheojax.io.readers._utils import (
+    get_column_header as _get_column_header,
+)
 from rheojax.io.readers.csv_reader import _to_float
 from rheojax.logging import get_logger
 
@@ -404,17 +410,3 @@ def load_excel(
         metadata=final_metadata,
         validate=True,
     )
-
-
-def _get_column_header(df, col: str | int) -> str:
-    """Get column header string from DataFrame."""
-    if isinstance(col, str):
-        return col
-    return str(df.columns[col])
-
-
-def _get_column_data(df, col: str | int):
-    """Get column data from DataFrame."""
-    if isinstance(col, str):
-        return df[col].values
-    return df.iloc[:, col].values

--- a/tests/io/test_csv_detection.py
+++ b/tests/io/test_csv_detection.py
@@ -147,3 +147,64 @@ def test_load_csv_percent_strain_normalized_to_fraction(tmp_path: Path):
 
     assert data.y_units == "dimensionless"
     np.testing.assert_allclose(data.y, [0.05, 0.10])
+
+
+def test_load_csv_unparseable_file_raises_value_error(tmp_path: Path):
+    """A structurally malformed CSV (unterminated quote) must fail through
+    _read_csv_dataframe's generic `except Exception` branch: the first
+    strict-encoding read raises pandas.errors.ParserError, the utf-16le
+    retry also fails (garbled headers), and the function must give up with
+    a ValueError rather than letting the ParserError or the retry's
+    unrelated ValueError propagate raw."""
+    csv_path = tmp_path / "malformed.csv"
+    _write(csv_path, 'time,stress\n1,"5.5\n2,6.0\n')
+
+    with pytest.raises(ValueError, match="Failed to parse CSV file"):
+        load_csv(csv_path, x_col="time", y_col="stress")
+
+
+def test_read_csv_dataframe_corrupted_numeric_column_raises(tmp_path: Path):
+    """VIS-CSV-001: a replacement character (U+FFFD) inside a value that
+    otherwise looks numeric must raise -- silently keeping corrupted
+    numeric data would poison a downstream fit."""
+    from rheojax.io.readers.csv_reader import _read_csv_dataframe
+
+    csv_path = tmp_path / "corrupt_numeric.csv"
+    csv_path.write_bytes(b"time,stress\n1.0,5\xff5\n2.0,6.0\n")
+
+    with pytest.raises(
+        ValueError, match="Encoding corruption detected in numeric column"
+    ):
+        _read_csv_dataframe(
+            csv_path,
+            x_col="time",
+            y_col="stress",
+            y_cols=None,
+            column_mapping=None,
+            delimiter=None,
+            encoding=None,
+            header=0,
+        )
+
+
+def test_read_csv_dataframe_corrupted_non_numeric_column_warns_only(tmp_path: Path):
+    """VIS-CSV-001: a replacement character inside a non-numeric-looking
+    value (e.g. a text label) must not raise -- only numeric columns are
+    treated as corruption, since text-mode data is expected to carry all
+    kinds of arbitrary characters."""
+    from rheojax.io.readers.csv_reader import _read_csv_dataframe
+
+    csv_path = tmp_path / "corrupt_label.csv"
+    csv_path.write_bytes(b"time,label\n1.0,ab\xffcd\n2.0,xyz\n")
+
+    df, used_encoding, default_encoding = _read_csv_dataframe(
+        csv_path,
+        x_col="time",
+        y_col="label",
+        y_cols=None,
+        column_mapping=None,
+        delimiter=None,
+        encoding=None,
+        header=0,
+    )
+    assert "�" in df["label"].iloc[0]


### PR DESCRIPTION
## Summary

Behavior-preserving structural refactor of `rheojax/io/readers/` via `/orch-refine-code`, scoped to the small/safe items approved for this pass (deduplication + long-function splitting). The fractional-model `_fit` conversion and two other candidates were investigated and explicitly declined — see below.

- Moved the duplicated `_get_column_header`/`_get_column_data` helpers out of `csv_reader.py` and `excel_reader.py` into the shared `io/readers/_utils.py` (matching the existing shared-helper pattern both readers already use for other utilities), added to `_utils.py`'s `__all__` for consistency.
- Extracted `load_csv()`'s delimiter/encoding/comment-preamble detection and tolerant CSV read (UTF-16 fallback, corruption checks) — previously ~166 lines inline — into a new `_read_csv_dataframe()` helper. `load_csv()` drops from ~495 to ~210 lines. Done via precise line-slicing from the git blob (not manual retyping) to avoid transcription errors.

## Declined (investigated, not applied — with reasons)

- **`load_excel()` further splitting** — remaining bulk is linear procedural param-threading (many independent scalar inputs flowing straight into a metadata dict); splitting would just relocate the same parameter list into a new signature without reducing real complexity.
- **`parse_trios_csv()` first-table/next-table dedup** — the two blocks look like copy-pasted duplicates but aren't identical: the first table's unit-row detection checks a 20-cell evidence window, the "next table" logic only checks 6. Unifying requires picking one behavior — a correctness change, not a structural one. Flagging as a separate defect worth its own investigation.
- **Fractional models `_fit` → `BaseModel._standard_nlsq_fit`** (originally in scope) — `_standard_nlsq_fit`'s failure-path validation is strictly more lenient than the fractional models' current unconditional `raise` (it warns-and-continues when the optimizer reports `!success` but the cost is finite and below `1e6*n_points`). The existing test suite exercises success paths, not this marginal-failure divergence, so it can't serve as a safety net for the leniency change per `/orch-refine-code`'s behavior-neutral contract. This belongs in a `/orch-change-feature` pass.
- Deleting a stray untracked `.bak` test file was skipped — it's untracked in git (only lives in the shared main checkout, outside any commit), and that checkout currently has unrelated in-progress `rheojax/gui/` work from another session.

## Verification

- `tests/io/` + `tests/models/fractional/`: 773/773 passed (baseline, before any change)
- `tests/io/`: 525/525 passed (after column-helper extraction)
- `tests/io/`: 525/525 passed (after `load_csv` split)
- `ruff check`: clean
- `mypy`: unchanged at 39 pre-existing errors (none in the touched files)
- Independent Gate-2 code-review agent verified the extracted function body is byte-identical to the original inline block, and traced the one behavioral-looking difference (`kwargs.pop("comment", ...)` now mutating a copy inside the new helper rather than `load_csv`'s own dict) to confirm it's inert — nothing downstream reads that key. **Verdict: APPROVE, genuinely behavior-neutral.**

## Test plan

- [x] `tests/io/` full suite green before and after
- [x] `ruff check` clean
- [x] `mypy` error count unchanged
- [x] Independent code-review pass for behavior-neutrality

🤖 Generated with [Claude Code](https://claude.com/claude-code)