### PR TITLE
ci: pin codeql-action and gitleaks-action to commit SHAs

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -30,13 +30,13 @@ jobs:
     - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
     - name: Initialize CodeQL
-      uses: github/codeql-action/init@v4
+      uses: github/codeql-action/init@ff2f1c621b7f889edc0d3c761ac2e6a3f8cdb0dd # v4.37.7
       with:
         languages: python
         queries: +security-extended
 
     - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@v4
+      uses: github/codeql-action/analyze@ff2f1c621b7f889edc0d3c761ac2e6a3f8cdb0dd # v4.37.7
       with:
         category: "/language:python"
 
@@ -67,7 +67,7 @@ jobs:
 
     - name: Upload SARIF
       if: always()
-      uses: github/codeql-action/upload-sarif@v4
+      uses: github/codeql-action/upload-sarif@ff2f1c621b7f889edc0d3c761ac2e6a3f8cdb0dd # v4.37.7
       with:
         sarif_file: semgrep.sarif
         category: semgrep
@@ -82,7 +82,7 @@ jobs:
         fetch-depth: 0
 
     - name: Run Gitleaks
-      uses: gitleaks/gitleaks-action@v2
+      uses: gitleaks/gitleaks-action@ff98106e4c7b2bc287b24eaf42907196329070c7 # v2.3.9
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
@@ -108,7 +108,7 @@ jobs:
 
     - name: Upload Trivy SARIF
       if: always()
-      uses: github/codeql-action/upload-sarif@v4
+      uses: github/codeql-action/upload-sarif@ff2f1c621b7f889edc0d3c761ac2e6a3f8cdb0dd # v4.37.7
       with:
         sarif_file: trivy-results.sarif
         category: trivy


### PR DESCRIPTION
## Summary
Follow-up to #117. Its dependency-review check flagged 4 packages with "unknown license": `github/codeql-action/{init,analyze,upload-sarif}@v4` and `gitleaks/gitleaks-action@v2`. Same root cause as the `actions/checkout` finding fixed in that PR — a mutable tag ref resolves as a version range in the dependency graph, so GitHub Actions ecosystem packages can't be license-looked-up. Pinning to the resolved commit SHA clears it.

- `github/codeql-action/{init,analyze,upload-sarif}` -> `v4.37.7`
- `gitleaks/gitleaks-action` -> `v2.3.9`

## Test plan
- [ ] YAML validated locally
- [ ] CI run on this PR exercises `security.yml`'s codeql/gitleaks jobs
- [ ] dependency-review check shows 0 unknown-license packages