### PR TITLE
fix(io): close unhandled-exception gap in CSV encoding fallback chain

### DIFF
--- a/rheojax/io/readers/csv_reader.py
+++ b/rheojax/io/readers/csv_reader.py
@@ -484,66 +484,64 @@ def _read_csv_dataframe(
         comment=comment_char,
         **kwargs,
     )
-    tried_utf16 = False
-
     used_encoding = default_encoding
 
     with log_io(logger, "read", filepath=str(filepath)) as io_ctx:
+        logger.debug("Reading CSV file (strict encoding)", encoding=default_encoding)
         try:
             # Try strict encoding first to detect corruption early
-            logger.debug(
-                "Reading CSV file (strict encoding)", encoding=default_encoding
-            )
             df = pd.read_csv(filepath, **{**read_kwargs, "encoding_errors": "strict"})
-        except UnicodeDecodeError:
-            # Strict failed — fall back to replacement characters with a warning
-            logger.warning(
-                "Encoding errors in CSV file — using replacement characters",
-                filepath=str(filepath),
-                encoding=default_encoding,
-            )
-            try:
-                df = pd.read_csv(filepath, **read_kwargs)
-            except UnicodeDecodeError:
-                read_kwargs["encoding"] = "utf-16le"
-                tried_utf16 = True
-                logger.info(
-                    "Encoding fallback triggered",
+        except Exception as strict_exc:
+            # Build the fallback plan: retry with replacement characters at the
+            # same encoding only if strict decoding itself failed (only a
+            # decode error is something "replace" mode can fix); always try
+            # utf-16le as the last resort. Every candidate is read through the
+            # SAME try/except below, so no exception -- regardless of type or
+            # which attempt raises it -- can escape this function unhandled
+            # and unlogged (see #115: a previous nested-try version let a
+            # non-UnicodeDecodeError failure from an inner retry propagate
+            # raw, since a sibling `except` cannot catch an exception raised
+            # inside another `except` block of the same `try` statement).
+            fallback_attempts: list[tuple[str, dict]] = []
+            if isinstance(strict_exc, UnicodeDecodeError):
+                logger.warning(
+                    "Encoding errors in CSV file — using replacement characters",
                     filepath=str(filepath),
-                    from_encoding=default_encoding,
-                    to_encoding="utf-16le",
+                    encoding=default_encoding,
                 )
-                df = pd.read_csv(filepath, **read_kwargs)
-                used_encoding = "utf-16le"
-        except Exception as e:
-            # If UTF-8 path failed and we haven't tried utf-16, attempt before giving up
-            if not tried_utf16:
-                try:
-                    read_kwargs["encoding"] = "utf-16le"
+                fallback_attempts.append((default_encoding, dict(read_kwargs)))
+            fallback_attempts.append(
+                ("utf-16le", {**read_kwargs, "encoding": "utf-16le"})
+            )
+
+            df = None
+            last_exc: Exception = strict_exc
+            tried_encodings = [default_encoding]
+            for candidate_encoding, candidate_kwargs in fallback_attempts:
+                if candidate_encoding not in tried_encodings:
+                    tried_encodings.append(candidate_encoding)
+                if candidate_encoding == "utf-16le":
                     logger.info(
                         "Encoding fallback triggered",
                         filepath=str(filepath),
                         from_encoding=default_encoding,
                         to_encoding="utf-16le",
                     )
-                    df = pd.read_csv(filepath, **read_kwargs)
-                    used_encoding = "utf-16le"
-                except Exception:
-                    logger.error(
-                        "Failed to parse CSV file",
-                        filepath=str(filepath),
-                        tried_encodings=[default_encoding, "utf-16le"],
-                        exc_info=True,
-                    )
-                    raise ValueError(f"Failed to parse CSV file: {e}") from e
-            else:
+                try:
+                    df = pd.read_csv(filepath, **candidate_kwargs)
+                    used_encoding = candidate_encoding
+                    break
+                except Exception as candidate_exc:
+                    last_exc = candidate_exc
+
+            if df is None:
                 logger.error(
                     "Failed to parse CSV file",
                     filepath=str(filepath),
-                    tried_encodings=[default_encoding, "utf-16le"],
+                    tried_encodings=tried_encodings,
                     exc_info=True,
                 )
-                raise ValueError(f"Failed to parse CSV file: {e}") from e
+                raise ValueError(f"Failed to parse CSV file: {last_exc}") from last_exc
 
         # VIS-CSV-001: Check for encoding replacement artifacts without
         # materialising .astype(str) twice per column. Cache col_str and reuse

--- a/tests/io/test_csv_detection.py
+++ b/tests/io/test_csv_detection.py
@@ -208,3 +208,42 @@ def test_read_csv_dataframe_corrupted_non_numeric_column_warns_only(tmp_path: Pa
         header=0,
     )
     assert "�" in df["label"].iloc[0]
+
+
+def test_read_csv_dataframe_nested_retry_failure_is_wrapped(tmp_path: Path):
+    """Regression test for #115.
+
+    A file with BOTH an invalid encoding byte (so the strict-mode read
+    raises UnicodeDecodeError, entering the replacement-character retry
+    path) AND a structurally malformed row (an unterminated quote, so the
+    replace-mode retry raises pandas.errors.ParserError instead of
+    succeeding or raising another UnicodeDecodeError) used to escape
+    _read_csv_dataframe completely unhandled and unlogged: a sibling
+    `except Exception` cannot catch an exception raised inside another
+    `except` block of the same `try` statement, so the ParserError
+    propagated raw past every handler in the function.
+
+    Note pandas.errors.ParserError subclasses ValueError, so a naive
+    ``pytest.raises(ValueError)`` would pass even with the bug present --
+    this test asserts the *exact* exception type and message prefix to
+    distinguish "our deliberately wrapped ValueError" from "an unrelated
+    ValueError subclass that leaked out unwrapped".
+    """
+    from rheojax.io.readers.csv_reader import _read_csv_dataframe
+
+    csv_path = tmp_path / "corrupt_and_malformed.csv"
+    csv_path.write_bytes(b'time,label\n1.0,"ab\xffcd\n2.0,xyz\n')
+
+    with pytest.raises(ValueError, match="Failed to parse CSV file") as exc_info:
+        _read_csv_dataframe(
+            csv_path,
+            x_col="time",
+            y_col="label",
+            y_cols=None,
+            column_mapping=None,
+            delimiter=None,
+            encoding=None,
+            header=0,
+        )
+
+    assert type(exc_info.value) is ValueError


### PR DESCRIPTION
## Summary

Fixes #115 — a pre-existing bug found during PR #113's review, where `_read_csv_dataframe()`'s encoding-fallback chain let an exception escape completely unhandled and unlogged.

**Root cause:** the fallback logic was three levels of nested `try/except`. If the replace-mode retry raised anything other than `UnicodeDecodeError`, or if the innermost utf-16le retry raised anything at all, the exception propagated raw out of the function — a sibling `except Exception` cannot catch an exception raised inside another `except` block of the *same* `try` statement, and the innermost retry had no `try/except` of its own.

**Fix:** restructured the chain into a flat loop over fallback candidates (replace-mode-same-encoding only when the initial failure was a decode error, then always utf-16le as the last resort), all read through one shared `try/except` inside the loop — so no attempt's exception, of any type, can escape uncaught.

Two side effects of the restructuring, both disclosed and intentional:
- Each candidate now builds its own `read_kwargs` dict instead of mutating a shared one in place (the old code's `read_kwargs["encoding"] = "utf-16le"` mutated the same dict object across attempts).
- The final error message now reports the *most recent* failure (`last_exc`) instead of always the first attempt's exception — by the time three fallbacks have been tried, the first exception is often the least relevant one.

## Verification

- Reproduced the bug empirically before fixing: a file with an invalid encoding byte (triggers strict-mode `UnicodeDecodeError`, entering the retry path) combined with an unterminated quote (makes the replace-mode retry raise `pandas.errors.ParserError` instead of succeeding) escaped every handler and propagated as a raw, unwrapped `ParserError`. Note `ParserError` subclasses `ValueError`, so a naive `pytest.raises(ValueError)` check would have passed even with the bug present — the new regression test asserts the exact exception type (`type(exc_info.value) is ValueError`) in addition to the message, to actually distinguish "our deliberately wrapped ValueError" from "an unrelated ValueError subclass that leaked out."
- `tests/io/`: 529/529 pass (528 baseline + 1 new regression test)
- `ruff check`: clean
- `mypy`: unchanged at 39 pre-existing errors (none in the touched file)
- Independent review by a second agent, which verified the fix against the pre-fix code by stashing only the source file (test left in place) and confirming the regression test fails pre-fix / passes post-fix, then traced all four previously-working code paths for behavior parity. **Verdict: APPROVE, no findings.**

## Test plan

- [x] Regression test reproduces the original bug against pre-fix code (verified by an independent reviewer via git stash)
- [x] `tests/io/` full suite green
- [x] `ruff check` clean
- [x] `mypy` error count unchanged
- [x] Independent adversarial review of the exception-handling correctness

🤖 Generated with [Claude Code](https://claude.com/claude-code)