### PR TITLE
ci: self-heal missing labels in dependabot-auto-merge.yml

### DIFF
--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -6,6 +6,7 @@ on:
 permissions:
   contents: write
   pull-requests: write
+  issues: write
 
 jobs:
   auto-merge:
@@ -30,7 +31,15 @@ jobs:
 
     - name: Label major updates for manual review
       if: steps.metadata.outputs.update-type == 'version-update:semver-major'
-      run: gh pr edit "$PR_URL" --add-label "major-update,needs-review"
+      run: |
+        # Labels aren't guaranteed to exist (e.g. after a repo reset) —
+        # create them idempotently before applying, so this step is
+        # self-healing instead of hard-failing on a missing label.
+        gh label create "major-update" --color "B60205" \
+          --description "Major dependency version bump" --force
+        gh label create "needs-review" --color "FBCA04" \
+          --description "Needs manual review before merge" --force
+        gh pr edit "$PR_URL" --add-label "major-update,needs-review"
       env:
         PR_URL: ${{ github.event.pull_request.html_url }}
         GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary
PR #119's `auto-merge` check failed: `gh pr edit --add-label "major-update,needs-review"` errored with `'major-update' not found` — the repo never had those two labels created, so any semver-major dependabot bump hard-fails this workflow.

- Created `major-update` and `needs-review` labels in the repo (unblocks #119's re-run)
- Hardened `dependabot-auto-merge.yml` to create both labels idempotently (`gh label create ... --force`) before applying them, so a future label deletion/reset doesn't repeat this
- Added `issues: write` to the job's permissions — label creation needs it beyond `pull-requests: write`

## Test plan
- [ ] CI green on this PR
- [ ] Re-run PR #119's `auto-merge` check and confirm it now passes