### PR TITLE
release: prepare v0.7.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,11 @@ All notable changes to RheoJAX will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [0.7.0] - 2026-08-14
+
+### Changed
+- **BREAKING:** Removed the legacy `RheoJAXMainWindow` GUI shell and the deprecated `--legacy`/`--workspace` CLI flags. The workspace shell (`WorkspaceWindow`) has been the default since 0.x and is now the only GUI entry point. Migration: drop `--legacy`/`--workspace` from any scripts invoking `rheojax-gui`; both flags now produce an argparse "unrecognized arguments" error. All CLI capabilities the legacy shell exposed (`--project`, `--import`/`--protocol`, `--maximized`) are already fully supported on the default (and now only) workspace path.
+- **BREAKING (0.7.0):** RheoJAX is now shear-only. Removed DMTA — `DeformationMode`, the `deformation_mode`/`poisson_ratio` parameters, `modulus_conversion`/`POISSON_PRESETS`, and tensile `modulus_type`. Migration: convert tensile data to shear externally before loading; remove `deformation_mode`/`poisson_ratio` from calls, CLI flags, and YAML configs.
 
 ### Fixed
 - **Fixed** `rheojax export` (`cmd_export.py::_build_pipeline_from_envelope`) set nonexistent `pipe._data`/`pipe._source` attributes instead of constructing `Pipeline(data=data)`, so exports built from a piped envelope (`rheojax load --json | rheojax export -`) always saw an empty `pipeline.data`.
@@ -16,14 +20,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Removed
 - **Removed** `rheojax.utils.optimization.nlsq_optimize_global`, a 4-line pass-through to `nlsq_optimize(..., workflow="auto_global")` with no production callers and no public export. Call `nlsq_optimize(objective, parameters, workflow="auto_global", ...)` directly.
-
-### Changed
-- **BREAKING:** Removed the legacy `RheoJAXMainWindow` GUI shell and the deprecated `--legacy`/`--workspace` CLI flags. The workspace shell (`WorkspaceWindow`) has been the default since 0.x and is now the only GUI entry point. Migration: drop `--legacy`/`--workspace` from any scripts invoking `rheojax-gui`; both flags now produce an argparse "unrecognized arguments" error. All CLI capabilities the legacy shell exposed (`--project`, `--import`/`--protocol`, `--maximized`) are already fully supported on the default (and now only) workspace path.
-
-## [0.7.0] - 2026-06-29
-
-### Changed
-- **BREAKING (0.7.0):** RheoJAX is now shear-only. Removed DMTA — `DeformationMode`, the `deformation_mode`/`poisson_ratio` parameters, `modulus_conversion`/`POISSON_PRESETS`, and tensile `modulus_type`. Migration: convert tensile data to shear externally before loading; remove `deformation_mode`/`poisson_ratio` from calls, CLI flags, and YAML configs.
 
 ### Added — Herschel-Bulkley-Capable EPM Kernels (scalar and tensorial)
 
@@ -795,6 +791,7 @@ Refactored the smart initialization system to use the Template Method design pat
 
 Previous releases documented in git history.
 
+[0.7.0]: https://github.com/imewei/rheojax/compare/v0.6.1...v0.7.0
 [0.6.1]: https://github.com/imewei/rheojax/compare/v0.6.0...v0.6.1
 [0.6.0]: https://github.com/imewei/rheojax/compare/v0.5.0...v0.6.0
 [0.5.0]: https://github.com/imewei/rheojax/compare/v0.4.0...v0.5.0

--- a/README.md
+++ b/README.md
@@ -1018,7 +1018,7 @@ If you use rheojax in your research, please cite:
   year = {2024-2026},
   author = {Wei Chen},
   url = {https://github.com/imewei/rheojax},
-  version = {0.6.1}
+  version = {0.7.0}
 }
 ```
 

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -14,8 +14,8 @@ sys.path.insert(0, os.path.abspath("../.."))
 project = "rheojax"
 copyright = "2025, Wei Chen"
 author = "Wei Chen"
-release = "0.6.1"
-version = "0.6.1"
+release = "0.7.0"
+version = "0.7.0"
 
 # -- General configuration ---------------------------------------------------
 # https://www.sphinx-doc.org/en/master/usage/configuration.html#general-configuration

--- a/rheojax/gui/__init__.py
+++ b/rheojax/gui/__init__.py
@@ -24,7 +24,7 @@ Requirements:
     - Additional dependencies via `pip install rheojax[gui]`
 """
 
-__version__ = "0.6.1"
+__version__ = "0.7.0"
 
 __all__ = [
     "__version__",


### PR DESCRIPTION
## Summary
- pyproject.toml and rheojax/__init__.py were already bumped to 0.7.0 (commit 6af091df) but never tagged/released — v0.6.1 is still the latest GitHub release.
- Fixes stale `0.6.1` version strings left behind in `docs/source/conf.py`, README's citation block, and `rheojax/gui/__init__.py`.
- Folds CHANGELOG's `[Unreleased]` section into `[0.7.0]` (dated today) since nothing has shipped as 0.7.0 yet, and adds the missing compare link.

## Test plan
- [x] `uv run pytest tests/test_import.py -q` — 4 passed, confirms `rheojax.__version__ == "0.7.0"`
- [ ] After merge: `git tag v0.7.0 && git push origin v0.7.0` to trigger `.github/workflows/release.yml` (PyPI publish) — left for explicit approval, not run here.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>